### PR TITLE
Added alphabetic sorting to extensions lists

### DIFF
--- a/packages/suite-base/src/components/ExtensionsSettings/hooks/useExtensionSettings.test.ts
+++ b/packages/suite-base/src/components/ExtensionsSettings/hooks/useExtensionSettings.test.ts
@@ -5,6 +5,7 @@
 
 import { renderHook, act } from "@testing-library/react";
 
+import { InstalledExtension } from "@lichtblick/suite-base/components/ExtensionsSettings/types";
 import { useExtensionCatalog } from "@lichtblick/suite-base/context/ExtensionCatalogContext";
 import { useExtensionMarketplace } from "@lichtblick/suite-base/context/ExtensionMarketplaceContext";
 
@@ -14,7 +15,21 @@ jest.mock("@lichtblick/suite-base/context/ExtensionCatalogContext");
 jest.mock("@lichtblick/suite-base/context/ExtensionMarketplaceContext");
 
 describe("useExtensionSettings", () => {
-  const mockInstalledExtensions = [
+  const mockInstalledExtensions: InstalledExtension[] = [
+    {
+      id: "4",
+      displayName: "Extension 4",
+      description: "Description 4",
+      publisher: "Publisher 4",
+      homepage: "http://example.com",
+      license: "MIT",
+      version: "1.0.0",
+      keywords: ["keyword4"],
+      namespace: "namespace1",
+      installed: true,
+      name: "Extension 4",
+      qualifiedName: "Extension 4",
+    },
     {
       id: "1",
       displayName: "Extension 1",
@@ -25,13 +40,15 @@ describe("useExtensionSettings", () => {
       version: "1.0.0",
       keywords: ["keyword1"],
       namespace: "namespace1",
-      qualifiedName: "qualifiedName1",
+      installed: true,
+      name: "Extension 1",
+      qualifiedName: "Extension 1",
     },
   ];
 
   const mockAvailableExtensions = [
     {
-      id: "2",
+      id: "5",
       name: "Extension 2",
       description: "Description 2",
       publisher: "Publisher 2",
@@ -39,6 +56,17 @@ describe("useExtensionSettings", () => {
       license: "MIT",
       version: "1.0.0",
       keywords: ["keyword2"],
+      namespace: "namespace2",
+    },
+    {
+      id: "6",
+      name: "Extension 1",
+      description: "Description 1",
+      publisher: "Publisher 1",
+      homepage: "http://example.com",
+      license: "MIT",
+      version: "1.0.0",
+      keywords: ["keyword1"],
       namespace: "namespace2",
     },
   ];
@@ -85,7 +113,7 @@ describe("useExtensionSettings", () => {
     expect(result.current.groupedMarketplaceData).toEqual([
       {
         namespace: "namespace2",
-        entries: [mockAvailableExtensions[0]],
+        entries: [mockAvailableExtensions[1], mockAvailableExtensions[0]],
       },
     ]);
   });
@@ -98,9 +126,12 @@ describe("useExtensionSettings", () => {
         namespace: "namespace1",
         entries: [
           {
+            ...mockInstalledExtensions[1],
+            name: mockInstalledExtensions[1]?.displayName,
+          },
+          {
             ...mockInstalledExtensions[0],
-            installed: true,
-            name: mockInstalledExtensions[0]!.displayName,
+            name: mockInstalledExtensions[0]?.displayName,
           },
         ],
       },

--- a/packages/suite-base/src/components/ExtensionsSettings/hooks/useExtensionSettings.ts
+++ b/packages/suite-base/src/components/ExtensionsSettings/hooks/useExtensionSettings.ts
@@ -38,9 +38,9 @@ const useExtensionSettings = (): UseExtensionSettingsHook => {
   const groupedMarketplaceData = useMemo(() => {
     return Object.entries(groupedMarketplaceEntries).map(([namespace, entries]) => ({
       namespace,
-      entries: entries.filter((entry) =>
-        entry.name.toLowerCase().includes(debouncedFilterText.toLowerCase()),
-      ),
+      entries: entries
+        .filter((entry) => entry.name.toLowerCase().includes(debouncedFilterText.toLowerCase()))
+        .sort((a, b) => a.name.localeCompare(b.name)),
     }));
   }, [groupedMarketplaceEntries, debouncedFilterText]);
 
@@ -81,9 +81,9 @@ const useExtensionSettings = (): UseExtensionSettingsHook => {
 
   const namespacedData = Object.entries(namespacedEntries).map(([namespace, entries]) => ({
     namespace,
-    entries: entries.filter((entry) =>
-      entry.name.toLowerCase().includes(debouncedFilterText.toLowerCase()),
-    ),
+    entries: entries
+      .filter((entry) => entry.name.toLowerCase().includes(debouncedFilterText.toLowerCase()))
+      .sort((a, b) => a.name.localeCompare(b.name)),
   }));
 
   return {


### PR DESCRIPTION
**User-Facing Changes**
Display of extensions is now always alphabetic ordered by their name.

**Description**
Added a sort by name to the extensions lists.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [X] The web version was tested and it is running ok
- [X] The desktop version was tested and it is running ok
- [X] This change is covered by unit tests
- [X] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
