### PR TITLE
Test/create unit tests to use panel settings in state transitions

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -168,6 +168,7 @@ overrides:
           args: after-used
           varsIgnorePattern: "^_."
           argsIgnorePattern: "^_."
+      "@typescript-eslint/no-unsafe-enum-comparison": off
 
   - rules:
       "@typescript-eslint/no-explicit-any": off

--- a/packages/suite-base/src/i18n/en/stateTransitions.ts
+++ b/packages/suite-base/src/i18n/en/stateTransitions.ts
@@ -7,9 +7,24 @@
 
 export const stateTransitions = {
   addSeriesButton: "Click to add a series",
+  labels: {
+    addSeries: "Add series",
+    deleteSeries: "Delete series",
+    general: "General",
+    helpGeneral: "Display a point for every state transition message",
+    label: "Label",
+    messagePath: "Message path",
+    series: "Series",
+    showPoints: "Show points",
+    sync: "Sync with other plots",
+    timestamp: "Timestamp",
+    timestampHeaderStamp: "Header Stamp",
+    timestampReceiveTime: "Receive Time",
+  },
   max: "Max",
   maxXError: "X max must be greater than X min.",
   min: "Min",
+  pathErrorMessage: "This path resolves to more than one value",
   secondsRange: "Range (seconds)",
   xAxis: "X Axis",
 };

