### PR TITLE
[Docs] Add instructions LIBGL_ALWAYS_SOFTWARE to ubuntu users

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ $ yarn install
 Launch the development environment:
 
 ```sh
-# To launch the desktop app (run both scripts concurrently):
-$ yarn desktop:serve        # start webpack
-$ yarn desktop:start        # launch electron
+# To launch the desktop app (run scripts in different terminals):
+$ yarn desktop:serve        # start webpack dev server
+$ yarn desktop:start        # launch electron (make sure the desktop:serve finished to build)
 
 # To launch the web app:
 $ yarn run web:serve        # it will be avaiable in http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ $ yarn desktop:start        # launch electron (make sure the desktop:serve finis
 $ yarn run web:serve        # it will be avaiable in http://localhost:8080
 ```
 
+:warning: Ubuntu users: the application may present some issues using GPU. In order to bypass the GPU and process it using directly the CPU (software), please run lichtblick using the variable `LIBGL_ALWAYS_SOFTWARE` set to `1`:
+```sh
+$ LIBGL_ALWAYS_SOFTWARE=1 yarn desktop:start
+```
+
 ## :hammer_and_wrench: Building Lichtblick
 
 Build the application for production using these commands:

--- a/packages/suite-desktop/src/webpackDevServerConfig.ts
+++ b/packages/suite-desktop/src/webpackDevServerConfig.ts
@@ -50,6 +50,37 @@ export const webpackDevServerConfig =
             );
           },
         },
+        client: {
+          overlay: {
+            runtimeErrors: (error) => {
+              // Suppress overlays for importScript errors from terminated webworkers.
+              //
+              // When a webworker is terminated, any pending `importScript` calls are cancelled by the
+              // browser. These appear in the devtools network tab as "(cancelled)" and bubble up to the
+              // parent page as errors which trigger `window.onerror`.
+              //
+              // webpack devserver attaches to the window error handler surface unhandled errors sent to
+              // the page. However this kind of error is a false-positive for a worker that is
+              // terminated because we do not care that its network requests were cancelled since the
+              // worker itself is gone.
+              //
+              // Will this hide real importScript errors during development?
+              // It is possible that a worker encounters this error during normal operation (if
+              // importing a script does fail for a legitimate reason). In that case we expect the
+              // worker logic that depended on the script to fail execution and trigger other kinds of
+              // errors. The developer can still see the importScripts error in devtools console.
+              if (
+                error.message.startsWith(
+                  `Uncaught NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope'`,
+                )
+              ) {
+                return false;
+              }
+
+              return true;
+            },
+          },
+        },
         hot: true,
         // The problem and solution are described at <https://github.com/webpack/webpack-dev-server/issues/1604>.
         // When running in dev mode two errors are logged to the dev console:


### PR DESCRIPTION
**User-Facing Changes**
Ubuntu users are having issues to open lichtblick.

**Description**
The issue appears to be related to GPU compatibility on Ubuntu, which is not a new problem. The environment variable LIBGL_SOFTWARE_ALWAYS=1 was previously required for older versions, and it seems this issue may be tied to the "three.js" library, which handles object rendering in certain panels.
The proposed solution is to update the documentation, advising users to apply this flag on Ubuntu if they encounter any rendering issues or malfunctions.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [X] I've updated/created the storybook file(s)
