### PR TITLE
Add option to publish as pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      pre_release:
+        type: boolean
+        description: "Pre-release"
+        default: true
 
 jobs:
   build:
@@ -63,6 +68,7 @@ jobs:
           name: "v${{ env.new_version }}"
           commit: main
           generateReleaseNotes: true
+          prerelease: ${{ github.event.inputs.pre_release }}
           token: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}
           artifacts: |
             dist/lichtblick-${{ env.new_version }}-linux-amd64.deb


### PR DESCRIPTION
**User-Facing Changes**
No user facing changes.

**Description**
Add to "release" workflow the option to create a release as a pre-release. This option is true by default. 

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] I've updated/created the storybook file(s)
