### PR TITLE
Replace URI scheme to lichtblick

### DIFF
--- a/packages/suite-base/src/screens/LaunchingInDesktopScreen.tsx
+++ b/packages/suite-base/src/screens/LaunchingInDesktopScreen.tsx
@@ -25,7 +25,7 @@ export function LaunchingInDesktopScreen(): ReactElement {
   }
 
   useEffect(() => {
-    const desktopURL = new URL("foxglove://open");
+    const desktopURL = new URL("lichtblick://open");
     cleanWebURL.searchParams.forEach((v, k) => {
       if (k && v) {
         desktopURL.searchParams.set(k, v);

--- a/packages/suite-base/src/util/appURLState.test.ts
+++ b/packages/suite-base/src/util/appURLState.test.ts
@@ -23,9 +23,9 @@ const mockIsDesktop = isDesktopApp as jest.MockedFunction<typeof isDesktopApp>;
 
 describe("app state url parser", () => {
   // Note that the foxglove URL here is different from actual foxglove URLs because Node's URL parser
-  // interprets foxglove:// URLs differently than the browser does.
+  // interprets lichtblick:// URLs differently than the browser does.
   describe.each([
-    { isDesktop: true, urlBuilder: () => new URL("foxglove://host/open") },
+    { isDesktop: true, urlBuilder: () => new URL("lichtblick://host/open") },
     { isDesktop: false, urlBuilder: () => new URL("https://studio.foxglove.dev/") },
   ])("url tests", ({ isDesktop, urlBuilder }) => {
     beforeEach(() => mockIsDesktop.mockReturnValue(isDesktop));

--- a/packages/suite-desktop/src/common/rendererArgs.test.ts
+++ b/packages/suite-desktop/src/common/rendererArgs.test.ts
@@ -9,10 +9,10 @@ import { decodeRendererArg, encodeRendererArg } from "./rendererArgs";
 
 describe("encodeRendererArg & decodeRendererArg", () => {
   it("encodes and decodes", () => {
-    const encoded = encodeRendererArg("deepLinks", ["foxglove://example"]);
-    expect(encoded).toEqual("--deepLinks=WyJmb3hnbG92ZTovL2V4YW1wbGUiXQ==");
+    const encoded = encodeRendererArg("deepLinks", ["lichtblick://example"]);
+    expect(encoded).toEqual("--deepLinks=WyJsaWNodGJsaWNrOi8vZXhhbXBsZSJd");
     expect(decodeRendererArg("deepLinks", ["arg1", encoded, "arg2"])).toEqual([
-      "foxglove://example",
+      "lichtblick://example",
     ]);
   });
 });

--- a/packages/suite-desktop/src/main/index.ts
+++ b/packages/suite-desktop/src/main/index.ts
@@ -112,7 +112,7 @@ export async function main(): Promise<void> {
     someWindow?.restore();
     someWindow?.focus();
 
-    const deepLinks = argv.slice(1).filter((arg) => arg.startsWith("foxglove://"));
+    const deepLinks = argv.slice(1).filter((arg) => arg.startsWith("lichtblick://"));
     for (const link of deepLinks) {
       app.emit("open-url", { preventDefault() {} }, link);
     }
@@ -132,7 +132,7 @@ export async function main(): Promise<void> {
 
   if (!app.isDefaultProtocolClient("foxglove")) {
     if (!app.setAsDefaultProtocolClient("foxglove")) {
-      log.warn("Could not set app as handler for foxglove://");
+      log.warn("Could not set app as handler for lichtblick://");
     }
   }
 
@@ -183,13 +183,13 @@ export async function main(): Promise<void> {
   // tho it is a bit strange since it isn't clear when this runs...
   app.on("open-url", (ev, url) => {
     log.debug("open-url handler", url);
-    if (!url.startsWith("foxglove://")) {
+    if (!url.startsWith("lichtblick://")) {
       return;
     }
 
     ev.preventDefault();
 
-    if (url.startsWith("foxglove://signin-complete")) {
+    if (url.startsWith("lichtblick://signin-complete")) {
       // When completing sign in from Console, the browser can launch this URL to re-focus the app.
       app.focus({ steal: true });
     } else if (app.isReady()) {
@@ -220,7 +220,7 @@ export async function main(): Promise<void> {
   app.on("ready", async () => {
     updateNativeColorScheme();
     const argv = process.argv;
-    const deepLinks = argv.filter((arg) => arg.startsWith("foxglove://"));
+    const deepLinks = argv.filter((arg) => arg.startsWith("lichtblick://"));
 
     // create the initial window now to display to the user immediately
     // loading the app url happens at the end of ready to ensure we've setup all the handlers, settings, etc


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**
It replaced the URI scheme from foxglove:// to lichtblick://

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Build the app in desktop version and open it using "lichtblick://"
