### PR TITLE
[Fix] Suppress importScripts error as done in web version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ $ yarn install
 Launch the development environment:
 
 ```sh
-# To launch the desktop app (run both scripts concurrently):
-$ yarn desktop:serve        # start webpack
-$ yarn desktop:start        # launch electron
+# To launch the desktop app (run scripts in different terminals):
+$ yarn desktop:serve        # start webpack dev server
+$ yarn desktop:start        # launch electron (make sure the desktop:serve finished to build)
 
 # To launch the web app:
 $ yarn run web:serve        # it will be avaiable in http://localhost:8080

--- a/packages/suite-desktop/src/webpackDevServerConfig.ts
+++ b/packages/suite-desktop/src/webpackDevServerConfig.ts
@@ -50,6 +50,37 @@ export const webpackDevServerConfig =
             );
           },
         },
+        client: {
+          overlay: {
+            runtimeErrors: (error) => {
+              // Suppress overlays for importScript errors from terminated webworkers.
+              //
+              // When a webworker is terminated, any pending `importScript` calls are cancelled by the
+              // browser. These appear in the devtools network tab as "(cancelled)" and bubble up to the
+              // parent page as errors which trigger `window.onerror`.
+              //
+              // webpack devserver attaches to the window error handler surface unhandled errors sent to
+              // the page. However this kind of error is a false-positive for a worker that is
+              // terminated because we do not care that its network requests were cancelled since the
+              // worker itself is gone.
+              //
+              // Will this hide real importScript errors during development?
+              // It is possible that a worker encounters this error during normal operation (if
+              // importing a script does fail for a legitimate reason). In that case we expect the
+              // worker logic that depended on the script to fail execution and trigger other kinds of
+              // errors. The developer can still see the importScripts error in devtools console.
+              if (
+                error.message.startsWith(
+                  `Uncaught NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope'`,
+                )
+              ) {
+                return false;
+              }
+
+              return true;
+            },
+          },
+        },
         hot: true,
         // The problem and solution are described at <https://github.com/webpack/webpack-dev-server/issues/1604>.
         // When running in dev mode two errors are logged to the dev console:


### PR DESCRIPTION
**User-Facing Changes**
User receiving error about "importScripts" when running the desktop in dev mode.

**Description**
This bug is related to certain calls being cancelled when a web worker is terminated. While this error can be a false positive—since the termination of a worker is usually not a concern—it can still involve legitimate cancelled calls. Handling such situations should be managed within the web worker's own logic. Regardless, the error will still appear in the developer console if debugging is necessary.

The proposed fix is to suppress this error for the desktop version, just as it was done for the web version. The user who reported the bug has confirmed that the web version works without warnings.

**Checklist**
- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] I've updated/created the storybook file(s)
