### PR TITLE
[FIX] License type badge fix on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/lichtblick-suite/lichtblick/issues"><img src="https://img.shields.io/github/issues/lichtblick-suite/lichtblick" alt="Issues Badge"/></a>
   <a href="https://github.com/lichtblick-suite/lichtblick/issues"><img src="https://img.shields.io/github/package-json/v/lichtblick-suite/lichtblick" alt="Versions Badge"/></a>
   <a href="https://github.com/lichtblick-suite/lichtblick/graphs/contributors"><img alt="GitHub contributors" src="https://img.shields.io/github/contributors/lichtblick-suite/lichtblick?color=2b9348"></a>
- <img alt="GitHub License" src="https://img.shields.io/github/license/lichtblick-suite/lichtblick">
+  <a href="https://opensource.org/licenses/MPL-2.0"><img src="https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg" alt="License: MPL 2.0"></a>
 
   <br />
 <p  align="center">


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**
Fixed HTML badge referring to the type of license, is showing as "not identifiable by github" right now on:
https://github.com/Lichtblick-Suite/lichtblick?tab=readme-ov-file#lichtblick


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
