### PR TITLE
[FIX] Fix icon resolution and separate build tasks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      pre_release:
+        type: boolean
+        description: "Pre-release"
+        default: true
 
 jobs:
   build:
@@ -63,6 +68,7 @@ jobs:
           name: "v${{ env.new_version }}"
           commit: main
           generateReleaseNotes: true
+          prerelease: ${{ github.event.inputs.pre_release }}
           token: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}
           artifacts: |
             dist/lichtblick-${{ env.new_version }}-linux-amd64.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,14 @@ jobs:
         run: |
           yarn run desktop:build:prod
 
-      - name: Build release binaries for multiple OS
-        run: |
-          yarn run package:win
-          yarn run package:linux
-          yarn run package:darwin
+      - name: Build windows version
+        run: yarn run package:win
+
+      - name: Build linux version
+        run: yarn run package:linux
+
+      - name: Build macOS version
+        run: yarn run package:darwin
 
       # Important to use [skip actions] to avoid triggering other verisoning workflows
       # https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs

--- a/packages/suite-desktop/resources/icon/icon.icns
+++ b/packages/suite-desktop/resources/icon/icon.icns
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dff35056a2cd8aa28ba6520fcf2ffde80b0d50b46d2f334002199764c20cb26c
-size 3072
+oid sha256:2f32a5952c4ff2043a266c0cc7e77dc58f19ce147b663877284d8e1587cb5ce9
+size 79536

--- a/packages/suite-desktop/resources/icon/icon.png
+++ b/packages/suite-desktop/resources/icon/icon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c4566d17fe8ea1e1fb984627e487cef90624c2893a90f79a57c7cc13e9f1cbc3
-size 38470
+oid sha256:b13cf930c4d1e267f53730a5435c7f96d2900013f0901c6fdb7d6f527cfada1d
+size 69949


### PR DESCRIPTION
**User-Facing Changes**
Build linuxn version was failing.

**Description**
The problem was the resolution of the icons. It was 588x588 and for ICNS should be standard as 128x128, 256x256, 512x512 etc.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] I've updated/created the storybook file(s)
