### PR TITLE
Use normal font style for single values in the raw messages panel

### DIFF
--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -425,7 +425,7 @@ function RawMessages(props: Props) {
         />
         {shouldDisplaySingleVal ? (
           <Typography
-            variant="h1"
+            variant="body1"
             fontSize={fontSize}
             whiteSpace="pre-wrap"
             style={{ wordWrap: "break-word" }}


### PR DESCRIPTION
**User-Facing Changes**

Bold font is unneccesary prominent. If a user wants the dispaly of single value to be more prominent, still the font size can be increased through the panel settings.

**Description**

*before*:

![image](https://github.com/user-attachments/assets/14e26191-24fd-45f8-8f10-1489a970b6f6)
![image](https://github.com/user-attachments/assets/1e48ea0b-6278-41cf-aa97-78f337a3af02)

*after*:

![image](https://github.com/user-attachments/assets/d66cee14-5ac2-4756-a349-6fc5a595bdbb)
![image](https://github.com/user-attachments/assets/eefa798f-32e7-472e-9f6c-64e1a5e18fe0)

