### PR TITLE
Updating number of blocks in BlockLoader

### DIFF
--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -66,7 +66,7 @@ const MIN_MEM_CACHE_BLOCK_SIZE_NS = 0.1e9;
 // Preloading algorithms slow when there are too many blocks.
 // Adaptive block sizing is simpler than using a tree structure for immutable updates but
 // less flexible, so we may want to move away from a single-level block structure in the future.
-const MAX_BLOCKS = 400;
+const MAX_BLOCKS = 100;
 
 // Amount to seek into the data source from the start when loading the player. The purpose of this
 // is to provide some initial data to subscribers.


### PR DESCRIPTION
**User-Facing Changes**
Users will see a substantially decrease on loading times for when the data from a file is loaded.

**Description**

To conduct a small study on how BlockLoader performs with different MAX_BLOCKS values, I decided to create several test cases, each with 30 samples.

I began by testing with the initial value of 400 MAX_BLOCKS, which took, on average, 6.5 seconds for BlockLoader to load all the chunks of data. Following a recommendation from a previous study on this topic, I then adjusted the MAX_BLOCKS value, starting from 50 and progressively testing 75, 100, and 150.
From my findings setting MAX_BLOCKS to 100 reduced the loading time, on average, by 60% and kept the user experience smooth.

All this test cases were done using the same Lichtblick version, same file and same layout.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
