### PR TITLE
Fixed rpy representation of quaternions following robotics ZYX order.

### DIFF
--- a/packages/suite-base/src/util/quatToEuler.ts
+++ b/packages/suite-base/src/util/quatToEuler.ts
@@ -12,6 +12,8 @@ const tempEuler = new THREE.Euler();
 
 /**
  * Convert a quaternion to roll-pitch-yaw Euler angles.
+ * Returns angles in degrees using extrinsic ZYX (yaw-pitch-roll) convention,
+ * which is the standard for aerospace and robotics.
  */
 export function quatToEuler(
   x: number,
@@ -20,7 +22,7 @@ export function quatToEuler(
   w: number,
 ): [roll: number, pitch: number, yaw: number] {
   tempQuaternion.set(x, y, z, w);
-  tempEuler.setFromQuaternion(tempQuaternion, "XYZ");
+  tempEuler.setFromQuaternion(tempQuaternion, "ZYX");
   return [
     THREE.MathUtils.radToDeg(tempEuler.x),
     THREE.MathUtils.radToDeg(tempEuler.y),


### PR DESCRIPTION
**User-Facing Changes**
Fixed rpy representation of quaternions following robotics ZYX order.

**Description**
Fixes #339 

**Checklist**

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
