### PR TITLE
Bugfix: Downgrade electron version

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,7 @@
     "@lichtblick/suite-desktop": "workspace:*",
     "@lichtblick/tsconfig": "1.0.0",
     "@types/ws": "^8",
-    "electron": "33.2.1",
+    "electron": "29.4.6",
     "playwright": "1.49.1",
     "ws": "8.18.0"
   }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "babel-plugin-transform-import-meta": "2.2.1",
     "cross-env": "7.0.3",
     "depcheck": "1.4.7",
-    "electron": "33.2.1",
+    "electron": "29.4.6",
     "electron-builder": "25.1.8",
     "eslint": "8.57",
     "eslint-config-prettier": "9.1.0",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -27,7 +27,7 @@
     "async-mutex": "0.4.0",
     "builder-util": "*",
     "clean-webpack-plugin": "4.0.0",
-    "electron": "33.2.1",
+    "electron": "29.4.6",
     "electron-builder": "25.1.8",
     "electron-devtools-installer": "4.0.0",
     "electron-squirrel-startup": "1.0.1",

--- a/packages/suite-desktop/src/main/StudioWindow.ts
+++ b/packages/suite-desktop/src/main/StudioWindow.ts
@@ -298,15 +298,15 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
       { role: "paste" },
       ...(isMac
         ? [
-          { role: "pasteAndMatchStyle" } as const,
-          { role: "delete" } as const,
-          { role: "selectAll" } as const,
-        ]
+            { role: "pasteAndMatchStyle" } as const,
+            { role: "delete" } as const,
+            { role: "selectAll" } as const,
+          ]
         : [
-          { role: "delete" } as const,
-          { type: "separator" } as const,
-          { role: "selectAll" } as const,
-        ]),
+            { role: "delete" } as const,
+            { type: "separator" } as const,
+            { role: "selectAll" } as const,
+          ]),
     ],
   });
 
@@ -319,15 +319,15 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
       workers.length === 0
         ? [{ label: t("desktopWindow:noSharedWorkers"), enabled: false }]
         : workers.map(
-          (worker) =>
-            new MenuItem({
-              label: worker.url,
-              click() {
-                browserWindow.webContents.closeDevTools();
-                browserWindow.webContents.inspectSharedWorkerById(worker.id);
-              },
-            }),
-        ),
+            (worker) =>
+              new MenuItem({
+                label: worker.url,
+                click() {
+                  browserWindow.webContents.closeDevTools();
+                  browserWindow.webContents.inspectSharedWorkerById(worker.id);
+                },
+              }),
+          ),
     ).popup();
   };
 

--- a/packages/suite-desktop/src/main/StudioWindow.ts
+++ b/packages/suite-desktop/src/main/StudioWindow.ts
@@ -13,11 +13,11 @@ import {
   Menu,
   MenuItem,
   MenuItemConstructorOptions,
-  TitleBarOverlayOptions,
   app,
   nativeTheme,
   shell,
   systemPreferences,
+  TitleBarOverlay,
 } from "electron";
 import path from "path";
 
@@ -52,7 +52,7 @@ function getWindowBackgroundColor(): string | undefined {
   return theme.background?.default;
 }
 
-function getTitleBarOverlayOptions(): TitleBarOverlayOptions {
+function getTitleBarOverlayOptions(): TitleBarOverlay {
   const theme = palette[nativeTheme.shouldUseDarkColors ? "dark" : "light"];
   if (isWindows) {
     return {
@@ -298,15 +298,15 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
       { role: "paste" },
       ...(isMac
         ? [
-            { role: "pasteAndMatchStyle" } as const,
-            { role: "delete" } as const,
-            { role: "selectAll" } as const,
-          ]
+          { role: "pasteAndMatchStyle" } as const,
+          { role: "delete" } as const,
+          { role: "selectAll" } as const,
+        ]
         : [
-            { role: "delete" } as const,
-            { type: "separator" } as const,
-            { role: "selectAll" } as const,
-          ]),
+          { role: "delete" } as const,
+          { type: "separator" } as const,
+          { role: "selectAll" } as const,
+        ]),
     ],
   });
 
