### PR TITLE
Fix/release details

### DIFF
--- a/packages/suite-desktop/src/electronBuilderConfig.js
+++ b/packages/suite-desktop/src/electronBuilderConfig.js
@@ -27,8 +27,8 @@ function makeElectronBuilderConfig(params) {
     icon: path.join(__dirname, "../resources/icon/icon.icns"),
     protocols: [
       {
-        name: "foxglove",
-        schemes: ["foxglove"],
+        name: "lichtblick",
+        schemes: ["lichtblick"],
       },
     ],
     linux: {

--- a/packages/suite-desktop/src/preload/index.ts
+++ b/packages/suite-desktop/src/preload/index.ts
@@ -142,7 +142,7 @@ export function main(): void {
     },
     async fetchLayouts() {
       const homePath = (await ipcRenderer.invoke("getHomePath")) as string;
-      const userExtensionRoot = pathJoin(homePath, ".lichtblick", "layouts");
+      const userExtensionRoot = pathJoin(homePath, ".lichtblick-suite", "layouts");
       return await fetchLayouts(userExtensionRoot);
     },
     async installExtension(foxeFileData: Uint8Array) {


### PR DESCRIPTION
**User-Facing Changes**
Corrected the default user directory for layouts, ensuring consistency with the directory used for extensions. Removed an incorrect reference to "foxglove" in the protocol schemas of the electron configuration, which was mistakenly appearing in the MimeType.

**Description**
- Fixed the incorrect default user directory for layouts, aligning it with the one used for extensions.
- Updated the protocol schemas to remove the erroneous "foxglove" reference in the MimeType.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] I've updated/created the storybook file(s)
