### PR TITLE
Fix toggling of panels by listen only to revert event

### DIFF
--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -215,11 +215,16 @@ export default function CurrentLayoutProvider({
     [setLayoutState],
   );
 
-  // Changes to the layout storage from external user actions (such as resetting a layout to a
-  // previous saved state) need to trigger setLayoutState.
+  /**
+   * Changes to the layout storage from external user actions need to trigger setLayoutState.
+   * Before it was beeing trigged on every change. Now it is triggered only when the layout
+   * is reverted, otherize it has some toggling issues when resizing panels.
+   */
   useEffect(() => {
-    const listener: LayoutManagerEventTypes["change"] = ({ updatedLayout }) => {
+    const listener: LayoutManagerEventTypes["change"] = (event) => {
+      const { updatedLayout } = event;
       if (
+        event.type === "revert" &&
         updatedLayout &&
         layoutStateRef.current.selectedLayout &&
         updatedLayout.id === layoutStateRef.current.selectedLayout.id

--- a/packages/suite-base/src/services/ILayoutManager.ts
+++ b/packages/suite-base/src/services/ILayoutManager.ts
@@ -13,8 +13,7 @@ import { Layout, LayoutPermission } from "@lichtblick/suite-base/services/ILayou
 
 export type LayoutManagerChangeEvent =
   | { type: "delete"; updatedLayout?: undefined; layoutId: LayoutID }
-  | { type: "change"; updatedLayout: Layout | undefined }
-  | { type: "revert"; updatedLayout: Layout | undefined };
+  | { type: "change" | "revert"; updatedLayout: Layout | undefined };
 
 export type LayoutManagerEventTypes = {
   /**

--- a/packages/suite-base/src/services/ILayoutManager.ts
+++ b/packages/suite-base/src/services/ILayoutManager.ts
@@ -13,7 +13,8 @@ import { Layout, LayoutPermission } from "@lichtblick/suite-base/services/ILayou
 
 export type LayoutManagerChangeEvent =
   | { type: "delete"; updatedLayout?: undefined; layoutId: LayoutID }
-  | { type: "change"; updatedLayout: Layout | undefined };
+  | { type: "change"; updatedLayout: Layout | undefined }
+  | { type: "revert"; updatedLayout: Layout | undefined };
 
 export type LayoutManagerEventTypes = {
   /**

--- a/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
@@ -448,7 +448,7 @@ export default class LayoutManager implements ILayoutManager {
         working: undefined,
       });
     });
-    this.#notifyChangeListeners({ type: "change", updatedLayout: result });
+    this.#notifyChangeListeners({ type: "revert", updatedLayout: result });
     return result;
   }
 


### PR DESCRIPTION
**User-Facing Changes**
Users use to experience some toggling in some layouts, which made impossible to use Lichtblick.  

**Description**
The toggling was solved by filtering the "change event" in the CurrentLayoutProvider, and update in that specific moment only if it is a revert action (revert the unsaved modifications on current layout) instead of all changes. For some reason this change event is possibly duplicated and is not necessary in this part.

The tests passed and it was tested manually too. It seems that all functionality regards to the layouts is still working.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
