### PR TITLE
Read CLI parameters

### DIFF
--- a/packages/suite-base/src/App.test.tsx
+++ b/packages/suite-base/src/App.test.tsx
@@ -21,6 +21,7 @@ import NativeWindowContext, {
   INativeWindow,
 } from "@lichtblick/suite-base/context/NativeWindowContext";
 import { UserScriptStateProvider } from "@lichtblick/suite-base/context/UserScriptStateContext";
+import AppParametersProvider from "@lichtblick/suite-base/providers/AppParametersProvider";
 import CurrentLayoutProvider from "@lichtblick/suite-base/providers/CurrentLayoutProvider";
 import EventsProvider from "@lichtblick/suite-base/providers/EventsProvider";
 import ExtensionCatalogProvider from "@lichtblick/suite-base/providers/ExtensionCatalogProvider";
@@ -30,8 +31,9 @@ import ProblemsContextProvider from "@lichtblick/suite-base/providers/ProblemsCo
 import { StudioLogsSettingsProvider } from "@lichtblick/suite-base/providers/StudioLogsSettingsProvider";
 import TimelineInteractionStateProvider from "@lichtblick/suite-base/providers/TimelineInteractionStateProvider";
 import UserProfileLocalStorageProvider from "@lichtblick/suite-base/providers/UserProfileLocalStorageProvider";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
 
