### PR TITLE
Reset view in Plot panel is not working when sync is disabled

### DIFF
--- a/packages/suite-base/src/panels/Plot/Plot.tsx
+++ b/packages/suite-base/src/panels/Plot/Plot.tsx
@@ -604,7 +604,7 @@ export function Plot(props: Props): React.JSX.Element {
   }, [coordinator, globalBounds, shouldSync, subscriberId]);
 
   useEffect(() => {
-    if (!coordinator || !shouldSync) {
+    if (!coordinator) {
       return;
     }
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
Fixed the "Reset view" button behaviour in the Plot panel when sync is disabled.

**Description**
Removed the condition that was blocking the "Reset view" button.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
