### PR TITLE
fix: i18n of the main process

### DIFF
--- a/packages/suite-base/src/i18n/index.ts
+++ b/packages/suite-base/src/i18n/index.ts
@@ -36,3 +36,5 @@ export async function initI18n(options?: { context?: "browser" | "electron-main"
     },
   });
 }
+
+export const sharedI18nObject = i18n;

--- a/packages/suite-base/src/i18n/index.ts
+++ b/packages/suite-base/src/i18n/index.ts
@@ -37,4 +37,5 @@ export async function initI18n(options?: { context?: "browser" | "electron-main"
   });
 }
 
+// ts-unused-exports:disable-next-line
 export const sharedI18nObject = i18n;

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -37,7 +37,6 @@
     "eventemitter3": "5.0.1",
     "fork-ts-checker-webpack-plugin": "9.0.2",
     "html-webpack-plugin": "5.5.3",
-    "i18next": "23.5.1",
     "jszip": "3.10.1",
     "path-browserify": "1.0.1",
     "plist": "3.1.0",

--- a/packages/suite-desktop/src/main/StudioWindow.ts
+++ b/packages/suite-desktop/src/main/StudioWindow.ts
@@ -19,12 +19,12 @@ import {
   shell,
   systemPreferences,
 } from "electron";
-import i18n, { t } from "i18next";
 import path from "path";
 
 import Logger from "@lichtblick/log";
 import { APP_BAR_HEIGHT } from "@lichtblick/suite-base/src/components/AppBar/constants";
 import { NativeAppMenuEvent } from "@lichtblick/suite-base/src/context/NativeAppMenuContext";
+import { sharedI18nObject as i18n } from "@lichtblick/suite-base/src/i18n";
 import { palette } from "@lichtblick/theme";
 
 import StudioAppUpdater from "./StudioAppUpdater";
@@ -44,6 +44,8 @@ const rendererPath = MAIN_WINDOW_WEBPACK_ENTRY;
 
 const closeMenuItem: MenuItemConstructorOptions = isMac ? { role: "close" } : { role: "quit" };
 const log = Logger.getLogger(__filename);
+
+const { t } = i18n;
 
 function getWindowBackgroundColor(): string | undefined {
   const theme = palette[nativeTheme.shouldUseDarkColors ? "dark" : "light"];

--- a/packages/suite-desktop/src/main/index.ts
+++ b/packages/suite-desktop/src/main/index.ts
@@ -7,12 +7,11 @@
 
 import { app, BrowserWindow, ipcMain, Menu, nativeTheme, session } from "electron";
 import fs from "fs";
-import i18n from "i18next";
 import path from "path";
 
 import Logger from "@lichtblick/log";
 import { AppSetting } from "@lichtblick/suite-base/src/AppSetting";
-import { initI18n } from "@lichtblick/suite-base/src/i18n";
+import { initI18n, sharedI18nObject as i18n } from "@lichtblick/suite-base/src/i18n";
 
 import StudioAppUpdater from "./StudioAppUpdater";
 import StudioWindow from "./StudioWindow";

--- a/packages/suite-desktop/src/main/index.ts
+++ b/packages/suite-desktop/src/main/index.ts
@@ -12,6 +12,7 @@ import path from "path";
 
 import Logger from "@lichtblick/log";
 import { AppSetting } from "@lichtblick/suite-base/src/AppSetting";
+import { initI18n } from "@lichtblick/suite-base/src/i18n";
 
 import StudioAppUpdater from "./StudioAppUpdater";
 import StudioWindow from "./StudioWindow";
@@ -60,8 +61,8 @@ async function updateLanguage() {
 }
 
 export async function main(): Promise<void> {
-  // await initI18n({ context: "electron-main" });
-  // await updateLanguage();
+  await initI18n({ context: "electron-main" });
+  await updateLanguage();
 
   // Allow integration tests to override the userData directory
   const userDataOverride = process.argv.find((arg) => arg.startsWith("--user-data-dir="));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3405,7 +3405,6 @@ __metadata:
     eventemitter3: 5.0.1
     fork-ts-checker-webpack-plugin: 9.0.2
     html-webpack-plugin: 5.5.3
-    i18next: 23.5.1
     jszip: 3.10.1
     path-browserify: 1.0.1
     plist: 3.1.0
@@ -12560,15 +12559,6 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.23.2
   checksum: c465b9bacf3066b6d112982deb03fa8a2578be38cf1e973749c884401ba1165431655e1a4438f0da08c978ce5525170ec3809968691190c194af80b20e496538
-  languageName: node
-  linkType: hard
-
-"i18next@npm:23.5.1":
-  version: 23.5.1
-  resolution: "i18next@npm:23.5.1"
-  dependencies:
-    "@babel/runtime": ^7.22.5
-  checksum: 4be043bd72287bfae9777a3252b9458d2e3f5e9a97ea62cf434e6e3767b45df4365d8780d0dd14efd4e9da5eb0f90534510b138f1372d1cb9012000a69bbedaf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
fix i18n of the main process

**Description**
https://github.com/Lichtblick-Suite/lichtblick/issues/227

- Remove duplicate i18next dependency from suite-desktop package
- Enable previously commented out i18n initialization code
- Import initI18n from suite-base package

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
