### PR TITLE
Fix/raw message panel collapsing and extending topics

### DIFF
--- a/desktop/integration-test/websocket.test.ts
+++ b/desktop/integration-test/websocket.test.ts
@@ -32,6 +32,9 @@ describe("websocket connection", () => {
 
     const rawMessagesPanel = app.renderer.getByTestId(/RawMessages/);
 
+    //Expanding the data parent to check for attributes
+    await rawMessagesPanel.getByText("data").click();
+
     // Check if message is correctly beeing displayed
     const attributesToCheck = ["hello", '"world"', "foo", "42"];
 

--- a/packages/suite-base/src/panels/RawMessages/Toolbar.tsx
+++ b/packages/suite-base/src/panels/RawMessages/Toolbar.tsx
@@ -18,7 +18,8 @@ import PanelToolbar from "@lichtblick/suite-base/components/PanelToolbar";
 import Stack from "@lichtblick/suite-base/components/Stack";
 import { SaveConfig } from "@lichtblick/suite-base/types/panels";
 
-import { Constants, RawMessagesPanelConfig } from "./types";
+import { PREV_MSG_METHOD, CUSTOM_METHOD } from "./constants";
+import { RawMessagesPanelConfig } from "./types";
 
 type Props = {
   canExpandAll: boolean;
@@ -118,10 +119,10 @@ function ToolbarComponent(props: Props): JSX.Element {
               });
             }}
           >
-            <MenuItem value={Constants.PREV_MSG_METHOD}>{Constants.PREV_MSG_METHOD}</MenuItem>
-            <MenuItem value={Constants.CUSTOM_METHOD}>custom</MenuItem>
+            <MenuItem value={PREV_MSG_METHOD}>{PREV_MSG_METHOD}</MenuItem>
+            <MenuItem value={CUSTOM_METHOD}>custom</MenuItem>
           </Select>
