### PR TITLE
Change snackbar message when adding unsupported files

### DIFF
--- a/packages/suite-base/src/components/DocumentDropListener.tsx
+++ b/packages/suite-base/src/components/DocumentDropListener.tsx
@@ -134,7 +134,7 @@ export default function DocumentDropListener(props: Props): JSX.Element {
 
       // Check for no supported files
       if (filteredFiles.length === 0 && filteredHandles?.length === 0) {
-        enqueueSnackbar("The file format is unsupported.", { variant: "error" });
+        enqueueSnackbar("The file format is not supported.", { variant: "error" });
         return;
       }
 


### PR DESCRIPTION
**User-Facing Changes**
Snackbar message when the user tries to load an unsupported file.
Old message: The file format is unsupported.
**New message: The file format is not supported.**

**Description**
Updated snackbar message

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
