### PR TITLE
Fix/making-metadata-possibly-undefined

### DIFF
--- a/packages/suite/src/index.ts
+++ b/packages/suite/src/index.ts
@@ -289,7 +289,7 @@ export type PanelExtensionContext = {
    * An array of metadata entries. Each entry includes a name and a map of key-value pairs
    * representing the metadata associated with that name (only avaiable in MCAP files).
    */
-  readonly metadata: ReadonlyArray<Readonly<Metadata>>;
+  readonly metadata?: ReadonlyArray<Readonly<Metadata>>;
 
   /**
    * Subscribe to updates on this field within the render state. Render will only be invoked when


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**
In order to guarantee extensions compatibility with Foxglove metadata can now be undefined, this way future extensions devs will get warnings if they try to access metadata property.

**Checklist**

- [X] The web version was tested and it is running ok
- [X] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