-import { App } from "./App";
+import { App, AppProps } from "./App";
 import Workspace from "./Workspace";
 
 function mockProvider(testId: string) {
@@ -41,6 +43,7 @@ function mockProvider(testId: string) {
 // Mocking shared providers and components
 jest.mock("./providers/LayoutManagerProvider", () => mockProvider("layout-manager-provider"));
 jest.mock("./providers/PanelCatalogProvider", () => mockProvider("panel-catalog-provider"));
+jest.mock("./providers/AppParametersProvider", () => mockProvider("app-parameters-provider"));
 jest.mock("./components/MultiProvider", () => mockProvider("multi-provider"));
 jest.mock("./components/StudioToastProvider", () => mockProvider("studio-toast-provider"));
 jest.mock("./components/GlobalCss", () => mockProvider("global-css"));
@@ -70,8 +73,9 @@ const mockAppConfiguration: IAppConfiguration = {
 };
 
 // Helper to render the App with default props
-const setup = (overrides: Partial<React.ComponentProps<typeof App>> = {}) => {
-  const defaultProps = {
+const setup = (overrides: Partial<AppProps> = {}) => {
+  const defaultProps: AppProps = {
+    appParameters: {},
     appConfiguration: mockAppConfiguration,
     deepLinks: [],
     dataSources: [],
@@ -89,6 +93,7 @@ describe("App Component", () => {
 
   it("renders without crashing", () => {
     setup();
+    expect(screen.getByTestId("app-parameters-provider")).toBeDefined();
     expect(screen.getByTestId("color-scheme-theme")).toBeDefined();
     expect(screen.getByTestId("css-baseline")).toBeDefined();
     expect(screen.getByTestId("error-boundary")).toBeDefined();
@@ -186,6 +191,19 @@ describe("App Component MultiProvider Tests", () => {
     expectedProviders.forEach((provider) => {
       expect(extractProviderTypes()).toContain(provider);
     });
+  });
+
+  it("verifies that AppParametersProvider is called with correct parameters", () => {
+    const appParameters = {
+      [BasicBuilder.string()]: BasicBuilder.string(),
+      [BasicBuilder.string()]: BasicBuilder.string(),
+      [BasicBuilder.string()]: BasicBuilder.string(),
+    };
+    setup({ appParameters });
+    expect(screen.getByTestId("app-parameters-provider")).toBeDefined();
+
+    const props = (AppParametersProvider as jest.Mock).mock.calls[0][0];
+    expect(props.appParameters).toBe(appParameters);
   });
 
   it("verifies that MultiProvider has rendered all providers when its nativeApp", () => {

--- a/packages/suite-base/src/App.tsx
+++ b/packages/suite-base/src/App.tsx
@@ -108,10 +108,6 @@ export function App(props: AppProps): React.JSX.Element {
     providers.unshift(...extraProviders);
   }
 
-  // The toast and logs provider comes first so they are available to all downstream providers
-  providers.unshift(<StudioToastProvider />);
-  providers.unshift(<StudioLogsSettingsProvider />);
-
   // Problems provider also must come before other, dependent contexts.
   providers.unshift(<ProblemsContextProvider />);
   providers.unshift(<CurrentLayoutProvider loaders={layoutLoaders} />);
@@ -120,6 +116,10 @@ export function App(props: AppProps): React.JSX.Element {
 
   const layoutStorage = useMemo(() => new IdbLayoutStorage(), []);
   providers.unshift(<LayoutStorageContext.Provider value={layoutStorage} />);
+
+  // The toast and logs provider comes first so they are available to all downstream providers
+  providers.unshift(<StudioToastProvider />);
+  providers.unshift(<StudioLogsSettingsProvider />);
 
   const MaybeLaunchPreference = enableLaunchPreferenceScreen === true ? LaunchPreference : Fragment;
 

--- a/packages/suite-base/src/App.tsx
+++ b/packages/suite-base/src/App.tsx
@@ -11,7 +11,7 @@ import { HTML5Backend } from "react-dnd-html5-backend";
 
 import { IdbLayoutStorage } from "@lichtblick/suite-base/IdbLayoutStorage";
 import GlobalCss from "@lichtblick/suite-base/components/GlobalCss";
-import { AppParameters } from "@lichtblick/suite-base/context/AppParametersContext";
+import { AppParametersInput } from "@lichtblick/suite-base/context/AppParametersContext";
 import LayoutStorageContext from "@lichtblick/suite-base/context/LayoutStorageContext";
 import { UserScriptStateProvider } from "@lichtblick/suite-base/context/UserScriptStateContext";
 import AppParametersProvider from "@lichtblick/suite-base/providers/AppParametersProvider";
@@ -46,7 +46,7 @@ import { ExtensionLoader } from "./services/ExtensionLoader";
 
 export type AppProps = CustomWindowControlsProps & {
   appConfiguration: IAppConfiguration;
-  appParameters: AppParameters;
+  appParameters: AppParametersInput;
   dataSources: IDataSourceFactory[];
   deepLinks: string[];
   extensionLoaders: readonly ExtensionLoader[];

--- a/packages/suite-base/src/App.tsx
+++ b/packages/suite-base/src/App.tsx
@@ -11,8 +11,10 @@ import { HTML5Backend } from "react-dnd-html5-backend";
 
 import { IdbLayoutStorage } from "@lichtblick/suite-base/IdbLayoutStorage";
 import GlobalCss from "@lichtblick/suite-base/components/GlobalCss";
+import { AppParameters } from "@lichtblick/suite-base/context/AppParametersContext";
 import LayoutStorageContext from "@lichtblick/suite-base/context/LayoutStorageContext";
 import { UserScriptStateProvider } from "@lichtblick/suite-base/context/UserScriptStateContext";
+import AppParametersProvider from "@lichtblick/suite-base/providers/AppParametersProvider";
 import EventsProvider from "@lichtblick/suite-base/providers/EventsProvider";
 import LayoutManagerProvider from "@lichtblick/suite-base/providers/LayoutManagerProvider";
 import ProblemsContextProvider from "@lichtblick/suite-base/providers/ProblemsContextProvider";
@@ -42,10 +44,11 @@ import PanelCatalogProvider from "./providers/PanelCatalogProvider";
 import { LaunchPreference } from "./screens/LaunchPreference";
 import { ExtensionLoader } from "./services/ExtensionLoader";
 
-type AppProps = CustomWindowControlsProps & {
-  deepLinks: string[];
+export type AppProps = CustomWindowControlsProps & {
   appConfiguration: IAppConfiguration;
+  appParameters: AppParameters;
   dataSources: IDataSourceFactory[];
+  deepLinks: string[];
   extensionLoaders: readonly ExtensionLoader[];
   layoutLoaders: readonly LayoutLoader[];
   nativeAppMenu?: INativeAppMenu;
@@ -70,6 +73,7 @@ function contextMenuHandler(event: MouseEvent) {
 export function App(props: AppProps): React.JSX.Element {
   const {
     appConfiguration,
+    appParameters = {},
     dataSources,
     extensionLoaders,
     layoutLoaders,
@@ -128,36 +132,38 @@ export function App(props: AppProps): React.JSX.Element {
 
   return (
     <AppConfigurationContext.Provider value={appConfiguration}>
-      <ColorSchemeThemeProvider>
-        {enableGlobalCss && <GlobalCss />}
-        <CssBaseline>
-          <ErrorBoundary>
-            <MaybeLaunchPreference>
-              <MultiProvider providers={providers}>
-                <DocumentTitleAdapter />
-                <SendNotificationToastAdapter />
-                <DndProvider backend={HTML5Backend}>
-                  <Suspense fallback={<></>}>
-                    <PanelCatalogProvider>
-                      <Workspace
-                        deepLinks={deepLinks}
-                        appBarLeftInset={props.appBarLeftInset}
-                        onAppBarDoubleClick={props.onAppBarDoubleClick}
-                        showCustomWindowControls={props.showCustomWindowControls}
-                        isMaximized={props.isMaximized}
-                        onMinimizeWindow={props.onMinimizeWindow}
-                        onMaximizeWindow={props.onMaximizeWindow}
-                        onUnmaximizeWindow={props.onUnmaximizeWindow}
-                        onCloseWindow={props.onCloseWindow}
-                      />
-                    </PanelCatalogProvider>
-                  </Suspense>
-                </DndProvider>
-              </MultiProvider>
-            </MaybeLaunchPreference>
-          </ErrorBoundary>
-        </CssBaseline>
-      </ColorSchemeThemeProvider>
+      <AppParametersProvider appParameters={appParameters}>
+        <ColorSchemeThemeProvider>
+          {enableGlobalCss && <GlobalCss />}
+          <CssBaseline>
+            <ErrorBoundary>
+              <MaybeLaunchPreference>
+                <MultiProvider providers={providers}>
+                  <DocumentTitleAdapter />
+                  <SendNotificationToastAdapter />
+                  <DndProvider backend={HTML5Backend}>
+                    <Suspense fallback={<></>}>
+                      <PanelCatalogProvider>
+                        <Workspace
+                          deepLinks={deepLinks}
+                          appBarLeftInset={props.appBarLeftInset}
+                          onAppBarDoubleClick={props.onAppBarDoubleClick}
+                          showCustomWindowControls={props.showCustomWindowControls}
+                          isMaximized={props.isMaximized}
+                          onMinimizeWindow={props.onMinimizeWindow}
+                          onMaximizeWindow={props.onMaximizeWindow}
+                          onUnmaximizeWindow={props.onUnmaximizeWindow}
+                          onCloseWindow={props.onCloseWindow}
+                        />
+                      </PanelCatalogProvider>
+                    </Suspense>
+                  </DndProvider>
+                </MultiProvider>
+              </MaybeLaunchPreference>
+            </ErrorBoundary>
+          </CssBaseline>
+        </ColorSchemeThemeProvider>
+      </AppParametersProvider>
     </AppConfigurationContext.Provider>
   );
 }

--- a/packages/suite-base/src/AppParameters.ts
+++ b/packages/suite-base/src/AppParameters.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-export enum AppParameters {
+export enum AppParametersEnum {
   // Used to start with a specific layout passed as parameter
   DEFAULT_LAYOUT = "defaultLayout",
 }

--- a/packages/suite-base/src/AppParameters.ts
+++ b/packages/suite-base/src/AppParameters.ts
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+export enum AppParameters {
+  // Used to start with a specific layout passed as parameter
+  DEFAULT_LAYOUT = "defaultLayout",
+}

--- a/packages/suite-base/src/SharedRoot.tsx
+++ b/packages/suite-base/src/SharedRoot.tsx
@@ -10,6 +10,7 @@ import {
   ISharedRootContext,
   SharedRootContext,
 } from "@lichtblick/suite-base/context/SharedRootContext";
+import AppParametersProvider from "@lichtblick/suite-base/providers/AppParametersProvider";
 
 import { ColorSchemeThemeProvider } from "./components/ColorSchemeThemeProvider";
 import CssBaseline from "./components/CssBaseline";
@@ -36,29 +37,31 @@ export function SharedRoot(
 
   return (
     <AppConfigurationContext.Provider value={appConfiguration}>
-      <ColorSchemeThemeProvider>
-        {enableGlobalCss && <GlobalCss />}
-        <CssBaseline>
-          <ErrorBoundary>
-            <SharedRootContext.Provider
-              value={{
-                appBarLeftInset,
-                AppBarComponent,
-                appConfiguration,
-                customWindowControlProps,
-                dataSources,
-                deepLinks,
-                enableLaunchPreferenceScreen,
-                extensionLoaders,
-                extraProviders,
-                onAppBarDoubleClick,
-              }}
-            >
-              {children}
-            </SharedRootContext.Provider>
-          </ErrorBoundary>
-        </CssBaseline>
-      </ColorSchemeThemeProvider>
+      <AppParametersProvider>
+        <ColorSchemeThemeProvider>
+          {enableGlobalCss && <GlobalCss />}
+          <CssBaseline>
+            <ErrorBoundary>
+              <SharedRootContext.Provider
+                value={{
+                  appBarLeftInset,
+                  AppBarComponent,
+                  appConfiguration,
+                  customWindowControlProps,
+                  dataSources,
+                  deepLinks,
+                  enableLaunchPreferenceScreen,
+                  extensionLoaders,
+                  extraProviders,
+                  onAppBarDoubleClick,
+                }}
+              >
+                {children}
+              </SharedRootContext.Provider>
+            </ErrorBoundary>
+          </CssBaseline>
+        </ColorSchemeThemeProvider>
+      </AppParametersProvider>
     </AppConfigurationContext.Provider>
   );
 }

--- a/packages/suite-base/src/context/AppParametersContext.ts
+++ b/packages/suite-base/src/context/AppParametersContext.ts
@@ -8,8 +8,9 @@
 import { createContext, useContext } from "react";
 
 import { Immutable } from "@lichtblick/suite";
+import { AppParametersEnum } from "@lichtblick/suite-base/AppParameters";
 
-export type AppParameters = Readonly<Record<string, string>>;
+export type AppParameters = Readonly<Record<AppParametersEnum | (string & {}), string>>;
 
 export type AppParametersContext = Immutable<AppParameters>;
 

--- a/packages/suite-base/src/context/AppParametersContext.ts
+++ b/packages/suite-base/src/context/AppParametersContext.ts
@@ -23,7 +23,7 @@ export const AppParametersContext = createContext<undefined | AppParametersConte
 export function useAppParameters(): AppParameters {
   const context = useContext(AppParametersContext);
   if (context == undefined) {
-    throw new Error("A AppParameters provider is required to useAppParameters");
+    throw new Error("useAppParameters must be used within a AppParametersProvider");
   }
   return context;
 }

--- a/packages/suite-base/src/context/AppParametersContext.ts
+++ b/packages/suite-base/src/context/AppParametersContext.ts
@@ -10,7 +10,11 @@ import { createContext, useContext } from "react";
 import { Immutable } from "@lichtblick/suite";
 import { AppParametersEnum } from "@lichtblick/suite-base/AppParameters";
 
-export type AppParameters = Readonly<Record<AppParametersEnum | (string & {}), string>>;
+// Defines a type for input parameters, allowing any string keys with string values.
+export type AppParametersInput = Readonly<Record<string, string>>;
+
+// Defines a type for application parameters, restricting keys to the AppParametersEnum for type-safe usage.
+export type AppParameters = Readonly<Record<AppParametersEnum, string>>;
 
 export type AppParametersContext = Immutable<AppParameters>;
 

--- a/packages/suite-base/src/context/AppParametersContext.ts
+++ b/packages/suite-base/src/context/AppParametersContext.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext, useContext } from "react";
+
+import { Immutable } from "@lichtblick/suite";
+
+export type AppParameters = Readonly<Record<string, string>>;
+
+export type AppParametersContext = Immutable<AppParameters>;
+
+export const AppParametersContext = createContext<undefined | AppParametersContext>(undefined);
+
+export function useAppParameters(): AppParameters {
+  const context = useContext(AppParametersContext);
+  if (context == undefined) {
+    throw new Error("A LayoutManager provider is required to useLayoutManager");
+  }
+  return context;
+}

--- a/packages/suite-base/src/context/AppParametersContext.ts
+++ b/packages/suite-base/src/context/AppParametersContext.ts
@@ -14,7 +14,7 @@ import { AppParametersEnum } from "@lichtblick/suite-base/AppParameters";
 export type AppParametersInput = Readonly<Record<string, string>>;
 
 // Defines a type for application parameters, restricting keys to the AppParametersEnum for type-safe usage.
-export type AppParameters = Readonly<Record<AppParametersEnum, string>>;
+export type AppParameters = Readonly<Record<AppParametersEnum, string | undefined>>;
 
 export type AppParametersContext = Immutable<AppParameters>;
 

--- a/packages/suite-base/src/context/AppParametersContext.ts
+++ b/packages/suite-base/src/context/AppParametersContext.ts
@@ -18,7 +18,7 @@ export const AppParametersContext = createContext<undefined | AppParametersConte
 export function useAppParameters(): AppParameters {
   const context = useContext(AppParametersContext);
   if (context == undefined) {
-    throw new Error("A LayoutManager provider is required to useLayoutManager");
+    throw new Error("A AppParameters provider is required to useAppParameters");
   }
   return context;
 }

--- a/packages/suite-base/src/i18n/en/general.ts
+++ b/packages/suite-base/src/i18n/en/general.ts
@@ -9,4 +9,6 @@
 export const general = {
   foxglove: "Foxglove",
   learnMore: "Learn more",
+  noDefaultLayoutParameter:
+    "The layout '{{layoutName}}' specified in the app parameters does not exist.",
 };

--- a/packages/suite-base/src/index.ts
+++ b/packages/suite-base/src/index.ts
@@ -37,8 +37,6 @@ export type { LayoutInfo } from "./types/layouts";
 export type { LayoutData } from "./context/CurrentLayoutContext";
 export type { ExtensionInfo, ExtensionNamespace } from "./types/Extensions";
 export { AppSetting } from "./AppSetting";
-export { AppParametersEnum } from "./AppParameters";
-export type { AppParameters, AppParametersInput } from "./context/AppParametersContext";
 export { default as FoxgloveWebSocketDataSourceFactory } from "./dataSources/FoxgloveWebSocketDataSourceFactory";
 export { default as Ros1LocalBagDataSourceFactory } from "./dataSources/Ros1LocalBagDataSourceFactory";
 export { default as Ros1SocketDataSourceFactory } from "./dataSources/Ros1SocketDataSourceFactory";

--- a/packages/suite-base/src/index.ts
+++ b/packages/suite-base/src/index.ts
@@ -38,6 +38,7 @@ export type { LayoutData } from "./context/CurrentLayoutContext";
 export type { ExtensionInfo, ExtensionNamespace } from "./types/Extensions";
 export { AppSetting } from "./AppSetting";
 export { AppParametersEnum } from "./AppParameters";
+export type { AppParameters, AppParametersInput } from "./context/AppParametersContext";
 export { default as FoxgloveWebSocketDataSourceFactory } from "./dataSources/FoxgloveWebSocketDataSourceFactory";
 export { default as Ros1LocalBagDataSourceFactory } from "./dataSources/Ros1LocalBagDataSourceFactory";
 export { default as Ros1SocketDataSourceFactory } from "./dataSources/Ros1SocketDataSourceFactory";

--- a/packages/suite-base/src/index.ts
+++ b/packages/suite-base/src/index.ts
@@ -37,6 +37,7 @@ export type { LayoutInfo } from "./types/layouts";
 export type { LayoutData } from "./context/CurrentLayoutContext";
 export type { ExtensionInfo, ExtensionNamespace } from "./types/Extensions";
 export { AppSetting } from "./AppSetting";
+export { AppParametersEnum } from "./AppParameters";
 export { default as FoxgloveWebSocketDataSourceFactory } from "./dataSources/FoxgloveWebSocketDataSourceFactory";
 export { default as Ros1LocalBagDataSourceFactory } from "./dataSources/Ros1LocalBagDataSourceFactory";
 export { default as Ros1SocketDataSourceFactory } from "./dataSources/Ros1SocketDataSourceFactory";

--- a/packages/suite-base/src/providers/AppParametersProvider.test.tsx
+++ b/packages/suite-base/src/providers/AppParametersProvider.test.tsx
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { render } from "@testing-library/react";
+
+import { useAppParameters } from "@lichtblick/suite-base/context/AppParametersContext";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+
+import AppParametersProvider from "./AppParametersProvider";
+
+describe("AppParametersProvider", () => {
+  it("provides app parameters to its children", () => {
+    const mockParameters = { key: BasicBuilder.string() };
+    const TestComponent = () => {
+      const appParameters = useAppParameters();
+      return <div>{appParameters.key}</div>;
+    };
+
+    const { getByText } = render(
+      <AppParametersProvider appParameters={mockParameters}>
+        <TestComponent />
+      </AppParametersProvider>,
+    );
+
+    expect(getByText(mockParameters.key)).toBeDefined();
+  });
+
+  it("provides default app parameters when none are given", () => {
+    const TestComponent = () => {
+      const appParameters = useAppParameters();
+      expect(Object.keys(appParameters)).toHaveLength(0);
+      return <div>{Object.keys(appParameters).length}</div>;
+    };
+
+    const { getByText } = render(
+      <AppParametersProvider>
+        <TestComponent />
+      </AppParametersProvider>,
+    );
+
+    expect(getByText("0")).toBeDefined();
+  });
+});

--- a/packages/suite-base/src/providers/AppParametersProvider.test.tsx
+++ b/packages/suite-base/src/providers/AppParametersProvider.test.tsx
@@ -12,10 +12,10 @@ import AppParametersProvider from "./AppParametersProvider";
 
 describe("AppParametersProvider", () => {
   it("provides app parameters to its children", () => {
-    const mockParameters = { key: BasicBuilder.string() };
+    const mockParameters = { defaultLayout: BasicBuilder.string() };
     const TestComponent = () => {
       const appParameters = useAppParameters();
-      return <div>{appParameters.key}</div>;
+      return <div>{appParameters.defaultLayout}</div>;
     };
 
     const { getByText } = render(
@@ -24,7 +24,7 @@ describe("AppParametersProvider", () => {
       </AppParametersProvider>,
     );
 
-    expect(getByText(mockParameters.key)).toBeDefined();
+    expect(getByText(mockParameters.defaultLayout)).toBeDefined();
   });
 
   it("provides default app parameters when none are given", () => {
@@ -41,5 +41,17 @@ describe("AppParametersProvider", () => {
     );
 
     expect(getByText("0")).toBeDefined();
+  });
+
+  it("should throw an error if useAppParameters is called without AppParametersProvider", () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const TestComponent = () => {
+      useAppParameters();
+      return <div />;
+    };
+
+    expect(() => render(<TestComponent />)).toThrow();
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/packages/suite-base/src/providers/AppParametersProvider.tsx
+++ b/packages/suite-base/src/providers/AppParametersProvider.tsx
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PropsWithChildren, useMemo } from "react";
+
+import {
+  AppParameters,
+  AppParametersContext,
+} from "@lichtblick/suite-base/context/AppParametersContext";
+
+type Props = PropsWithChildren<{
+  appParameters?: AppParameters;
+}>;
+
+export default function AppParametersProvider({
+  children,
+  appParameters = {},
+}: Props): React.JSX.Element {
+  const parameters = useMemo(() => appParameters, [appParameters]);
+  return (
+    <AppParametersContext.Provider value={parameters}>{children}</AppParametersContext.Provider>
+  );
+}

--- a/packages/suite-base/src/providers/AppParametersProvider.tsx
+++ b/packages/suite-base/src/providers/AppParametersProvider.tsx
@@ -10,17 +10,27 @@ import { PropsWithChildren, useMemo } from "react";
 import {
   AppParameters,
   AppParametersContext,
+  AppParametersInput,
 } from "@lichtblick/suite-base/context/AppParametersContext";
 
 type Props = PropsWithChildren<{
-  appParameters?: AppParameters;
+  appParameters?: AppParametersInput;
 }>;
 
+/**
+ * AppParametersProvider:
+ *
+ * This component provides a context for application parameters within the Lichtblick ecosystem.
+ *
+ * Type Safety:
+ *   The `appParameters` input is cast to the `AppParameters` type, ensuring that keys align with
+ *   the expected enumeration. This guarantees proper autocomplete and type-checking for developers.
+ */
 export default function AppParametersProvider({
   children,
   appParameters = {},
 }: Props): React.JSX.Element {
-  const parameters = useMemo(() => appParameters, [appParameters]);
+  const parameters: AppParameters = useMemo(() => appParameters, [appParameters]);
   return (
     <AppParametersContext.Provider value={parameters}>{children}</AppParametersContext.Provider>
   );

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -24,6 +24,7 @@ import {
   UserProfileStorage,
   UserProfileStorageContext,
 } from "@lichtblick/suite-base/context/UserProfileStorageContext";
+import AppParametersProvider from "@lichtblick/suite-base/providers/AppParametersProvider";
 import CurrentLayoutProvider from "@lichtblick/suite-base/providers/CurrentLayoutProvider";
 import { MAX_SUPPORTED_LAYOUT_VERSION } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/constants";
 import { ILayoutManager } from "@lichtblick/suite-base/services/ILayoutManager";
@@ -102,16 +103,18 @@ function renderTest({
           childMounted.notifyAll();
         }, []);
         return (
-          <SnackbarProvider>
-            <LayoutManagerContext.Provider value={mockLayoutManager}>
-              <UserProfileStorageContext.Provider value={mockUserProfile}>
-                <CurrentLayoutProvider loaders={[]}>
-                  {children}
-                  <CurrentLayoutSyncAdapter />
-                </CurrentLayoutProvider>
-              </UserProfileStorageContext.Provider>
-            </LayoutManagerContext.Provider>
-          </SnackbarProvider>
+          <AppParametersProvider>
+            <SnackbarProvider>
+              <LayoutManagerContext.Provider value={mockLayoutManager}>
+                <UserProfileStorageContext.Provider value={mockUserProfile}>
+                  <CurrentLayoutProvider loaders={[]}>
+                    {children}
+                    <CurrentLayoutSyncAdapter />
+                  </CurrentLayoutProvider>
+                </UserProfileStorageContext.Provider>
+              </LayoutManagerContext.Provider>
+            </SnackbarProvider>
+          </AppParametersProvider>
         );
       },
     },

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -125,6 +125,17 @@ function renderTest({
 }
 
 describe("CurrentLayoutProvider", () => {
+  const mockLayoutManager = makeMockLayoutManager();
+  const mockUserProfile = makeMockUserProfile();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default mocks
+    mockLayoutManager.getLayout.mockImplementation(async () => undefined);
+    mockLayoutManager.getLayouts.mockImplementation(() => []);
+    mockUserProfile.getUserProfile.mockResolvedValue({ currentLayoutId: undefined });
+  });
+
   afterEach(() => {
     (console.warn as jest.Mock).mockClear();
   });
@@ -139,7 +150,6 @@ describe("CurrentLayoutProvider", () => {
     };
     const condvar = new Condvar();
     const layoutStorageGetCalledWait = condvar.wait();
-    const mockLayoutManager = makeMockLayoutManager();
     mockLayoutManager.getLayout.mockImplementation(async () => {
       condvar.notifyAll();
       return {
@@ -149,7 +159,6 @@ describe("CurrentLayoutProvider", () => {
       };
     });
 
-    const mockUserProfile = makeMockUserProfile();
     mockUserProfile.getUserProfile.mockResolvedValue({ currentLayoutId: "example" });
 
     const { all } = renderTest({ mockLayoutManager, mockUserProfile });
@@ -183,7 +192,6 @@ describe("CurrentLayoutProvider", () => {
 
     const condvar = new Condvar();
     const layoutStorageGetCalledWait = condvar.wait();
-    const mockLayoutManager = makeMockLayoutManager();
     mockLayoutManager.getLayout.mockImplementation(async () => {
       condvar.notifyAll();
       return {
@@ -193,7 +201,6 @@ describe("CurrentLayoutProvider", () => {
       };
     });
 
-    const mockUserProfile = makeMockUserProfile();
     mockUserProfile.getUserProfile.mockResolvedValue({ currentLayoutId: "example" });
 
     const { all } = renderTest({ mockLayoutManager, mockUserProfile });
@@ -209,8 +216,6 @@ describe("CurrentLayoutProvider", () => {
   });
 
   it("keeps identity of action functions when modifying layout", async () => {
-    const mockLayoutManager = makeMockLayoutManager();
-    mockLayoutManager.getLayouts.mockImplementation(() => []);
     mockLayoutManager.getLayout.mockImplementation(async () => {
       return {
         id: "TEST_ID",
@@ -226,7 +231,6 @@ describe("CurrentLayoutProvider", () => {
         baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
       };
     });
-    const mockUserProfile = makeMockUserProfile();
     mockUserProfile.getUserProfile.mockResolvedValue({ currentLayoutId: "example" });
 
     const { result } = renderTest({
@@ -248,8 +252,6 @@ describe("CurrentLayoutProvider", () => {
   });
 
   it("selects the first layout in alphabetic order, when there is no selected layout", async () => {
-    const mockLayoutManager = makeMockLayoutManager();
-    mockLayoutManager.getLayout.mockImplementation(async () => undefined);
     mockLayoutManager.getLayouts.mockImplementation(async () => {
       return [
         {
@@ -264,9 +266,6 @@ describe("CurrentLayoutProvider", () => {
         },
       ];
     });
-
-    const mockUserProfile = makeMockUserProfile();
-    mockUserProfile.getUserProfile.mockResolvedValue({ currentLayoutId: undefined });
 
     const { result, all } = renderTest({
       mockLayoutManager,
@@ -286,8 +285,6 @@ describe("CurrentLayoutProvider", () => {
 
   it("should select a layout though app parameters", async () => {
     const mockAppParameters = { defaultLayout: "LAYOUT 2" };
-    const mockLayoutManager = makeMockLayoutManager();
-    mockLayoutManager.getLayout.mockImplementation(async () => undefined);
     mockLayoutManager.getLayouts.mockImplementation(async () => {
       return [
         {
@@ -302,9 +299,6 @@ describe("CurrentLayoutProvider", () => {
         },
       ];
     });
-
-    const mockUserProfile = makeMockUserProfile();
-    mockUserProfile.getUserProfile.mockResolvedValue({ currentLayoutId: undefined });
 
     const { result, all } = renderTest({
       mockLayoutManager,

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -51,10 +51,10 @@ function makeMockLayoutManager() {
     isBusy: false,
     isOnline: false,
     error: undefined,
-    on: jest.fn(/*noop*/),
-    off: jest.fn(/*noop*/),
-    setError: jest.fn(/*noop*/),
-    setOnline: jest.fn(/*noop*/),
+    on: jest.fn(),
+    off: jest.fn(),
+    setError: jest.fn(),
+    setOnline: jest.fn(),
     getLayouts: jest.fn(),
     getLayout: jest.fn(),
     saveNewLayout: jest.fn().mockImplementation(mockThrow("saveNewLayout")),
@@ -205,6 +205,7 @@ describe("CurrentLayoutProvider", () => {
 
   it("keeps identity of action functions when modifying layout", async () => {
     const mockLayoutManager = makeMockLayoutManager();
+    mockLayoutManager.getLayouts.mockImplementation(() => []);
     mockLayoutManager.getLayout.mockImplementation(async () => {
       return {
         id: "TEST_ID",

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -129,7 +129,6 @@ describe("CurrentLayoutProvider", () => {
   const mockUserProfile = makeMockUserProfile();
 
   beforeEach(() => {
-    jest.clearAllMocks();
     // Default mocks
     mockLayoutManager.getLayout.mockImplementation(async () => undefined);
     mockLayoutManager.getLayouts.mockImplementation(() => []);
@@ -138,6 +137,7 @@ describe("CurrentLayoutProvider", () => {
 
   afterEach(() => {
     (console.warn as jest.Mock).mockClear();
+    jest.clearAllMocks();
   });
 
   it("uses currentLayoutId from UserProfile to load from LayoutStorage", async () => {

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -280,7 +280,7 @@ export default function CurrentLayoutProvider({
       return;
     }
 
-    // For some reason, this needs to go befre the setSelectedLayoutId, probably some initialization
+    // For some reason, this needs to go before the setSelectedLayoutId, probably some initialization
     const { currentLayoutId } = await getUserProfile();
 
     // Try to load default layouts, before checking to add the fallback "Default".
@@ -291,7 +291,7 @@ export default function CurrentLayoutProvider({
     // Check if there's a layout specified by app parameter
     const defaultLayoutFromParameters = layouts.find((l) => l.name === appParameters.defaultLayout);
     if (defaultLayoutFromParameters) {
-      await setSelectedLayoutId(defaultLayoutFromParameters.id, { saveToProfile: false });
+      await setSelectedLayoutId(defaultLayoutFromParameters.id, { saveToProfile: true });
       return;
     }
 

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -16,7 +16,6 @@ import { v4 as uuidv4 } from "uuid";
 import { useShallowMemo } from "@lichtblick/hooks";
 import Logger from "@lichtblick/log";
 import { VariableValue } from "@lichtblick/suite";
-import { AppParameters } from "@lichtblick/suite-base/AppParameters";
 import { useAnalytics } from "@lichtblick/suite-base/context/AnalyticsContext";
 import { useAppParameters } from "@lichtblick/suite-base/context/AppParametersContext";
 import CurrentLayoutContext, {
@@ -278,17 +277,16 @@ export default function CurrentLayoutProvider({
       return;
     }
 
+    // For some reason, this needs to go befre the setSelectedLayoutId, probably some initialization
+    const { currentLayoutId } = await getUserProfile();
+
     // Try to load default layouts, before checking to add the fallback "Default".
     await loadDefaultLayouts(layoutManager, loaders);
 
-    // For some reason, this needs to go befre the setSelectedLayoutId, zprobably some initialization
-    const { currentLayoutId } = await getUserProfile();
-
     const layouts = await layoutManager.getLayouts();
 
-    // Check if there's a layout specified by app parameter
-    const predefinedLayout = appParameters[AppParameters.DEFAULT_LAYOUT];
-    const defaultLayoutFromParameters = layouts.find((l) => l.name === predefinedLayout);
+    // // Check if there's a layout specified by app parameter
+    const defaultLayoutFromParameters = layouts.find((l) => l.name === appParameters.defaultLayout);
     if (defaultLayoutFromParameters) {
       await setSelectedLayoutId(defaultLayoutFromParameters.id, { saveToProfile: false });
       return;

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -8,6 +8,7 @@
 import * as _ from "lodash-es";
 import { useSnackbar } from "notistack";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { getNodeAtPath } from "react-mosaic-component";
 import { useAsync, useAsyncFn, useMountedState } from "react-use";
 import shallowequal from "shallowequal";
@@ -70,6 +71,8 @@ export default function CurrentLayoutProvider({
   const layoutManager = useLayoutManager();
   const analytics = useAnalytics();
   const isMounted = useMountedState();
+
+  const { t } = useTranslation("general");
 
   const appParameters = useAppParameters();
 
@@ -285,11 +288,18 @@ export default function CurrentLayoutProvider({
 
     const layouts = await layoutManager.getLayouts();
 
-    // // Check if there's a layout specified by app parameter
+    // Check if there's a layout specified by app parameter
     const defaultLayoutFromParameters = layouts.find((l) => l.name === appParameters.defaultLayout);
     if (defaultLayoutFromParameters) {
       await setSelectedLayoutId(defaultLayoutFromParameters.id, { saveToProfile: false });
       return;
+    }
+
+    // It there is a defaultLayout setted but didnt found a layout, show a error to the user
+    if (appParameters.defaultLayout) {
+      enqueueSnackbar(t("noDefaultLayoutParameter", { layoutName: appParameters.defaultLayout }), {
+        variant: "warning",
+      });
     }
 
     // Retreive the selected layout id from the user's profile. If there's no layout specified

--- a/packages/suite-desktop/src/common/types.ts
+++ b/packages/suite-desktop/src/common/types.ts
@@ -75,6 +75,8 @@ type DesktopLayout = {
   from: string;
 };
 
+export type CLIFlags = Readonly<Record<string, string>>;
+
 interface Desktop {
   /** https://www.electronjs.org/docs/tutorial/represented-file */
   setRepresentedFilename(path: string | undefined): Promise<void>;
@@ -108,6 +110,9 @@ interface Desktop {
   // Uninstall an extension. Returns true if the extension was found and uninstalled, or false if it
   // was not found (i.e. already uninstalled)
   uninstallExtension: (id: string) => Promise<boolean>;
+
+  // Get CLI flags passed when the app was launched
+  getCLIFlags: () => Promise<CLIFlags>;
 
   /** Handle a double-click on the custom title bar */
   handleTitleBarDoubleClick(): void;

--- a/packages/suite-desktop/src/main/index.ts
+++ b/packages/suite-desktop/src/main/index.ts
@@ -18,6 +18,7 @@ import StudioWindow from "./StudioWindow";
 import getDevModeIcon from "./getDevModeIcon";
 import injectFilesToOpen from "./injectFilesToOpen";
 import installChromeExtensions from "./installChromeExtensions";
+import { parseCLIFlags } from "./parseCLIFlags";
 import {
   registerRosPackageProtocolHandlers,
   registerRosPackageProtocolSchemes,
@@ -120,7 +121,10 @@ export async function main(): Promise<void> {
       app.emit("open-url", { preventDefault() {} }, link);
     }
 
-    const files = argv.slice(1).filter((arg) => isFileToOpen(arg));
+    const files = argv
+      .slice(1)
+      .filter((arg) => !arg.startsWith("--")) // Filter out flags
+      .filter((arg) => isFileToOpen(arg));
     for (const file of files) {
       app.emit("open-file", { preventDefault() {} }, file);
     }
@@ -143,6 +147,7 @@ export async function main(): Promise<void> {
   // or command line arguments.
   const filesToOpen: string[] = process.argv
     .slice(1)
+    .filter((arg) => !arg.startsWith("--")) // Filter out flags
     .map((filePath) => path.resolve(filePath)) // Convert to absolute path, linux has some problems to resolve relative paths
     .filter(isFileToOpen);
 
@@ -208,6 +213,10 @@ export async function main(): Promise<void> {
   // support preload lookups for the user data path and home directory
   ipcMain.handle("getUserDataPath", () => app.getPath("userData"));
   ipcMain.handle("getHomePath", () => app.getPath("home"));
+
+  // Get the command line flags passed to the app when it was launched
+  const parsedCLIFlags = parseCLIFlags(process.argv);
+  ipcMain.handle("getCLIFlags", () => parsedCLIFlags);
 
   // Must be called before app.ready event
   registerRosPackageProtocolSchemes();

--- a/packages/suite-desktop/src/main/parseCLIFlags.test.ts
+++ b/packages/suite-desktop/src/main/parseCLIFlags.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { parseCLIFlags } from "./parseCLIFlags";
+
+describe("parseCLIFlags", () => {
+  it("should parse single flag correctly", () => {
+    const argv = ["--flag=value"];
+    const result = parseCLIFlags(argv);
+    expect(result).toEqual({ flag: "value" });
+  });
+
+  it("should parse multiple flags correctly", () => {
+    const argv = ["--flag1=value1", "--flag2=value2"];
+    const result = parseCLIFlags(argv);
+    expect(result).toEqual({ flag1: "value1", flag2: "value2" });
+  });
+
+  it("should overwrite duplicated flags", () => {
+    const argv = ["--flag=value1", "--flag=value2"];
+    const result = parseCLIFlags(argv);
+    expect(result).toEqual({ flag: "value2" });
+  });
+
+  it("should ignore arguments that do not start with '--'", () => {
+    const argv = ["--flag1=value1", "someArg", "someOther=Arg", "--flag2=value2"];
+    const result = parseCLIFlags(argv);
+    expect(result).toEqual({ flag1: "value1", flag2: "value2" });
+  });
+
+  it("should return an empty object if no valid flags are provided", () => {
+    const argv = ["someArg", "--flag", "--flag1=", "--=value1"];
+    const result = parseCLIFlags(argv);
+    expect(result).toEqual({});
+  });
+
+  it("should return a readonly object", () => {
+    const argv = ["--flag1=value1"];
+    const result = parseCLIFlags(argv);
+    expect(() => {
+      (result as any).flag1 = "newValue";
+    }).toThrow();
+  });
+});

--- a/packages/suite-desktop/src/main/parseCLIFlags.ts
+++ b/packages/suite-desktop/src/main/parseCLIFlags.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { CLIFlags } from "../common/types";
+
+/**
+ * Parses CLI flags from the process arguments and returns a readonly record.
+ * Flags are expected to start with '--'.
+ *
+ * @param argv - The process arguments to parse (e.g., process.argv).
+ * @returns A readonly record containing the flag names as keys and their corresponding values as strings.
+ */
+export function parseCLIFlags(argv: string[]): CLIFlags {
+  const flags = argv.reduce<Record<string, string>>((prev, curr) => {
+    if (curr.startsWith("--")) {
+      const [key, value] = curr.slice(2).split("=");
+      if (key && value) {
+        prev[key] = value;
+      }
+    }
+    return prev;
+  }, {});
+
+  return Object.freeze(flags);
+}

--- a/packages/suite-desktop/src/preload/index.ts
+++ b/packages/suite-desktop/src/preload/index.ts
@@ -117,6 +117,9 @@ export function main(): void {
     async updateLanguage() {
       await ipcRenderer.invoke("updateLanguage");
     },
+    async getCLIFlags(): Promise<Readonly<Record<string, string>>> {
+      return await (ipcRenderer.invoke("getCLIFlags") as Promise<Readonly<Record<string, string>>>);
+    },
     getDeepLinks(): string[] {
       return deepLinks;
     },

--- a/packages/suite-desktop/src/renderer/Root.tsx
+++ b/packages/suite-desktop/src/renderer/Root.tsx
@@ -25,13 +25,12 @@ import {
   UlogLocalDataSourceFactory,
   VelodyneDataSourceFactory,
 } from "@lichtblick/suite-base";
-import { AppParametersInput } from "@lichtblick/suite-base/context/AppParametersContext";
 
 import { DesktopExtensionLoader } from "./services/DesktopExtensionLoader";
 import { DesktopLayoutLoader } from "./services/DesktopLayoutLoader";
 import { NativeAppMenu } from "./services/NativeAppMenu";
 import { NativeWindow } from "./services/NativeWindow";
-import { Desktop, NativeMenuBridge, Storage } from "../common/types";
+import { CLIFlags, Desktop, NativeMenuBridge, Storage } from "../common/types";
 
 const desktopBridge = (global as unknown as { desktopBridge: Desktop }).desktopBridge;
 const storageBridge = (global as unknown as { storageBridge?: Storage }).storageBridge;
@@ -39,7 +38,7 @@ const menuBridge = (global as { menuBridge?: NativeMenuBridge }).menuBridge;
 const ctxbridge = (global as { ctxbridge?: OsContext }).ctxbridge;
 
 export default function Root(props: {
-  appParameters: AppParametersInput;
+  appParameters: CLIFlags;
   appConfiguration: IAppConfiguration;
   extraProviders: React.JSX.Element[] | undefined;
   dataSources: IDataSourceFactory[] | undefined;

--- a/packages/suite-desktop/src/renderer/Root.tsx
+++ b/packages/suite-desktop/src/renderer/Root.tsx
@@ -25,6 +25,7 @@ import {
   UlogLocalDataSourceFactory,
   VelodyneDataSourceFactory,
 } from "@lichtblick/suite-base";
+import { AppParameters } from "@lichtblick/suite-base/context/AppParametersContext";
 
 import { DesktopExtensionLoader } from "./services/DesktopExtensionLoader";
 import { DesktopLayoutLoader } from "./services/DesktopLayoutLoader";
@@ -38,6 +39,7 @@ const menuBridge = (global as { menuBridge?: NativeMenuBridge }).menuBridge;
 const ctxbridge = (global as { ctxbridge?: OsContext }).ctxbridge;
 
 export default function Root(props: {
+  appParameters: AppParameters;
   appConfiguration: IAppConfiguration;
   extraProviders: React.JSX.Element[] | undefined;
   dataSources: IDataSourceFactory[] | undefined;
@@ -148,28 +150,27 @@ export default function Root(props: {
   }, []);
 
   return (
-    <>
-      <App
-        deepLinks={deepLinks}
-        dataSources={dataSources}
-        appConfiguration={appConfiguration}
-        extensionLoaders={extensionLoaders}
-        layoutLoaders={layoutLoaders}
-        nativeAppMenu={nativeAppMenu}
-        nativeWindow={nativeWindow}
-        enableGlobalCss
-        appBarLeftInset={ctxbridge?.platform === "darwin" && !isFullScreen ? 72 : undefined}
-        onAppBarDoubleClick={() => {
-          nativeWindow.handleTitleBarDoubleClick();
-        }}
-        showCustomWindowControls={ctxbridge?.platform === "linux"}
-        isMaximized={isMaximized}
-        onMinimizeWindow={onMinimizeWindow}
-        onMaximizeWindow={onMaximizeWindow}
-        onUnmaximizeWindow={onUnmaximizeWindow}
-        onCloseWindow={onCloseWindow}
-        extraProviders={props.extraProviders}
-      />
-    </>
+    <App
+      appParameters={props.appParameters}
+      deepLinks={deepLinks}
+      dataSources={dataSources}
+      appConfiguration={appConfiguration}
+      extensionLoaders={extensionLoaders}
+      layoutLoaders={layoutLoaders}
+      nativeAppMenu={nativeAppMenu}
+      nativeWindow={nativeWindow}
+      enableGlobalCss
+      appBarLeftInset={ctxbridge?.platform === "darwin" && !isFullScreen ? 72 : undefined}
+      onAppBarDoubleClick={() => {
+        nativeWindow.handleTitleBarDoubleClick();
+      }}
+      showCustomWindowControls={ctxbridge?.platform === "linux"}
+      isMaximized={isMaximized}
+      onMinimizeWindow={onMinimizeWindow}
+      onMaximizeWindow={onMaximizeWindow}
+      onUnmaximizeWindow={onUnmaximizeWindow}
+      onCloseWindow={onCloseWindow}
+      extraProviders={props.extraProviders}
+    />
   );
 }

--- a/packages/suite-desktop/src/renderer/Root.tsx
+++ b/packages/suite-desktop/src/renderer/Root.tsx
@@ -25,7 +25,7 @@ import {
   UlogLocalDataSourceFactory,
   VelodyneDataSourceFactory,
 } from "@lichtblick/suite-base";
-import { AppParameters } from "@lichtblick/suite-base/context/AppParametersContext";
+import { AppParametersInput } from "@lichtblick/suite-base/context/AppParametersContext";
 
 import { DesktopExtensionLoader } from "./services/DesktopExtensionLoader";
 import { DesktopLayoutLoader } from "./services/DesktopLayoutLoader";
@@ -39,7 +39,7 @@ const menuBridge = (global as { menuBridge?: NativeMenuBridge }).menuBridge;
 const ctxbridge = (global as { ctxbridge?: OsContext }).ctxbridge;
 
 export default function Root(props: {
-  appParameters: AppParameters;
+  appParameters: AppParametersInput;
   appConfiguration: IAppConfiguration;
   extraProviders: React.JSX.Element[] | undefined;
   dataSources: IDataSourceFactory[] | undefined;

--- a/packages/suite-desktop/src/renderer/index.tsx
+++ b/packages/suite-desktop/src/renderer/index.tsx
@@ -23,6 +23,9 @@ import {
 } from "@lichtblick/suite-base";
 
 import Root from "./Root";
+import { Desktop } from "../common/types";
+
+const desktopBridge = (global as unknown as { desktopBridge: Desktop }).desktopBridge;
 
 const log = Logger.getLogger(__filename);
 
@@ -61,10 +64,13 @@ export async function main(params: MainParams): Promise<void> {
   await waitForFonts();
   await initI18n();
 
+  const cliFlags = await desktopBridge.getCLIFlags();
+
   const root = createRoot(rootEl);
   root.render(
     <LogAfterRender>
       <Root
+        appParameters={cliFlags}
         appConfiguration={params.appConfiguration}
         extraProviders={params.extraProviders}
         dataSources={params.dataSources}


### PR DESCRIPTION
**User-Facing Changes**
Users were not allowed to use custom flags when opening Lichtblick.

**Description**

- Introduced the `AppParameters` provider, which accepts a `Record<string, string>` input and allows other components to access these global parameters.

- Implemented the flow for the desktop application to read CLI parameters starting with `--` and parse them into an object if the input is valid.

- This mechanism is reusable, for example, to parse URL parameters from the web version and pass them to the same "agnostic" provider.

In order to test in development mode, it is just execute the command `yarn desktop:start --defaultLayout=<SOME_LAYOUT>` after serving the development server.

In production, it should be done something like this:

- Linux: `lichtblick --layoutDefault="layout_example"`
- MacOS: `/Applications/Lichtblick.app/Contents/MacOS/Lichtblick --layoutDefault="layout_example"`
- Windows: `C:\Users\<USER>\AppData\Local\Programs\lichtblick\Lichtblick.exe --layoutDefault="layout_example"`

![image](https://github.com/user-attachments/assets/3f9a6369-e8cb-4993-b449-6e10e6708131)

**Checklist**

- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
