### PR TITLE
Add arm build to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      pre_release:
-        type: boolean
-        description: "Pre-release"
-        default: true
 
 jobs:
   build:
@@ -71,7 +66,6 @@ jobs:
           name: "v${{ env.new_version }}"
           commit: main
           generateReleaseNotes: true
-          prerelease: ${{ github.event.inputs.pre_release }}
           token: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}
           artifacts: |
             dist/lichtblick-${{ env.new_version }}-linux-amd64.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,8 @@ jobs:
           artifacts: |
             dist/lichtblick-${{ env.new_version }}-linux-amd64.deb
             dist/lichtblick-${{ env.new_version }}-linux-x64.tar.gz
+            dist/lichtblick-${{ env.new_version }}-linux-arm64.deb
+            dist/lichtblick-${{ env.new_version }}-linux-arm64.tar.gz
             dist/lichtblick-${{ env.new_version }}-mac-universal.dmg
             dist/lichtblick-${{ env.new_version }}-win.exe
             dist/latest-linux.yml

--- a/packages/suite-desktop/src/electronBuilderConfig.js
+++ b/packages/suite-desktop/src/electronBuilderConfig.js
@@ -39,7 +39,7 @@ function makeElectronBuilderConfig(params) {
         },
         {
           target: "tar.gz",
-          arch: ["x64"],
+          arch: ["x64, arm64"],
         },
       ],
       fileAssociations: [


### PR DESCRIPTION
### **User-Facing Changes**
Users on ARM architectures can now directly download the ARM version of Lichtblick without needing to build it from source.

**Description**
- Added ARM64 to the Electron build configuration to support native builds for ARM architecture.
- Included the ARM64 build in the list of files to be added to the release artifacts.
- Removed unused "pre-release" option from release pipeline.

**Checklist**
- [x] The desktop version was tested and it is running ok
