### PR TITLE
Make Indicator Panel works with the global vars in the message path

### DIFF
--- a/packages/suite-base/src/panels/Gauge/Gauge.tsx
+++ b/packages/suite-base/src/panels/Gauge/Gauge.tsx
@@ -35,6 +35,7 @@ export function Gauge({ context }: GaugeProps): React.JSX.Element {
     stateReducer,
     config,
     ({ path }): GaugeAndIndicatorState => ({
+      globalVariables: undefined,
       path,
       parsedPath: parseMessagePath(path),
       latestMessage: undefined,

--- a/packages/suite-base/src/panels/Indicator/Indicator.style.ts
+++ b/packages/suite-base/src/panels/Indicator/Indicator.style.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { makeStyles } from "tss-react/mui";
+
+export const useStyles = makeStyles()({
+  root: {
+    width: 40,
+    height: 40,
+    borderRadius: "50%",
+    position: "relative",
+    backgroundImage: [
+      `radial-gradient(transparent, transparent 55%, rgba(255,255,255,0.4) 80%, rgba(255,255,255,0.4))`,
+      `radial-gradient(circle at 38% 35%, rgba(255,255,255,0.8), transparent 30%, transparent)`,
+      `radial-gradient(circle at 46% 44%, transparent, transparent 61%, rgba(0,0,0,0.7) 74%, rgba(0,0,0,0.7))`,
+    ].join(","),
+  },
+});

--- a/packages/suite-base/src/panels/Indicator/Indicator.test.tsx
+++ b/packages/suite-base/src/panels/Indicator/Indicator.test.tsx
@@ -58,22 +58,12 @@ describe("Indicator Component", () => {
       },
     };
 
-    const renderStates: Immutable<RenderState>[] = [];
     const config: IndicatorConfig = {
       ...IndicatorBuilder.config(),
       ...configOverride,
     };
     const saveConfig = () => {};
-    const initPanel = jest.fn((context: PanelExtensionContext) => {
-      context.watch("currentFrame");
-      context.watch("didSeek");
-      context.watch("variables");
-      context.subscribe([{ topic: "x", preload: false }]);
-      context.onRender = (renderState, done) => {
-        renderStates.push({ ...renderState });
-        done();
-      };
-    });
+    const initPanel = jest.fn();
 
     const ui: React.ReactElement = (
       <ThemeProvider isDark>
@@ -93,12 +83,17 @@ describe("Indicator Component", () => {
     };
     (getMatchingRule as jest.Mock).mockReturnValue(matchingRule);
 
+    const augmentColor = jest.fn(({ color: { main } }) => ({
+      contrastText: `${main}-contrast`,
+    }));
+
     return {
       ...render(ui),
       config,
       matchingRule,
       props,
       user: userEvent.setup(),
+      augmentColor,
     };
   }
 

--- a/packages/suite-base/src/panels/Indicator/Indicator.test.tsx
+++ b/packages/suite-base/src/panels/Indicator/Indicator.test.tsx
@@ -1,0 +1,111 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+import { userEvent } from "@storybook/testing-library";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { Immutable, PanelExtensionContext, RenderState } from "@lichtblick/suite";
+import MockPanelContextProvider from "@lichtblick/suite-base/components/MockPanelContextProvider";
+import { PanelExtensionAdapter } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
+import Indicator from "@lichtblick/suite-base/panels/Indicator";
+import { getMatchingRule } from "@lichtblick/suite-base/panels/Indicator/getMatchingRule";
+import { IndicatorConfig, IndicatorProps } from "@lichtblick/suite-base/panels/Indicator/types";
+import PanelSetup from "@lichtblick/suite-base/stories/PanelSetup";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+import IndicatorBuilder from "@lichtblick/suite-base/testing/builders/IndicatorBuilder";
+import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
+
+jest.mock("./getMatchingRule", () => ({
+  getMatchingRule: jest.fn(),
+}));
+
+type Setup = {
+  configOverride?: Partial<IndicatorConfig>;
+  contextOverride?: Partial<PanelExtensionContext>;
+};
+
+describe("Indicator Component", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function setup({ contextOverride, configOverride }: Setup = {}) {
+    const props: IndicatorProps = {
+      context: {
+        initialState: {},
+        layout: {
+          addPanel: jest.fn(),
+        },
+        onRender: undefined,
+        panelElement: document.createElement("div"),
+        saveState: jest.fn(),
+        setDefaultPanelTitle: jest.fn(),
+        setParameter: jest.fn(),
+        setPreviewTime: jest.fn(),
+        setSharedPanelState: jest.fn(),
+        setVariable: jest.fn(),
+        subscribe: jest.fn(),
+        subscribeAppSettings: jest.fn(),
+        unsubscribeAll: jest.fn(),
+        updatePanelSettingsEditor: jest.fn(),
+        watch: jest.fn(),
+        ...contextOverride,
+      },
+    };
+
+    const renderStates: Immutable<RenderState>[] = [];
+    const config: IndicatorConfig = {
+      ...IndicatorBuilder.config(),
+      ...configOverride,
+    };
+    const saveConfig = () => {};
+    const initPanel = jest.fn((context: PanelExtensionContext) => {
+      context.watch("currentFrame");
+      context.watch("didSeek");
+      context.watch("variables");
+      context.subscribe([{ topic: "x", preload: false }]);
+      context.onRender = (renderState, done) => {
+        renderStates.push({ ...renderState });
+        done();
+      };
+    });
+
+    const ui: React.ReactElement = (
+      <ThemeProvider isDark>
+        <MockPanelContextProvider>
+          <PanelSetup>
+            <PanelExtensionAdapter config={config} saveConfig={saveConfig} initPanel={initPanel}>
+              <Indicator {...props} />
+            </PanelExtensionAdapter>
+          </PanelSetup>
+        </MockPanelContextProvider>
+      </ThemeProvider>
+    );
+
+    const matchingRule = {
+      color: "#68e24a",
+      label: BasicBuilder.string(),
+    };
+    (getMatchingRule as jest.Mock).mockReturnValue(matchingRule);
+
+    return {
+      ...render(ui),
+      config,
+      matchingRule,
+      props,
+      user: userEvent.setup(),
+    };
+  }
+
+  it("renders Indicator component", () => {
+    const { matchingRule } = setup();
+
+    const element = screen.getByText(matchingRule.label);
+    expect(element).toBeTruthy();
+  });
+});

--- a/packages/suite-base/src/panels/Indicator/Indicator.test.tsx
+++ b/packages/suite-base/src/panels/Indicator/Indicator.test.tsx
@@ -5,7 +5,7 @@ import { userEvent } from "@storybook/testing-library";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 
-import { Immutable, PanelExtensionContext, RenderState } from "@lichtblick/suite";
+import { PanelExtensionContext } from "@lichtblick/suite";
 import MockPanelContextProvider from "@lichtblick/suite-base/components/MockPanelContextProvider";
 import { PanelExtensionAdapter } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
 import Indicator from "@lichtblick/suite-base/panels/Indicator";

--- a/packages/suite-base/src/panels/Indicator/Indicator.tsx
+++ b/packages/suite-base/src/panels/Indicator/Indicator.tsx
@@ -19,7 +19,7 @@ import { GaugeAndIndicatorState } from "@lichtblick/suite-base/panels/types";
 
 import { getMatchingRule } from "./getMatchingRule";
 import { settingsActionReducer, useSettingsTree } from "./settings";
-import { IndicatorConfig, IndicatorProps } from "./types";
+import { IndicatorConfig, IndicatorProps, RawValueIndicator } from "./types";
 
 export function Indicator({ context }: IndicatorProps): React.JSX.Element {
   // panel extensions must notify when they've completed rendering
@@ -118,19 +118,16 @@ export function Indicator({ context }: IndicatorProps): React.JSX.Element {
   }, [renderDone]);
 
   const rawValue = useMemo(() => {
-    if (
-      typeof latestMatchingQueriedData === "boolean" ||
-      typeof latestMatchingQueriedData === "number" ||
-      typeof latestMatchingQueriedData === "bigint" ||
-      typeof latestMatchingQueriedData === "string"
-    ) {
-      return latestMatchingQueriedData;
-    }
-    return undefined;
+    return ["boolean", "number", "bigint", "string"].includes(typeof latestMatchingQueriedData)
+      ? latestMatchingQueriedData
+      : undefined;
   }, [latestMatchingQueriedData]);
 
   const { style, rules, fallbackColor, fallbackLabel } = config;
-  const matchingRule = useMemo(() => getMatchingRule(rawValue, rules), [rawValue, rules]);
+  const matchingRule = useMemo(
+    () => getMatchingRule(rawValue as RawValueIndicator, rules),
+    [rawValue, rules],
+  );
 
   const bulbStyle = useMemo(
     () => ({

--- a/packages/suite-base/src/panels/Indicator/Indicator.tsx
+++ b/packages/suite-base/src/panels/Indicator/Indicator.tsx
@@ -139,16 +139,6 @@ export function Indicator({ context }: IndicatorProps): React.JSX.Element {
     [matchingRule?.color, fallbackColor],
   );
 
-  const color = useMemo(
-    () =>
-      style === "background"
-        ? augmentColor({
-            color: { main: matchingRule?.color ?? fallbackColor },
-          }).contrastText
-        : matchingRule?.color ?? fallbackColor,
-    [style, augmentColor, matchingRule?.color, fallbackColor],
-  );
-
   return (
     <Stack fullHeight>
       <Stack
@@ -164,7 +154,18 @@ export function Indicator({ context }: IndicatorProps): React.JSX.Element {
       >
         <Stack direction="row" alignItems="center" gap={2}>
           {style === "bulb" && <div className={classes.root} style={bulbStyle} />}
-          <Typography color={color} fontFamily="fontMonospace" variant="h1" whiteSpace="pre">
+          <Typography
+            color={
+              style === "background"
+                ? augmentColor({
+                    color: { main: matchingRule?.color ?? fallbackColor },
+                  }).contrastText
+                : matchingRule?.color ?? fallbackColor
+            }
+            fontFamily="fontMonospace"
+            variant="h1"
+            whiteSpace="pre"
+          >
             {matchingRule?.label ?? fallbackLabel}
           </Typography>
         </Stack>

--- a/packages/suite-base/src/panels/Indicator/Indicator.tsx
+++ b/packages/suite-base/src/panels/Indicator/Indicator.tsx
@@ -37,19 +37,21 @@ export function Indicator({ context }: IndicatorProps): React.JSX.Element {
     ...(context.initialState as Partial<IndicatorConfig>),
   }));
 
-  const [{ error, latestMatchingQueriedData, parsedPath, pathParseError }, dispatch] = useReducer(
+  const [state, dispatch] = useReducer(
     stateReducer,
     config,
-    ({ path: pathState }): GaugeAndIndicatorState => ({
+    ({ path: statePath }): GaugeAndIndicatorState => ({
       globalVariables: undefined,
       error: undefined,
       latestMatchingQueriedData: undefined,
       latestMessage: undefined,
-      parsedPath: parseMessagePath(pathState),
-      path: pathState,
+      parsedPath: parseMessagePath(statePath),
+      path: statePath,
       pathParseError: undefined,
     }),
   );
+
+  const { error, latestMatchingQueriedData, parsedPath, pathParseError } = state;
 
   useLayoutEffect(() => {
     dispatch({ type: "path", path: config.path });

--- a/packages/suite-base/src/panels/Indicator/Indicator.tsx
+++ b/packages/suite-base/src/panels/Indicator/Indicator.tsx
@@ -139,6 +139,16 @@ export function Indicator({ context }: IndicatorProps): React.JSX.Element {
     [matchingRule?.color, fallbackColor],
   );
 
+  const color = useMemo(
+    () =>
+      style === "background"
+        ? augmentColor({
+            color: { main: matchingRule?.color ?? fallbackColor },
+          }).contrastText
+        : matchingRule?.color ?? fallbackColor,
+    [style, augmentColor, matchingRule?.color, fallbackColor],
+  );
+
   return (
     <Stack fullHeight>
       <Stack
@@ -154,18 +164,7 @@ export function Indicator({ context }: IndicatorProps): React.JSX.Element {
       >
         <Stack direction="row" alignItems="center" gap={2}>
           {style === "bulb" && <div className={classes.root} style={bulbStyle} />}
-          <Typography
-            color={
-              style === "background"
-                ? augmentColor({
-                    color: { main: matchingRule?.color ?? fallbackColor },
-                  }).contrastText
-                : matchingRule?.color ?? fallbackColor
-            }
-            fontFamily="fontMonospace"
-            variant="h1"
-            whiteSpace="pre"
-          >
+          <Typography color={color} fontFamily="fontMonospace" variant="h1" whiteSpace="pre">
             {matchingRule?.label ?? fallbackLabel}
           </Typography>
         </Stack>

--- a/packages/suite-base/src/panels/Indicator/Indicator.tsx
+++ b/packages/suite-base/src/panels/Indicator/Indicator.tsx
@@ -9,7 +9,7 @@ import { Typography } from "@mui/material";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useState } from "react";
 
 import { parseMessagePath } from "@lichtblick/message-path";
-import { PanelExtensionContext, SettingsTreeAction } from "@lichtblick/suite";
+import { SettingsTreeAction } from "@lichtblick/suite";
 import Stack from "@lichtblick/suite-base/components/Stack";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
 import { useStyles } from "@lichtblick/suite-base/panels/Indicator/Indicator.style";
@@ -19,11 +19,7 @@ import { GaugeAndIndicatorState } from "@lichtblick/suite-base/panels/types";
 
 import { getMatchingRule } from "./getMatchingRule";
 import { settingsActionReducer, useSettingsTree } from "./settings";
-import { Config } from "./types";
-
-type IndicatorProps = {
-  context: PanelExtensionContext;
-};
+import { IndicatorConfig, IndicatorProps } from "./types";
 
 export function Indicator({ context }: IndicatorProps): React.JSX.Element {
   // panel extensions must notify when they've completed rendering
@@ -38,7 +34,7 @@ export function Indicator({ context }: IndicatorProps): React.JSX.Element {
 
   const [config, setConfig] = useState(() => ({
     ...DEFAULT_CONFIG,
-    ...(context.initialState as Partial<Config>),
+    ...(context.initialState as Partial<IndicatorConfig>),
   }));
 
   const [{ error, latestMatchingQueriedData, parsedPath, pathParseError }, dispatch] = useReducer(

--- a/packages/suite-base/src/panels/Indicator/constants.ts
+++ b/packages/suite-base/src/panels/Indicator/constants.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
-import { Config } from "./types";
+import { IndicatorConfig } from "./types";
 
-export const DEFAULT_CONFIG: Config = {
+export const DEFAULT_CONFIG: IndicatorConfig = {
   path: "",
   style: "bulb",
   fallbackColor: "#a0a0a0",

--- a/packages/suite-base/src/panels/Indicator/constants.ts
+++ b/packages/suite-base/src/panels/Indicator/constants.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+import { Config } from "./types";
+
+export const DEFAULT_CONFIG: Config = {
+  path: "",
+  style: "bulb",
+  fallbackColor: "#a0a0a0",
+  fallbackLabel: "False",
+  rules: [{ operator: "=", rawValue: "true", color: "#68e24a", label: "True" }],
+};

--- a/packages/suite-base/src/panels/Indicator/getMatchingRule.test.ts
+++ b/packages/suite-base/src/panels/Indicator/getMatchingRule.test.ts
@@ -6,7 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { getMatchingRule } from "./getMatchingRule";
-import { Rule } from "./types";
+import { IndicatorRule } from "./types";
 
 describe("getMatchingRule", () => {
   it.each([
@@ -20,7 +20,7 @@ describe("getMatchingRule", () => {
     [100000000000000000001n, "Large int"],
     [-1.4, undefined],
   ])("matches %s with %s", (value, expectedLabel) => {
-    const rules: Rule[] = [
+    const rules: IndicatorRule[] = [
       {
         rawValue: "hello",
         operator: "=",

--- a/packages/suite-base/src/panels/Indicator/getMatchingRule.ts
+++ b/packages/suite-base/src/panels/Indicator/getMatchingRule.ts
@@ -7,7 +7,7 @@
 
 import { assertNever } from "@lichtblick/suite-base/util/assertNever";
 
-import { Rule } from "./types";
+import { IndicatorRule } from "./types";
 
 export function getMatchingRule(
   rawValue:
@@ -17,8 +17,8 @@ export function getMatchingRule(
     | number
     | string
     | { data?: boolean | bigint | number | string },
-  rules: readonly Rule[],
-): Rule | undefined {
+  rules: readonly IndicatorRule[],
+): IndicatorRule | undefined {
   const value = typeof rawValue === "object" ? rawValue.data : rawValue;
   if (value == undefined) {
     return undefined;

--- a/packages/suite-base/src/panels/Indicator/getMatchingRule.ts
+++ b/packages/suite-base/src/panels/Indicator/getMatchingRule.ts
@@ -7,16 +7,10 @@
 
 import { assertNever } from "@lichtblick/suite-base/util/assertNever";
 
-import { IndicatorRule } from "./types";
+import { IndicatorRule, RawValueIndicator } from "./types";
 
 export function getMatchingRule(
-  rawValue:
-    | undefined
-    | boolean
-    | bigint
-    | number
-    | string
-    | { data?: boolean | bigint | number | string },
+  rawValue: RawValueIndicator,
   rules: readonly IndicatorRule[],
 ): IndicatorRule | undefined {
   const value = typeof rawValue === "object" ? rawValue.data : rawValue;

--- a/packages/suite-base/src/panels/Indicator/index.tsx
+++ b/packages/suite-base/src/panels/Indicator/index.tsx
@@ -17,7 +17,7 @@ import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
 import { SaveConfig } from "@lichtblick/suite-base/types/panels";
 
 import { Indicator } from "./Indicator";
-import { Config } from "./types";
+import { IndicatorConfig } from "./types";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
   return createSyncRoot(
@@ -31,8 +31,8 @@ function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionCo
 }
 
 type IndicatorPanelAdapterProps = {
-  config: Config;
-  saveConfig: SaveConfig<Config>;
+  config: IndicatorConfig;
+  saveConfig: SaveConfig<IndicatorConfig>;
 };
 
 function IndicatorLightPanelAdapter({ config, saveConfig }: IndicatorPanelAdapterProps) {

--- a/packages/suite-base/src/panels/Indicator/index.tsx
+++ b/packages/suite-base/src/panels/Indicator/index.tsx
@@ -30,18 +30,18 @@ function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionCo
   );
 }
 
-type IndicatorProps = {
+type IndicatorPanelAdapterProps = {
   config: Config;
   saveConfig: SaveConfig<Config>;
 };
 
-function IndicatorLightPanelAdapter(props: IndicatorProps) {
+function IndicatorLightPanelAdapter({ config, saveConfig }: IndicatorPanelAdapterProps) {
   const crash = useCrash();
   const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
   return (
     <PanelExtensionAdapter
-      config={props.config}
-      saveConfig={props.saveConfig}
+      config={config}
+      saveConfig={saveConfig}
       initPanel={boundInitPanel}
       highestSupportedConfigVersion={1}
     />

--- a/packages/suite-base/src/panels/Indicator/index.tsx
+++ b/packages/suite-base/src/panels/Indicator/index.tsx
@@ -30,15 +30,14 @@ function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionCo
   );
 }
 
-type Props = {
+type IndicatorProps = {
   config: Config;
   saveConfig: SaveConfig<Config>;
 };
 
-function IndicatorLightPanelAdapter(props: Props) {
+function IndicatorLightPanelAdapter(props: IndicatorProps) {
   const crash = useCrash();
   const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
-
   return (
     <PanelExtensionAdapter
       config={props.config}
@@ -49,7 +48,9 @@ function IndicatorLightPanelAdapter(props: Props) {
   );
 }
 
-IndicatorLightPanelAdapter.panelType = "Indicator";
-IndicatorLightPanelAdapter.defaultConfig = {};
-
-export default Panel(IndicatorLightPanelAdapter);
+export default Panel(
+  Object.assign(IndicatorLightPanelAdapter, {
+    panelType: "Indicator",
+    defaultConfig: {},
+  }),
+);

--- a/packages/suite-base/src/panels/Indicator/settings.ts
+++ b/packages/suite-base/src/panels/Indicator/settings.ts
@@ -18,9 +18,9 @@ import {
   SettingsTreeNodes,
 } from "@lichtblick/suite";
 
-import { Config, Rule } from "./types";
+import { IndicatorConfig, IndicatorRule } from "./types";
 
-function ruleToString(rule: Rule): string {
+function ruleToString(rule: IndicatorRule): string {
   const operator = {
     "=": "=",
     "<": "<",
@@ -31,7 +31,10 @@ function ruleToString(rule: Rule): string {
   return `data ${operator} ${rule.rawValue}`;
 }
 
-export function settingsActionReducer(prevConfig: Config, action: SettingsTreeAction): Config {
+export function settingsActionReducer(
+  prevConfig: IndicatorConfig,
+  action: SettingsTreeAction,
+): IndicatorConfig {
   return produce(prevConfig, (draft) => {
     switch (action.action) {
       case "perform-node-action":
@@ -89,7 +92,7 @@ export function settingsActionReducer(prevConfig: Config, action: SettingsTreeAc
 }
 
 const memoizedCreateRuleNode = memoizeWeak(
-  (rule: Rule, i: number, rules: readonly Rule[]): SettingsTreeNode => {
+  (rule: IndicatorRule, i: number, rules: readonly IndicatorRule[]): SettingsTreeNode => {
     const actions: (SettingsTreeNodeAction | false)[] = [
       { type: "action", id: "delete-rule", label: "Delete rule", icon: "Delete" },
       i > 0 && { type: "action", id: "move-up", label: "Move up", icon: "MoveUp" },
@@ -139,7 +142,7 @@ const memoizedCreateRuleNode = memoizeWeak(
 );
 
 export function useSettingsTree(
-  config: Config,
+  config: IndicatorConfig,
   pathParseError: string | undefined,
   error: string | undefined,
 ): SettingsTreeNodes {

--- a/packages/suite-base/src/panels/Indicator/types.ts
+++ b/packages/suite-base/src/panels/Indicator/types.ts
@@ -1,22 +1,31 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
+import { PanelExtensionContext } from "@lichtblick/suite";
+
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-export type Operator = "=" | "<" | "<=" | ">" | ">=";
-export type Rule = {
-  rawValue: string;
-  operator: Operator;
+export type IndicatorOperator = "=" | "<" | "<=" | ">" | ">=";
+
+export type IndicatorStyle = "bulb" | "background";
+
+export type IndicatorRule = {
   color: string;
   label: string;
+  operator: IndicatorOperator;
+  rawValue: string;
 };
 
-export type Config = {
-  path: string;
-  style: "bulb" | "background";
-  rules: Rule[];
+export type IndicatorConfig = {
   fallbackColor: string;
   fallbackLabel: string;
+  path: string;
+  rules: IndicatorRule[];
+  style: IndicatorStyle;
+};
+
+export type IndicatorProps = {
+  context: PanelExtensionContext;
 };

--- a/packages/suite-base/src/panels/Indicator/types.ts
+++ b/packages/suite-base/src/panels/Indicator/types.ts
@@ -18,6 +18,14 @@ export type IndicatorRule = {
   rawValue: string;
 };
 
+export type RawValueIndicator =
+  | undefined
+  | boolean
+  | bigint
+  | number
+  | string
+  | { data?: boolean | bigint | number | string };
+
 export type IndicatorConfig = {
   fallbackColor: string;
   fallbackLabel: string;

--- a/packages/suite-base/src/panels/shared/gaugeAndIndicatorStateReducer.test.ts
+++ b/packages/suite-base/src/panels/shared/gaugeAndIndicatorStateReducer.test.ts
@@ -90,6 +90,7 @@ describe("stateReducer", () => {
   } = {}) {
     const state: GaugeAndIndicatorState = {
       error: undefined,
+      globalVariables: undefined,
       latestMatchingQueriedData: undefined,
       latestMessage: undefined,
       parsedPath: buildMessagePath(),
@@ -222,31 +223,6 @@ describe("stateReducer", () => {
       expect(newState.pathParseError).toBeUndefined();
       expect(newState.latestMatchingQueriedData).toBeUndefined();
     });
-
-    it.each<Partial<MessagePathPart>>([
-      { type: "filter", value: Object() },
-      { type: "slice", start: Object() },
-      { type: "slice", end: Object() },
-    ])(
-      "should set pathParseError when using unsupported variables in path",
-      (messagePathPart: Partial<MessagePathPart>) => {
-        const { action, state } = setup({
-          actionOverride: buildPathAction(),
-        });
-        const newPath: MessagePath = {
-          messagePath: [messagePathPart as MessagePathPart],
-          topicName: "",
-          topicNameRepr: "",
-        };
-        (parseMessagePath as jest.Mock).mockReturnValue(newPath);
-
-        const newState = stateReducer(state, action);
-
-        expect(newState.pathParseError).toBe(
-          "Message paths using variables are not currently supported",
-        );
-      },
-    );
 
     it("should parse the path and update latestMatchingQueriedData", () => {
       const { action, state } = setup({

--- a/packages/suite-base/src/panels/shared/gaugeAndIndicatorStateReducer.test.ts
+++ b/packages/suite-base/src/panels/shared/gaugeAndIndicatorStateReducer.test.ts
@@ -11,6 +11,7 @@ import {
   SeekAction,
 } from "@lichtblick/suite-base/panels/types";
 import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+import GlobalVariableBuilder from "@lichtblick/suite-base/testing/builders/GlobalVariableBuilder";
 import MessageEventBuilder from "@lichtblick/suite-base/testing/builders/MessageEventBuilder";
 
 import { stateReducer, getSingleDataItem } from "./gaugeAndIndicatorStateReducer";
@@ -265,6 +266,33 @@ describe("stateReducer", () => {
       expect(newState.latestMessage).toBeUndefined();
       expect(newState.latestMatchingQueriedData).toBeUndefined();
       expect(newState.error).toBeUndefined();
+    });
+  });
+
+  describe("stateReducer when updateGlobalVariables action", () => {
+    it("should update globalVariables in the state", () => {
+      const initialGlobalVariables = GlobalVariableBuilder.globalVariables();
+      const newGlobalVariables = GlobalVariableBuilder.globalVariables();
+
+      const { action, state } = setup({
+        actionOverride: {
+          type: "updateGlobalVariables",
+          globalVariables: newGlobalVariables,
+        },
+        stateOverride: {
+          globalVariables: initialGlobalVariables,
+        },
+      });
+
+      const newState = stateReducer(state, action);
+
+      expect(newState.globalVariables).toEqual(newGlobalVariables);
+      expect(newState.error).toBe(state.error);
+      expect(newState.latestMatchingQueriedData).toBe(state.latestMatchingQueriedData);
+      expect(newState.latestMessage).toBe(state.latestMessage);
+      expect(newState.parsedPath).toBe(state.parsedPath);
+      expect(newState.path).toBe(state.path);
+      expect(newState.pathParseError).toBe(state.pathParseError);
     });
   });
 });

--- a/packages/suite-base/src/panels/types.ts
+++ b/packages/suite-base/src/panels/types.ts
@@ -3,9 +3,11 @@
 
 import { MessagePath } from "@lichtblick/message-path";
 import { MessageEvent } from "@lichtblick/suite";
+import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
 
 export type GaugeAndIndicatorState = {
   error: Error | undefined;
+  globalVariables: GlobalVariables | undefined;
   latestMatchingQueriedData: unknown;
   latestMessage: MessageEvent | undefined;
   parsedPath: MessagePath | undefined;
@@ -16,4 +18,12 @@ export type GaugeAndIndicatorState = {
 export type FrameAction = { type: "frame"; messages: readonly MessageEvent[] };
 export type PathAction = { type: "path"; path: string };
 export type SeekAction = { type: "seek" };
-export type GaugeAndIndicatorAction = FrameAction | PathAction | SeekAction;
+export type UpdateGlobalVariablesAction = {
+  type: "updateGlobalVariables";
+  globalVariables: GlobalVariables;
+};
+export type GaugeAndIndicatorAction =
+  | FrameAction
+  | PathAction
+  | SeekAction
+  | UpdateGlobalVariablesAction;

--- a/packages/suite-base/src/testing/builders/GlobalVariableBuilder.ts
+++ b/packages/suite-base/src/testing/builders/GlobalVariableBuilder.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+
+class GlobalVariableBuilder {
+  public static globalVariables(): GlobalVariables {
+    return {
+      [BasicBuilder.string()]: undefined,
+      [BasicBuilder.string()]: BasicBuilder.number(),
+      [BasicBuilder.string()]: BasicBuilder.boolean(),
+      [BasicBuilder.string()]: BasicBuilder.string(),
+      [BasicBuilder.string()]: BasicBuilder.strings(),
+      [BasicBuilder.string()]: BasicBuilder.genericDictionary(String),
+    };
+  }
+}
+
+export default GlobalVariableBuilder;

--- a/packages/suite-base/src/testing/builders/IndicatorBuilder.ts
+++ b/packages/suite-base/src/testing/builders/IndicatorBuilder.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import {
+  IndicatorConfig,
+  IndicatorRule,
+  IndicatorStyle,
+  IndicatorOperator,
+} from "@lichtblick/suite-base/panels/Indicator/types";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+import { defaults } from "@lichtblick/suite-base/testing/builders/utilities";
+
+export default class IndicatorBuilder {
+  public static style(): IndicatorStyle {
+    return BasicBuilder.sample(["bulb", "background"]);
+  }
+
+  public static operator(): IndicatorOperator {
+    return BasicBuilder.sample(["=", "<", "<=", ">", ">="]);
+  }
+
+  public static rule(props: Partial<IndicatorRule> = {}): IndicatorRule {
+    return defaults<IndicatorRule>(props, {
+      color: BasicBuilder.string(),
+      label: BasicBuilder.string(),
+      operator: IndicatorBuilder.operator(),
+      rawValue: BasicBuilder.string(),
+    });
+  }
+
+  public static rules(count = 3): IndicatorRule[] {
+    return BasicBuilder.multiple(IndicatorBuilder.rule, count);
+  }
+
+  public static config(props: Partial<IndicatorConfig> = {}): IndicatorConfig {
+    return defaults<IndicatorConfig>(props, {
+      fallbackColor: BasicBuilder.string(),
+      fallbackLabel: BasicBuilder.string(),
+      path: BasicBuilder.string(),
+      rules: IndicatorBuilder.rules(),
+      style: IndicatorBuilder.style(),
+    });
+  }
+}


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
Enables the user to use global variables in the Indicator panel when selecting the topic in the message path input.

Indicator panel working with _$testVariable_:
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/66a7ee6d-afb4-4dfe-a03b-2c21fc1ddc91" />

Autocomplete with the list of global variables:
<img width="489" alt="Screenshot 2025-01-07 at 20 39 15" src="https://github.com/user-attachments/assets/9f7b605e-7bdf-4a96-94e1-f1f76db2663b" />


**Description**
- Reused existent logic to fill the paths when using global variables.
- Improved performance of the component using the proper react state hooks.
- Improved coding with good practices.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
