### PR TITLE
Add additional value in Raw Message panel when single value

### DIFF
--- a/packages/suite-base/src/panels/RawMessages/index.test.ts
+++ b/packages/suite-base/src/panels/RawMessages/index.test.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+import { MessagePathDataItem } from "@lichtblick/suite-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+
+import { getSingleValue } from "./index";
+
+describe("getSingleValue", () => {
+  it("should return a string with value and constantName if data is a single-element array", () => {
+    const data = BasicBuilder.strings({ count: 1 });
+    const queriedData = [{ constantName: BasicBuilder.string() }] as MessagePathDataItem[];
+
+    const result = getSingleValue(data, queriedData);
+
+    expect(result).toBe(`${data[0]} (${queriedData[0]?.constantName})`);
+  });
+
+  it("should return the data unchanged if data is not a single-element array", () => {
+    const data = BasicBuilder.strings();
+    const queriedData = [{ constantName: BasicBuilder.string() }] as MessagePathDataItem[];
+
+    const result = getSingleValue(data, queriedData);
+
+    expect(result).toBe(data);
+  });
+
+  it("should not handle undefined constantName and return just the value", () => {
+    const data = BasicBuilder.strings({ count: 1 });
+    const queriedData = [{}] as MessagePathDataItem[];
+
+    const result = getSingleValue(data, queriedData);
+
+    expect(result).toBe(data[0]);
+  });
+
+  it("should return the data unchanged if data is not an array", () => {
+    const data = BasicBuilder.string();
+    const queriedData = [{ constantName: BasicBuilder.string() }] as MessagePathDataItem[];
+
+    const result = getSingleValue(data, queriedData);
+
+    expect(result).toBe(data);
+  });
+
+  it("should return the data unchanged if data is an empty array", () => {
+    const data: unknown = [];
+    const queriedData = [{ constantName: BasicBuilder.string() }] as MessagePathDataItem[];
+
+    const result = getSingleValue(data, queriedData);
+
+    expect(result).toBe(data);
+  });
+});

--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -402,7 +402,9 @@ function RawMessages(props: Props) {
     const shouldDisplaySingleVal =
       (data != undefined && typeof data !== "object") ||
       (isSingleElemArray(data) && data[0] != undefined && typeof data[0] !== "object");
-    const singleVal = isSingleElemArray(data) ? data[0] : data;
+    const singleVal = isSingleElemArray(data)
+      ? `${data[0]} (${baseItem.queriedData[0]?.constantName})`
+      : data;
 
     const diffData =
       diffItem && dataWithoutWrappingArray(diffItem.queriedData.map(({ value }) => value));

--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -82,6 +82,18 @@ const dataWithoutWrappingArray = (data: unknown) => {
   return isSingleElemArray(data) && typeof data[0] === "object" ? data[0] : data;
 };
 
+export const getSingleValue = (data: unknown, queriedData: MessagePathDataItem[]): unknown => {
+  if (!isSingleElemArray(data)) {
+    return data;
+  }
+
+  if (queriedData[0]?.constantName == undefined) {
+    return data[0];
+  }
+
+  return `${data[0]} (${queriedData[0]?.constantName})`;
+};
+
 const useStyles = makeStyles()((theme) => ({
   topic: {
     fontFamily: theme.typography.body1.fontFamily,
@@ -402,9 +414,7 @@ function RawMessages(props: Props) {
     const shouldDisplaySingleVal =
       (data != undefined && typeof data !== "object") ||
       (isSingleElemArray(data) && data[0] != undefined && typeof data[0] !== "object");
-    const singleVal = isSingleElemArray(data)
-      ? `${data[0]} (${baseItem.queriedData[0]?.constantName})`
-      : data;
+    const singleVal = getSingleValue(data, baseItem.queriedData);
 
     const diffData =
       diffItem && dataWithoutWrappingArray(diffItem.queriedData.map(({ value }) => value));


### PR DESCRIPTION
**User-Facing Changes**
Added additional information in the Raw Message panel when a final topic is selected.

<img width="421" alt="Screenshot 2024-12-26 at 14 13 24" src="https://github.com/user-attachments/assets/e01727db-8905-41a0-ac4a-b01b5308285a" />

BEFORE value: 104
NEW value: 104 (EXTENDED_DATA_QUALIFIER_V1_MISSING_MAP_DATA)

**Description**
Created a function just to process the single value and implemented unit test for this function.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
