### PR TITLE
[FIX] Replace React.DOM render with createRoot

### DIFF
--- a/benchmark/src/index.tsx
+++ b/benchmark/src/index.tsx
@@ -33,7 +33,7 @@ async function main() {
   }
 
   const root = createRoot(rootEl);
-  root.render(<Root />)
+  root.render(<Root />);
 }
 
 void main();

--- a/benchmark/src/index.tsx
+++ b/benchmark/src/index.tsx
@@ -5,7 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import Logger from "@lichtblick/log";
 import { initI18n } from "@lichtblick/suite-base";
@@ -17,11 +17,6 @@ window.onerror = (...args) => {
   console.error(...args);
 };
 
-const rootEl = document.getElementById("root");
-if (!rootEl) {
-  throw new Error("missing #root element");
-}
-
 async function main() {
   const { overwriteFetch, waitForFonts } = await import("@lichtblick/suite-base");
   overwriteFetch();
@@ -32,8 +27,13 @@ async function main() {
 
   const { Root } = await import("./Root");
 
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(<Root />, rootEl);
+  const rootEl = document.getElementById("root");
+  if (!rootEl) {
+    throw new Error("missing #root element");
+  }
+
+  const root = createRoot(rootEl);
+  root.render(<Root />)
 }
 
 void main();

--- a/packages/suite-base/src/components/Chart/index.tsx
+++ b/packages/suite-base/src/components/Chart/index.tsx
@@ -162,7 +162,7 @@ function Chart(props: Props): JSX.Element {
 
     return () => {
       log.info(`Unregister chart ${id}`);
-      sendWrapper("destroy").catch(() => { }); // may fail if worker is torn down
+      sendWrapper("destroy").catch(() => {}); // may fail if worker is torn down
       rpcSendRef.current = undefined;
       sendWrapperRef.current = undefined;
       initialized.current = false;
@@ -308,7 +308,9 @@ function Chart(props: Props): JSX.Element {
       // Using queueMicrotask to ensure the canvas is completely inserted into the DOM
       // before sending the initialization request to the worker.
       queueMicrotask(async () => {
-        if (!sendWrapperRef.current) { return }
+        if (!sendWrapperRef.current) {
+          return;
+        }
         const scales = await sendWrapperRef.current<RpcScales>(
           "initialize",
           {
@@ -342,7 +344,7 @@ function Chart(props: Props): JSX.Element {
         await flushUpdates(sendWrapperRef.current);
         // once we are initialized, we can allow other handlers to send to the rpc endpoint
         rpcSendRef.current = sendWrapperRef.current;
-      })
+      });
     },
     [maybeUpdateScales, onFinishRender, onStartRender, type, flushUpdates],
   );

--- a/packages/suite-base/src/components/DocumentDropListener.test.tsx
+++ b/packages/suite-base/src/components/DocumentDropListener.test.tsx
@@ -33,7 +33,7 @@ describe("<DocumentDropListener>", () => {
     wrapper = document.createElement("div");
     document.body.appendChild(wrapper);
 
-    const root = createRoot(wrapper)
+    const root = createRoot(wrapper);
     root.render(
       <div>
         <SnackbarProvider>
@@ -41,7 +41,7 @@ describe("<DocumentDropListener>", () => {
             <DocumentDropListener allowedExtensions={[]} />
           </ThemeProvider>
         </SnackbarProvider>
-      </div>
+      </div>,
     );
 
     (console.error as jest.Mock).mockClear();

--- a/packages/suite-base/src/components/DocumentDropListener.test.tsx
+++ b/packages/suite-base/src/components/DocumentDropListener.test.tsx
@@ -16,7 +16,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { SnackbarProvider } from "notistack";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { act } from "react-dom/test-utils";
 
 import DocumentDropListener from "@lichtblick/suite-base/components/DocumentDropListener";
@@ -33,16 +33,15 @@ describe("<DocumentDropListener>", () => {
     wrapper = document.createElement("div");
     document.body.appendChild(wrapper);
 
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.render(
+    const root = createRoot(wrapper)
+    root.render(
       <div>
         <SnackbarProvider>
           <ThemeProvider isDark={false}>
             <DocumentDropListener allowedExtensions={[]} />
           </ThemeProvider>
         </SnackbarProvider>
-      </div>,
-      wrapper,
+      </div>
     );
 
     (console.error as jest.Mock).mockClear();
@@ -65,9 +64,7 @@ describe("<DocumentDropListener>", () => {
     (event as any).dataTransfer = {
       types: ["Files"],
     };
-    act(() => {
-      document.dispatchEvent(event); // The event should NOT bubble up from the document to the window
-    });
+    document.dispatchEvent(event); // The event should NOT bubble up from the document to the window
 
     expect(windowDragoverHandler).not.toHaveBeenCalled();
   });

--- a/packages/suite-base/src/panels/CallService/index.tsx
+++ b/packages/suite-base/src/panels/CallService/index.tsx
@@ -5,7 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode, useMemo } from "react";
+import { useMemo } from "react";
 
 import { useCrash } from "@lichtblick/hooks";
 import { PanelExtensionContext } from "@lichtblick/suite";
@@ -20,11 +20,9 @@ import { Config } from "./types";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
   return createSyncRoot(
-    <StrictMode>
-      <CaptureErrorBoundary onError={crash}>
-        <CallService context={context} />
-      </CaptureErrorBoundary>
-    </StrictMode>,
+    <CaptureErrorBoundary onError={crash}>
+      <CallService context={context} />
+    </CaptureErrorBoundary>,
     context.panelElement,
   );
 }

--- a/packages/suite-base/src/panels/Gauge/index.tsx
+++ b/packages/suite-base/src/panels/Gauge/index.tsx
@@ -5,7 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode, useMemo } from "react";
+import { useMemo } from "react";
 
 import { useCrash } from "@lichtblick/hooks";
 import { PanelExtensionContext } from "@lichtblick/suite";
@@ -21,13 +21,11 @@ import { Config } from "./types";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
   return createSyncRoot(
-    <StrictMode>
-      <CaptureErrorBoundary onError={crash}>
-        <ThemeProvider isDark>
-          <Gauge context={context} />
-        </ThemeProvider>
-      </CaptureErrorBoundary>
-    </StrictMode>,
+    <CaptureErrorBoundary onError={crash}>
+      <ThemeProvider isDark>
+        <Gauge context={context} />
+      </ThemeProvider>
+    </CaptureErrorBoundary>,
     context.panelElement,
   );
 }

--- a/packages/suite-base/src/panels/Indicator/index.tsx
+++ b/packages/suite-base/src/panels/Indicator/index.tsx
@@ -5,7 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode, useMemo } from "react";
+import { useMemo } from "react";
 
 import { useCrash } from "@lichtblick/hooks";
 import { PanelExtensionContext } from "@lichtblick/suite";
@@ -21,13 +21,11 @@ import { Config } from "./types";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
   return createSyncRoot(
-    <StrictMode>
-      <CaptureErrorBoundary onError={crash}>
-        <ThemeProvider isDark>
-          <Indicator context={context} />
-        </ThemeProvider>
-      </CaptureErrorBoundary>
-    </StrictMode>,
+    <CaptureErrorBoundary onError={crash}>
+      <ThemeProvider isDark>
+        <Indicator context={context} />
+      </ThemeProvider>
+    </CaptureErrorBoundary>,
     context.panelElement,
   );
 }

--- a/packages/suite-base/src/panels/StateTransitions/index.tsx
+++ b/packages/suite-base/src/panels/StateTransitions/index.tsx
@@ -200,7 +200,7 @@ function StateTransitions(props: Props) {
     const xAxisHeight = 30;
     return {
       height: Math.max(80, onlyTopicsHeight + xAxisHeight),
-      heightPerTopic: onlyTopicsHeight / paths.length,
+      heightPerTopic: paths.length === 0 ? 0 : onlyTopicsHeight / paths.length,
     };
   }, [paths.length]);
 

--- a/packages/suite-base/src/panels/Teleop/index.tsx
+++ b/packages/suite-base/src/panels/Teleop/index.tsx
@@ -5,7 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode, useMemo } from "react";
+import { useMemo } from "react";
 
 import { useCrash } from "@lichtblick/hooks";
 import { PanelExtensionContext } from "@lichtblick/suite";
@@ -19,11 +19,9 @@ import TeleopPanel from "./TeleopPanel";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
   return createSyncRoot(
-    <StrictMode>
-      <CaptureErrorBoundary onError={crash}>
-        <TeleopPanel context={context} />
-      </CaptureErrorBoundary>
-    </StrictMode>,
+    <CaptureErrorBoundary onError={crash}>
+      <TeleopPanel context={context} />
+    </CaptureErrorBoundary>,
     context.panelElement,
   );
 }

--- a/packages/suite-base/src/panels/ThreeDeeRender/index.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/index.tsx
@@ -5,7 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode, useMemo } from "react";
+import { useMemo } from "react";
 import { DeepPartial } from "ts-essentials";
 
 import { useCrash } from "@lichtblick/hooks";
