### PR TITLE
Fix outdated files to run Storybooks correctly

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,7 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { GlobalStyles } from "@mui/material";
-import { Story, StoryContext } from "@storybook/react";
+import { StoryContext, StoryFn } from "@storybook/react";
 import { useMemo, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -166,7 +166,7 @@ function StudioContextProviders({
   );
 }
 
-function WithContextProviders(Child: Story, ctx: StoryContext): React.JSX.Element {
+function WithContextProviders(Child: StoryFn, ctx: StoryContext): React.JSX.Element {
   if (
     (ctx.parameters.fileName as string).includes("/packages/suite-base/") ||
     (ctx.parameters.fileName as string).includes("/packages/theme/")
@@ -192,7 +192,7 @@ function WithI18n({
   return <>{children}</>;
 }
 
-function WithI18nUnlessDisabled(Child: Story, ctx: StoryContext): React.JSX.Element {
+function WithI18nUnlessDisabled(Child: StoryFn, ctx: StoryContext): React.JSX.Element {
   const { disableI18n = false }: { disableI18n?: boolean } = ctx.parameters;
   if (disableI18n) {
     return <Child />;


### PR DESCRIPTION
**Description**

This small change aims to fix the bug when running `yarn run storybook `.
 It was not running correctly cause some files were still using the @deprecated type Story instead of StoryFn.
