### PR TITLE
Change default layout behavior

### DIFF
--- a/packages/suite-base/src/App.tsx
+++ b/packages/suite-base/src/App.tsx
@@ -110,9 +110,9 @@ export function App(props: AppProps): JSX.Element {
 
   // Problems provider also must come before other, dependent contexts.
   providers.unshift(<ProblemsContextProvider />);
-  providers.unshift(<CurrentLayoutProvider />);
+  providers.unshift(<CurrentLayoutProvider loaders={layoutLoaders} />);
   providers.unshift(<UserProfileLocalStorageProvider />);
-  providers.unshift(<LayoutManagerProvider loaders={layoutLoaders} />);
+  providers.unshift(<LayoutManagerProvider />);
 
   const layoutStorage = useMemo(() => new IdbLayoutStorage(), []);
   providers.unshift(<LayoutStorageContext.Provider value={layoutStorage} />);

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -56,8 +56,8 @@ function makeMockLayoutManager() {
     off: jest.fn(/*noop*/),
     setError: jest.fn(/*noop*/),
     setOnline: jest.fn(/*noop*/),
-    getLayouts: jest.fn().mockImplementation(mockThrow("getLayouts")),
-    getLayout: jest.fn().mockImplementation(mockThrow("getLayout")),
+    getLayouts: jest.fn(),
+    getLayout: jest.fn(),
     saveNewLayout: jest.fn().mockImplementation(mockThrow("saveNewLayout")),
     updateLayout: jest.fn().mockImplementation(mockThrow("updateLayout")),
     deleteLayout: jest.fn().mockImplementation(mockThrow("deleteLayout")),
@@ -154,6 +154,13 @@ describe("CurrentLayoutProvider", () => {
       { selectedLayout: undefined },
       {
         selectedLayout: {
+          data: undefined,
+          id: "example",
+          loading: true,
+        },
+      },
+      {
+        selectedLayout: {
           loading: false,
           id: "example",
           data: expectedState,
@@ -197,6 +204,13 @@ describe("CurrentLayoutProvider", () => {
     expect(mockLayoutManager.getLayout.mock.calls).toEqual([["example"], ["example"]]);
     expect(all.map((item) => (item instanceof Error ? undefined : item.layoutState))).toEqual([
       { selectedLayout: undefined },
+      {
+        selectedLayout: {
+          data: undefined,
+          id: "example",
+          loading: true,
+        },
+      },
       { selectedLayout: undefined },
     ]);
     (console.warn as jest.Mock).mockClear();

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -57,7 +57,7 @@ function makeMockLayoutManager() {
     setError: jest.fn(/*noop*/),
     setOnline: jest.fn(/*noop*/),
     getLayouts: jest.fn(),
-    getLayout: jest.fn(),
+    getLayout: jest.fn().mockImplementation(mockThrow("getLayouts")),
     saveNewLayout: jest.fn().mockImplementation(mockThrow("saveNewLayout")),
     updateLayout: jest.fn().mockImplementation(mockThrow("updateLayout")),
     deleteLayout: jest.fn().mockImplementation(mockThrow("deleteLayout")),
@@ -154,13 +154,6 @@ describe("CurrentLayoutProvider", () => {
       { selectedLayout: undefined },
       {
         selectedLayout: {
-          data: undefined,
-          id: "example",
-          loading: true,
-        },
-      },
-      {
-        selectedLayout: {
           loading: false,
           id: "example",
           data: expectedState,
@@ -204,13 +197,6 @@ describe("CurrentLayoutProvider", () => {
     expect(mockLayoutManager.getLayout.mock.calls).toEqual([["example"], ["example"]]);
     expect(all.map((item) => (item instanceof Error ? undefined : item.layoutState))).toEqual([
       { selectedLayout: undefined },
-      {
-        selectedLayout: {
-          data: undefined,
-          id: "example",
-          loading: true,
-        },
-      },
       { selectedLayout: undefined },
     ]);
     (console.warn as jest.Mock).mockClear();

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -106,7 +106,7 @@ function renderTest({
           <SnackbarProvider>
             <LayoutManagerContext.Provider value={mockLayoutManager}>
               <UserProfileStorageContext.Provider value={mockUserProfile}>
-                <CurrentLayoutProvider>
+                <CurrentLayoutProvider loaders={[]}>
                   {children}
                   <CurrentLayoutSyncAdapter />
                 </CurrentLayoutProvider>
@@ -119,6 +119,7 @@ function renderTest({
   );
   return { result, all };
 }
+
 describe("CurrentLayoutProvider", () => {
   it("uses currentLayoutId from UserProfile to load from LayoutStorage", async () => {
     const expectedState: LayoutData = {

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -57,7 +57,7 @@ function makeMockLayoutManager() {
     setError: jest.fn(/*noop*/),
     setOnline: jest.fn(/*noop*/),
     getLayouts: jest.fn(),
-    getLayout: jest.fn().mockImplementation(mockThrow("getLayouts")),
+    getLayout: jest.fn().mockImplementation(mockThrow("getLayout")),
     saveNewLayout: jest.fn().mockImplementation(mockThrow("saveNewLayout")),
     updateLayout: jest.fn().mockImplementation(mockThrow("updateLayout")),
     deleteLayout: jest.fn().mockImplementation(mockThrow("deleteLayout")),

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -286,7 +286,8 @@ export default function CurrentLayoutProvider({
       });
       await setSelectedLayoutId(newLayout.id);
     }
-  }, [getUserProfile, layoutManager, loaders, setSelectedLayoutId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [getUserProfile, layoutManager, setSelectedLayoutId]);
 
   const actions: ICurrentLayout["actions"] = useMemo(
     () => ({

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -39,8 +39,10 @@ import {
 import { useLayoutManager } from "@lichtblick/suite-base/context/LayoutManagerContext";
 import { useUserProfileStorage } from "@lichtblick/suite-base/context/UserProfileStorageContext";
 import { defaultLayout } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/defaultLayout";
+import { loadDefaultLayouts } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/loadDefaultLayouts";
 import panelsReducer from "@lichtblick/suite-base/providers/CurrentLayoutProvider/reducers";
 import { AppEvent } from "@lichtblick/suite-base/services/IAnalytics";
+import { LayoutLoader } from "@lichtblick/suite-base/services/ILayoutLoader";
 import { LayoutManagerEventTypes } from "@lichtblick/suite-base/services/ILayoutManager";
 import { PanelConfig, PlaybackConfig, UserScripts } from "@lichtblick/suite-base/types/panels";
 import { windowAppURLState } from "@lichtblick/suite-base/util/appURLState";
@@ -56,7 +58,12 @@ export const MAX_SUPPORTED_LAYOUT_VERSION = 1;
  * Concrete implementation of CurrentLayoutContext.Provider which handles
  * automatically restoring the current layout from LayoutStorage.
  */
-export default function CurrentLayoutProvider({ children }: React.PropsWithChildren): JSX.Element {
+export default function CurrentLayoutProvider({
+  children,
+  loaders = [],
+}: React.PropsWithChildren<{
+  loaders?: readonly LayoutLoader[];
+}>): JSX.Element {
   const { enqueueSnackbar } = useSnackbar();
   const { getUserProfile, setUserProfile } = useUserProfileStorage();
   const layoutManager = useLayoutManager();
@@ -259,12 +266,18 @@ export default function CurrentLayoutProvider({ children }: React.PropsWithChild
       return;
     }
 
+    // Try to load default layouts, before checking to add the fallback "Default".
+    await loadDefaultLayouts(layoutManager, loaders);
+
     // Retreive the selected layout id from the user's profile. If there's no layout specified
     // or we can't load it then save and select a default layout.
     const { currentLayoutId } = await getUserProfile();
     const layout = currentLayoutId ? await layoutManager.getLayout(currentLayoutId) : undefined;
+    const layouts = await layoutManager.getLayouts();
     if (layout) {
       await setSelectedLayoutId(currentLayoutId, { saveToProfile: false });
+    } else if (layouts[0]) {
+      await setSelectedLayoutId(layouts[0].id);
     } else {
       const newLayout = await layoutManager.saveNewLayout({
         name: "Default",
@@ -273,7 +286,7 @@ export default function CurrentLayoutProvider({ children }: React.PropsWithChild
       });
       await setSelectedLayoutId(newLayout.id);
     }
-  }, [getUserProfile, layoutManager, setSelectedLayoutId]);
+  }, [getUserProfile, layoutManager, loaders, setSelectedLayoutId]);
 
   const actions: ICurrentLayout["actions"] = useMemo(
     () => ({

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -273,19 +273,25 @@ export default function CurrentLayoutProvider({
     // or we can't load it then save and select a default layout.
     const { currentLayoutId } = await getUserProfile();
     const layout = currentLayoutId ? await layoutManager.getLayout(currentLayoutId) : undefined;
-    const layouts = await layoutManager.getLayouts();
+
     if (layout) {
       await setSelectedLayoutId(currentLayoutId, { saveToProfile: false });
-    } else if (layouts[0]) {
-      await setSelectedLayoutId(layouts[0].id);
-    } else {
-      const newLayout = await layoutManager.saveNewLayout({
-        name: "Default",
-        data: defaultLayout,
-        permission: "CREATOR_WRITE",
-      });
-      await setSelectedLayoutId(newLayout.id);
+      return;
     }
+
+    const layouts = await layoutManager.getLayouts();
+    if (layouts[0]) {
+      await setSelectedLayoutId(layouts[0].id);
+      return;
+    }
+
+    const newLayout = await layoutManager.saveNewLayout({
+      name: "Default",
+      data: defaultLayout,
+      permission: "CREATOR_WRITE",
+    });
+    await setSelectedLayoutId(newLayout.id);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getUserProfile, layoutManager, setSelectedLayoutId]);
 

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/loadDefaultLayouts.test.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/loadDefaultLayouts.test.ts
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+import { LayoutData } from "@lichtblick/suite-base/context/CurrentLayoutContext";
+import { loadDefaultLayouts } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/loadDefaultLayouts";
+import { LayoutLoader } from "@lichtblick/suite-base/services/ILayoutLoader";
+import MockLayoutManager from "@lichtblick/suite-base/services/LayoutManager/MockLayoutManager";
+
+// Mock layout manager
+const mockLayoutManager = new MockLayoutManager();
+
+jest.mock("@lichtblick/suite-base/services/LayoutManager/LayoutManager", () =>
+  jest.fn(() => mockLayoutManager),
+);
+
+describe("loadDefaultLayouts", () => {
+  const mockLayoutLoader: jest.Mocked<LayoutLoader> = {
+    fetchLayouts: jest.fn(),
+    namespace: "local",
+  };
+
+  const consoleErrorMock = console.error as ReturnType<typeof jest.fn>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should not proceed if loaders array is empty", async () => {
+    await loadDefaultLayouts(mockLayoutManager, []);
+    expect(mockLayoutManager.getLayouts).not.toHaveBeenCalled();
+  });
+
+  it("should not save layouts if fetched layouts are empty", async () => {
+    mockLayoutLoader.fetchLayouts.mockResolvedValueOnce([]);
+    mockLayoutManager.getLayouts.mockResolvedValueOnce([]);
+
+    await loadDefaultLayouts(mockLayoutManager, [mockLayoutLoader]);
+
+    expect(mockLayoutManager.getLayouts).toHaveBeenCalledTimes(1);
+    expect(mockLayoutLoader.fetchLayouts).toHaveBeenCalledTimes(1);
+    expect(mockLayoutManager.saveNewLayout).not.toHaveBeenCalled();
+  });
+
+  it("should save new layouts and log errors if there are rejections during fetch", async () => {
+    const fetchError = new Error("Fetch failed");
+    mockLayoutLoader.fetchLayouts.mockRejectedValueOnce(fetchError);
+    mockLayoutManager.getLayouts.mockResolvedValueOnce([]);
+
+    await loadDefaultLayouts(mockLayoutManager, [mockLayoutLoader]);
+
+    expect(mockLayoutLoader.fetchLayouts).toHaveBeenCalledTimes(1);
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      `Failed to fetch layouts from loader: ${fetchError}`,
+    );
+    consoleErrorMock.mockClear();
+  });
+
+  it("should save only new layouts that are not in current layouts", async () => {
+    const existingLayout = {
+      from: "layout1.json",
+      name: "existing-layout",
+      data: {} as LayoutData,
+    };
+    const newLayout = { from: "layout2.json", name: "new-layout", data: {} as LayoutData };
+
+    mockLayoutLoader.fetchLayouts.mockResolvedValueOnce([existingLayout, newLayout]);
+    mockLayoutManager.getLayouts.mockResolvedValueOnce([existingLayout]);
+
+    await loadDefaultLayouts(mockLayoutManager, [mockLayoutLoader]);
+
+    expect(mockLayoutManager.getLayouts).toHaveBeenCalledTimes(1);
+    expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledTimes(1);
+    expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledWith(
+      expect.objectContaining({ from: "layout2.json", name: "new-layout" }),
+    );
+  });
+
+  it("should log errors if saving a layout fails", async () => {
+    const newLayout = { from: "layout2.json", name: "new-layout", data: {} as LayoutData };
+    const saveError = new Error("Save failed");
+
+    mockLayoutLoader.fetchLayouts.mockResolvedValueOnce([newLayout]);
+    mockLayoutManager.getLayouts.mockResolvedValueOnce([]);
+    mockLayoutManager.saveNewLayout.mockRejectedValueOnce(saveError);
+
+    await loadDefaultLayouts(mockLayoutManager, [mockLayoutLoader]);
+
+    expect(mockLayoutLoader.fetchLayouts).toHaveBeenCalledTimes(1);
+    expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledTimes(1);
+    expect(consoleErrorMock).toHaveBeenCalledWith(`Failed to save layout: ${saveError}`);
+    consoleErrorMock.mockClear();
+  });
+
+  it("should handle multiple loaders and save new layouts from each", async () => {
+    const loader1Layouts = [
+      { from: "layout1.json", name: "layout1", data: {} as LayoutData },
+      { from: "layout2.json", name: "layout2", data: {} as LayoutData },
+    ];
+    const loader2Layouts = [
+      { from: "layout3.json", name: "layout3", data: {} as LayoutData },
+      { from: "layout4.json", name: "layout4", data: {} as LayoutData },
+    ];
+
+    const loader1: jest.Mocked<LayoutLoader> = {
+      fetchLayouts: jest.fn().mockResolvedValueOnce(loader1Layouts),
+      namespace: "loader1",
+    } as any;
+
+    const loader2: jest.Mocked<LayoutLoader> = {
+      fetchLayouts: jest.fn().mockResolvedValueOnce(loader2Layouts),
+      namespace: "loader2",
+    } as any;
+
+    mockLayoutManager.getLayouts.mockResolvedValueOnce([]);
+
+    await loadDefaultLayouts(mockLayoutManager, [loader1, loader2]);
+
+    expect(loader1.fetchLayouts).toHaveBeenCalledTimes(1);
+    expect(loader2.fetchLayouts).toHaveBeenCalledTimes(1);
+
+    expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledTimes(4);
+  });
+
+  it("should log a general error if an exception occurs in the try block", async () => {
+    const errorMessage = "General loading error";
+    const expectedError = `Loading default layouts failed: ${errorMessage}`;
+
+    mockLayoutManager.getLayouts.mockRejectedValueOnce(errorMessage);
+
+    await loadDefaultLayouts(mockLayoutManager, [mockLayoutLoader]);
+
+    expect(consoleErrorMock).toHaveBeenCalledWith(expectedError);
+    consoleErrorMock.mockClear();
+  });
+});

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/loadDefaultLayouts.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/loadDefaultLayouts.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import Logger from "@lichtblick/log";
+import { LayoutLoader } from "@lichtblick/suite-base/services/ILayoutLoader";
+import { ILayoutManager } from "@lichtblick/suite-base/services/ILayoutManager";
+
+const log = Logger.getLogger(__filename);
+
+const isFulfilled = <T>(result: PromiseSettledResult<T>): result is PromiseFulfilledResult<T> =>
+  result.status === "fulfilled";
+
+const isRejected = (result: PromiseSettledResult<unknown>): result is PromiseRejectedResult =>
+  result.status === "rejected";
+
+export const loadDefaultLayouts = async (
+  layoutManager: ILayoutManager,
+  loaders: readonly LayoutLoader[],
+): Promise<void> => {
+  if (loaders.length === 0) {
+    return;
+  }
+
+  try {
+    const currentLayouts = await layoutManager.getLayouts();
+    const currentLayoutsFroms = new Set(currentLayouts.map((layout) => layout.from));
+
+    const loaderPromises = loaders.map(async (loader) => await loader.fetchLayouts());
+    const loaderResults = await Promise.allSettled(loaderPromises);
+
+    const newLayouts = loaderResults
+      .filter(isFulfilled)
+      .flatMap((result) => result.value)
+      .filter((layout) => !currentLayoutsFroms.has(layout.from));
+
+    // Log errors cause failed to fetch some layout from a specific loader
+    loaderResults.filter(isRejected).forEach((result) => {
+      log.error(`Failed to fetch layouts from loader: ${result.reason}`);
+    });
+
+    const savedPromises = newLayouts.map(
+      async (layout) =>
+        await layoutManager.saveNewLayout({
+          ...layout,
+          permission: "CREATOR_WRITE",
+        }),
+    );
+
+    // Try to save all layouts
+    const saveResults = await Promise.allSettled(savedPromises);
+
+    // Log errors cause failed to save a layout
+    saveResults.filter(isRejected).forEach((result) => {
+      log.error(`Failed to save layout: ${result.reason}`);
+    });
+  } catch (err) {
+    log.error(`Loading default layouts failed: ${err}`);
+  }
+};

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/loadDefaultLayouts.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/loadDefaultLayouts.ts
@@ -24,7 +24,7 @@ export const loadDefaultLayouts = async (
   try {
     const currentLayouts = await layoutManager.getLayouts();
     const currentLayoutsFroms = new Set(currentLayouts.map((layout) => layout.from));
-
+    const currentLayoutsFroms = new Set(currentLayouts.map(({ from }) => from));
     const loaderPromises = loaders.map(async (loader) => await loader.fetchLayouts());
     const loaderResults = await Promise.allSettled(loaderPromises);
 
@@ -32,11 +32,13 @@ export const loadDefaultLayouts = async (
       .filter(isFulfilled)
       .flatMap((result) => result.value)
       .filter((layout) => !currentLayoutsFroms.has(layout.from));
-
+      .flatMap(({ value }) => value)
+      .filter(({ from }) => !currentLayoutsFroms.has(from));
     // Log errors cause failed to fetch some layout from a specific loader
     loaderResults.filter(isRejected).forEach((result) => {
       log.error(`Failed to fetch layouts from loader: ${result.reason}`);
-    });
+    loaderResults.filter(isRejected).forEach(({ reason }) => {
+      log.error(`Failed to fetch layouts from loader: ${reason}`);
 
     const savedPromises = newLayouts.map(
       async (layout) =>
@@ -48,11 +50,12 @@ export const loadDefaultLayouts = async (
 
     // Try to save all layouts
     const saveResults = await Promise.allSettled(savedPromises);
-
+    const savedResults = await Promise.allSettled(savedPromises);
     // Log errors cause failed to save a layout
     saveResults.filter(isRejected).forEach((result) => {
       log.error(`Failed to save layout: ${result.reason}`);
-    });
+    saveResults.filter(isRejected).forEach(({ reason }) => {
+      log.error(`Failed to save layout: ${reason}`);
   } catch (err) {
     log.error(`Loading default layouts failed: ${err}`);
   }

--- a/packages/suite-base/src/providers/LayoutManagerProvider.test.tsx
+++ b/packages/suite-base/src/providers/LayoutManagerProvider.test.tsx
@@ -10,11 +10,9 @@ import { render, waitFor } from "@testing-library/react";
 import { useNetworkState } from "react-use";
 
 import { useVisibilityState } from "@lichtblick/hooks";
-import { LayoutData } from "@lichtblick/suite-base/context/CurrentLayoutContext";
 import { useLayoutStorage } from "@lichtblick/suite-base/context/LayoutStorageContext";
 import { useRemoteLayoutStorage } from "@lichtblick/suite-base/context/RemoteLayoutStorageContext";
 import LayoutManagerProvider from "@lichtblick/suite-base/providers/LayoutManagerProvider";
-import { LayoutLoader } from "@lichtblick/suite-base/services/ILayoutLoader";
 import MockLayoutManager from "@lichtblick/suite-base/services/LayoutManager/MockLayoutManager";
 
 // Mock dependencies
@@ -30,18 +28,11 @@ jest.mock("@lichtblick/suite-base/services/LayoutManager/LayoutManager", () =>
 );
 
 describe("LayoutManagerProvider", () => {
-  const mockLayoutLoader: jest.Mocked<LayoutLoader> = {
-    fetchLayouts: jest.fn(),
-    namespace: "local",
-  };
-
   // Mock necessary hooks to render <LayoutManagerProvider /> component, otherwise it will fail
   (useNetworkState as jest.Mock).mockReturnValue({ online: true });
   (useVisibilityState as jest.Mock).mockReturnValue("visible");
   (useLayoutStorage as jest.Mock).mockReturnValue({});
   (useRemoteLayoutStorage as jest.Mock).mockReturnValue({});
-
-  const consoleErrorMock = console.error as ReturnType<typeof jest.fn>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -58,212 +49,6 @@ describe("LayoutManagerProvider", () => {
       expect(mockLayoutManager.setOnline).toHaveBeenCalledTimes(2);
       expect(mockLayoutManager.setOnline).toHaveBeenCalledWith(true);
       expect(mockLayoutManager.setOnline).toHaveBeenCalledWith(false);
-    });
-  });
-
-  it("should not call getLayouts or saveNewLayout if layout loaders is undefined or an empty array", async () => {
-    // 1 render with no loaders and another with empty array.
-    render(<LayoutManagerProvider />);
-    render(<LayoutManagerProvider loaders={[]} />);
-
-    await waitFor(() => {
-      expect(mockLayoutManager.getLayouts).toHaveBeenCalledTimes(0);
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  it("should not call layoutManager.saveNewLayout if there is no layouts", async () => {
-    mockLayoutLoader.fetchLayouts.mockResolvedValueOnce([]);
-
-    render(<LayoutManagerProvider loaders={[mockLayoutLoader]} />);
-
-    await waitFor(() => {
-      expect(mockLayoutManager.getLayouts).toHaveBeenCalledTimes(1);
-      expect(mockLayoutLoader.fetchLayouts).toHaveBeenCalledTimes(1);
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  it("should fetch layouts from loaders and save the new layouts", async () => {
-    mockLayoutLoader.fetchLayouts.mockResolvedValueOnce([
-      { from: "layout1.json", name: "layout1", data: {} as LayoutData },
-      { from: "layout2.json", name: "layout2", data: {} as LayoutData },
-    ]);
-
-    render(<LayoutManagerProvider loaders={[mockLayoutLoader]} />);
-
-    await waitFor(() => {
-      // Should be called 2 times, because only one loader.
-      expect(mockLayoutLoader.fetchLayouts).toHaveBeenCalledTimes(1);
-
-      // Should be called 1 time, once for all loaders.
-      expect(mockLayoutManager.getLayouts).toHaveBeenCalledTimes(1);
-
-      // Expect all layouts to be saved.
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledTimes(2);
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledWith(
-        expect.objectContaining({ from: "layout1.json", name: "layout1" }),
-      );
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledWith(
-        expect.objectContaining({ from: "layout2.json", name: "layout2" }),
-      );
-    });
-  });
-
-  it("should fetch layouts from multiple loaders and save the new layouts", async () => {
-    // Mock two loaders with different layouts.
-    mockLayoutLoader.fetchLayouts
-      .mockResolvedValueOnce([
-        { from: "layout1.json", name: "layout1", data: {} as LayoutData },
-        { from: "layout2.json", name: "layout2", data: {} as LayoutData },
-      ])
-      .mockResolvedValueOnce([
-        { from: "layout3.json", name: "layout3", data: {} as LayoutData },
-        { from: "layout4.json", name: "layout4", data: {} as LayoutData },
-      ]);
-
-    render(<LayoutManagerProvider loaders={[mockLayoutLoader, mockLayoutLoader]} />);
-
-    await waitFor(() => {
-      // Should be called 2 times, one per loader.
-      expect(mockLayoutLoader.fetchLayouts).toHaveBeenCalledTimes(2);
-
-      // Should be called 1 time, once for all loaders.
-      expect(mockLayoutManager.getLayouts).toHaveBeenCalledTimes(1);
-
-      // Expect all layouts to be saved.
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledTimes(4);
-
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledWith(
-        expect.objectContaining({ from: "layout1.json", name: "layout1" }),
-      );
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledWith(
-        expect.objectContaining({ from: "layout2.json", name: "layout2" }),
-      );
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledWith(
-        expect.objectContaining({ from: "layout3.json", name: "layout3" }),
-      );
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledWith(
-        expect.objectContaining({ from: "layout4.json", name: "layout4" }),
-      );
-    });
-  });
-
-  it("should fetch layouts from loaders and not save duplicated layouts", async () => {
-    // Make layouts with same name, but different "from"
-    mockLayoutLoader.fetchLayouts.mockResolvedValueOnce([
-      { from: "layout1.json", name: "layout", data: {} as LayoutData },
-      { from: "layout2.json", name: "layout", data: {} as LayoutData },
-      { from: "layout3.json", name: "layout", data: {} as LayoutData },
-    ]);
-
-    // Mock an existing layout with "from" equals to "layout2"
-    mockLayoutManager.getLayouts.mockResolvedValueOnce([{ from: "layout2.json", name: "layout" }]);
-
-    render(<LayoutManagerProvider loaders={[mockLayoutLoader]} />);
-
-    await waitFor(() => {
-      expect(mockLayoutLoader.fetchLayouts).toHaveBeenCalledTimes(1);
-      expect(mockLayoutManager.getLayouts).toHaveBeenCalledTimes(1);
-
-      // Expect only "layout1.json" and "layout3.json" to be saved.
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledTimes(2);
-
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledWith(
-        expect.objectContaining({ from: "layout1.json", name: "layout" }),
-      );
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledWith(
-        expect.objectContaining({ from: "layout3.json", name: "layout" }),
-      );
-
-      // Expect "layout2.json" to not be saved, because it has been already loaded.
-      expect(mockLayoutManager.saveNewLayout).not.toHaveBeenCalledWith(
-        expect.objectContaining({ from: "layout2.json", name: "layout" }),
-      );
-    });
-  });
-
-  it("should log the correct error when fetchLayouts fails", async () => {
-    const errorMessage = "Failed to fetch layouts";
-    const expectedError = `Failed to fetch layouts from loader: ${errorMessage}`;
-
-    mockLayoutLoader.fetchLayouts.mockRejectedValueOnce(errorMessage);
-
-    render(<LayoutManagerProvider loaders={[mockLayoutLoader]} />);
-
-    await waitFor(() => {
-      expect(consoleErrorMock.mock.calls[0]).toContain(expectedError);
-      consoleErrorMock.mockClear();
-    });
-  });
-
-  it("should log the correct error when saveNewLayout fails", async () => {
-    const errorMessage = "Failed to save layout";
-    const expectedError = `Failed to save layout: ${errorMessage}`;
-
-    mockLayoutLoader.fetchLayouts.mockResolvedValueOnce([
-      { from: "layout1.json", name: "layout1", data: {} as LayoutData },
-    ]);
-
-    mockLayoutManager.saveNewLayout.mockRejectedValueOnce(errorMessage);
-
-    render(<LayoutManagerProvider loaders={[mockLayoutLoader]} />);
-
-    await waitFor(() => {
-      expect(mockLayoutLoader.fetchLayouts).toHaveBeenCalledTimes(1);
-      expect(mockLayoutManager.getLayouts).toHaveBeenCalledTimes(1);
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledTimes(1);
-      expect(consoleErrorMock.mock.calls[0]).toContain(expectedError);
-      consoleErrorMock.mockClear();
-    });
-  });
-
-  it("should log the correct error when the entire loadAndSaveLayouts process fails", async () => {
-    const errorMessage = "General loading error";
-    const expectedError = `Loading default layouts failed: ${errorMessage}`;
-
-    mockLayoutManager.getLayouts.mockRejectedValueOnce(errorMessage);
-
-    render(<LayoutManagerProvider loaders={[mockLayoutLoader]} />);
-
-    await waitFor(() => {
-      expect(mockLayoutManager.getLayouts).toHaveBeenCalledTimes(1);
-      expect(mockLayoutLoader.fetchLayouts).toHaveBeenCalledTimes(0);
-      expect(consoleErrorMock.mock.calls[0]).toContain(expectedError);
-      consoleErrorMock.mockClear();
-    });
-  });
-
-  it("should handle partial successes and log correct errors", async () => {
-    const fetchErrorMessage = "Fetch failed";
-    const expectedFetchError = `Failed to fetch layouts from loader: ${fetchErrorMessage}`;
-
-    const saveErrorMessage = "Save failed";
-    const expectedSaveError = `Failed to save layout: ${saveErrorMessage}`;
-
-    const layouts = [
-      { from: "layout1.json", name: "layout1", data: {} as LayoutData },
-      { from: "layout2.json", name: "layout2", data: {} as LayoutData },
-    ];
-
-    mockLayoutLoader.fetchLayouts
-      .mockResolvedValueOnce(layouts)
-      .mockRejectedValueOnce(fetchErrorMessage);
-
-    mockLayoutManager.saveNewLayout
-      .mockResolvedValueOnce("sucess")
-      .mockRejectedValueOnce(saveErrorMessage);
-
-    render(<LayoutManagerProvider loaders={[mockLayoutLoader, mockLayoutLoader]} />);
-
-    await waitFor(() => {
-      expect(mockLayoutLoader.fetchLayouts).toHaveBeenCalledTimes(2);
-      expect(mockLayoutManager.getLayouts).toHaveBeenCalledTimes(1);
-      expect(mockLayoutManager.saveNewLayout).toHaveBeenCalledTimes(2);
-      expect(consoleErrorMock.mock.calls[0]).toContain(expectedFetchError);
-      expect(consoleErrorMock.mock.calls[1]).toContain(expectedSaveError);
-
-      consoleErrorMock.mockClear();
     });
   });
 

--- a/packages/suite-base/src/providers/LayoutManagerProvider.tsx
+++ b/packages/suite-base/src/providers/LayoutManagerProvider.tsx
@@ -13,7 +13,6 @@ import Logger from "@lichtblick/log";
 import LayoutManagerContext from "@lichtblick/suite-base/context/LayoutManagerContext";
 import { useLayoutStorage } from "@lichtblick/suite-base/context/LayoutStorageContext";
 import { useRemoteLayoutStorage } from "@lichtblick/suite-base/context/RemoteLayoutStorageContext";
-import { LayoutLoader } from "@lichtblick/suite-base/services/ILayoutLoader";
 import LayoutManager from "@lichtblick/suite-base/services/LayoutManager/LayoutManager";
 import delay from "@lichtblick/suite-base/util/delay";
 
@@ -22,18 +21,7 @@ const log = Logger.getLogger(__filename);
 const SYNC_INTERVAL_BASE_MS = 30_000;
 const SYNC_INTERVAL_MAX_MS = 3 * 60_000;
 
-const isFulfilled = <T,>(result: PromiseSettledResult<T>): result is PromiseFulfilledResult<T> =>
-  result.status === "fulfilled";
-
-const isRejected = (result: PromiseSettledResult<unknown>): result is PromiseRejectedResult =>
-  result.status === "rejected";
-
-export default function LayoutManagerProvider({
-  children,
-  loaders = [],
-}: React.PropsWithChildren<{
-  loaders?: readonly LayoutLoader[];
-}>): JSX.Element {
+export default function LayoutManagerProvider({ children }: React.PropsWithChildren): JSX.Element {
   const layoutStorage = useLayoutStorage();
   const remoteLayoutStorage = useRemoteLayoutStorage();
 
@@ -47,51 +35,6 @@ export default function LayoutManagerProvider({
   useEffect(() => {
     layoutManager.setOnline(online);
   }, [layoutManager, online]);
-
-  useEffect(() => {
-    if (loaders.length === 0) {
-      return;
-    }
-
-    const loadAndSaveLayouts = async () => {
-      try {
-        const currentLayouts = await layoutManager.getLayouts();
-        const currentLayoutsFroms = new Set(currentLayouts.map((layout) => layout.from));
-
-        const loaderPromises = loaders.map(async (loader) => await loader.fetchLayouts());
-        const loaderResults = await Promise.allSettled(loaderPromises);
-
-        const newLayouts = loaderResults
-          .filter(isFulfilled)
-          .flatMap((result) => result.value)
-          .filter((layout) => !currentLayoutsFroms.has(layout.from));
-
-        // Log errors cause failed to fetch some layout from a specific loader
-        loaderResults.filter(isRejected).forEach((result) => {
-          log.error(`Failed to fetch layouts from loader: ${result.reason}`);
-        });
-
-        const savedPromises = newLayouts.map(
-          async (layout) =>
-            await layoutManager.saveNewLayout({
-              ...layout,
-              permission: "CREATOR_WRITE",
-            }),
-        );
-
-        // Try to save all layouts
-        const saveResults = await Promise.allSettled(savedPromises);
-
-        // Log errors cause failed to save a layout
-        saveResults.filter(isRejected).forEach((result) => {
-          log.error(`Failed to save layout: ${result.reason}`);
-        });
-      } catch (err) {
-        log.error(`Loading default layouts failed: ${err}`);
-      }
-    };
-    void loadAndSaveLayouts();
-  }, [layoutManager, loaders]);
 
   // Sync periodically when logged in, online, and the app is not hidden
   const enableSyncing = remoteLayoutStorage != undefined && online && visibilityState === "visible";


### PR DESCRIPTION
**User-Facing Changes**
Lichtblick was creating and selecting a new "Default" layout, even when user-defined layouts were already present in the ~/.lichtblick-suite/layouts folder.

**Description**
This PR refines the layout selection logic as follows:
- Loading User Layouts: All layouts in the ~/.lichtblick-suite/layouts folder are now loaded first.
- Layout Selection: If user-defined layouts are present, the first one is selected. If no layouts are found, only then is a new "Default" layout created and selected.

_Implementation Details_
- The logic for loading layouts has been moved from the LayoutManagerProvider to the CurrentLayoutProvider to ensure proper interaction order between the two providers.
- The layout-loading logic has been extracted into a separate function outside the provider, rather than being embedded within a useEffect, to improve readability and maintainability.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