@@ -40,18 +40,16 @@ type InitPanelArgs = {
 function initPanel(args: InitPanelArgs, context: BuiltinPanelExtensionContext) {
   const { crash, forwardedAnalytics, interfaceMode, testOptions, customSceneExtensions } = args;
   return createSyncRoot(
-    <StrictMode>
-      <CaptureErrorBoundary onError={crash}>
-        <ForwardAnalyticsContextProvider forwardedAnalytics={forwardedAnalytics}>
-          <ThreeDeeRender
-            context={context}
-            interfaceMode={interfaceMode}
-            testOptions={testOptions}
-            customSceneExtensions={customSceneExtensions}
-          />
-        </ForwardAnalyticsContextProvider>
-      </CaptureErrorBoundary>
-    </StrictMode>,
+    <CaptureErrorBoundary onError={crash}>
+      <ForwardAnalyticsContextProvider forwardedAnalytics={forwardedAnalytics}>
+        <ThreeDeeRender
+          context={context}
+          interfaceMode={interfaceMode}
+          testOptions={testOptions}
+          customSceneExtensions={customSceneExtensions}
+        />
+      </ForwardAnalyticsContextProvider>
+    </CaptureErrorBoundary>,
     context.panelElement,
   );
 }

--- a/packages/suite-base/src/panels/createSyncRoot.test.tsx
+++ b/packages/suite-base/src/panels/createSyncRoot.test.tsx
@@ -5,7 +5,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import { act, screen } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 
 import { createSyncRoot } from "@lichtblick/suite-base/panels/createSyncRoot";
 
@@ -35,13 +35,15 @@ describe("createSyncRoot", () => {
     const text = "Unmount Component Test";
     const TestComponent = () => <div>{text}</div>;
     act(() => {
-      setTimeout(() => {
-        const unmount = createSyncRoot(<TestComponent />, container);
+      const unmount = createSyncRoot(<TestComponent />, container);
+      queueMicrotask(() => {
         unmount();
-      }, 0);
+      });
     });
 
-    expect(container.innerHTML).not.toContain(text);
-    expect(screen.queryByText(text)).toBeNull();
+    await waitFor(() => {
+      expect(container.innerHTML).not.toContain(text);
+      expect(screen.queryByText(text)).toBeNull();
+    });
   });
 });