-          {diffMethod === Constants.CUSTOM_METHOD && (
+          {diffMethod === CUSTOM_METHOD && (
             <MessagePathInput
               index={1}
               path={diffTopicPath}

--- a/packages/suite-base/src/panels/RawMessages/constants.ts
+++ b/packages/suite-base/src/panels/RawMessages/constants.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+export const PATH_NAME_AGGREGATOR = "~";
+
+export const CUSTOM_METHOD = "custom";
+
+export const PREV_MSG_METHOD = "previous message";
+
+export const FONT_SIZE_OPTIONS = [8, 9, 10, 11, 12, 14, 16, 18, 24, 30, 36, 48, 60, 72];

--- a/packages/suite-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.stories.tsx
@@ -19,6 +19,7 @@ import { StoryObj } from "@storybook/react";
 import RawMessages from "@lichtblick/suite-base/panels/RawMessages";
 import PanelSetup from "@lichtblick/suite-base/stories/PanelSetup";
 
+import { PREV_MSG_METHOD } from "./constants";
 import {
   enumAdvancedFixture,
   enumFixture,
@@ -30,7 +31,7 @@ import {
   withMissingData,
 } from "./fixture";
 import type { RawMessagesPanelConfig } from "./types";
-import { Constants, NodeState } from "./types";
+import { NodeState } from "./types";
 
 const noDiffConfig = {
   diffMethod: "custom",
@@ -318,7 +319,7 @@ export const DiffConsecutiveMessages: StoryObj = {
       <RawMessages
         overrideConfig={{
           topicPath: "/foo",
-          diffMethod: Constants.PREV_MSG_METHOD,
+          diffMethod: PREV_MSG_METHOD,
           diffTopicPath: "",
           diffEnabled: true,
           showFullMessageForDiff: true,
@@ -336,7 +337,7 @@ export const DiffConsecutiveMessagesWithFilter: StoryObj = {
       <RawMessages
         overrideConfig={{
           topicPath: "/foo{type==2}",
-          diffMethod: Constants.PREV_MSG_METHOD,
+          diffMethod: PREV_MSG_METHOD,
           diffTopicPath: "",
           diffEnabled: true,
           showFullMessageForDiff: true,
@@ -354,7 +355,7 @@ export const DiffConsecutiveMessagesWithBigint: StoryObj = {
       <RawMessages
         overrideConfig={{
           topicPath: "/baz/bigint",
-          diffMethod: Constants.PREV_MSG_METHOD,
+          diffMethod: PREV_MSG_METHOD,
           diffTopicPath: "",
           diffEnabled: true,
           showFullMessageForDiff: true,
@@ -372,7 +373,7 @@ export const DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet: 
       <RawMessages
         overrideConfig={{
           topicPath: "/foo",
-          diffMethod: Constants.PREV_MSG_METHOD,
+          diffMethod: PREV_MSG_METHOD,
           diffTopicPath: "/another/baz/enum_advanced",
           diffEnabled: false,
           showFullMessageForDiff: true,

--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -191,7 +191,7 @@ function RawMessages(props: Props) {
 
   const onTopicPathChange = useCallback(
     (newTopicPath: string) => {
-      setExpansion('none');
+      setExpansion("none");
       saveConfig({ topicPath: newTopicPath });
     },
     [saveConfig],
@@ -214,7 +214,9 @@ function RawMessages(props: Props) {
 
   const onLabelClick = useCallback(
     (keypath: (string | number)[]) => {
-      setExpansion((old) => toggleExpansion(old ?? "none", nodes, keypath.join(PATH_NAME_AGGREGATOR)));
+      setExpansion((old) =>
+        toggleExpansion(old ?? "none", nodes, keypath.join(PATH_NAME_AGGREGATOR)),
+      );
     },
     [nodes],
   );

--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -113,6 +113,7 @@ function RawMessages(props: Props) {
         const path = paths[0];
         if (path) {
           saveConfig({ topicPath: path.path });
+          setExpansion("none");
         }
       },
     });
@@ -188,10 +189,6 @@ function RawMessages(props: Props) {
     }
   }, [expansion]);
 
-  useEffect(() => {
-      setExpansion("none");
-  }, [topicPath]);
-
   const onTopicPathChange = useCallback(
     (newTopicPath: string) => {
       setExpansion('none');
@@ -217,7 +214,7 @@ function RawMessages(props: Props) {
 
   const onLabelClick = useCallback(
     (keypath: (string | number)[]) => {
-      setExpansion((old) => toggleExpansion(old ?? "all", nodes, keypath.join(PATH_NAME_AGGREGATOR)));
+      setExpansion((old) => toggleExpansion(old ?? "none", nodes, keypath.join(PATH_NAME_AGGREGATOR)));
     },
     [nodes],
   );

--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -53,11 +53,17 @@ import MaybeCollapsedValue from "./MaybeCollapsedValue";
 import Metadata from "./Metadata";
 import Value from "./Value";
 import {
+  PREV_MSG_METHOD,
+  CUSTOM_METHOD,
+  FONT_SIZE_OPTIONS,
+  PATH_NAME_AGGREGATOR,
+} from "./constants";
+import {
   ValueAction,
   getStructureItemForPath,
   getValueActionForValue,
 } from "./getValueActionForValue";
-import { Constants, NodeState, RawMessagesPanelConfig, PATH_NAME_AGGREGATOR } from "./types";
+import { NodeState, RawMessagesPanelConfig } from "./types";
 import { DATA_ARRAY_PREVIEW_LIMIT, generateDeepKeyPaths, toggleExpansion } from "./utils";
 
 type Props = {
@@ -159,7 +165,7 @@ function RawMessages(props: Props) {
   const currTickObj = matchedMessages[matchedMessages.length - 1];
   const prevTickObj = matchedMessages[matchedMessages.length - 2];
 
-  const inTimetickDiffMode = diffEnabled && diffMethod === Constants.PREV_MSG_METHOD;
+  const inTimetickDiffMode = diffEnabled && diffMethod === PREV_MSG_METHOD;
   const baseItem = inTimetickDiffMode ? prevTickObj : currTickObj;
   const diffItem = inTimetickDiffMode ? currTickObj : diffTopicObj;
 
@@ -380,7 +386,7 @@ function RawMessages(props: Props) {
     if (topicPath.length === 0) {
       return <EmptyState>No topic selected</EmptyState>;
     }
-    if (diffEnabled && diffMethod === Constants.CUSTOM_METHOD && (!baseItem || !diffItem)) {
+    if (diffEnabled && diffMethod === CUSTOM_METHOD && (!baseItem || !diffItem)) {
       return (
         <EmptyState>{`Waiting to diff next messages from "${topicPath}" and "${diffTopicPath}"`}</EmptyState>
       );
@@ -668,7 +674,7 @@ function RawMessages(props: Props) {
               input: "select",
               options: [
                 { label: "auto", value: undefined },
-                ...Constants.FONT_SIZE_OPTIONS.map((value) => ({
+                ...FONT_SIZE_OPTIONS.map((value) => ({
                   label: `${value} px`,
                   value,
                 })),
@@ -702,7 +708,7 @@ function RawMessages(props: Props) {
 
 const defaultConfig: RawMessagesPanelConfig = {
   diffEnabled: false,
-  diffMethod: Constants.CUSTOM_METHOD,
+  diffMethod: CUSTOM_METHOD,
   diffTopicPath: "",
   showFullMessageForDiff: false,
   topicPath: "",

--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -57,7 +57,7 @@ import {
   getStructureItemForPath,
   getValueActionForValue,
 } from "./getValueActionForValue";
-import { Constants, NodeState, RawMessagesPanelConfig } from "./types";
+import { Constants, NodeState, RawMessagesPanelConfig, PATH_NAME_AGGREGATOR } from "./types";
 import { DATA_ARRAY_PREVIEW_LIMIT, generateDeepKeyPaths, toggleExpansion } from "./utils";
 
 type Props = {
@@ -165,7 +165,7 @@ function RawMessages(props: Props) {
   const nodes = useMemo(() => {
     if (baseItem) {
       const data = dataWithoutWrappingArray(baseItem.queriedData.map(({ value }) => value));
-      return generateDeepKeyPaths(data, 5);
+      return generateDeepKeyPaths(data);
     } else {
       return new Set<string>();
     }
@@ -188,9 +188,13 @@ function RawMessages(props: Props) {
     }
   }, [expansion]);
 
+  useEffect(() => {
+      setExpansion("none");
+  }, [topicPath]);
+
   const onTopicPathChange = useCallback(
     (newTopicPath: string) => {
-      setExpansion(undefined);
+      setExpansion('none');
       saveConfig({ topicPath: newTopicPath });
     },
     [saveConfig],
@@ -213,7 +217,7 @@ function RawMessages(props: Props) {
 
   const onLabelClick = useCallback(
     (keypath: (string | number)[]) => {
-      setExpansion((old) => toggleExpansion(old ?? "all", nodes, keypath.join("~")));
+      setExpansion((old) => toggleExpansion(old ?? "all", nodes, keypath.join(PATH_NAME_AGGREGATOR)));
     },
     [nodes],
   );
@@ -363,7 +367,7 @@ function RawMessages(props: Props) {
         return false;
       }
 
-      const joinedPath = keypath.join("~");
+      const joinedPath = keypath.join(PATH_NAME_AGGREGATOR);
       if (expansion && expansion[joinedPath] === NodeState.Collapsed) {
         return false;
       }

--- a/packages/suite-base/src/panels/RawMessages/types.ts
+++ b/packages/suite-base/src/panels/RawMessages/types.ts
@@ -11,8 +11,6 @@ export enum NodeState {
   Expanded = "e",
 }
 
-export const PATH_NAME_AGGREGATOR = "~";
-
 export type NodeExpansion = "all" | "none" | Record<string, NodeState>;
 
 export type RawMessagesPanelConfig = {
@@ -24,9 +22,3 @@ export type RawMessagesPanelConfig = {
   topicPath: string;
   fontSize: number | undefined;
 };
-
-export const Constants = {
-  CUSTOM_METHOD: "custom",
-  PREV_MSG_METHOD: "previous message",
-  FONT_SIZE_OPTIONS: [8, 9, 10, 11, 12, 14, 16, 18, 24, 30, 36, 48, 60, 72],
-} as const;

--- a/packages/suite-base/src/panels/RawMessages/types.ts
+++ b/packages/suite-base/src/panels/RawMessages/types.ts
@@ -11,7 +11,7 @@ export enum NodeState {
   Expanded = "e",
 }
 
-export const PATH_NAME_AGGREGATOR = '~';
+export const PATH_NAME_AGGREGATOR = "~";
 
 export type NodeExpansion = "all" | "none" | Record<string, NodeState>;
 

--- a/packages/suite-base/src/panels/RawMessages/types.ts
+++ b/packages/suite-base/src/panels/RawMessages/types.ts
@@ -11,6 +11,8 @@ export enum NodeState {
   Expanded = "e",
 }
 
+export const PATH_NAME_AGGREGATOR = '~';
+
 export type NodeExpansion = "all" | "none" | Record<string, NodeState>;
 
 export type RawMessagesPanelConfig = {

--- a/packages/suite-base/src/panels/RawMessages/utils.test.ts
+++ b/packages/suite-base/src/panels/RawMessages/utils.test.ts
@@ -5,7 +5,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { getMessageDocumentationLink } from "@lichtblick/suite-base/panels/RawMessages/utils";
+import { NodeExpansion, NodeState } from "@lichtblick/suite-base/panels/RawMessages/types";
+import { getMessageDocumentationLink, toggleExpansion } from "@lichtblick/suite-base/panels/RawMessages/utils";
 
 describe("getMessageDocumentationLink", () => {
   it("links to ROS and Foxglove docs", () => {
@@ -22,5 +23,50 @@ describe("getMessageDocumentationLink", () => {
       "https://docs.foxglove.dev/docs/visualization/message-schemas/circle-annotation",
     );
     expect(getMessageDocumentationLink("foxglove.DoesNotExist")).toBeUndefined();
+  });
+});
+
+describe("toggleExpansion", () => {
+  const PATH_NAME_AGGREGATOR = "~";
+
+  it("should keep all states expanded when state is 'all' except for the state of the key passed, changes it to collapsed", () => {
+    const paths = new Set(["key1", "key2", `child${PATH_NAME_AGGREGATOR}key1`]);
+    const result = toggleExpansion("all", paths, "key1");
+
+    expect(result).toEqual({
+      key1: NodeState.Collapsed,
+      key2: NodeState.Expanded,
+      [`child${PATH_NAME_AGGREGATOR}key1`]: NodeState.Expanded,
+    });
+  });
+
+  it("should keep all states collapsed when state is 'none' except for the state of the key passed, changes it to expanded", () => {
+    const paths = new Set(["key1", "key2", `child${PATH_NAME_AGGREGATOR}key1`]);
+    const result = toggleExpansion("none", paths, "key1");
+
+    expect(result).toEqual({
+      key1: NodeState.Expanded,
+      key2: NodeState.Collapsed,
+      [`child${PATH_NAME_AGGREGATOR}key1`]: NodeState.Collapsed,
+    });
+  });
+
+  it("should toggle an individual path without affecting others (children or not)", () => {
+    const paths = new Set(["key1", "key1~child", "key1~child~grandchild"]);
+    const initialState: NodeExpansion = {
+      key1: NodeState.Expanded,
+      [`child${PATH_NAME_AGGREGATOR}key1`]: NodeState.Expanded,
+      [`grandchild${PATH_NAME_AGGREGATOR}child${PATH_NAME_AGGREGATOR}key1`]: NodeState.Expanded,
+      key2: NodeState.Collapsed,
+    };
+
+    const result = toggleExpansion(initialState, paths, "key1");
+
+    expect(result).toEqual({
+      key1: NodeState.Collapsed,
+      [`child${PATH_NAME_AGGREGATOR}key1`]: NodeState.Expanded,
+      [`grandchild${PATH_NAME_AGGREGATOR}child${PATH_NAME_AGGREGATOR}key1`]: NodeState.Expanded,
+      key2: NodeState.Collapsed,
+    });
   });
 });

--- a/packages/suite-base/src/panels/RawMessages/utils.test.ts
+++ b/packages/suite-base/src/panels/RawMessages/utils.test.ts
@@ -6,7 +6,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { NodeExpansion, NodeState } from "@lichtblick/suite-base/panels/RawMessages/types";
-import { getMessageDocumentationLink, toggleExpansion } from "@lichtblick/suite-base/panels/RawMessages/utils";
+import {
+  getMessageDocumentationLink,
+  toggleExpansion,
+} from "@lichtblick/suite-base/panels/RawMessages/utils";
 
 describe("getMessageDocumentationLink", () => {
   it("links to ROS and Foxglove docs", () => {

--- a/packages/suite-base/src/panels/RawMessages/utils.ts
+++ b/packages/suite-base/src/panels/RawMessages/utils.ts
@@ -21,7 +21,7 @@ import { ros1 } from "@lichtblick/rosmsg-msgs-common";
 import { diffLabels, DiffObject } from "@lichtblick/suite-base/panels/RawMessages/getDiff";
 
 import type { NodeExpansion } from "./types";
-import { NodeState } from "./types";
+import { NodeState, PATH_NAME_AGGREGATOR } from "./types";
 
 export const DATA_ARRAY_PREVIEW_LIMIT = 20;
 const ROS1_COMMON_MSG_PACKAGES = new Set(Object.keys(ros1).map((key) => key.split("/")[0]!));
@@ -52,8 +52,8 @@ export function toggleExpansion(
     const next = state === "all" ? NodeState.Expanded : NodeState.Collapsed;
     const nextState: NodeExpansion = {};
     for (const leaf of paths) {
-      // Implicitly expand all descendants when toggling collapsed root node
-      if (next === NodeState.Collapsed && leaf.endsWith(key)) {
+      // Implicitly all descendents are collapsed
+      if (next === NodeState.Collapsed && leaf.startsWith(key + PATH_NAME_AGGREGATOR)) {
         continue;
       }
       nextState[leaf] = leaf === key ? invert(next) : next;
@@ -72,7 +72,7 @@ export function toggleExpansion(
 /**
  * Recursively traverses all keypaths in obj, for use in JSON tree expansion.
  */
-export function generateDeepKeyPaths(obj: unknown, maxArrayLength: number): Set<string> {
+export function generateDeepKeyPaths(obj: unknown): Set<string> {
   const keys = new Set<string>();
   const recurseMapKeys = (path: string[], nestedObj: unknown) => {
     if (nestedObj == undefined) {
@@ -83,16 +83,12 @@ export function generateDeepKeyPaths(obj: unknown, maxArrayLength: number): Set<
       return;
     }
 
-    if (Array.isArray(nestedObj) && nestedObj.length > maxArrayLength) {
-      return;
-    }
-
     if (isTypedArray(nestedObj)) {
       return;
     }
 
     if (path.length > 0) {
-      keys.add(path.join("~"));
+      keys.add(path.join(PATH_NAME_AGGREGATOR));
     }
 
     for (const key of Object.getOwnPropertyNames(nestedObj)) {

--- a/packages/suite-base/src/panels/RawMessages/utils.ts
+++ b/packages/suite-base/src/panels/RawMessages/utils.ts
@@ -20,8 +20,9 @@ import * as _ from "lodash-es";
 import { ros1 } from "@lichtblick/rosmsg-msgs-common";
 import { diffLabels, DiffObject } from "@lichtblick/suite-base/panels/RawMessages/getDiff";
 
+import { PATH_NAME_AGGREGATOR } from "./constants";
 import type { NodeExpansion } from "./types";
-import { NodeState, PATH_NAME_AGGREGATOR } from "./types";
+import { NodeState } from "./types";
 
 export const DATA_ARRAY_PREVIEW_LIMIT = 20;
 const ROS1_COMMON_MSG_PACKAGES = new Set(Object.keys(ros1).map((key) => key.split("/")[0]!));


### PR DESCRIPTION
**User-Facing Changes**

- On Raw Messages Panel all items are now collapsed by default;
- Now changing the status of an item, either expanding or collapsing, wont affect the status of it's children, grandchildren and so on;


**Description**

Default Collapsed State: When a new topic is opened, its expansion state is now set to "none", ensuring all items start in a collapsed state. This eliminates initial loading delays previously experienced for some topics.

Enhanced Path Generation: Modified the generateDeepKeyPaths function to handle both objects and arrays, ensuring that all elements start collapsed by default.

Improved Expansion Toggle Behavior: Adjusted toggleExpansion so that changing a parent’s state no longer affects its children. Now, children with keys containing the parent’s name and the separator (~) are preserved in their current state.

**Checklist**

- [X] The web version was tested and it is running ok
- [X] The desktop version was tested and it is running ok
- [X] This change is covered by unit tests
