### PR TITLE
Add support for layoutUrl as a param

### DIFF
--- a/packages/suite-base/src/Workspace.tsx
+++ b/packages/suite-base/src/Workspace.tsx
@@ -608,7 +608,6 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
 
     const layoutData = parsedState as LayoutData;
     setCurrentLayout({
-      name: "test-layout",
       data: layoutData,
     });
   };

--- a/packages/suite-base/src/Workspace.tsx
+++ b/packages/suite-base/src/Workspace.tsx
@@ -61,6 +61,10 @@ import VariablesList from "@lichtblick/suite-base/components/VariablesList";
 import { WorkspaceDialogs } from "@lichtblick/suite-base/components/WorkspaceDialogs";
 import { useAppContext } from "@lichtblick/suite-base/context/AppContext";
 import {
+  LayoutData,
+  useCurrentLayoutActions,
+} from "@lichtblick/suite-base/context/CurrentLayoutContext";
+import {
   LayoutState,
   useCurrentLayoutSelector,
 } from "@lichtblick/suite-base/context/CurrentLayoutContext";
@@ -565,21 +569,57 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
     [getMessagePipeline],
   );
 
+  const { setCurrentLayout } = useCurrentLayoutActions();
+
   const targetUrlState = useMemo(() => {
     const deepLinks = props.deepLinks ?? [];
     return deepLinks[0] ? parseAppURLState(new URL(deepLinks[0])) : undefined;
   }, [props.deepLinks]);
 
   const [unappliedSourceArgs, setUnappliedSourceArgs] = useState(
-    targetUrlState ? { ds: targetUrlState.ds, dsParams: targetUrlState.dsParams } : undefined,
+    targetUrlState
+      ? {
+          ds: targetUrlState.ds,
+          dsParams: targetUrlState.dsParams,
+          layoutUrl: targetUrlState.layoutUrl,
+        }
+      : undefined,
   );
 
   const selectEvent = useEvents(selectSelectEvent);
+
+  const fetchLayoutFromUrl = async (layoutUrl: string) => {
+    if (!layoutUrl) {
+      return;
+    }
+    let res;
+    try {
+      res = await fetch(layoutUrl);
+    } catch {
+      log.debug(`Could not load the layout from ${layoutUrl}`);
+      return;
+    }
+    const parsedState: unknown = JSON.parse(await res.text());
+
+    if (typeof parsedState !== "object" || !parsedState) {
+      log.debug(`${layoutUrl} does not contain valid layout JSON`);
+      return;
+    }
+
+    const layoutData = parsedState as LayoutData;
+    setCurrentLayout({
+      name: "test-layout",
+      data: layoutData,
+    });
+  };
+
   // Load data source from URL.
   useEffect(() => {
     if (!unappliedSourceArgs) {
       return;
     }
+
+    let shouldUpdate;
 
     // Apply any available data source args
     if (unappliedSourceArgs.ds) {
@@ -589,7 +629,15 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
         params: unappliedSourceArgs.dsParams,
       });
       selectEvent(unappliedSourceArgs.dsParams?.eventId);
-      setUnappliedSourceArgs({ ds: undefined, dsParams: undefined });
+      shouldUpdate = true;
+    }
+    // Apply any available datasource args
+    if (unappliedSourceArgs.layoutUrl) {
+      fetchLayoutFromUrl(unappliedSourceArgs.layoutUrl);
+      shouldUpdate = true;
+    }
+    if (shouldUpdate) {
+      setUnappliedSourceArgs({ ds: undefined, dsParams: undefined, layoutUrl: undefined });
     }
   }, [selectEvent, selectSource, unappliedSourceArgs, setUnappliedSourceArgs]);
 

--- a/packages/suite-base/src/util/appURLState.ts
+++ b/packages/suite-base/src/util/appURLState.ts
@@ -12,6 +12,7 @@ import { LayoutID } from "@lichtblick/suite-base/context/CurrentLayoutContext";
 
 export type AppURLState = {
   ds?: string;
+  layoutUrl?: string;
   dsParams?: Record<string, string>;
   layoutId?: LayoutID;
   time?: Time;
@@ -43,6 +44,14 @@ export function updateAppURLState(url: URL, urlState: AppURLState): URL {
     }
   }
 
+  if ("layoutUrl" in urlState) {
+    if (urlState.layoutUrl) {
+      newURL.searchParams.set("layoutUrl", urlState.layoutUrl);
+    } else {
+      newURL.searchParams.delete("layoutUrl");
+    }
+  }
+
   if ("dsParams" in urlState) {
     [...newURL.searchParams].forEach(([k]) => {
       if (k.startsWith("ds.")) {
@@ -69,6 +78,7 @@ export function updateAppURLState(url: URL, urlState: AppURLState): URL {
  */
 export function parseAppURLState(url: URL): AppURLState | undefined {
   const ds = url.searchParams.get("ds") ?? undefined;
+  const layoutUrl = url.searchParams.get("layoutUrl");
   const timeString = url.searchParams.get("time");
   const time = timeString == undefined ? undefined : fromRFC3339String(timeString);
   const dsParams: Record<string, string> = {};
@@ -83,6 +93,7 @@ export function parseAppURLState(url: URL): AppURLState | undefined {
     {
       time,
       ds,
+      layoutUrl,
       dsParams: _.isEmpty(dsParams) ? undefined : dsParams,
     },
     _.isEmpty,


### PR DESCRIPTION
**User-Facing Changes**
Added the option to pass a URL to a layout file

**Description**

Just before Foxglove went close source, we saw a lot of users asking for a way to preload a layout in the URL for easy sharing of configuration between people just with the URL. A user at that time did a PR adding this functionality but they declined it. We ported this to our fork and it is very helpful inside our team.

Now we would like this to be part of the open-source platform that remains. Since our fork is from when Foxglove was open source days we had to port to your version which has changed. 

If you think this would be nice to be merged I'd appreciate some input on this PR since it doesn't work, somehow the layout is not updated correctly. What am I missing? 

Note: for this to work, you need to enable the CORS policy wherever you store your layouts JSON files so the browser can get them.

I enabled this temporarily on some data so you can debug it if you want locally at: http://localhost:8080/?layoutUrl=https%3A%2F%2Fstorage.googleapis.com%2Fgcp-io-tests%2Fexample_layout.json


**Checklist**

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