--- a/packages/suite-base/src/panels/createSyncRoot.test.tsx
+++ b/packages/suite-base/src/panels/createSyncRoot.test.tsx
@@ -5,8 +5,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import { screen } from "@testing-library/react";
-import { act } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 
 import { createSyncRoot } from "@lichtblick/suite-base/panels/createSyncRoot";
 

--- a/packages/suite-base/src/panels/createSyncRoot.test.tsx
+++ b/packages/suite-base/src/panels/createSyncRoot.test.tsx
@@ -6,7 +6,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import { screen } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import { act } from "@testing-library/react";
+// import { act } from "react-dom/test-utils";
 
 import { createSyncRoot } from "@lichtblick/suite-base/panels/createSyncRoot";
 
@@ -36,8 +37,10 @@ describe("createSyncRoot", () => {
     const text = "Unmount Component Test";
     const TestComponent = () => <div>{text}</div>;
     act(() => {
-      const unmount = createSyncRoot(<TestComponent />, container);
-      unmount();
+      setTimeout(() => {
+        const unmount = createSyncRoot(<TestComponent />, container);
+        unmount();
+      }, 0)
     });
 
     expect(container.innerHTML).not.toContain(text);

--- a/packages/suite-base/src/panels/createSyncRoot.test.tsx
+++ b/packages/suite-base/src/panels/createSyncRoot.test.tsx
@@ -7,7 +7,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import { screen } from "@testing-library/react";
 import { act } from "@testing-library/react";
-// import { act } from "react-dom/test-utils";
 
 import { createSyncRoot } from "@lichtblick/suite-base/panels/createSyncRoot";
 
@@ -40,7 +39,7 @@ describe("createSyncRoot", () => {
       setTimeout(() => {
         const unmount = createSyncRoot(<TestComponent />, container);
         unmount();
-      }, 0)
+      }, 0);
     });
 
     expect(container.innerHTML).not.toContain(text);

