### PR TITLE
Fix icns file

### DIFF
--- a/packages/suite-desktop/resources/icon/icon.icns
+++ b/packages/suite-desktop/resources/icon/icon.icns
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9d82df2b47a03dd20800fbf9dd4319c8ad8089f8a101e7f916f267b76e2fd6aa
-size 223984
+oid sha256:f7f82fa00afb7b1fee890a0c7120cddc5363d74e2ad82f6b596f513f95691d5f
+size 344159


### PR DESCRIPTION
**User-Facing Changes**
Developers couldn't build the desktop version

**Description**
The ICNS file was recreated using more than 1 resolution, apparently the electron-builder had some issue with the previous one, created from a single 1024x1024 PNG image

**Checklist**

- [x] The desktop version was tested and it is running ok