@@ -319,15 +319,15 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
       workers.length === 0
         ? [{ label: t("desktopWindow:noSharedWorkers"), enabled: false }]
         : workers.map(
-            (worker) =>
-              new MenuItem({
-                label: worker.url,
-                click() {
-                  browserWindow.webContents.closeDevTools();
-                  browserWindow.webContents.inspectSharedWorkerById(worker.id);
-                },
-              }),
-          ),
+          (worker) =>
+            new MenuItem({
+              label: worker.url,
+              click() {
+                browserWindow.webContents.closeDevTools();
+                browserWindow.webContents.inspectSharedWorkerById(worker.id);
+              },
+            }),
+        ),
     ).popup();
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3333,7 +3333,7 @@ __metadata:
     async-mutex: 0.4.0
     builder-util: "*"
     clean-webpack-plugin: 4.0.0
-    electron: 33.2.1
+    electron: 29.4.6
     electron-builder: 25.1.8
     electron-devtools-installer: 4.0.0
     electron-squirrel-startup: 1.0.1
@@ -9509,7 +9509,7 @@ __metadata:
     "@lichtblick/suite-desktop": "workspace:*"
     "@lichtblick/tsconfig": 1.0.0
     "@types/ws": ^8
-    electron: 33.2.1
+    electron: 29.4.6
     playwright: 1.49.1
     ws: 8.18.0
   languageName: unknown
@@ -10008,16 +10008,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:33.2.1":
-  version: 33.2.1
-  resolution: "electron@npm:33.2.1"
+"electron@npm:29.4.6":
+  version: 29.4.6
+  resolution: "electron@npm:29.4.6"
   dependencies:
     "@electron/get": ^2.0.0
     "@types/node": ^20.9.0
     extract-zip: ^2.0.1
   bin:
     electron: cli.js
-  checksum: c5b7d5fe56f831da5d14be9d24d0a29fdb392d5b4e593b31200a9c01e6260d87bba1216c4cc17297b2f4838e0893428464b9e2ca71c3eaff499dbff1981c0670
+  checksum: 14f4ae506032227083e59db3188863c71cd89c9df9490cc4bb014af55c9d93bd585093e06db4f221e897aea5b01805d4ad11e5f6ae7b41cbe493d84d55e5ffbf
   languageName: node
   linkType: hard
 
@@ -14548,7 +14548,7 @@ __metadata:
     babel-plugin-transform-import-meta: 2.2.1
     cross-env: 7.0.3
     depcheck: 1.4.7
-    electron: 33.2.1
+    electron: 29.4.6
     electron-builder: 25.1.8
     eslint: 8.57
     eslint-config-prettier: 9.1.0


### PR DESCRIPTION
## User-Facing Changes  
This PR addresses an issue with the font size on the Indicator Panel, where the font appeared too large and did not adjust properly when resizing the application window.


## Description  
To resolve the font scaling issue, the Electron version has been downgraded from `33.2.1` to `29.4.6`. As a result of this downgrade, the `TitleBarOverlayOptions` API is no longer available. Consequently, the implementation has been updated to use the `TitleBarOverlay` API instead.

In order to test the changes there is needed to perform these steps:

- Update dependencies by performing `yarn install`
- Build the desired version (web | desktop - dev | prod)

## Checklist  
- [x] The web version has been tested and is functioning correctly.  
- [x] The desktop version has been tested and is functioning correctly.  

## Key Changes  
- **Electron Version**: Downgraded from `33.2.1` to `29.4.6`.  
- **API Update**: Replaced `TitleBarOverlayOptions` with `TitleBarOverlay` due to compatibility requirements.  