### PR TITLE
Fix calling services

### DIFF
--- a/packages/suite-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/suite-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -668,9 +668,17 @@ export default class FoxgloveWebSocketPlayer implements Player {
         const responseMsgEncoding = service.response?.encoding ?? this.#serviceCallEncoding;
 
         try {
-          if (service.request == undefined || service.response == undefined) {
+          if (
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
+            (service.request == undefined && service.requestSchema == undefined) ||
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
+            (service.response == undefined && service.responseSchema == undefined)
+          ) {
             throw new Error("Invalid service definition, at least one required field is missing");
-          } else if (!defaultSchemaEncoding) {
+          } else if (
+            !defaultSchemaEncoding &&
+            (service.request == undefined || service.response == undefined)
+          ) {
             throw new Error("Cannot determine service request or response schema encoding");
           } else if (!SUPPORTED_SERVICE_ENCODINGS.includes(requestMsgEncoding)) {
             const supportedEncodingsStr = SUPPORTED_SERVICE_ENCODINGS.join(", ");
@@ -685,8 +693,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
               messageEncoding: requestMsgEncoding,
               schema: {
                 name: requestType,
-                encoding: service.request.schemaEncoding,
-                data: textEncoder.encode(service.request.schema),
+                encoding: service.request?.schemaEncoding ?? defaultSchemaEncoding,
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
+                data: textEncoder.encode(service.request?.schema ?? service.requestSchema),
               },
             },
             parseChannelOptions,
@@ -696,8 +705,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
               messageEncoding: responseMsgEncoding,
               schema: {
                 name: responseType,
-                encoding: service.response.schemaEncoding,
-                data: textEncoder.encode(service.response.schema),
+                encoding: service.response?.schemaEncoding ?? defaultSchemaEncoding,
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
+                data: textEncoder.encode(service.response?.schema ?? service.responseSchema),
               },
             },
             parseChannelOptions,


### PR DESCRIPTION
**User-Facing Changes**
After the refactoring to update the ESLint version, users were unable to connect to Foxglove Bridge. This issue has been addressed to restore compatibility.

**Description**
The updated ESLint version flagged the usage of elements marked as deprecated. Specifically, services defined with responseSchema and requestSchema were identified as deprecated. However, removing these fields from our codebase caused errors, as users were still relying on them.

To address this, support for these deprecated fields was temporarily restored to maintain compatibility. Additionally, a warning mechanism was implemented to notify users about services that utilize these deprecated fields. The warning informs users that such fields will no longer be supported in future versions, encouraging migration. See the attached image for an example of the warning:

<img width="362" alt="image" src="https://github.com/user-attachments/assets/232261c3-20f6-4585-a297-2ea1e926a16b" />

this PR Fixes #302 

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