--- a/packages/suite-base/src/panels/Plot/plotableRosTypes.ts
+++ b/packages/suite-base/src/panels/Plot/plotableRosTypes.ts
@@ -5,19 +5,19 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-export const plotableRosTypes = [
+export const PLOTABLE_ROS_TYPES = [
   "bool",
-  "int8",
-  "uint8",
-  "int16",
-  "uint16",
-  "int32",
-  "uint32",
-  "int64",
-  "uint64",
+  "duration",
   "float32",
   "float64",
-  "time",
-  "duration",
+  "int16",
+  "int32",
+  "int64",
+  "int8",
   "string",
+  "time",
+  "uint16",
+  "uint32",
+  "uint64",
+  "uint8",
 ];

--- a/packages/suite-base/src/panels/Plot/settings.ts
+++ b/packages/suite-base/src/panels/Plot/settings.ts
@@ -18,7 +18,7 @@ import { SaveConfig } from "@lichtblick/suite-base/types/panels";
 import { lineColors } from "@lichtblick/suite-base/util/plotColors";
 
 import { PlotPath, PlotConfig, plotPathDisplayName } from "./config";
-import { plotableRosTypes } from "./plotableRosTypes";
+import { PLOTABLE_ROS_TYPES } from "./plotableRosTypes";
 
 export const DEFAULT_PATH: PlotPath = Object.freeze({
   timestampMethod: "receiveTime",
@@ -48,7 +48,7 @@ const makeSeriesNode = memoizeWeak(
           label: t("messagePath"),
           input: "messagepath",
           value: path.value,
-          validTypes: plotableRosTypes,
+          validTypes: PLOTABLE_ROS_TYPES,
           supportsMathModifiers: true,
         },
         label: {
@@ -202,7 +202,7 @@ function buildSettingsTree(config: PlotConfig, t: TFunction<"plot">): SettingsTr
                 label: t("messagePath"),
                 input: "messagepath",
                 value: config.xAxisPath?.value ?? "",
-                validTypes: plotableRosTypes,
+                validTypes: PLOTABLE_ROS_TYPES,
               }
             : undefined,
         showXAxisLabels: {

--- a/packages/suite-base/src/panels/RawMessages/Value.tsx
+++ b/packages/suite-base/src/panels/RawMessages/Value.tsx
@@ -27,7 +27,7 @@ import clipboard from "@lichtblick/suite-base/util/clipboard";
 import HighlightedValue from "./HighlightedValue";
 import { copyMessageReplacer } from "./copyMessageReplacer";
 import { ValueAction } from "./getValueActionForValue";
-import { transitionableRosTypes } from "../StateTransitions/constants";
+import { TRANSITIONABLE_ROS_TYPES } from "../StateTransitions/constants";
 
 const StyledIconButton = withStyles(HoverableIconButton, (theme) => ({
   root: {
@@ -136,7 +136,7 @@ function Value(props: ValueProps): JSX.Element {
     }
     if (valueAction != undefined) {
       const isPlotableType = PLOTABLE_ROS_TYPES.includes(valueAction.primitiveType);
-      const isTransitionalType = transitionableRosTypes.includes(valueAction.primitiveType);
+      const isTransitionalType = TRANSITIONABLE_ROS_TYPES.includes(valueAction.primitiveType);
       const isMultiSlicePath = valueAction.multiSlicePath === valueAction.singleSlicePath;
 
       if (valueAction.filterPath.length > 0) {

--- a/packages/suite-base/src/panels/RawMessages/Value.tsx
+++ b/packages/suite-base/src/panels/RawMessages/Value.tsx
@@ -19,7 +19,7 @@ import { withStyles, makeStyles } from "tss-react/mui";
 import HoverableIconButton from "@lichtblick/suite-base/components/HoverableIconButton";
 import Stack from "@lichtblick/suite-base/components/Stack";
 import { openSiblingPlotPanel } from "@lichtblick/suite-base/panels/Plot/openSiblingPlotPanel";
-import { plotableRosTypes } from "@lichtblick/suite-base/panels/Plot/plotableRosTypes";
+import { PLOTABLE_ROS_TYPES } from "@lichtblick/suite-base/panels/Plot/plotableRosTypes";
 import {
   openSiblingStateTransitionsPanel,
   transitionableRosTypes,
@@ -137,7 +137,7 @@ function Value(props: ValueProps): JSX.Element {
       });
     }
     if (valueAction != undefined) {
-      const isPlotableType = plotableRosTypes.includes(valueAction.primitiveType);
+      const isPlotableType = PLOTABLE_ROS_TYPES.includes(valueAction.primitiveType);
       const isTransitionalType = transitionableRosTypes.includes(valueAction.primitiveType);
       const isMultiSlicePath = valueAction.multiSlicePath === valueAction.singleSlicePath;
 

--- a/packages/suite-base/src/panels/StateTransitions/constants.ts
+++ b/packages/suite-base/src/panels/StateTransitions/constants.ts
@@ -43,7 +43,7 @@ export const STATE_TRANSITION_PLUGINS: ChartOptions["plugins"] = {
   },
 };
 
-export const transitionableRosTypes = [
+export const TRANSITIONABLE_ROS_TYPES = [
   "bool",
   "int8",
   "uint8",

--- a/packages/suite-base/src/panels/StateTransitions/index.tsx
+++ b/packages/suite-base/src/panels/StateTransitions/index.tsx
@@ -46,14 +46,14 @@ import {
   EMPTY_ITEMS_BY_PATH,
   STATE_TRANSITION_PLUGINS,
 } from "@lichtblick/suite-base/panels/StateTransitions/constants";
+import { usePanelSettings } from "@lichtblick/suite-base/panels/StateTransitions/usePanelSettings";
 import { subscribePayloadFromMessagePath } from "@lichtblick/suite-base/players/subscribePayloadFromMessagePath";
 import { SubscribePayload } from "@lichtblick/suite-base/players/types";
 import { OnClickArg as OnChartClickArgs } from "@lichtblick/suite-base/src/components/Chart";
 import { Bounds } from "@lichtblick/suite-base/types/Bounds";
 
 import { messagesToDataset } from "./messagesToDataset";
-import { PathState, useStateTransitionsPanelSettings } from "./settings";
-import { StateTransitionConfig, StateTransitionPanelProps } from "./types";
+import { PathState, StateTransitionConfig, StateTransitionPanelProps } from "./types";
 
 const useStyles = makeStyles()((theme) => ({
   chartWrapper: {
@@ -363,7 +363,7 @@ function StateTransitions(props: StateTransitionPanelProps) {
     [messagePipeline],
   );
 
-  useStateTransitionsPanelSettings(config, saveConfig, pathState, focusedPath);
+  usePanelSettings(config, saveConfig, pathState, focusedPath);
 
   return (
     <Stack flexGrow={1} overflow="hidden" style={{ zIndex: 0 }}>

--- a/packages/suite-base/src/panels/StateTransitions/types.ts
+++ b/packages/suite-base/src/panels/StateTransitions/types.ts
@@ -5,6 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { SettingsTreeAction, SettingsTreeNodeActionItem } from "@lichtblick/suite";
 import { SaveConfig } from "@lichtblick/suite-base/types/panels";
 import { TimestampMethod } from "@lichtblick/suite-base/util/time";
 
@@ -36,3 +37,26 @@ export type PathLegendProps = {
   setFocusedPath: (value: string[] | undefined) => void;
   saveConfig: SaveConfig<StateTransitionConfig>;
 };
+
+export interface IUsePanelSettings {
+  actionHandler: (action: SettingsTreeAction) => void;
+}
+
+export type PathState = {
+  path: StateTransitionPath;
+  // Whether the data the path refers to resolves to more than one value
+  isArray: boolean;
+};
+
+export type AxisTreeField = {
+  value: number | undefined;
+  label: string;
+  error?: string | undefined;
+};
+
+export type SeriesAction = Pick<SettingsTreeNodeActionItem, "label" | "icon" | "id">;
+
+export enum SeriesActionID {
+  ADD = "add-series",
+  DELETE = "delete-series",
+}

--- a/packages/suite-base/src/panels/StateTransitions/types.ts
+++ b/packages/suite-base/src/panels/StateTransitions/types.ts
@@ -56,7 +56,7 @@ export type AxisTreeField = {
 
 export type SeriesAction = Pick<SettingsTreeNodeActionItem, "label" | "icon" | "id">;
 
-export enum SeriesActionID {
+export enum SeriesActionId {
   ADD = "add-series",
   DELETE = "delete-series",
 }

--- a/packages/suite-base/src/panels/StateTransitions/usePanelSettings.test.tsx
+++ b/packages/suite-base/src/panels/StateTransitions/usePanelSettings.test.tsx
@@ -342,7 +342,7 @@ describe("usePanelSettings", () => {
     };
   };
 
-  it("should call saveConfig when isSynced changes", () => {
+  it("should update config when isSynced changes", () => {
     const { config } = setup();
 
     act(() => {
@@ -354,7 +354,7 @@ describe("usePanelSettings", () => {
     });
   });
 
-  it("should call saveConfig with updated config for action 'update' - isSynced", () => {
+  it("should update config with updated config for action 'update' - isSynced", () => {
     const { render } = setup({
       config: {
         isSynced: false,
@@ -381,7 +381,7 @@ describe("usePanelSettings", () => {
     });
   });
 
-  it("should call saveConfig with updated config for action 'update' - showPoints", () => {
+  it("should update config with updated config for action 'update' - showPoints", () => {
     const { render } = setup({
       config: {
         showPoints: false,
@@ -408,7 +408,7 @@ describe("usePanelSettings", () => {
     });
   });
 
-  it("should call saveConfig with xAxisRange reseted when xAxisMinValue or xAxisMaxValue are updated", () => {
+  it("should update config with xAxisRange reseted when xAxisMinValue or xAxisMaxValue are updated", () => {
     const { render, config } = setup();
     const settings: SettingsTreeAction = {
       action: "update",
@@ -440,7 +440,39 @@ describe("usePanelSettings", () => {
     );
   });
 
-  it("should call saveConfig with xAxisMinValue and xAxisMaxValue reseted when xAxisRange is updated", () => {
+  it("should update config with xAxisRange reseted when xAxisMaxValue is updated", () => {
+    const { render, config } = setup();
+    const settings: SettingsTreeAction = {
+      action: "update",
+      payload: {
+        input: "number",
+        path: ["xAxis", "xAxisMaxValue"],
+        value: BasicBuilder.number(),
+      },
+    };
+    const { actionHandler } = render.result.current;
+
+    act(() => {
+      actionHandler(settings);
+    });
+
+    expect(saveConfig).toHaveBeenCalledTimes(1);
+    expect(saveConfig).toHaveBeenCalledWith(expect.any(Function));
+    expect(
+      produce(
+        config,
+        (saveConfig as jest.Mock).mock.calls[0][0] as (draft: StateTransitionConfig) => void,
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        xAxisMaxValue: settings.payload.value,
+        xAxisMinValue: config.xAxisMinValue,
+        xAxisRange: undefined,
+      }),
+    );
+  });
+
+  it("should update config with xAxisMinValue and xAxisMaxValue reseted when xAxisRange is updated", () => {
     const { render, config } = setup();
     const settings: SettingsTreeAction = {
       action: "update",
@@ -470,6 +502,56 @@ describe("usePanelSettings", () => {
         xAxisRange: settings.payload.value,
       }),
     );
+  });
+
+  it("should update config when there is no path", () => {
+    const { render, config } = setup({ paths: [] });
+    const settings: SettingsTreeAction = {
+      action: "update",
+      payload: {
+        input: "number",
+        path: [],
+        value: BasicBuilder.number(),
+      },
+    };
+    const { actionHandler } = render.result.current;
+
+    act(() => {
+      actionHandler(settings);
+    });
+
+    const updatedConfig = produce(
+      config,
+      (saveConfig as jest.Mock).mock.calls[0][0] as (draft: StateTransitionConfig) => void,
+    );
+    expect(saveConfig).toHaveBeenCalledTimes(1);
+    expect(saveConfig).toHaveBeenCalledWith(expect.any(Function));
+    expect(updatedConfig.paths).toEqual([DEFAULT_STATE_TRANSITION_PATH]);
+  });
+
+  it("should update config when there are paths", () => {
+    const { render, config } = setup();
+    const settings: SettingsTreeAction = {
+      action: "update",
+      payload: {
+        input: "number",
+        path: [],
+        value: BasicBuilder.number(),
+      },
+    };
+    const { actionHandler } = render.result.current;
+
+    act(() => {
+      actionHandler(settings);
+    });
+
+    const updatedConfig = produce(
+      config,
+      (saveConfig as jest.Mock).mock.calls[0][0] as (draft: StateTransitionConfig) => void,
+    );
+    expect(saveConfig).toHaveBeenCalledTimes(1);
+    expect(saveConfig).toHaveBeenCalledWith(expect.any(Function));
+    expect(updatedConfig.paths).toEqual(config.paths);
   });
 
   it.each<{ paths: StateTransitionPath[] }>([

--- a/packages/suite-base/src/panels/StateTransitions/usePanelSettings.test.tsx
+++ b/packages/suite-base/src/panels/StateTransitions/usePanelSettings.test.tsx
@@ -15,7 +15,7 @@ import {
   IUsePanelSettings,
   PathState,
   SeriesAction,
-  SeriesActionID,
+  SeriesActionId,
   StateTransitionConfig,
   StateTransitionPath,
 } from "@lichtblick/suite-base/panels/StateTransitions/types";
@@ -99,7 +99,7 @@ describe("makeSeriesNode", () => {
       {
         display: "inline",
         icon: "Clear",
-        id: SeriesActionID.DELETE,
+        id: SeriesActionId.DELETE,
         label: "labels.deleteSeries",
         type: "action",
       },
@@ -178,7 +178,7 @@ describe("makeRootSeriesNode", () => {
       {
         display: "inline",
         icon: "Addchart",
-        id: SeriesActionID.ADD,
+        id: SeriesActionId.ADD,
         label: "labels.addSeries",
         type: "action",
       },
@@ -483,7 +483,7 @@ describe("usePanelSettings", () => {
 
     const settings: SettingsTreeAction = {
       action: "perform-node-action",
-      payload: { id: SeriesActionID.ADD, path: [] },
+      payload: { id: SeriesActionId.ADD, path: [] },
     };
 
     actionHandler(settings);
@@ -508,7 +508,7 @@ describe("usePanelSettings", () => {
 
     const settings: SettingsTreeAction = {
       action: "perform-node-action",
-      payload: { id: SeriesActionID.DELETE, path: ["", "2"] },
+      payload: { id: SeriesActionId.DELETE, path: ["", "2"] },
     };
 
     actionHandler(settings);

--- a/packages/suite-base/src/panels/StateTransitions/usePanelSettings.test.tsx
+++ b/packages/suite-base/src/panels/StateTransitions/usePanelSettings.test.tsx
@@ -408,7 +408,7 @@ describe("usePanelSettings", () => {
     });
   });
 
-  it("should update config with xAxisRange reseted when xAxisMinValue or xAxisMaxValue are updated", () => {
+  it("should update config with xAxisRange reseted when xAxisMinValue is updated", () => {
     const { render, config } = setup();
     const settings: SettingsTreeAction = {
       action: "update",

--- a/packages/suite-base/src/panels/StateTransitions/usePanelSettings.test.tsx
+++ b/packages/suite-base/src/panels/StateTransitions/usePanelSettings.test.tsx
@@ -1,0 +1,527 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+import { act, renderHook, RenderHookResult } from "@testing-library/react";
+import { t, TFunction } from "i18next";
+import { produce } from "immer";
+import * as _ from "lodash-es";
+import { PropsWithChildren } from "react";
+
+import { SettingsTreeAction } from "@lichtblick/suite";
+import MockPanelContextProvider from "@lichtblick/suite-base/components/MockPanelContextProvider";
+import { PLOTABLE_ROS_TYPES } from "@lichtblick/suite-base/panels/Plot/plotableRosTypes";
+import { DEFAULT_STATE_TRANSITION_PATH } from "@lichtblick/suite-base/panels/StateTransitions/constants";
+import {
+  IUsePanelSettings,
+  PathState,
+  SeriesAction,
+  SeriesActionID,
+  StateTransitionConfig,
+  StateTransitionPath,
+} from "@lichtblick/suite-base/panels/StateTransitions/types";
+import {
+  buildSettingsTree,
+  makeRootSeriesNode,
+  makeSeriesNode,
+  setSeriesAction,
+  usePanelSettings,
+} from "@lichtblick/suite-base/panels/StateTransitions/usePanelSettings";
+import { PanelStateContextProvider } from "@lichtblick/suite-base/providers/PanelStateContextProvider";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+import { SaveConfig } from "@lichtblick/suite-base/types/panels";
+import { TimestampMethod } from "@lichtblick/suite-base/util/time";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: jest.fn().mockImplementation((key) => key),
+  }),
+}));
+
+interface IUsePanelSettingsSetup<T> {
+  config: StateTransitionConfig;
+  focusedPath: string[];
+  render: RenderHookResult<T, unknown>;
+}
+
+const buildPath = (): StateTransitionPath => ({
+  label: BasicBuilder.string(),
+  value: BasicBuilder.string(),
+  timestampMethod: BasicBuilder.sample<TimestampMethod>(["receiveTime", "headerStamp"]),
+});
+
+describe("setSeriesAction", () => {
+  it("should return the SettingsTreeNodeActionItem", () => {
+    const seriesActions: SeriesAction = {
+      id: BasicBuilder.string(),
+      label: BasicBuilder.string(),
+      icon: "Add",
+    };
+
+    const { display, type, id, label, icon } = setSeriesAction(seriesActions);
+
+    expect(display).toBe("inline");
+    expect(type).toBe("action");
+    expect(id).toBe(seriesActions.id);
+    expect(icon).toBe(seriesActions.icon);
+    expect(label).toBe(seriesActions.label);
+  });
+});
+
+describe("makeSeriesNode", () => {
+  const setup = (propsOverride: Partial<PathState & { canDelete: boolean }> = {}) => {
+    const seriesNode: PathState & { canDelete: boolean } = {
+      path: {
+        value: BasicBuilder.string(),
+        label: BasicBuilder.string(),
+        timestampMethod: BasicBuilder.sample(["receiveTime", "headerStamp"]),
+      },
+      canDelete: true,
+      isArray: false,
+      ...propsOverride,
+    };
+
+    return {
+      index: 0,
+      seriesNode,
+    };
+  };
+
+  it("should return the node structure with actions when canDelete is true", () => {
+    const { seriesNode, index } = setup();
+
+    const { actions, label, fields } = makeSeriesNode(
+      index,
+      seriesNode,
+      t as unknown as TFunction<"stateTransitions">,
+    );
+
+    expect(actions).toEqual([
+      {
+        display: "inline",
+        icon: "Clear",
+        id: SeriesActionID.DELETE,
+        label: "labels.deleteSeries",
+        type: "action",
+      },
+    ]);
+    expect(label).toEqual(seriesNode.path.label);
+    expect(fields!.value).toEqual({
+      input: "messagepath",
+      label: "labels.messagePath",
+      validTypes: PLOTABLE_ROS_TYPES,
+      value: seriesNode.path.value,
+    });
+    expect(fields!.label).toEqual({
+      input: "string",
+      label: "labels.label",
+      value: seriesNode.path.label,
+    });
+    expect(fields!.timestampMethod).toEqual({
+      input: "select",
+      label: "labels.timestamp",
+      options: [
+        { label: "labels.timestampReceiveTime", value: "receiveTime" },
+        { label: "labels.timestampHeaderStamp", value: "headerStamp" },
+      ],
+      value: seriesNode.path.timestampMethod,
+    });
+  });
+
+  it("should return the node structure with actions when canDelete is false", () => {
+    const { seriesNode, index } = setup({ canDelete: false });
+
+    const { actions } = makeSeriesNode(
+      index,
+      seriesNode,
+      t as unknown as TFunction<"stateTransitions">,
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("should return error parameter in value field when isArray is true", () => {
+    const { seriesNode, index } = setup({ isArray: true });
+
+    const { fields } = makeSeriesNode(
+      index,
+      seriesNode,
+      t as unknown as TFunction<"stateTransitions">,
+    );
+
+    expect(fields!.value).toEqual(expect.objectContaining({ error: "pathErrorMessage" }));
+  });
+});
+
+describe("makeRootSeriesNode", () => {
+  const setup = (paths?: PathState[]): { paths: PathState[] } => {
+    const defaultPaths: PathState[] = paths ?? [
+      { path: buildPath(), isArray: false },
+      { path: buildPath(), isArray: false },
+      { path: buildPath(), isArray: false },
+    ];
+
+    return {
+      paths: defaultPaths,
+    };
+  };
+
+  it("should return node structure with actions when paths are provided", () => {
+    const { paths } = setup();
+
+    const { label, children, actions } = makeRootSeriesNode(
+      paths,
+      t as unknown as TFunction<"stateTransitions">,
+    );
+
+    expect(label).toEqual("labels.series");
+    expect(actions).toEqual([
+      {
+        display: "inline",
+        icon: "Addchart",
+        id: SeriesActionID.ADD,
+        label: "labels.addSeries",
+        type: "action",
+      },
+    ]);
+    expect(_.size(children)).toBe(3);
+    expect(children).toHaveProperty("0");
+    expect(children).toHaveProperty("1");
+    expect(children).toHaveProperty("2");
+    expect(children!["0"]?.actions).toHaveLength(1);
+    expect(children!["1"]?.actions).toHaveLength(1);
+    expect(children!["2"]?.actions).toHaveLength(1);
+  });
+
+  it("should return node structure with actions when paths are not provided", () => {
+    const { paths } = setup([]);
+
+    const { children } = makeRootSeriesNode(paths, t as unknown as TFunction<"stateTransitions">);
+
+    expect(_.size(children)).toBe(1);
+    expect(children).toHaveProperty("0");
+    expect(children).not.toHaveProperty("1");
+    expect(children!["0"]?.actions).toEqual([]);
+  });
+});
+
+describe("buildSettingsTree", () => {
+  const setup = ({
+    config = {},
+    paths = undefined,
+  }: Partial<{
+    config: Partial<Omit<StateTransitionConfig, "paths">>;
+    paths: PathState[] | undefined;
+  }> = {}): { paths: PathState[]; config: Omit<StateTransitionConfig, "paths"> } => {
+    const defaultPaths: PathState[] = paths ?? [
+      { path: buildPath(), isArray: false },
+      { path: buildPath(), isArray: false },
+      { path: buildPath(), isArray: false },
+    ];
+
+    const defaultConfig: Omit<StateTransitionConfig, "paths"> = {
+      isSynced: BasicBuilder.boolean(),
+      showPoints: BasicBuilder.boolean(),
+      xAxisMaxValue: BasicBuilder.number({ min: 50, max: 100 }),
+      xAxisMinValue: BasicBuilder.number({ min: 0, max: 49 }),
+      xAxisRange: BasicBuilder.number(),
+      ...config,
+    };
+
+    return {
+      paths: defaultPaths,
+      config: defaultConfig,
+    };
+  };
+
+  it("should build settings tree nodes", () => {
+    const { paths, config } = setup();
+
+    const {
+      general,
+      xAxis,
+      paths: pathsResult,
+    } = buildSettingsTree(
+      config as StateTransitionConfig,
+      paths,
+      t as unknown as TFunction<"stateTransitions">,
+    );
+
+    // General settings
+    expect(general).toBeDefined();
+    expect(general!.label).toEqual("labels.general");
+    expect(general!.fields!.isSynced).toEqual({
+      label: "labels.sync",
+      input: "boolean",
+      value: config.isSynced,
+    });
+
+    // X axis settings
+    expect(xAxis).toBeDefined();
+    expect(xAxis!.label).toEqual("xAxis");
+    expect(xAxis!.fields!.xAxisMaxValue!.label).toEqual("max");
+    expect(xAxis!.fields!.xAxisMaxValue!.value).toEqual(config.xAxisMaxValue);
+    expect(xAxis!.fields!.xAxisMinValue!.label).toEqual("min");
+    expect(xAxis!.fields!.xAxisMinValue!.value).toEqual(config.xAxisMinValue);
+
+    // Paths settings
+    expect(pathsResult).toBeDefined();
+  });
+
+  it("should return error when xAxisMinValue is greater or equal to xAxisMaxValue", () => {
+    const { paths, config } = setup({
+      config: {
+        xAxisMaxValue: BasicBuilder.number({ min: 0, max: 50 }),
+        xAxisMinValue: BasicBuilder.number({ min: 50, max: 100 }),
+      },
+    });
+
+    const { xAxis } = buildSettingsTree(
+      config as StateTransitionConfig,
+      paths,
+      t as unknown as TFunction<"stateTransitions">,
+    );
+
+    expect(xAxis!.fields!.xAxisMaxValue!.error).toEqual("maxXError");
+  });
+});
+
+describe("usePanelSettings", () => {
+  let saveConfig: SaveConfig<StateTransitionConfig> = jest.fn();
+
+  beforeEach(() => {
+    saveConfig = jest.fn();
+    jest.clearAllMocks();
+    console.error = jest.fn();
+  });
+
+  const setup = ({
+    config = {},
+    focusedPath = undefined,
+    paths = undefined,
+  }: Partial<{
+    config: Partial<StateTransitionConfig>;
+    paths: PathState[] | undefined;
+    focusedPath: string[] | undefined;
+  }> = {}): IUsePanelSettingsSetup<IUsePanelSettings> => {
+    const defaultPaths: PathState[] = paths ?? [
+      { path: buildPath(), isArray: false },
+      { path: buildPath(), isArray: false },
+      { path: buildPath(), isArray: false },
+    ];
+    const xAxisMaxValue = BasicBuilder.number({ min: 5, max: 10 });
+    const xAxisMinValue = BasicBuilder.number({ min: 1, max: 4 });
+    const defaultConfig: StateTransitionConfig = {
+      isSynced: BasicBuilder.boolean(),
+      showPoints: BasicBuilder.boolean(),
+      xAxisMaxValue,
+      xAxisMinValue,
+      xAxisRange: xAxisMaxValue + xAxisMinValue,
+      paths: defaultPaths.map(({ path }) => path),
+      ...config,
+    };
+
+    const defaultFocusedPath: string[] = focusedPath ?? BasicBuilder.strings();
+
+    const render = renderHook(
+      () => usePanelSettings(defaultConfig, saveConfig, defaultPaths, defaultFocusedPath),
+      {
+        wrapper({ children }: PropsWithChildren) {
+          return (
+            <MockPanelContextProvider>
+              <PanelStateContextProvider>{children}</PanelStateContextProvider>
+            </MockPanelContextProvider>
+          );
+        },
+      },
+    );
+
+    return {
+      config: defaultConfig,
+      focusedPath: defaultFocusedPath,
+      render,
+    };
+  };
+
+  it("should call saveConfig when isSynced changes", () => {
+    const { config } = setup();
+
+    act(() => {
+      saveConfig({ isSynced: !config.isSynced });
+    });
+
+    expect(saveConfig).toHaveBeenCalledWith({
+      isSynced: !config.isSynced,
+    });
+  });
+
+  it("should call saveConfig with updated config for action 'update' - isSynced", () => {
+    const { render } = setup({
+      config: {
+        isSynced: false,
+      },
+      paths: [],
+    });
+    const { actionHandler } = render.result.current;
+
+    const action: SettingsTreeAction = {
+      action: "update",
+      payload: {
+        input: "boolean",
+        path: ["general", "isSynced"],
+        value: true,
+      },
+    };
+
+    act(() => {
+      actionHandler(action);
+    });
+
+    expect(saveConfig).toHaveBeenCalledWith({
+      isSynced: action.payload.value,
+    });
+  });
+
+  it("should call saveConfig with updated config for action 'update' - showPoints", () => {
+    const { render } = setup({
+      config: {
+        showPoints: false,
+      },
+      paths: [],
+    });
+    const { actionHandler } = render.result.current;
+
+    const action: SettingsTreeAction = {
+      action: "update",
+      payload: {
+        input: "boolean",
+        path: ["general", "showPoints"],
+        value: true,
+      },
+    };
+
+    act(() => {
+      actionHandler(action);
+    });
+
+    expect(saveConfig).toHaveBeenCalledWith({
+      showPoints: action.payload.value,
+    });
+  });
+
+  it("should call saveConfig with xAxisRange reseted when xAxisMinValue or xAxisMaxValue are updated", () => {
+    const { render, config } = setup();
+    const settings: SettingsTreeAction = {
+      action: "update",
+      payload: {
+        input: "number",
+        path: ["xAxis", "xAxisMinValue"],
+        value: BasicBuilder.number(),
+      },
+    };
+    const { actionHandler } = render.result.current;
+
+    act(() => {
+      actionHandler(settings);
+    });
+
+    expect(saveConfig).toHaveBeenCalledTimes(1);
+    expect(saveConfig).toHaveBeenCalledWith(expect.any(Function));
+    expect(
+      produce(
+        config,
+        (saveConfig as jest.Mock).mock.calls[0][0] as (draft: StateTransitionConfig) => void,
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        xAxisMaxValue: config.xAxisMaxValue,
+        xAxisMinValue: settings.payload.value,
+        xAxisRange: undefined,
+      }),
+    );
+  });
+
+  it("should call saveConfig with xAxisMinValue and xAxisMaxValue reseted when xAxisRange is updated", () => {
+    const { render, config } = setup();
+    const settings: SettingsTreeAction = {
+      action: "update",
+      payload: {
+        input: "number",
+        path: ["xAxis", "xAxisRange"],
+        value: BasicBuilder.number(),
+      },
+    };
+    const { actionHandler } = render.result.current;
+
+    act(() => {
+      actionHandler(settings);
+    });
+
+    expect(saveConfig).toHaveBeenCalledTimes(1);
+    expect(saveConfig).toHaveBeenCalledWith(expect.any(Function));
+    expect(
+      produce(
+        config,
+        (saveConfig as jest.Mock).mock.calls[0][0] as (draft: StateTransitionConfig) => void,
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        xAxisMaxValue: undefined,
+        xAxisMinValue: undefined,
+        xAxisRange: settings.payload.value,
+      }),
+    );
+  });
+
+  it.each<{ paths: StateTransitionPath[] }>([
+    { paths: [] },
+    { paths: [DEFAULT_STATE_TRANSITION_PATH] },
+  ])("should add a serie", ({ paths }) => {
+    const { render, config } = setup();
+    config.paths = paths;
+
+    const { actionHandler } = render.result.current;
+
+    const settings: SettingsTreeAction = {
+      action: "perform-node-action",
+      payload: { id: SeriesActionID.ADD, path: [] },
+    };
+
+    actionHandler(settings);
+
+    expect(saveConfig).toHaveBeenCalledTimes(1);
+    expect(saveConfig).toHaveBeenCalledWith(expect.any(Function));
+    const updatedConfig = produce(
+      config,
+      (saveConfig as jest.Mock).mock.calls[0][0] as (draft: StateTransitionConfig) => void,
+    );
+    expect(updatedConfig.paths).toHaveLength(2);
+    expect(updatedConfig.paths).toEqual([
+      DEFAULT_STATE_TRANSITION_PATH,
+      DEFAULT_STATE_TRANSITION_PATH,
+    ]);
+  });
+
+  it("should delete a serie", () => {
+    const { render, config } = setup();
+
+    const { actionHandler } = render.result.current;
+
+    const settings: SettingsTreeAction = {
+      action: "perform-node-action",
+      payload: { id: SeriesActionID.DELETE, path: ["", "2"] },
+    };
+
+    actionHandler(settings);
+
+    expect(saveConfig).toHaveBeenCalledTimes(1);
+    expect(saveConfig).toHaveBeenCalledWith(expect.any(Function));
+    const updatedConfig = produce(
+      config,
+      (saveConfig as jest.Mock).mock.calls[0][0] as (draft: StateTransitionConfig) => void,
+    );
+    expect(updatedConfig.paths).toHaveLength(2);
+    expect(updatedConfig.paths).toContain(config.paths[0]);
+    expect(updatedConfig.paths).toContain(config.paths[1]);
+    expect(updatedConfig.paths).not.toContain(config.paths[2]);
+  });
+});

--- a/packages/suite-base/src/panels/StateTransitions/usePanelSettings.ts
+++ b/packages/suite-base/src/panels/StateTransitions/usePanelSettings.ts
@@ -30,7 +30,7 @@ import {
   IUsePanelSettings,
   PathState,
   SeriesAction,
-  SeriesActionID,
+  SeriesActionId,
   StateTransitionConfig,
 } from "./types";
 
@@ -56,7 +56,7 @@ export const makeSeriesNode = memoizeWeak(
   ): SettingsTreeNode => {
     const action = setSeriesAction({
       label: t("labels.deleteSeries"),
-      id: SeriesActionID.DELETE,
+      id: SeriesActionId.DELETE,
       icon: "Clear",
     });
     return {
@@ -126,7 +126,7 @@ export const makeRootSeriesNode = memoizeWeak(
       actions: [
         setSeriesAction({
           label: t("labels.addSeries"),
-          id: SeriesActionID.ADD,
+          id: SeriesActionId.ADD,
           icon: "Addchart",
         }),
       ],
@@ -224,7 +224,7 @@ export function usePanelSettings(
       }
 
       if (action === "perform-node-action") {
-        if (payload.id === SeriesActionID.ADD) {
+        if (payload.id === SeriesActionId.ADD) {
           saveConfig(
             produce((draft: StateTransitionConfig) => {
               if (draft.paths.length === 0) {
@@ -233,7 +233,7 @@ export function usePanelSettings(
               draft.paths.push({ ...DEFAULT_STATE_TRANSITION_PATH });
             }),
           );
-        } else if (payload.id === SeriesActionID.DELETE) {
+        } else if (payload.id === SeriesActionId.DELETE) {
           const index = payload.path[1];
           saveConfig(
             produce((draft) => {

--- a/packages/suite-base/src/panels/StateTransitions/usePanelSettings.ts
+++ b/packages/suite-base/src/panels/StateTransitions/usePanelSettings.ts
@@ -12,179 +12,194 @@ import memoizeWeak from "memoize-weak";
 import { useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
-import { SettingsTreeAction, SettingsTreeNode, SettingsTreeNodes } from "@lichtblick/suite";
-import { plotableRosTypes } from "@lichtblick/suite-base/panels/Plot/plotableRosTypes";
+import {
+  SettingsTreeAction,
+  SettingsTreeField,
+  SettingsTreeNode,
+  SettingsTreeNodeActionItem,
+  SettingsTreeNodes,
+} from "@lichtblick/suite";
+import { PLOTABLE_ROS_TYPES } from "@lichtblick/suite-base/panels/Plot/plotableRosTypes";
 import { DEFAULT_STATE_TRANSITION_PATH } from "@lichtblick/suite-base/panels/StateTransitions/constants";
 import { usePanelSettingsTreeUpdate } from "@lichtblick/suite-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@lichtblick/suite-base/types/panels";
 
 import { stateTransitionPathDisplayName } from "./shared";
-import { StateTransitionConfig, StateTransitionPath } from "./types";
+import {
+  AxisTreeField,
+  IUsePanelSettings,
+  PathState,
+  SeriesAction,
+  SeriesActionID,
+  StateTransitionConfig,
+} from "./types";
 
 // Note - we use memoizeWeak here instead of react memoization to allow us to memoize
 // at the level of individual nodes in our tree. This keeps our DOM updates small since
 // the NodeEditor component is wrapped in a React.memo.
 
-export type PathState = {
-  path: StateTransitionPath;
-  // Whether the data the path refers to resolves to more than one value
-  isArray: boolean;
-};
-const makeSeriesNode = memoizeWeak(
+export function setSeriesAction({ label, icon, id }: SeriesAction): SettingsTreeNodeActionItem {
+  return {
+    display: "inline",
+    icon,
+    id,
+    label,
+    type: "action",
+  };
+}
+
+export const makeSeriesNode = memoizeWeak(
   (
     index: number,
     { path, canDelete, isArray }: PathState & { canDelete: boolean },
+    t: TFunction<"stateTransitions">,
   ): SettingsTreeNode => {
+    const action = setSeriesAction({
+      label: t("labels.deleteSeries"),
+      id: SeriesActionID.DELETE,
+      icon: "Clear",
+    });
     return {
-      actions: canDelete
-        ? [
-            {
-              type: "action",
-              id: "delete-series",
-              label: "Delete series",
-              display: "inline",
-              icon: "Clear",
-            },
-          ]
-        : [],
+      actions: canDelete ? [action] : [],
       label: stateTransitionPathDisplayName(path, index),
       fields: {
         value: {
-          label: "Message path",
+          ...(isArray ? { error: t("pathErrorMessage") } : {}),
           input: "messagepath",
+          label: t("labels.messagePath"),
+          validTypes: PLOTABLE_ROS_TYPES,
           value: path.value,
-          validTypes: plotableRosTypes,
-          ...(isArray ? { error: "This path resolves to more than one value" } : {}),
         },
         label: {
           input: "string",
-          label: "Label",
+          label: t("labels.label"),
           value: path.label,
         },
         timestampMethod: {
           input: "select",
-          label: "Timestamp",
-          value: path.timestampMethod,
+          label: t("labels.timestamp"),
           options: [
-            { label: "Receive Time", value: "receiveTime" },
-            { label: "Header Stamp", value: "headerStamp" },
+            { label: t("labels.timestampReceiveTime"), value: "receiveTime" },
+            { label: t("labels.timestampHeaderStamp"), value: "headerStamp" },
           ],
+          value: path.timestampMethod,
         },
       },
     };
   },
 );
 
-const makeRootSeriesNode = memoizeWeak((paths: PathState[]): SettingsTreeNode => {
-  const children = Object.fromEntries(
-    paths.length === 0
-      ? [
-          [
-            "0",
-            makeSeriesNode(0, {
-              path: DEFAULT_STATE_TRANSITION_PATH,
-              isArray: false,
-              canDelete: false,
-            }),
-          ],
-        ]
-      : paths.map(({ path, isArray }, index) => [
-          `${index}`,
-          makeSeriesNode(index, {
-            path,
-            isArray,
-            canDelete: true,
-          }),
-        ]),
-  );
-  return {
-    label: "Series",
-    children,
-    actions: [
-      {
-        type: "action",
-        id: "add-series",
-        label: "Add series",
-        display: "inline",
-        icon: "Addchart",
-      },
-    ],
-  };
-});
+export const makeRootSeriesNode = memoizeWeak(
+  (paths: PathState[], t: TFunction<"stateTransitions">): SettingsTreeNode => {
+    const children = Object.fromEntries(
+      paths.length === 0
+        ? [
+            [
+              "0",
+              makeSeriesNode(
+                0,
+                {
+                  path: DEFAULT_STATE_TRANSITION_PATH,
+                  isArray: false,
+                  canDelete: false,
+                },
+                t,
+              ),
+            ],
+          ]
+        : paths.map(({ path, isArray }, index) => [
+            `${index}`,
+            makeSeriesNode(
+              index,
+              {
+                path,
+                isArray,
+                canDelete: true,
+              },
+              t,
+            ),
+          ]),
+    );
+    return {
+      label: t("labels.series"),
+      children,
+      actions: [
+        setSeriesAction({
+          label: t("labels.addSeries"),
+          id: SeriesActionID.ADD,
+          icon: "Addchart",
+        }),
+      ],
+    };
+  },
+);
 
-function buildSettingsTree(
-  config: StateTransitionConfig,
+export function buildSettingsTree(
+  { isSynced, xAxisMaxValue, xAxisMinValue, xAxisRange, showPoints }: StateTransitionConfig,
   paths: PathState[],
   t: TFunction<"stateTransitions">,
 ): SettingsTreeNodes {
   const maxXError =
-    _.isNumber(config.xAxisMinValue) &&
-    _.isNumber(config.xAxisMaxValue) &&
-    config.xAxisMinValue >= config.xAxisMaxValue
+    _.isNumber(xAxisMinValue) && _.isNumber(xAxisMaxValue) && xAxisMinValue >= xAxisMaxValue
       ? t("maxXError")
       : undefined;
 
+  function setAxis({ value, label, error = undefined }: AxisTreeField): SettingsTreeField {
+    return {
+      label,
+      input: "number",
+      value,
+      placeholder: "auto",
+      error,
+    };
+  }
+
   return {
     general: {
-      label: "General",
+      label: t("labels.general"),
       fields: {
-        isSynced: { label: "Sync with other plots", input: "boolean", value: config.isSynced },
+        isSynced: { label: t("labels.sync"), input: "boolean", value: isSynced },
         showPoints: {
-          label: "Show points",
+          help: t("labels.helpGeneral"),
           input: "boolean",
-          value: config.showPoints,
-          help: "Display a point for every state transition message",
+          label: t("labels.showPoints"),
+          value: showPoints,
         },
       },
     },
     xAxis: {
       label: t("xAxis"),
       fields: {
-        xAxisMinValue: {
-          label: t("min"),
-          input: "number",
-          value: config.xAxisMinValue != undefined ? Number(config.xAxisMinValue) : undefined,
-          placeholder: "auto",
-        },
-        xAxisMaxValue: {
-          label: t("max"),
-          input: "number",
-          error: maxXError,
-          value: config.xAxisMaxValue != undefined ? Number(config.xAxisMaxValue) : undefined,
-          placeholder: "auto",
-        },
-        xAxisRange: {
-          label: t("secondsRange"),
-          input: "number",
-          placeholder: "auto",
-          value: config.xAxisRange,
-        },
+        xAxisMaxValue: setAxis({ label: t("max"), value: xAxisMaxValue, error: maxXError }),
+        xAxisMinValue: setAxis({ label: t("min"), value: xAxisMinValue }),
+        xAxisRange: setAxis({ label: t("secondsRange"), value: xAxisRange }),
       },
     },
-    paths: makeRootSeriesNode(paths),
+    paths: makeRootSeriesNode(paths, t),
   };
 }
 
-export function useStateTransitionsPanelSettings(
+export function usePanelSettings(
   config: StateTransitionConfig,
   saveConfig: SaveConfig<StateTransitionConfig>,
   paths: PathState[],
   focusedPath?: readonly string[],
-): void {
+): IUsePanelSettings {
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
   const { t } = useTranslation("stateTransitions");
 
   const actionHandler = useCallback(
-    (action: SettingsTreeAction) => {
-      if (action.action === "update") {
-        const { input, path, value } = action.payload;
+    ({ action, payload }: SettingsTreeAction) => {
+      if (action === "update") {
+        const { input, path, value } = payload;
+
         if (input === "boolean" && _.isEqual(path, ["general", "isSynced"])) {
           saveConfig({ isSynced: value });
         } else if (input === "boolean" && _.isEqual(path, ["general", "showPoints"])) {
           saveConfig({ showPoints: value });
         } else if (path[0] === "xAxis") {
           saveConfig(
-            produce((draft) => {
+            produce((draft: StateTransitionConfig) => {
               _.set(draft, path.slice(1), value);
 
               // X min/max and range are mutually exclusive.
@@ -198,7 +213,7 @@ export function useStateTransitionsPanelSettings(
           );
         } else {
           saveConfig(
-            produce((draft: StateTransitionConfig): void => {
+            produce((draft: StateTransitionConfig) => {
               if (draft.paths.length === 0) {
                 draft.paths.push({ ...DEFAULT_STATE_TRANSITION_PATH });
               }
@@ -208,18 +223,18 @@ export function useStateTransitionsPanelSettings(
         }
       }
 
-      if (action.action === "perform-node-action") {
-        if (action.payload.id === "add-series") {
+      if (action === "perform-node-action") {
+        if (payload.id === SeriesActionID.ADD) {
           saveConfig(
-            produce((draft) => {
+            produce((draft: StateTransitionConfig) => {
               if (draft.paths.length === 0) {
                 draft.paths.push({ ...DEFAULT_STATE_TRANSITION_PATH });
               }
               draft.paths.push({ ...DEFAULT_STATE_TRANSITION_PATH });
             }),
           );
-        } else if (action.payload.id === "delete-series") {
-          const index = action.payload.path[1];
+        } else if (payload.id === SeriesActionID.DELETE) {
+          const index = payload.path[1];
           saveConfig(
             produce((draft) => {
               draft.paths.splice(Number(index), 1);
@@ -238,4 +253,6 @@ export function useStateTransitionsPanelSettings(
       nodes: buildSettingsTree(config, paths, t),
     });
   }, [actionHandler, paths, config, focusedPath, t, updatePanelSettingsTree]);
+
+  return { actionHandler };
 }

--- a/packages/suite-base/src/players/UserScriptPlayer/transformerWorker/transform.ts
+++ b/packages/suite-base/src/players/UserScriptPlayer/transformerWorker/transform.ts
@@ -79,7 +79,6 @@ export const getInputTopics = (scriptData: ScriptData): ScriptData => {
 
   const inputsExport = typeChecker
     .getExportsOfModule(symbol)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
     .find((node) => node.escapedName === "inputs");
   if (!inputsExport) {
     const error: Diagnostic = {

--- a/packages/suite-base/src/players/UserScriptPlayer/transformerWorker/typescript/ast.ts
+++ b/packages/suite-base/src/players/UserScriptPlayer/transformerWorker/typescript/ast.ts
@@ -156,7 +156,6 @@ export const findDefaultExportFunction = (
 
   const defaultExportSymbol = checker
     .getExportsOfModule(symbol)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
     .find((node) => node.escapedName === "default");
   if (!defaultExportSymbol) {
     throw new DatatypeExtractionError(noFuncError);
@@ -455,7 +454,6 @@ export const constructDatatypes = (
         // One solution could potentially to 'cast' this node as an
         // ArrayTypeNode and recurse. Opting out of using 'Array' keyword for
         // now.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
         if (nextSymbol?.escapedName === "Array") {
           throw new DatatypeExtractionError(preferArrayLiteral);
         }

--- a/packages/suite-base/src/screens/LaunchPreference.tsx
+++ b/packages/suite-base/src/screens/LaunchPreference.tsx
@@ -36,10 +36,9 @@ export function LaunchPreference(props: PropsWithChildren): JSX.Element {
 
   const hasParams = Array.from(url.searchParams.entries()).length > 0;
   // Ask the user in which environment they want to open this session.
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+
   if (activePreference === LaunchPreferenceValue.ASK && hasParams) {
     return <LaunchPreferenceScreen />;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
   } else if (activePreference === LaunchPreferenceValue.DESKTOP && hasParams) {
     return <LaunchingInDesktopScreen />;
   } else {


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**
- Renamed file from settings.ts to usePanelSettings.ts (w/ git mv)
- Renamed hook from useStateTransitionsPanelSettings to useStatePanelSettings
- Implemented unit tests for usePanelSettings 
- Created an enum to identify the actions of the series (SeriesActionId.ADD/DELETE). 
- An exception rule in eslint was added to allow enum comparison.
- Used i18 in the usePanelSettings.ts


**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
