### PR TITLE
[Feature] Showing keyboard shortcuts on file menu

### DIFF
--- a/packages/suite-base/src/components/AppBar/AppMenu.tsx
+++ b/packages/suite-base/src/components/AppBar/AppMenu.tsx
@@ -21,6 +21,7 @@ import { useWorkspaceActions } from "@lichtblick/suite-base/context/Workspace/us
 import { NestedMenuItem } from "./NestedMenuItem";
 import { AppBarMenuItem } from "./types";
 
+
 export type AppMenuProps = {
   handleClose: () => void;
   anchorEl?: HTMLElement;
@@ -56,6 +57,9 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
   const rightSidebarOpen = useWorkspaceStore(selectRightSidebarOpen);
   const { sidebarActions, dialogActions, layoutActions } = useWorkspaceActions();
 
+  const isMac: boolean = process.platform === "darwin";
+  const ctrlOrCommand: string = isMac ? "Cmd" : "Ctrl";
+
   const handleNestedMenuClose = useCallback(() => {
     setNestedMenu(undefined);
     handleClose();
@@ -83,6 +87,7 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
         type: "item",
         label: t("openLocalFile"),
         key: "open-file",
+        shortcut: ctrlOrCommand + " + O",
         dataTestId: "menu-item-open-local-file",
         onClick: () => {
           handleNestedMenuClose();
@@ -93,6 +98,7 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
         type: "item",
         label: t("openConnection"),
         key: "open-connection",
+        shortcut: ctrlOrCommand + " + Shift + O",
         dataTestId: "menu-item-open-connection",
         onClick: () => {
           dialogActions.dataSource.open("connection");
@@ -123,6 +129,7 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
     handleNestedMenuClose,
     recentSources,
     selectRecent,
+    ctrlOrCommand,
     t,
   ]);
 

--- a/packages/suite-base/src/components/AppBar/AppMenu.tsx
+++ b/packages/suite-base/src/components/AppBar/AppMenu.tsx
@@ -22,9 +22,6 @@ import { formatKeyboardShortcut } from "@lichtblick/suite-base/util/formatKeyboa
 import { NestedMenuItem } from "./NestedMenuItem";
 import { AppBarMenuItem } from "./types";
 
-
-
-
 export type AppMenuProps = {
   handleClose: () => void;
   anchorEl?: HTMLElement;

--- a/packages/suite-base/src/components/AppBar/AppMenu.tsx
+++ b/packages/suite-base/src/components/AppBar/AppMenu.tsx
@@ -17,9 +17,12 @@ import {
   useWorkspaceStore,
 } from "@lichtblick/suite-base/context/Workspace/WorkspaceContext";
 import { useWorkspaceActions } from "@lichtblick/suite-base/context/Workspace/useWorkspaceActions";
+import { formatKeyboardShortcut } from "@lichtblick/suite-base/util/formatKeyboardShortcut";
 
 import { NestedMenuItem } from "./NestedMenuItem";
 import { AppBarMenuItem } from "./types";
+
+
 
 
 export type AppMenuProps = {
@@ -57,9 +60,6 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
   const rightSidebarOpen = useWorkspaceStore(selectRightSidebarOpen);
   const { sidebarActions, dialogActions, layoutActions } = useWorkspaceActions();
 
-  const isMac: boolean = process.platform === "darwin";
-  const ctrlOrCommand: string = isMac ? "Cmd" : "Ctrl";
-
   const handleNestedMenuClose = useCallback(() => {
     setNestedMenu(undefined);
     handleClose();
@@ -87,7 +87,7 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
         type: "item",
         label: t("openLocalFile"),
         key: "open-file",
-        shortcut: ctrlOrCommand + " + O",
+        shortcut: formatKeyboardShortcut("O", ["Meta"]),
         dataTestId: "menu-item-open-local-file",
         onClick: () => {
           handleNestedMenuClose();
@@ -98,7 +98,7 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
         type: "item",
         label: t("openConnection"),
         key: "open-connection",
-        shortcut: ctrlOrCommand + " + Shift + O",
+        shortcut: formatKeyboardShortcut("O", ["Meta", "Shift"]),
         dataTestId: "menu-item-open-connection",
         onClick: () => {
           dialogActions.dataSource.open("connection");
@@ -129,7 +129,6 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
     handleNestedMenuClose,
     recentSources,
     selectRecent,
-    ctrlOrCommand,
     t,
   ]);
 

--- a/packages/suite-base/src/components/KeyListener.tsx
+++ b/packages/suite-base/src/components/KeyListener.tsx
@@ -32,7 +32,7 @@ function callHandlers(handlers: KeyHandlers | undefined, event: KeyboardEvent): 
     return;
   }
 
-  const handler = handlers[event.key] ?? handlers[event.code];
+  const handler = handlers[event.key.toLowerCase()] ?? handlers[event.code];
 
   if (typeof handler === "function") {
     let preventDefault = true;

--- a/packages/suite-base/src/util/formatKeyboardShortcut.test.ts
+++ b/packages/suite-base/src/util/formatKeyboardShortcut.test.ts
@@ -18,20 +18,21 @@ describe("formatKeyboardShortcut", () => {
   it("formats shortcuts correctly for Windows", () => {
     userAgent.mockReturnValue("Windows");
     expect(formatKeyboardShortcut("O", ["Shift", "Meta"])).toBe("Shift+Ctrl+O");
+    expect(formatKeyboardShortcut("O", ["Shift", "Shift", "Shift"])).toBe("Shift+Shift+Shift+O");
+    expect(formatKeyboardShortcut("O", [])).toBe("O");
   });
 
   it("formats shortcuts correctly Linux", () => {
     userAgent.mockReturnValue("Linux");
     expect(formatKeyboardShortcut("O", ["Shift", "Meta"])).toBe("Shift+Ctrl+O");
+    expect(formatKeyboardShortcut("O", ["Shift", "Shift", "Shift"])).toBe("Shift+Shift+Shift+O");
+    expect(formatKeyboardShortcut("O", [])).toBe("O");
   });
 
   it("formats shortcuts correctly Mac", () => {
     userAgent.mockReturnValue("Mac");
     expect(formatKeyboardShortcut("O", ["Shift", "Meta"])).toBe("⇧⌘O");
-  });
-
-  it("formats shortcuts correctly Mac second test", () => {
-    userAgent.mockReturnValue("Mac");
-    expect(formatKeyboardShortcut("O", ["Alt", "Meta"])).toBe("⌥⌘O");
+    expect(formatKeyboardShortcut("O", ["Shift", "Shift", "Shift"])).toBe("⇧⇧⇧O");
+    expect(formatKeyboardShortcut("O", [])).toBe("O");
   });
 });

--- a/packages/suite-base/src/util/formatKeyboardShortcut.test.ts
+++ b/packages/suite-base/src/util/formatKeyboardShortcut.test.ts
@@ -32,6 +32,6 @@ describe("formatKeyboardShortcut", () => {
 
   it("formats shortcuts correctly Mac second test", () => {
     userAgent.mockReturnValue("Mac");
-    expect(formatKeyboardShortcut("O", ["Alt", "Control"])).toBe("⌥⌘O");
+    expect(formatKeyboardShortcut("O", ["Alt", "Meta"])).toBe("⌥⌘O");
   });
 });

--- a/packages/suite-base/src/util/formatKeyboardShortcut.test.ts
+++ b/packages/suite-base/src/util/formatKeyboardShortcut.test.ts
@@ -32,6 +32,6 @@ describe("formatKeyboardShortcut", () => {
 
   it("formats shortcuts correctly Mac second test", () => {
     userAgent.mockReturnValue("Mac");
-    expect(formatKeyboardShortcut("O", ["Alt", "Control"])).toBe("⌥⌘O")
-  })
+    expect(formatKeyboardShortcut("O", ["Alt", "Control"])).toBe("⌥⌘O");
+  });
 });

--- a/packages/suite-base/src/util/formatKeyboardShortcut.test.ts
+++ b/packages/suite-base/src/util/formatKeyboardShortcut.test.ts
@@ -29,4 +29,9 @@ describe("formatKeyboardShortcut", () => {
     userAgent.mockReturnValue("Mac");
     expect(formatKeyboardShortcut("O", ["Shift", "Meta"])).toBe("⇧⌘O");
   });
+
+  it("formats shortcuts correctly Mac second test", () => {
+    userAgent.mockReturnValue("Mac");
+    expect(formatKeyboardShortcut("O", ["Alt", "Control"])).toBe("⌥⌘O")
+  })
 });


### PR DESCRIPTION
**User-Facing Changes**

Keyboard shortcuts for the file menu options: _Open local file_ and _Open connection_ are now visible
 
**Description**

Made it so the keyboard shortcuts are now visible to the user, checking what kind of system the user is currently using and changing the shortcut whether they're using Mac or Win/Linux;

Also made it so letter case is ignored when using shortcuts, something that wasn't implemented until now.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [X] The web version was tested and it is running ok
- [X] The desktop version was tested and it is running ok
- [X] This change is covered by unit tests
