### PR TITLE
[Fix] Map extension with mcap files

### DIFF
--- a/desktop/integration-test/mapPanel.test.ts
+++ b/desktop/integration-test/mapPanel.test.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import path from "path";
+
+import { AppType, launchApp } from "./launchApp";
+
+describe("mapPanel", () => {
+  const closeDataSourceDialogAfterAppLaunch = async (app: AppType) => {
+    await expect(app.renderer.getByTestId("DataSourceDialog").isVisible()).resolves.toBe(true);
+    await app.renderer.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+    await expect(app.renderer.getByTestId("DataSourceDialog").isVisible()).resolves.toBe(false);
+  };
+
+  it("should open map panel when loading a file", async () => {
+    await using app = await launchApp();
+    await closeDataSourceDialogAfterAppLaunch(app);
+    //Add rosbag file from source
+    const filePath = path.resolve(
+      __dirname,
+      "../../packages/suite-base/src/test/fixtures/example.bag",
+    );
+    //Drag and drop file
+    const fileInput = app.renderer.locator("[data-puppeteer-file-upload]");
+    await fileInput.setInputFiles(filePath);
+
+    //Click on add panel and select Map
+    await app.renderer.getByTestId("AddPanelButton").click();
+
+    // Click on "Search panels" input field and type Map
+    const searchInput = app.renderer.getByPlaceholder("Search panels");
+    //   await searchInput.click();
+    await searchInput.type("Map");
+    await app.renderer.getByTestId("panel-menu-item Map").click();
+
+    const mapSettingsIcon = app.renderer.getByTestId("SettingsIcon").nth(0);
+    await mapSettingsIcon.click();
+
+    await expect(app.renderer.getByText("Map panel", { exact: true }).innerText()).resolves.toBe(
+      "Map panel",
+    );
+  }, 15_000);
+});

--- a/packages/suite-base/src/components/AppBar/index.tsx
+++ b/packages/suite-base/src/components/AppBar/index.tsx
@@ -229,6 +229,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
                 color="inherit"
                 disabled={!hasCurrentLayout}
                 id="add-panel-button"
+                data-testid="AddPanelButton"
                 data-tourid="add-panel-button"
                 title={t("addPanel")}
                 aria-label="Add panel button"

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -244,7 +244,7 @@ function PanelExtensionAdapter(
       sortedTopics,
       subscriptions: localSubscriptions,
       watchedFields,
-      config: initialState.current,
+      config: undefined,
     });
 
     if (!renderState) {


### PR DESCRIPTION
**User-Facing Changes**
This is a bug fix. Previoulsy, when loading a file and trying to load the Map panel there was an error being show. 

**Description**
Due the past implementations some bug was introduced when loading the config object on Panel Extension Adapter. When forcing it to be initialized with 'initialState.current' the topics were not being loaded correctly. We also added some tests to verify that the Map panel is being loaded correctly.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] I've updated/created the storybook file(s)
