### PR TITLE
[FIX] 3D panel camera sync functionality

### DIFF
--- a/packages/suite-base/src/context/CurrentLayoutContext/index.ts
+++ b/packages/suite-base/src/context/CurrentLayoutContext/index.ts
@@ -40,6 +40,8 @@ export type { LayoutData };
 
 export type SharedPanelState = RenderState["sharedPanelState"];
 
+export type UpdatePanelState = (type: PanelType, data: SharedPanelState) => void;
+
 export type SelectedLayout = {
   data: LayoutData | undefined;
   name?: string;
@@ -101,7 +103,7 @@ export interface ICurrentLayout {
     /**
      * Update the transient state associated with a particular panel type.
      */
-    updateSharedPanelState: (type: PanelType, data: SharedPanelState) => void;
+    updateSharedPanelState: UpdatePanelState;
 
     savePanelConfigs: (payload: SaveConfigsPayload) => void;
     updatePanelConfigs: (panelType: string, updater: (config: PanelConfig) => PanelConfig) => void;

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/hooks/useUpdateSharedPanelState.test.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/hooks/useUpdateSharedPanelState.test.ts
@@ -49,9 +49,9 @@ describe("useUpdateSharedPanelState", () => {
       configById: {},
       layout: undefined,
       globalVariables: {},
-      playbackConfig: { speed: 1 },
+      playbackConfig: { speed: BasicBuilder.number() },
       userNodes: {},
-      version: 1,
+      version: BasicBuilder.number(),
     };
 
     const { result } = renderHook(() => useUpdateSharedPanelState(layoutStateRef, setLayoutState));

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/hooks/useUpdateSharedPanelState.test.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/hooks/useUpdateSharedPanelState.test.ts
@@ -28,10 +28,10 @@ describe("useUpdateSharedPanelState", () => {
     },
   };
 
-  let setLayoutState: jest.Mock;
+  const setLayoutState = jest.fn();
 
   beforeEach(() => {
-    setLayoutState = jest.fn();
+    jest.clearAllMocks();
   });
 
   it("does not update state if selectedLayout.data is undefined", () => {

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/hooks/useUpdateSharedPanelState.test.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/hooks/useUpdateSharedPanelState.test.ts
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { renderHook, act } from "@testing-library/react";
+import { MutableRefObject } from "react";
+
+import { LayoutState, LayoutID } from "@lichtblick/suite-base/context/CurrentLayoutContext";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+
+import useUpdateSharedPanelState from "./useUpdateSharedPanelState";
+
+describe("useUpdateSharedPanelState", () => {
+  let mockLayoutStateRef: MutableRefObject<LayoutState>;
+  let mockSetLayoutState: jest.Mock;
+
+  beforeEach(() => {
+    // Set up the initial layout state ref and the mock function for setLayoutState
+    mockSetLayoutState = jest.fn();
+
+    mockLayoutStateRef = {
+      current: {
+        sharedPanelState: {},
+        selectedLayout: {
+          id: BasicBuilder.string() as LayoutID,
+          loading: BasicBuilder.boolean(),
+          data: undefined,
+          name: BasicBuilder.string(),
+          edited: BasicBuilder.boolean(),
+        },
+      },
+    };
+  });
+
+  it("does not update state if selectedLayout.data is undefined", () => {
+
+    const { result } = renderHook(() =>
+      useUpdateSharedPanelState(mockLayoutStateRef, mockSetLayoutState),
+    );
+
+    // Call updateSharedPanelState with sample data
+    act(() => {
+      result.current.updateSharedPanelState("testType", { someKey: "someValue" });
+    });
+
+    // Expect setLayoutState not to have been called because selectedLayout.data is undefined
+    expect(mockSetLayoutState).not.toHaveBeenCalled();
+  });
+});

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/hooks/useUpdateSharedPanelState.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/hooks/useUpdateSharedPanelState.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { MutableRefObject, useCallback } from "react";
+
+import {
+  ICurrentLayout,
+  LayoutState,
+  UpdatePanelState,
+} from "@lichtblick/suite-base/context/CurrentLayoutContext";
+
+type UseUpdateSharedPanelStateReturn = {
+  updateSharedPanelState: UpdatePanelState;
+};
+
+const useUpdateSharedPanelState = (
+  layoutStateRef: MutableRefObject<Readonly<LayoutState>>,
+  setLayoutState: (state: LayoutState) => void,
+): UseUpdateSharedPanelStateReturn => {
+  const updateSharedPanelState = useCallback<ICurrentLayout["actions"]["updateSharedPanelState"]>(
+    (type, newSharedState) => {
+      if (layoutStateRef.current.selectedLayout?.data == undefined) {
+        return;
+      }
+
+      setLayoutState({
+        ...layoutStateRef.current,
+        sharedPanelState: { ...layoutStateRef.current.sharedPanelState, [type]: newSharedState },
+      });
+    },
+    [setLayoutState, layoutStateRef],
+  );
+  return { updateSharedPanelState };
+};
+
+export default useUpdateSharedPanelState;

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -296,9 +296,23 @@ export default function CurrentLayoutProvider({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getUserProfile, layoutManager, setSelectedLayoutId]);
 
+  const updateSharedPanelState = useCallback<ICurrentLayout["actions"]["updateSharedPanelState"]>(
+    (type, newSharedState) => {
+      if (layoutStateRef.current.selectedLayout?.data == undefined) {
+        return;
+      }
+
+      setLayoutState({
+        ...layoutStateRef.current,
+        sharedPanelState: { ...layoutStateRef.current.sharedPanelState, [type]: newSharedState },
+      });
+    },
+    [setLayoutState],
+  );
+
   const actions: ICurrentLayout["actions"] = useMemo(
     () => ({
-      updateSharedPanelState: () => {},
+      updateSharedPanelState,
       setCurrentLayout: () => {},
       setSelectedLayoutId,
       getCurrentLayoutState: () => layoutStateRef.current,
@@ -389,7 +403,7 @@ export default function CurrentLayoutProvider({
         performAction({ type: "END_DRAG", payload });
       },
     }),
-    [analytics, performAction, setSelectedLayoutId, setSelectedPanelIds],
+    [analytics, performAction, setSelectedLayoutId, setSelectedPanelIds, updateSharedPanelState],
   );
 
   const value: ICurrentLayout = useShallowMemo({

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -39,6 +39,7 @@ import {
 import { useLayoutManager } from "@lichtblick/suite-base/context/LayoutManagerContext";
 import { useUserProfileStorage } from "@lichtblick/suite-base/context/UserProfileStorageContext";
 import { defaultLayout } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/defaultLayout";
+import useUpdateSharedPanelState from "@lichtblick/suite-base/providers/CurrentLayoutProvider/hooks/useUpdateSharedPanelState";
 import { loadDefaultLayouts } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/loadDefaultLayouts";
 import panelsReducer from "@lichtblick/suite-base/providers/CurrentLayoutProvider/reducers";
 import { AppEvent } from "@lichtblick/suite-base/services/IAnalytics";
@@ -296,19 +297,7 @@ export default function CurrentLayoutProvider({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getUserProfile, layoutManager, setSelectedLayoutId]);
 
-  const updateSharedPanelState = useCallback<ICurrentLayout["actions"]["updateSharedPanelState"]>(
-    (type, newSharedState) => {
-      if (layoutStateRef.current.selectedLayout?.data == undefined) {
-        return;
-      }
-
-      setLayoutState({
-        ...layoutStateRef.current,
-        sharedPanelState: { ...layoutStateRef.current.sharedPanelState, [type]: newSharedState },
-      });
-    },
-    [setLayoutState],
-  );
+  const { updateSharedPanelState } = useUpdateSharedPanelState(layoutStateRef, setLayoutState);
 
   const actions: ICurrentLayout["actions"] = useMemo(
     () => ({


### PR DESCRIPTION
**User-Facing Changes**
The option to sync panels on 3D panel is now operational again. The user can have 2 or more panels synced up and, for instance, by moving the camera on one panel, the other panel will simulate the same behavior while the Camera sync option is activated.

**Description**
After a while of studying the code I realized that problem wasn't on 3D panel itself, all the logic was correct there, but I observed that, no matter what, the sharedPanelState property would stay undefined even with the setter receiving all the correct data.  So seing that problem was on a macro level I started searching and realized on PR #8 some code was removed from the layout provider that served as a way to update the sharedPanelState. I've added that missing code back, code that allowed the updateSharedPanelState to receive the missing data, the panel it was coming from and the properties being passed.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [X] The web version was tested and it is running ok
- [X] The desktop version was tested and it is running ok
- [X] This change is covered by unit tests
- [X] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
