### PR TITLE
Removed integration-test folders from scanning

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -5,12 +5,5 @@
     "<rootDir>/desktop/jest.config.json",
     "<rootDir>/packages/*/jest.config.json"
   ],
-  "collectCoverage": true,
-  "coverageReporters": [
-    "text",
-    "lcov",
-    "json",
-    "xml"
-  ],
   "coverageDirectory": "coverage"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.inclusions=\
 # Path to tests
 sonar.tests=benchmark,ci,desktop,packages,web
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
-sonar.test.exclusions=web/integration-test/**,**/integration-test/**
+sonar.test.exclusions=**/integration-test/**
 
 # Code coverage
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.eslint.reportPaths=eslint-report.json
 
 # Path to sources
 sonar.sources=benchmark,ci,desktop,packages,web
-sonar.exclusions=**/*.test.ts,**/*.test.tsx
+sonar.exclusions=**/*.test.ts,**/*.test.tsx,**/integration-test/**
 sonar.inclusions=\
   **/*.ts,\
   **/*.tsx,\
@@ -18,6 +18,7 @@ sonar.inclusions=\
 # Path to tests
 sonar.tests=benchmark,ci,desktop,packages,web
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
+sonar.test.exclusions=web/integration-test/**,**/integration-test/**
 
 # Code coverage
 sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**
Removed integration tests from Sonar scanning.

Why not include E2E and integration tests in SonarQube:
Focus on production code: SonarQube is primarily designed to check the quality of production code (not test code). It focuses on static analysis, security, and code coverage metrics in unit tests, which are more precise in testing the internal logic of the code.

Unit test coverage is more relevant: Code coverage is a key metric to ensure that the production code has been well-tested in smaller units, which is the focus of quality analysis. E2E and integration tests can involve multiple layers of the application, which dilutes the granularity of the coverage.

Unnecessary noise in metrics: Including E2E and integration tests can artificially inflate the code coverage metric, as these tests tend to cover large portions of the code but do not provide the same accuracy as unit tests. This can lead to less clear reports.

Complexity in reports: E2E and integration tests may include many irrelevant details for code quality analysis, which can complicate the interpretation of SonarQube results.