--- a/packages/suite-base/src/panels/createSyncRoot.test.tsx
+++ b/packages/suite-base/src/panels/createSyncRoot.test.tsx
@@ -6,50 +6,41 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import { screen } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
 
 import { createSyncRoot } from "@lichtblick/suite-base/panels/createSyncRoot";
 
 describe("createSyncRoot", () => {
-  const originalError = console.error;
-
-  beforeAll(() => {
-    // Supress specific warning about ReactDOM.render
-    console.error = (...args) => {
-      if (args[0]?.includes("Warning: ReactDOM.render is no longer supported") === true) {
-        return;
-      }
-      originalError.call(console, ...args);
-    };
-  });
-
-  afterAll(() => {
-    // Restore original console.error after tests
-    console.error = originalError;
+  afterEach(() => {
+    document.body.innerHTML = '';
   });
 
   it("should mount the component", async () => {
-    const textTest = "Mount Component Test";
-    const TestComponent = () => <div>{textTest}</div>;
-
     const container = document.createElement("div");
     document.body.appendChild(container);
 
-    createSyncRoot(<TestComponent />, container);
+    const text = "Mount Component Test";
+    const TestComponent = () => <div>{text}</div>;
+    act(() => {
+      createSyncRoot(<TestComponent />, container);
+    });
 
-    expect(await screen.findByText(textTest)).toBeDefined();
+    expect(container.innerHTML).toContain(text);
+    await expect(screen.findByText(text)).resolves.not.toBeUndefined();
   });
 
-  it("should unmount the component", () => {
-    const textTest = "Unmount Component Test";
-    const TestComponent = () => <div>{textTest}</div>;
-
+  it("should unmount the component", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
 
-    const unmountCb = createSyncRoot(<TestComponent />, container);
-    expect(screen.queryAllByText(textTest)).toHaveLength(1);
+    const text = "Unmount Component Test";
+    const TestComponent = () => <div>{text}</div>;
+    act(() => {
+      const unmount = createSyncRoot(<TestComponent />, container);
+      unmount();
+    });
 
-    unmountCb();
-    expect(screen.queryAllByText(textTest)).toHaveLength(0);
+    expect(container.innerHTML).not.toContain(text);
+    expect(screen.queryByText(text)).toBeNull();
   });
 });

--- a/packages/suite-base/src/panels/createSyncRoot.test.tsx
+++ b/packages/suite-base/src/panels/createSyncRoot.test.tsx
@@ -12,7 +12,7 @@ import { createSyncRoot } from "@lichtblick/suite-base/panels/createSyncRoot";
 
 describe("createSyncRoot", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
   it("should mount the component", async () => {

--- a/packages/suite-base/src/panels/createSyncRoot.tsx
+++ b/packages/suite-base/src/panels/createSyncRoot.tsx
@@ -21,7 +21,10 @@ export function createSyncRoot(component: JSX.Element, panelElement: HTMLDivElem
   const root: Root = createRoot(panelElement);
   root.render(component);
   return () => {
-    root.unmount();
-    panelElement.remove();
+    // Use queueMicrotask to ensure that the onmount occurs after the render cycle
+    queueMicrotask(() => {
+      root.unmount();
+      panelElement.remove();
+    });
   };
 }

--- a/packages/suite-base/src/panels/createSyncRoot.tsx
+++ b/packages/suite-base/src/panels/createSyncRoot.tsx
@@ -21,7 +21,7 @@ export function createSyncRoot(component: JSX.Element, panelElement: HTMLDivElem
   const root: Root = createRoot(panelElement);
   root.render(component);
   return () => {
-    // Use queueMicrotask to ensure that the onmount occurs after the render cycle
+    // Use queueMicrotask to ensure that the unmount occurs after the render cycle
     queueMicrotask(() => {
       root.unmount();
       panelElement.remove();

--- a/packages/suite-base/src/panels/createSyncRoot.tsx
+++ b/packages/suite-base/src/panels/createSyncRoot.tsx
@@ -5,7 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import ReactDOM from "react-dom";
+import { createRoot, Root } from "react-dom/client";
 
 /**
  * Creates a root for rendering React components.
@@ -13,18 +13,15 @@ import ReactDOM from "react-dom";
  * This function is designed to centralize the creation of React roots
  * for rendering components within a given HTML element.
  *
- * This approach should be replaced by createRoot().render, but it create issues on the application.
- * In the future this has to solved.
- *
  * @param component The JSX element to be rendered within the root.
  * @param panelElement The HTML element to serve as the container for the root.
  * @returns A function to unmount the root when needed.
  */
 export function createSyncRoot(component: JSX.Element, panelElement: HTMLDivElement): () => void {
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(component, panelElement);
+  const root: Root = createRoot(panelElement);
+  root.render(component);
   return () => {
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.unmountComponentAtNode(panelElement);
+    root.unmount();
+    panelElement.remove();
   };
 }

--- a/packages/suite-desktop/src/quicklook/index.tsx
+++ b/packages/suite-desktop/src/quicklook/index.tsx
@@ -134,6 +134,6 @@ export function main(): void {
     <>
       <GlobalStyle />
       <Root />
-    </>
+    </>,
   );
 }

--- a/packages/suite-desktop/src/quicklook/index.tsx
+++ b/packages/suite-desktop/src/quicklook/index.tsx
@@ -8,7 +8,7 @@
 /// <reference types="quicklookjs" />
 
 import { useState, useEffect, useRef } from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { useAsync } from "react-use";
 
 import Logger from "@lichtblick/log";
@@ -128,12 +128,12 @@ export function main(): void {
       </div>
     );
   }
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
+
+  const root = createRoot(rootEl);
+  root.render(
     <>
       <GlobalStyle />
       <Root />
-    </>,
-    rootEl,
+    </>
   );
 }

--- a/packages/suite-desktop/src/renderer/index.tsx
+++ b/packages/suite-desktop/src/renderer/index.tsx
@@ -69,6 +69,6 @@ export async function main(params: MainParams): Promise<void> {
         extraProviders={params.extraProviders}
         dataSources={params.dataSources}
       />
-    </LogAfterRender>
+    </LogAfterRender>,
   );
 }

--- a/packages/suite-desktop/src/renderer/index.tsx
+++ b/packages/suite-desktop/src/renderer/index.tsx
@@ -9,8 +9,8 @@
 /// <reference types="electron" />
 
 import { Sockets } from "@foxglove/electron-socket/renderer";
-import { StrictMode, useEffect } from "react";
-import ReactDOM from "react-dom";
+import { useEffect } from "react";
+import { createRoot } from "react-dom/client";
 
 import Logger from "@lichtblick/log";
 import {
@@ -61,17 +61,14 @@ export async function main(params: MainParams): Promise<void> {
   await waitForFonts();
   await initI18n();
 
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
-    <StrictMode>
-      <LogAfterRender>
-        <Root
-          appConfiguration={params.appConfiguration}
-          extraProviders={params.extraProviders}
-          dataSources={params.dataSources}
-        />
-      </LogAfterRender>
-    </StrictMode>,
-    rootEl,
+  const root = createRoot(rootEl);
+  root.render(
+    <LogAfterRender>
+      <Root
+        appConfiguration={params.appConfiguration}
+        extraProviders={params.extraProviders}
+        dataSources={params.dataSources}
+      />
+    </LogAfterRender>
   );
 }

--- a/packages/suite-web/src/index.tsx
+++ b/packages/suite-web/src/index.tsx
@@ -62,7 +62,7 @@ export async function main(getParams: () => Promise<MainParams> = async () => ({
     root.render(
       <LogAfterRender>
         <CssBaseline>{banner}</CssBaseline>
-      </LogAfterRender>
+      </LogAfterRender>,
     );
     return;
   }
@@ -90,6 +90,6 @@ export async function main(getParams: () => Promise<MainParams> = async () => ({
     <LogAfterRender>
       {banner}
       {rootElement}
-    </LogAfterRender>
+    </LogAfterRender>,
   );
 }

--- a/packages/suite-web/src/index.tsx
+++ b/packages/suite-web/src/index.tsx
@@ -5,8 +5,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode, useEffect } from "react";
-import ReactDOM from "react-dom";
+import { useEffect } from "react";
+import { createRoot } from "react-dom/client";
 
 import Logger from "@lichtblick/log";
 import type { IDataSourceFactory } from "@lichtblick/suite-base";
@@ -58,14 +58,11 @@ export async function main(getParams: () => Promise<MainParams> = async () => ({
   );
 
   if (!canRender) {
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.render(
-      <StrictMode>
-        <LogAfterRender>
-          <CssBaseline>{banner}</CssBaseline>
-        </LogAfterRender>
-      </StrictMode>,
-      rootEl,
+    const root = createRoot(rootEl);
+    root.render(
+      <LogAfterRender>
+        <CssBaseline>{banner}</CssBaseline>
+      </LogAfterRender>
     );
     return;
   }
@@ -88,14 +85,11 @@ export async function main(getParams: () => Promise<MainParams> = async () => ({
     </WebRoot>
   );
 
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
-    <StrictMode>
-      <LogAfterRender>
-        {banner}
-        {rootElement}
-      </LogAfterRender>
-    </StrictMode>,
-    rootEl,
+  const root = createRoot(rootEl);
+  root.render(
+    <LogAfterRender>
+      {banner}
+      {rootElement}
+    </LogAfterRender>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
N/A

**Description**
It was removed from the deprecated React.DOM and replaced by createRoot.  
It removed StrictMode as it caused duplicate execution in the application's dialog.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok