### PR TITLE
Memory calculation

### DIFF
--- a/packages/suite-base/src/players/messageMemoryEstimation.ts
+++ b/packages/suite-base/src/players/messageMemoryEstimation.ts
@@ -256,10 +256,10 @@ export function estimateObjectSize(obj: unknown): number {
         // adapted from
         // medium.com/@bpmxmqd/v8-engine-jsobject-structure-analysis-and-memory-optimization-ideas-be30cfcdcd16
         const propertiesDictSize =
-          16 + 5 * 8 + 2 ** Math.ceil(Math.log2((numProps + 2) * 1.5)) * 3 * 4;
+          16 + 5 * 8 + 2 ** Math.ceil(Math.log2((numProps + 2) * 1.5)) * 3 * 8;
         // In return, properties are no longer stored in the properties array, so we subtract that.
         propertiesSize = propertiesDictSize - numProps * COMPRESSED_POINTER_SIZE;
-      }
+    }
 
       const valuesSize = Object.values(obj).reduce((acc, val) => acc + estimateObjectSize(val), 0);
       return OBJECT_BASE_SIZE + propertiesSize + valuesSize;

--- a/packages/suite-base/src/players/messageMemoryEstimation.ts
+++ b/packages/suite-base/src/players/messageMemoryEstimation.ts
@@ -259,7 +259,7 @@ export function estimateObjectSize(obj: unknown): number {
           16 + 5 * 8 + 2 ** Math.ceil(Math.log2((numProps + 2) * 1.5)) * 3 * 8;
         // In return, properties are no longer stored in the properties array, so we subtract that.
         propertiesSize = propertiesDictSize - numProps * COMPRESSED_POINTER_SIZE;
-    }
+      }
 
       const valuesSize = Object.values(obj).reduce((acc, val) => acc + estimateObjectSize(val), 0);
       return OBJECT_BASE_SIZE + propertiesSize + valuesSize;


### PR DESCRIPTION
**Description**

This PR comes from a spike where we were trying to understand and fix the memory estimation. When reading one of the[ articles that ](https://medium.com/@bpmxmqd/v8-engine-jsobject-structure-analysis-and-memory-optimization-ideas-be30cfcdcd16)was used for creating the memory estimation we realized that the calculation was wrong.

The actual formula is:
`16+5 * 8+ round_up_to_2^n( (number of properties +2)* 1.5) ) * 3 * 8`
 instead of 
` 16+5 * 8+ round_up_to_2^n( (number of properties +2)* 1.5) ) * 3 * 4`

 It could cause misscalculation and non efficient memory estimation


**Checklist**

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests

Resources

- [Medium article](https://medium.com/@bpmxmqd/v8-engine-jsobject-structure-analysis-and-memory-optimization-ideas-be30cfcdcd16)
