### PR TITLE
Add memory estimation feature option back

### DIFF
--- a/packages/suite-base/src/components/AppBar/index.tsx
+++ b/packages/suite-base/src/components/AppBar/index.tsx
@@ -39,6 +39,9 @@ import { AppMenu } from "./AppMenu";
 import { CustomWindowControls, CustomWindowControlsProps } from "./CustomWindowControls";
 import { DataSource } from "./DataSource";
 import { SettingsMenu } from "./SettingsMenu";
+import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks";
+import { AppSetting } from "@lichtblick/suite-base/AppSetting";
+import { MemoryUseIndicator } from "@lichtblick/suite-base/components/MemoryUseIndicator";
 
 const useStyles = makeStyles<{ debugDragRegion?: boolean }, "avatar">()((
   theme,
@@ -175,6 +178,9 @@ export function AppBar(props: AppBarProps): React.JSX.Element {
   const { t } = useTranslation("appBar");
 
   const { appBarLayoutButton } = useAppContext();
+  const [enableMemoryUseIndicator = false] = useAppConfigurationValue<boolean>(
+    AppSetting.ENABLE_MEMORY_USE_INDICATOR,
+  );
 
   const hasCurrentLayout = useCurrentLayoutSelector(selectHasCurrentLayout);
 
@@ -251,6 +257,7 @@ export function AppBar(props: AppBarProps): React.JSX.Element {
 
           <div className={classes.end}>
             <div className={classes.endInner}>
+              {enableMemoryUseIndicator && <MemoryUseIndicator />}
               {appBarLayoutButton}
               <Stack direction="row" alignItems="center" data-tourid="sidebar-button-group">
                 <AppBarIconButton

--- a/packages/suite-base/src/components/AppBar/index.tsx
+++ b/packages/suite-base/src/components/AppBar/index.tsx
@@ -19,7 +19,9 @@ import { useTranslation } from "react-i18next";
 import tc from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
 
+import { AppSetting } from "@lichtblick/suite-base/AppSetting";
 import { LichtblickLogo } from "@lichtblick/suite-base/components/LichtblickLogo";
+import { MemoryUseIndicator } from "@lichtblick/suite-base/components/MemoryUseIndicator";
 import Stack from "@lichtblick/suite-base/components/Stack";
 import { useAppContext } from "@lichtblick/suite-base/context/AppContext";
 import {
@@ -31,6 +33,7 @@ import {
   useWorkspaceStore,
 } from "@lichtblick/suite-base/context/Workspace/WorkspaceContext";
 import { useWorkspaceActions } from "@lichtblick/suite-base/context/Workspace/useWorkspaceActions";
+import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks";
 
 import { AddPanelMenu } from "./AddPanelMenu";
 import { AppBarContainer } from "./AppBarContainer";
@@ -39,9 +42,6 @@ import { AppMenu } from "./AppMenu";
 import { CustomWindowControls, CustomWindowControlsProps } from "./CustomWindowControls";
 import { DataSource } from "./DataSource";
 import { SettingsMenu } from "./SettingsMenu";
-import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks";
-import { AppSetting } from "@lichtblick/suite-base/AppSetting";
-import { MemoryUseIndicator } from "@lichtblick/suite-base/components/MemoryUseIndicator";
 
 const useStyles = makeStyles<{ debugDragRegion?: boolean }, "avatar">()((
   theme,

--- a/packages/suite-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/suite-base/src/components/ExperimentalFeatureSettings.tsx
@@ -48,6 +48,11 @@ function useFeatures(): Feature[] {
       name: t("newAppMenu"),
       description: <>{t("newAppMenuDescription")}</>,
     },
+    {
+      key: AppSetting.ENABLE_MEMORY_USE_INDICATOR,
+      name: t("memoryUseIndicator"),
+      description: <>{t("memoryUseIndicatorDescription")}</>,
+    },
   ];
 
   if (process.env.NODE_ENV === "development") {
@@ -57,7 +62,6 @@ function useFeatures(): Feature[] {
       description: <>{t("layoutDebuggingDescription")}</>,
     });
   }
-
   return features;
 }
 

--- a/packages/suite-base/src/i18n/en/appSettings.ts
+++ b/packages/suite-base/src/i18n/en/appSettings.ts
@@ -24,6 +24,8 @@ export const appSettings = {
   layoutDebuggingDescription: "Show extra controls for developing and debugging layout storage.",
   light: "Light",
   messageRate: "Message rate",
+  memoryUseIndicator: "Memory use indicator",
+  memoryUseIndicatorDescription: "Show the app memory use in the sidebar.",
   newAppMenu: "Enable unified navigation",
   newAppMenuDescription: "Show the new menu and navigation.",
   noExperimentalFeatures: "Currently there are no experimental features.",


### PR DESCRIPTION
**User-Facing Changes**

The memory estimation was disabled in the past and we are puttiing it back again. It can be used by accessing visualization settings>experimental features:

![image](https://github.com/user-attachments/assets/5b84f988-8381-4d1a-8b0d-3771a6554203)


When enabling it, a small memory panel is being displayed at the top right of the application:

![image](https://github.com/user-attachments/assets/372fa3a9-a24f-4a65-a017-ff4a3c220a11)

**Description**
This PR aims to put back again the memory estimation by adding the code that was present on previous versions of Foxglove

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests