### PR TITLE
Add foxglove compressedVideo support H264

### DIFF
--- a/packages/den/package.json
+++ b/packages/den/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@lichtblick/comlink": "1.0.3",
     "async-mutex": "0.4.0",
+    "eventemitter3": "5.0.1",
     "xacro-parser": "0.3.9"
   },
   "devDependencies": {

--- a/packages/den/video/VideoPlayer.ts
+++ b/packages/den/video/VideoPlayer.ts
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Mutex } from "async-mutex";
+import EventEmitter from "eventemitter3";
+
+import Logger from "@lichtblick/log";
+
+// foxglove-depcheck-used: @types/dom-webcodecs
+
+const MAX_DECODE_WAIT_MS = 30;
+
+export type VideoPlayerEventTypes = {
+  frame: (frame: VideoFrame) => void;
+  debug: (message: string) => void;
+  warn: (message: string) => void;
+  error: (error: Error) => void;
+};
+
+const log = Logger.getLogger(__filename);
+
+/**
+ * A wrapper around the WebCodecs VideoDecoder API that is safe to use from
+ * multiple asynchronous contexts, is keyframe-aware, exposes a simple decode
+ * method that takes a chunk of encoded video bitstream representing a single
+ * frame and returns the decoded VideoFrame, and emits events for debugging
+ * and error handling.
+ */
+export class VideoPlayer extends EventEmitter<VideoPlayerEventTypes> {
+  #decoderInit: VideoDecoderInit;
+  #decoder: VideoDecoder;
+  #decoderConfig: VideoDecoderConfig | undefined;
+  #mutex = new Mutex();
+  #timeoutId: ReturnType<typeof setTimeout> | undefined;
+  #pendingFrame: VideoFrame | undefined;
+  #codedSize: { width: number; height: number } | undefined;
+  // Stores the last decoded frame as an ImageBitmap, should be set after decode()
+  lastImageBitmap: ImageBitmap | undefined;
+
+  /** Reports whether video decoding is supported in this browser session */
+  public static IsSupported(): boolean {
+    return self.isSecureContext && "VideoDecoder" in globalThis;
+  }
+
+  public constructor() {
+    super();
+    this.#decoderInit = {
+      output: (videoFrame: VideoFrame) => {
+        this.#pendingFrame?.close();
+        this.#pendingFrame = videoFrame;
+        this.emit("frame", videoFrame);
+      },
+      error: (error) => this.emit("error", error),
+    };
+    this.#decoder = new VideoDecoder(this.#decoderInit);
+  }
+
+  /**
+   * Configures the VideoDecoder with the given VideoDecoderConfig. This must
+   * be called before decode() will return a VideoFrame.
+   */
+  public async init(decoderConfig: VideoDecoderConfig): Promise<void> {
+    await this.#mutex.runExclusive(async () => {
+      // Optimize for latency means we do not have to call flush() in every decode() call
+      // See <https://github.com/w3c/webcodecs/issues/206>
+      decoderConfig.optimizeForLatency = true;
+
+      // Try with 'prefer-hardware' first
+      let modifiedConfig = { ...decoderConfig };
+      modifiedConfig.hardwareAcceleration = "prefer-hardware";
+
+      let support = await VideoDecoder.isConfigSupported(modifiedConfig);
+      if (support.supported !== true) {
+        log.warn(
+          `VideoDecoder does not support configuration ${JSON.stringify(modifiedConfig)}. Trying without 'prefer-hardware'`,
+        );
+        // If 'prefer-hardware' is not supported, try without it
+        modifiedConfig = { ...decoderConfig };
+        support = await VideoDecoder.isConfigSupported(modifiedConfig);
+      }
+
+      if (support.supported !== true) {
+        const err = new Error(
+          `VideoDecoder does not support configuration ${JSON.stringify(decoderConfig)}`,
+        );
+        this.emit("error", err);
+        return;
+      }
+
+      if (this.#decoder.state === "closed") {
+        this.emit("debug", "VideoDecoder is closed, creating a new one");
+        this.#decoder = new VideoDecoder(this.#decoderInit);
+      }
+
+      this.emit("debug", `Configuring VideoDecoder with ${JSON.stringify(decoderConfig)}`);
+      this.#decoder.configure(decoderConfig);
+      this.#decoderConfig = decoderConfig;
+      this.#codedSize = undefined;
+      if (decoderConfig.codedWidth != undefined && decoderConfig.codedHeight != undefined) {
+        this.#codedSize = { width: decoderConfig.codedWidth, height: decoderConfig.codedHeight };
+      }
+    });
+  }
+
+  /** Returns true if the VideoDecoder is open and configured, ready for decoding. */
+  public isInitialized(): boolean {
+    return this.#decoder.state === "configured";
+  }
+
+  /** Returns the VideoDecoderConfig given to init(), or undefined if init() has not been called. */
+  public decoderConfig(): VideoDecoderConfig | undefined {
+    return this.#decoderConfig;
+  }
+
+  /** Returns the dimensions of the coded video frames, if known. */
+  public codedSize(): { width: number; height: number } | undefined {
+    return this.#codedSize;
+  }
+
+  /**
+   * Takes a chunk of encoded video bitstream, sends it to the VideoDecoder,
+   * and returns a Promise that resolves to the decoded VideoFrame. If the
+   * VideoDecoder is not yet configured, we are waiting on a keyframe, or we
+   * time out waiting for the decoder to return a frame, this will return
+   * undefined.
+   *
+   * @param data A chunk of encoded video bitstream
+   * @param timestampMicros The timestamp of the chunk of encoded video
+   *   bitstream in microseconds relative to the start of the stream
+   * @param type "key" if this chunk contains a keyframe, "delta" otherwise
+   * @returns A VideoFrame or undefined if no frame was decoded
+   */
+  public async decode(
+    data: Uint8Array,
+    timestampMicros: number,
+    type: "key" | "delta",
+  ): Promise<VideoFrame | undefined> {
+    return await this.#mutex.runExclusive(async () => {
+      if (this.#decoder.state === "closed") {
+        this.emit("warn", "VideoDecoder is closed, creating a new one");
+        this.#decoder = new VideoDecoder(this.#decoderInit);
+      }
+
+      if (this.#decoder.state === "unconfigured") {
+        this.emit("debug", "Waiting for initialization...");
+        return undefined;
+      }
+
+      await new Promise<void>((resolve) => {
+        const frameHandler = () => {
+          if (this.#timeoutId != undefined) {
+            clearTimeout(this.#timeoutId);
+          }
+          resolve();
+        };
+
+        if (this.#timeoutId != undefined) {
+          clearTimeout(this.#timeoutId);
+        }
+
+        this.#timeoutId = setTimeout(() => {
+          this.removeListener("frame", frameHandler);
+          this.emit(
+            "warn",
+            `Timed out decoding ${data.byteLength} byte chunk at time ${timestampMicros}`,
+          );
+          resolve(undefined);
+        }, MAX_DECODE_WAIT_MS);
+
+        this.once("frame", frameHandler);
+
+        try {
+          this.#decoder.decode(new EncodedVideoChunk({ type, data, timestamp: timestampMicros }));
+        } catch (unk) {
+          clearTimeout(this.#timeoutId);
+          this.removeListener("frame", frameHandler);
+
+          const error = new Error(
+            `Failed to decode ${data.byteLength} byte chunk at time ${timestampMicros}: ${
+              (unk as Error).message
+            }`,
+          );
+          this.emit("error", error);
+          resolve();
+        }
+      });
+
+      const maybeVideoFrame = this.#pendingFrame;
+      this.#pendingFrame = undefined;
+
+      // Update the coded and display sizes if we have a new frame
+      if (maybeVideoFrame) {
+        if (!this.#codedSize) {
+          this.#codedSize = { width: 0, height: 0 };
+        }
+        this.#codedSize.width = maybeVideoFrame.codedWidth;
+        this.#codedSize.height = maybeVideoFrame.codedHeight;
+      }
+
+      return maybeVideoFrame;
+    });
+  }
+
+  /**
+   * Reset the VideoDecoder and clear any pending frames, but do not clear any
+   * cached stream information or decoder configuration. This should be called
+   * when seeking to a new position in the stream.
+   */
+  public resetForSeek(): void {
+    if (this.#decoder.state === "configured") {
+      this.#decoder.reset();
+    }
+    if (this.#timeoutId != undefined) {
+      clearTimeout(this.#timeoutId);
+    }
+    this.#pendingFrame?.close();
+    this.#pendingFrame = undefined;
+  }
+
+  /**
+   * Close the VideoDecoder and clear any pending frames. Also clear any cached
+   * stream information or decoder configuration.
+   */
+  public close(): void {
+    if (this.#decoder.state !== "closed") {
+      this.#decoder.close();
+    }
+    if (this.#timeoutId != undefined) {
+      clearTimeout(this.#timeoutId);
+    }
+    this.#pendingFrame?.close();
+    this.#pendingFrame = undefined;
+  }
+}

--- a/packages/den/video/h264/Bitstream.test.ts
+++ b/packages/den/video/h264/Bitstream.test.ts
@@ -1,0 +1,121 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Bitstream } from "./Bitstream";
+
+describe("Bitstream", () => {
+  it("Reads bits correctly", () => {
+    // Let's use a buffer with two bytes: 0b10101010 (0xAA) and 0b11001100 (0xCC)
+    const bitstream = new Bitstream(new Uint8Array([0xaa, 0xcc]));
+
+    // u_1 should return the first bit of the first byte (1)
+    expect(bitstream.u_1()).toEqual(1);
+
+    // u_2 should return the next two bits of the first byte (01 = 1)
+    expect(bitstream.u_2()).toEqual(1);
+
+    // u_3 should return the next three bits of the first byte (010 = 2)
+    expect(bitstream.u_3()).toEqual(2);
+
+    // u_8 should return the remaining two bits of the first byte and the first
+    // six bits of the second byte (10110011 = 0xB3)
+    expect(bitstream.u_8()).toEqual(0xb3);
+  });
+
+  it("Handles emulation prevention bytes correctly", () => {
+    // Let's use a buffer with the bytes 0x00, 0x00, 0x03, 0xFF, 0x00
+    const bitstream = new Bitstream(new Uint8Array([0x00, 0x00, 0x03, 0xff, 0x00]));
+
+    // u_8 should return the first byte (0x00)
+    expect(bitstream.u_8()).toEqual(0x00);
+
+    // u_8 should return the second byte (0x00)
+    expect(bitstream.u_8()).toEqual(0x00);
+
+    // The second u_8 should skip the emulation prevention byte (0x03) and
+    // return the fourth byte (0xFF)
+    expect(bitstream.u_8()).toEqual(0xff);
+
+    bitstream.reset();
+
+    // u(16) should return the first two bytes (0x0000)
+    expect(bitstream.u(16)).toEqual(0);
+
+    // u_1 should skip the emulation prevention byte (0x03) and return the first
+    // bit of the fourth byte (1)
+    expect(bitstream.u_1()).toEqual(1);
+
+    bitstream.reset();
+
+    // u(15) should return the first 15 bits (0x0000), leaving the pointer at an
+    // unaligned position
+    // just before the emulation prevention byte
+    expect(bitstream.u(15)).toEqual(0);
+
+    // u_8 should return 0b01111111 (0x7F)
+    expect(bitstream.u_8()).toEqual(0x7f);
+
+    bitstream.reset();
+
+    // u(17) should return the first 16 bits, skip over the emulation prevention
+    // byte (0x03), then the first bit of the fourth byte (1)
+    expect(bitstream.u(17)).toEqual(1);
+  });
+
+  it("Reads example NAL data correctly", () => {
+    const NALU = [
+      0x25, 0x00, 0x1f, 0xe2, 0x22, 0x00, 0x00, 0x03, 0x02, 0x00, 0x00, 0x80, 0xab, 0xff,
+    ];
+    const bitstream = new Bitstream(new Uint8Array(NALU));
+
+    // u_8 should return the first byte (0x25)
+    expect(bitstream.u_8()).toEqual(0x25);
+
+    // Reading two more bytes should give 0x00 and 0x1F
+    expect(bitstream.u_8()).toEqual(0x00);
+    expect(bitstream.u_8()).toEqual(0x1f);
+
+    // Reading a 16-bit value should return 0xE222
+    expect(bitstream.u(16)).toEqual(0xe222);
+
+    // The next two bytes should be 0x00 and 0x00
+    expect(bitstream.u(16)).toEqual(0);
+
+    // The next byte should be 0x02, skipping over the emulation prevention byte
+    // (0x03)
+    expect(bitstream.u_8()).toEqual(0x02);
+
+    // Reading a 32-bit value should return 0x000080AB
+    expect(bitstream.u(32)).toEqual(0x000080ab);
+
+    // The final byte should be 0xFF
+    expect(bitstream.u_8()).toEqual(0xff);
+  });
+
+  it("Reads unsigned exponential Golomb-coded numbers correctly", () => {
+    // 00100000 01011110 01010001 10100000
+    // [3, 22, 0, 4, 12]
+    const NALU = [0x20, 0x5e, 0x51, 0xa0];
+    const bitstream = new Bitstream(new Uint8Array(NALU));
+
+    expect(bitstream.ue_v()).toEqual(3);
+    expect(bitstream.ue_v()).toEqual(22);
+    expect(bitstream.ue_v()).toEqual(0);
+    expect(bitstream.ue_v()).toEqual(4);
+    expect(bitstream.ue_v()).toEqual(12);
+  });
+
+  it("Reads signed exponential Golomb-coded numbers correctly", () => {
+    // 00100000 01011110 01010001 10100000
+    // [2, -11, 0, -2, -6]
+    const NALU = [0x20, 0x5e, 0x51, 0xa0];
+    const bitstream = new Bitstream(new Uint8Array(NALU));
+
+    expect(bitstream.se_v()).toEqual(2);
+    expect(bitstream.se_v()).toEqual(-11);
+    expect(bitstream.se_v()).toEqual(0);
+    expect(bitstream.se_v()).toEqual(-2);
+    expect(bitstream.se_v()).toEqual(-6);
+  });
+});

--- a/packages/den/video/h264/Bitstream.ts
+++ b/packages/den/video/h264/Bitstream.ts
@@ -1,0 +1,185 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * Bitstream reader for H264 data, handling emulation prevention bytes and
+ * decoding exponential Golomb format integers.
+ */
+export class Bitstream {
+  #buffer: Uint8Array;
+  #ptr: number = 0;
+  #bytePtr: number = 0;
+  #lastTwoBytes: number = 0;
+  #max: number;
+
+  /**
+   * Construct a bitstream
+   * @param stream Buffer containing the stream
+   */
+  public constructor(stream: Uint8Array) {
+    this.#buffer = stream;
+    this.#max = this.#buffer.byteLength << 3;
+  }
+
+  public reset(): void {
+    this.#ptr = 0;
+    this.#bytePtr = 0;
+    this.#lastTwoBytes = 0;
+  }
+
+  /**
+   * get one bit
+   * @returns {number}
+   */
+  public u_1(): number {
+    if (this.#ptr + 1 > this.#max) {
+      throw new Error("Bitstream error: bitstream exhausted");
+    }
+
+    const byteOffset = this.#ptr >> 3;
+    const bitOffset = 0x07 - (this.#ptr & 0x07);
+
+    // Save the current buffer pointer
+    const savedBytePtr = this.#bytePtr;
+
+    // Set the buffer pointer to the start of the byte containing the bit we are interested in
+    this.#bytePtr = byteOffset;
+
+    // Read the byte (with possible deemulation)
+    const byte = this.#readByte();
+
+    // Restore the buffer pointer
+    this.#bytePtr = savedBytePtr;
+
+    const val = (byte >> bitOffset) & 0x01;
+    this.#ptr++;
+    return val;
+  }
+
+  /**
+   * get two bits
+   * @returns {number}
+   */
+  public u_2(): number {
+    return (this.u_1() << 1) | this.u_1();
+  }
+
+  /**
+   * get three bits
+   * @returns {number}
+   */
+  public u_3(): number {
+    return (this.u_1() << 2) | (this.u_1() << 1) | this.u_1();
+  }
+
+  /**
+   * get one byte (as an unsigned number)
+   * @returns {number}
+   */
+  public u_8(): number {
+    if (this.#ptr + 8 > this.#max) {
+      throw new Error("Bitstream error: bitstream exhausted");
+    }
+    const byteOffset = this.#ptr >> 3;
+    const bitOffset = this.#ptr & 0x07;
+
+    // Save the current buffer pointer
+    const savedBytePtr = this.#bytePtr;
+
+    // Set the buffer pointer to the start of the byte containing the first bit we are interested in
+    this.#bytePtr = byteOffset;
+
+    // If the current bit pointer is not aligned with a byte boundary
+    if (bitOffset !== 0) {
+      // Read the two bytes straddling the bit boundary (with possible deemulation)
+      const byte1 = this.#readByte();
+      const byte2 = this.#readByte();
+
+      // Extract the 8 bits we are interested in
+      const val =
+        ((byte1 & ((1 << (8 - bitOffset)) - 1)) << bitOffset) | (byte2 >> (8 - bitOffset));
+
+      // Restore the buffer pointer
+      this.#bytePtr = savedBytePtr;
+
+      this.#ptr += 8;
+      return val;
+    } else {
+      // Read the byte (with possible deemulation)
+      const val = this.#readByte();
+
+      // Restore the buffer pointer
+      this.#bytePtr = savedBytePtr;
+
+      this.#ptr += 8;
+      return val;
+    }
+  }
+
+  /**
+   * get an unsigned H.264-style variable-bit number
+   * in exponential Golomb format
+   * @returns {number}
+   */
+  public ue_v(): number {
+    let zeros = 0;
+    while (this.u_1() === 0) {
+      zeros++;
+    }
+    let val = 1 << zeros;
+    for (let i = zeros - 1; i >= 0; i--) {
+      val |= this.u_1() << i;
+    }
+    return val - 1;
+  }
+
+  /**
+   * get a signed h.264-style variable bit number
+   * in exponential Golomb format
+   * @returns {number} (without negative zeros)
+   */
+  public se_v(): number {
+    const codeword = this.ue_v();
+    const result = (codeword & 1) === 1 ? 1 + (codeword >> 1) : -(codeword >> 1);
+    return result === 0 ? 0 : result;
+  }
+
+  /**
+   * get n bits
+   * @param n
+   * @returns {number}
+   */
+  public u(n: number): number {
+    // console.log(`u(${n})`);
+    if (n === 8) {
+      return this.u_8();
+    }
+    if (this.#ptr + n >= this.#max) {
+      throw new Error("NALUStream error: bitstream exhausted");
+    }
+    let val = 0;
+    for (let i = 0; i < n; i++) {
+      val = (val << 1) | this.u_1();
+      // console.log(`val: ${val}`);
+    }
+    return val;
+  }
+
+  #readByte(): number {
+    if (this.#bytePtr >= this.#buffer.length) {
+      throw new Error("Attempted to read past end of buffer");
+    }
+
+    // If the current byte is 0x03 and the last two bytes were zeros, skip over it
+    if (this.#buffer[this.#bytePtr] === 0x03 && this.#lastTwoBytes === 0) {
+      this.#bytePtr++;
+      this.#ptr += 8; // Skip 8 bits in the bitstream
+      this.#lastTwoBytes = (this.#lastTwoBytes << 8) & 0xffff; // Shift in a zero to the last two bytes
+    }
+
+    // Update the last two bytes and return the current byte
+    this.#lastTwoBytes = ((this.#lastTwoBytes << 8) | this.#buffer[this.#bytePtr]!) & 0xffff;
+    return this.#buffer[this.#bytePtr++]!;
+  }
+}

--- a/packages/den/video/h264/H264.test.ts
+++ b/packages/den/video/h264/H264.test.ts
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { H264 } from "./H264";
+
+describe("H264", () => {
+  it("FindNextStartCode", () => {
+    const NALU1 = new Uint8Array([0x00, 0x00, 0x00, 0x01, 0x02, 0x03]);
+
+    expect(H264.FindNextStartCode(NALU1, 0)).toBe(0);
+    expect(H264.FindNextStartCode(NALU1, 1)).toBe(1);
+    expect(H264.FindNextStartCode(NALU1, 2)).toBe(6);
+    expect(H264.FindNextStartCode(NALU1, 3)).toBe(6);
+    expect(H264.FindNextStartCode(NALU1, 4)).toBe(6);
+    expect(H264.FindNextStartCode(NALU1, 5)).toBe(6);
+    expect(H264.FindNextStartCode(NALU1, 6)).toBe(6);
+    expect(H264.FindNextStartCode(NALU1, 7)).toBe(6);
+
+    const NALU2 = new Uint8Array([
+      0x00, 0x01, 0x03, 0x0a, 0x00, 0x00, 0x01, 0x0b, 0x0c, 0x00, 0x00, 0x00, 0x01, 0x0d,
+    ]);
+    expect(H264.FindNextStartCode(NALU2, 0)).toBe(4);
+    expect(H264.FindNextStartCode(NALU2, 1)).toBe(4);
+    expect(H264.FindNextStartCode(NALU2, 2)).toBe(4);
+    expect(H264.FindNextStartCode(NALU2, 3)).toBe(4);
+    expect(H264.FindNextStartCode(NALU2, 4)).toBe(4);
+    expect(H264.FindNextStartCode(NALU2, 5)).toBe(9);
+    expect(H264.FindNextStartCode(NALU2, 6)).toBe(9);
+    expect(H264.FindNextStartCode(NALU2, 7)).toBe(9);
+    expect(H264.FindNextStartCode(NALU2, 8)).toBe(9);
+    expect(H264.FindNextStartCode(NALU2, 9)).toBe(9);
+    expect(H264.FindNextStartCode(NALU2, 10)).toBe(10);
+    expect(H264.FindNextStartCode(NALU2, 11)).toBe(14);
+    expect(H264.FindNextStartCode(NALU2, 12)).toBe(14);
+    expect(H264.FindNextStartCode(NALU2, 13)).toBe(14);
+    expect(H264.FindNextStartCode(NALU2, 14)).toBe(14);
+    expect(H264.FindNextStartCode(NALU2, 15)).toBe(14);
+  });
+
+  it("FindNextStartCodeEnd", () => {
+    const NALU1 = new Uint8Array([0x00, 0x00, 0x00, 0x01, 0x02, 0x03]);
+
+    expect(H264.FindNextStartCodeEnd(NALU1, 0)).toBe(0 + 4);
+    expect(H264.FindNextStartCodeEnd(NALU1, 1)).toBe(1 + 3);
+    expect(H264.FindNextStartCodeEnd(NALU1, 2)).toBe(6);
+    expect(H264.FindNextStartCodeEnd(NALU1, 3)).toBe(6);
+    expect(H264.FindNextStartCodeEnd(NALU1, 4)).toBe(6);
+    expect(H264.FindNextStartCodeEnd(NALU1, 5)).toBe(6);
+    expect(H264.FindNextStartCodeEnd(NALU1, 6)).toBe(6);
+    expect(H264.FindNextStartCodeEnd(NALU1, 7)).toBe(6);
+
+    const NALU2 = new Uint8Array([
+      0x00, 0x01, 0x03, 0x0a, 0x00, 0x00, 0x01, 0x0b, 0x0c, 0x00, 0x00, 0x00, 0x01, 0x0d,
+    ]);
+    expect(H264.FindNextStartCodeEnd(NALU2, 0)).toBe(4 + 3);
+    expect(H264.FindNextStartCodeEnd(NALU2, 1)).toBe(4 + 3);
+    expect(H264.FindNextStartCodeEnd(NALU2, 2)).toBe(4 + 3);
+    expect(H264.FindNextStartCodeEnd(NALU2, 3)).toBe(4 + 3);
+    expect(H264.FindNextStartCodeEnd(NALU2, 4)).toBe(4 + 3);
+    expect(H264.FindNextStartCodeEnd(NALU2, 5)).toBe(9 + 4);
+    expect(H264.FindNextStartCodeEnd(NALU2, 6)).toBe(9 + 4);
+    expect(H264.FindNextStartCodeEnd(NALU2, 7)).toBe(9 + 4);
+    expect(H264.FindNextStartCodeEnd(NALU2, 8)).toBe(9 + 4);
+    expect(H264.FindNextStartCodeEnd(NALU2, 9)).toBe(9 + 4);
+    expect(H264.FindNextStartCodeEnd(NALU2, 10)).toBe(10 + 3);
+    expect(H264.FindNextStartCodeEnd(NALU2, 11)).toBe(14);
+    expect(H264.FindNextStartCodeEnd(NALU2, 12)).toBe(14);
+    expect(H264.FindNextStartCodeEnd(NALU2, 13)).toBe(14);
+    expect(H264.FindNextStartCodeEnd(NALU2, 14)).toBe(14);
+    expect(H264.FindNextStartCodeEnd(NALU2, 15)).toBe(14);
+  });
+
+  it("GetFirstNALUOfType", () => {
+    const INPUT = new Uint8Array([
+      0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0x00, 0x0a, 0xf8, 0x41, 0xa2, 0x00, 0x00, 0x00, 0x01,
+      0xff,
+    ]);
+
+    const nalu = H264.GetFirstNALUOfType(INPUT, 7); // SPS
+    expect(nalu).not.toBeUndefined();
+    expect(nalu!.byteLength).toBe(7);
+    expect(nalu![0]).toBe(0x67);
+  });
+
+  it("ParseDecoderConfig", () => {
+    const NALU = new Uint8Array([
+      0x00, 0x00, 0x01, 0x67, 0x64, 0x0, 0x1e, 0xac, 0xb2, 0x1, 0x40, 0x5f, 0xf2, 0xe0, 0x2d, 0x40,
+      0x40, 0x40, 0x50, 0x0, 0x0, 0x3, 0x0, 0x10, 0x0, 0x0, 0x3, 0x3, 0x20, 0xf1, 0x62, 0xe4, 0x80,
+    ]);
+    const decoderConfig = H264.ParseDecoderConfig(NALU);
+    expect(decoderConfig).toEqual({
+      codec: "avc1.64001E",
+      codedWidth: 640,
+      codedHeight: 368,
+    });
+  });
+});

--- a/packages/den/video/h264/H264.ts
+++ b/packages/den/video/h264/H264.ts
@@ -1,0 +1,182 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { SPS as SPSNALU } from "./SPS";
+
+export enum H264NaluType {
+  NDR = 1,
+  IDR = 5,
+  SEI = 6,
+  SPS = 7,
+  PPS = 8,
+  AUD = 9,
+}
+
+export class H264 {
+  public static IsAnnexB(data: Uint8Array): boolean {
+    return H264.AnnexBBoxSize(data) != undefined;
+  }
+
+  public static AnnexBBoxSize(data: Uint8Array): number | undefined {
+    // Annex B is a byte stream format where each NALU is prefixed with a start code, typically
+    // 0x000001 or 0x00000001. The type of the NALU is determined by the 5 least significant bits of
+    // the byte that follows the start code.
+    //
+    // AVCC is a length-prefixed format, where each NALU is prefixed by its length (typically 4
+    // bytes). The type of the NALU is determined by the 5 least significant bits of the first byte
+    // of the NALU itself.
+
+    if (data.length < 4) {
+      return undefined;
+    }
+
+    if (data[0] === 0 && data[1] === 0) {
+      if (data[2] === 1) {
+        return 3;
+      } else if (data[2] === 0 && data[3] === 1) {
+        return 4;
+      }
+    }
+
+    return undefined;
+  }
+
+  public static IsKeyframe(data: Uint8Array): boolean {
+    // Determine what type of encoding is used
+    const boxSize = H264.AnnexBBoxSize(data);
+    if (boxSize == undefined) {
+      return false;
+    }
+
+    // Iterate over the NAL units in the H264 Annex B frame, looking for NaluTypes.IDR
+    let i = boxSize;
+    while (i < data.length) {
+      // Annex B NALU type is the 5 least significant bits of the first byte following the start
+      // code
+      const naluType = data[i]! & 0x1f;
+      if (naluType === H264NaluType.IDR) {
+        return true;
+      }
+
+      // Scan for another start code, signifying the beginning of the next NAL unit
+      i = H264.FindNextStartCodeEnd(data, i + 1);
+    }
+
+    return false;
+  }
+
+  public static GetFirstNALUOfType(
+    data: Uint8Array,
+    naluType: H264NaluType,
+  ): Uint8Array | undefined {
+    // Determine what type of encoding is used
+    const boxSize = H264.AnnexBBoxSize(data);
+    if (boxSize == undefined) {
+      return undefined;
+    }
+
+    // Iterate over the NAL units in the H264 Annex B frame, looking for the requested naluType
+    let i = boxSize;
+    while (i < data.length) {
+      // Annex B NALU type is the 5 least significant bits of the first byte following the start
+      // code
+      const curNaluType = data[i]! & 0x1f;
+      if (curNaluType === naluType) {
+        // Find the end of this NALU
+        const end = H264.FindNextStartCode(data, i + 1);
+
+        // Return the NALU
+        return data.subarray(i, end);
+      }
+
+      // Scan for another start code, signifying the beginning of the next NAL unit
+      i = H264.FindNextStartCodeEnd(data, i + 1);
+    }
+
+    return undefined;
+  }
+
+  public static ParseDecoderConfig(data: Uint8Array): VideoDecoderConfig | undefined {
+    // Find the first SPS NALU and extrat MIME, picHeight, and picWidth fields
+    const spsData = H264.GetFirstNALUOfType(data, H264NaluType.SPS);
+    if (spsData == undefined) {
+      return undefined;
+    }
+
+    // Extract the SPS fields
+    const sps = new SPSNALU(spsData);
+    if (sps.nal_unit_type !== H264NaluType.SPS) {
+      return undefined;
+    }
+
+    const config: VideoDecoderConfig = {
+      codec: sps.MIME(),
+      codedWidth: sps.picWidth,
+      codedHeight: sps.picHeight,
+    };
+
+    // If the aspect ratio is specified, use it to calculate the display aspect ratio
+    const aspectWidth = sps.sar_width ?? 0;
+    const aspectHeight = sps.sar_height ?? 0;
+    if (aspectWidth > 1 || aspectHeight > 1) {
+      // The Sample Aspect Ratio (SAR) is the ratio of the width to the height of an individual
+      // pixel. Display Aspect Ratio (DAR) is the ratio of the width to the height of the video as
+      // it should be displayed
+      config.displayAspectWidth = Math.round(sps.picWidth * (aspectWidth / aspectHeight));
+      config.displayAspectHeight = sps.picHeight;
+    }
+
+    return config;
+  }
+
+  /**
+   * Find the index of the next start code (0x000001 or 0x00000001) in the
+   * given buffer, starting at the given offset.
+   */
+  public static FindNextStartCode(data: Uint8Array, start: number): number {
+    let i = start;
+    while (i < data.length - 3) {
+      const isStartCode3Bytes = data[i + 0] === 0 && data[i + 1] === 0 && data[i + 2] === 1;
+      if (isStartCode3Bytes) {
+        return i;
+      }
+      const isStartCode4Bytes =
+        i + 3 < data.length &&
+        data[i + 0] === 0 &&
+        data[i + 1] === 0 &&
+        data[i + 2] === 0 &&
+        data[i + 3] === 1;
+      if (isStartCode4Bytes) {
+        return i;
+      }
+      i++;
+    }
+    return data.length;
+  }
+
+  /**
+   * Find the index of the end of the next start code (0x000001 or 0x00000001) in the
+   * given buffer, starting at the given offset.
+   */
+  public static FindNextStartCodeEnd(data: Uint8Array, start: number): number {
+    let i = start;
+    while (i < data.length - 3) {
+      const isStartCode3Bytes = data[i + 0] === 0 && data[i + 1] === 0 && data[i + 2] === 1;
+      if (isStartCode3Bytes) {
+        return i + 3;
+      }
+      const isStartCode4Bytes =
+        i + 3 < data.length &&
+        data[i + 0] === 0 &&
+        data[i + 1] === 0 &&
+        data[i + 2] === 0 &&
+        data[i + 3] === 1;
+      if (isStartCode4Bytes) {
+        return i + 4;
+      }
+      i++;
+    }
+    return data.length;
+  }
+}

--- a/packages/den/video/h264/SPS.test.ts
+++ b/packages/den/video/h264/SPS.test.ts
@@ -1,0 +1,194 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { SPS } from "./SPS";
+
+describe("SPS", () => {
+  it("Parses a simple SPS NALU correctly", () => {
+    const NALU = [0x67, 0x42, 0x00, 0x0a, 0xf8, 0x41, 0xa2];
+    const sps = new SPS(new Uint8Array(NALU));
+
+    // forbidden_zero_bit	                  u(1)  0  Must be zero
+    // nal_ref_idc                          u(2)  3  Means it is “important” (this is an SPS)
+    // nal_unit_type                        u(5)  7  Indicates this is a sequence parameter set
+    // profile_idc                          u(8)  66 Baseline profile
+    // constraint_set0_flag                 u(1)  0  We're not going to honor constraints
+    // constraint_set1_flag                 u(1)  0  We're not going to honor constraints
+    // constraint_set2_flag                 u(1)  0  We're not going to honor constraints
+    // constraint_set3_flag                 u(1)  0  We're not going to honor constraints
+    // reserved_zero_4bits                  u(4)  0  Better set them to zero
+    // level_idc                            u(8)  10 Level 1, sec A.3.1
+    // seq_parameter_set_id                 ue(v) 0  We'll just use id 0
+    // log2_max_frame_num_minus4            ue(v) 0  Let's have as few frame numbers as possible
+    // pic_order_cnt_type                   ue(v) 0  Keep things simple
+    // log2_max_pic_order_cnt_lsb_minus4    ue(v) 0  Fewer is better
+    // num_ref_frames                       ue(v) 0  We will only send I slices
+    // gaps_in_frame_num_value_allowed_flag u(1)  0  We will have no gaps
+    // pic_width_in_mbs_minus_1             ue(v) 7  SQCIF is 8 macroblocks wide
+    // pic_height_in_map_units_minus_1      ue(v) 5  SQCIF is 6 macroblocks high
+    // frame_mbs_only_flag                  u(1)  1  We will not to field/frame encoding
+    // direct_8x8_inference_flag            u(1)  0  Used for B slices. We will not send B slices
+    // frame_cropping_flag                  u(1)  0  We will not do frame cropping
+    // vui_prameters_present_flag           u(1)  0  We will not send VUI data
+    // rbsp_stop_one_bit                    u(1)  1  Stop bit
+
+    expect(sps.nal_ref_id).toBe(3);
+    expect(sps.nal_unit_type).toBe(7);
+    expect(sps.profile_idc).toBe(66);
+    expect(sps.profileName).toBe("BASELINE");
+    expect(sps.constraint_set0_flag).toBe(0);
+    expect(sps.constraint_set1_flag).toBe(0);
+    expect(sps.constraint_set2_flag).toBe(0);
+    expect(sps.constraint_set3_flag).toBe(0);
+    expect(sps.level_idc).toBe(10);
+    expect(sps.seq_parameter_set_id).toBe(0);
+    expect(sps.has_no_chroma_format_idc).toBe(true);
+    expect(sps.chroma_format_idc).toBeUndefined();
+    expect(sps.bit_depth_luma_minus8).toBeUndefined();
+    expect(sps.separate_colour_plane_flag).toBeUndefined();
+    expect(sps.chromaArrayType).toBeUndefined();
+    expect(sps.bitDepthLuma).toBeUndefined();
+    expect(sps.bit_depth_chroma_minus8).toBeUndefined();
+    expect(sps.lossless_qpprime_flag).toBeUndefined();
+    expect(sps.bitDepthChroma).toBeUndefined();
+    expect(sps.seq_scaling_matrix_present_flag).toBeUndefined();
+    expect(sps.seq_scaling_list_present_flag).toBeUndefined();
+    expect(sps.seq_scaling_list).toBeUndefined();
+    expect(sps.log2_max_frame_num_minus4).toBe(0);
+    expect(sps.maxFrameNum).toBe(16);
+    expect(sps.pic_order_cnt_type).toBe(0);
+    expect(sps.log2_max_pic_order_cnt_lsb_minus4).toBe(0);
+    expect(sps.maxPicOrderCntLsb).toBe(16);
+    expect(sps.delta_pic_order_always_zero_flag).toBeUndefined();
+    expect(sps.offset_for_non_ref_pic).toBeUndefined();
+    expect(sps.offset_for_top_to_bottom_field).toBeUndefined();
+    expect(sps.num_ref_frames_in_pic_order_cnt_cycle).toBeUndefined();
+    expect(sps.offset_for_ref_frame).toBeUndefined();
+    expect(sps.max_num_ref_frames).toBe(0);
+    expect(sps.gaps_in_frame_num_value_allowed_flag).toBe(0);
+    expect(sps.pic_width_in_mbs_minus_1).toBe(7);
+    expect(sps.picWidth).toBe(128);
+    expect(sps.pic_height_in_map_units_minus_1).toBe(5);
+    expect(sps.frame_mbs_only_flag).toBe(1);
+    expect(sps.interlaced).toBe(false);
+    expect(sps.mb_adaptive_frame_field_flag).toBeUndefined();
+    expect(sps.picHeight).toBe(96);
+    expect(sps.direct_8x8_inference_flag).toBe(0);
+    expect(sps.frame_cropping_flag).toBe(0);
+    expect(sps.frame_cropping_rect_left_offset).toBeUndefined();
+    expect(sps.frame_cropping_rect_right_offset).toBeUndefined();
+    expect(sps.frame_cropping_rect_top_offset).toBeUndefined();
+    expect(sps.frame_cropping_rect_bottom_offset).toBeUndefined();
+    expect(sps.cropRect).toEqual({ x: 0, y: 0, width: 128, height: 96 });
+    expect(sps.vui_parameters_present_flag).toBe(0);
+    expect(sps.aspect_ratio_info_present_flag).toBeUndefined();
+    expect(sps.aspect_ratio_idc).toBeUndefined();
+    expect(sps.sar_width).toBeUndefined();
+    expect(sps.sar_height).toBeUndefined();
+    expect(sps.overscan_info_present_flag).toBeUndefined();
+    expect(sps.overscan_appropriate_flag).toBeUndefined();
+    expect(sps.video_signal_type_present_flag).toBeUndefined();
+    expect(sps.video_format).toBeUndefined();
+    expect(sps.video_full_range_flag).toBeUndefined();
+    expect(sps.color_description_present_flag).toBeUndefined();
+    expect(sps.color_primaries).toBeUndefined();
+    expect(sps.transfer_characteristics).toBeUndefined();
+    expect(sps.matrix_coefficients).toBeUndefined();
+    expect(sps.chroma_loc_info_present_flag).toBeUndefined();
+    expect(sps.chroma_sample_loc_type_top_field).toBeUndefined();
+    expect(sps.chroma_sample_loc_type_bottom_field).toBeUndefined();
+    expect(sps.timing_info_present_flag).toBeUndefined();
+    expect(sps.num_units_in_tick).toBeUndefined();
+    expect(sps.time_scale).toBeUndefined();
+    expect(sps.fixed_frame_rate_flag).toBeUndefined();
+    expect(sps.framesPerSecond).toBeUndefined();
+    expect(sps.nal_hrd_parameters_present_flag).toBeUndefined();
+
+    expect(sps.profileCompatibility()).toBe(0);
+    expect(sps.MIME()).toBe("avc1.42000A");
+  });
+
+  it("Parses a real-world example SPS", () => {
+    const NALU = [
+      0x67, 0x64, 0x0, 0x1e, 0xac, 0xb2, 0x1, 0x40, 0x5f, 0xf2, 0xe0, 0x2d, 0x40, 0x40, 0x40, 0x50,
+      0x0, 0x0, 0x3, 0x0, 0x10, 0x0, 0x0, 0x3, 0x3, 0x20, 0xf1, 0x62, 0xe4, 0x80,
+    ];
+    const sps = new SPS(new Uint8Array(NALU));
+
+    expect(sps.nal_ref_id).toBe(3);
+    expect(sps.nal_unit_type).toBe(7);
+    expect(sps.profile_idc).toBe(100);
+    expect(sps.profileName).toBe("FREXT_HP");
+    expect(sps.constraint_set0_flag).toBe(0);
+    expect(sps.constraint_set1_flag).toBe(0);
+    expect(sps.constraint_set2_flag).toBe(0);
+    expect(sps.constraint_set3_flag).toBe(0);
+    expect(sps.level_idc).toBe(30);
+    expect(sps.seq_parameter_set_id).toBe(0);
+    expect(sps.has_no_chroma_format_idc).toBe(false);
+    expect(sps.chroma_format_idc).toBe(1);
+    expect(sps.bit_depth_luma_minus8).toBe(0);
+    expect(sps.separate_colour_plane_flag).toBeUndefined();
+    expect(sps.chromaArrayType).toBeUndefined();
+    expect(sps.bitDepthLuma).toBe(8);
+    expect(sps.bit_depth_chroma_minus8).toBe(0);
+    expect(sps.lossless_qpprime_flag).toBe(0);
+    expect(sps.bitDepthChroma).toBe(8);
+    expect(sps.seq_scaling_matrix_present_flag).toBe(0);
+    expect(sps.seq_scaling_list_present_flag).toBeUndefined();
+    expect(sps.seq_scaling_list).toBeUndefined();
+    expect(sps.log2_max_frame_num_minus4).toBe(0);
+    expect(sps.maxFrameNum).toBe(16);
+    expect(sps.pic_order_cnt_type).toBe(2);
+    expect(sps.log2_max_pic_order_cnt_lsb_minus4).toBeUndefined();
+    expect(sps.maxPicOrderCntLsb).toBeUndefined();
+    expect(sps.delta_pic_order_always_zero_flag).toBeUndefined();
+    expect(sps.offset_for_non_ref_pic).toBeUndefined();
+    expect(sps.offset_for_top_to_bottom_field).toBeUndefined();
+    expect(sps.num_ref_frames_in_pic_order_cnt_cycle).toBeUndefined();
+    expect(sps.offset_for_ref_frame).toBeUndefined();
+    expect(sps.max_num_ref_frames).toBe(3);
+    expect(sps.gaps_in_frame_num_value_allowed_flag).toBe(0);
+    expect(sps.pic_width_in_mbs_minus_1).toBe(39);
+    expect(sps.picWidth).toBe(640);
+    expect(sps.pic_height_in_map_units_minus_1).toBe(22);
+    expect(sps.frame_mbs_only_flag).toBe(1);
+    expect(sps.interlaced).toBe(false);
+    expect(sps.mb_adaptive_frame_field_flag).toBeUndefined();
+    expect(sps.picHeight).toBe(368);
+    expect(sps.direct_8x8_inference_flag).toBe(1);
+    expect(sps.frame_cropping_flag).toBe(1);
+    expect(sps.frame_cropping_rect_left_offset).toBe(0);
+    expect(sps.frame_cropping_rect_right_offset).toBe(0);
+    expect(sps.frame_cropping_rect_top_offset).toBe(0);
+    expect(sps.frame_cropping_rect_bottom_offset).toBe(4);
+    expect(sps.cropRect).toEqual({ x: 0, y: 0, width: 640, height: 360 });
+    expect(sps.vui_parameters_present_flag).toBe(1);
+    expect(sps.aspect_ratio_info_present_flag).toBe(1);
+    expect(sps.aspect_ratio_idc).toBe(1);
+    expect(sps.sar_width).toBe(1);
+    expect(sps.sar_height).toBe(1);
+    expect(sps.overscan_info_present_flag).toBe(0);
+    expect(sps.overscan_appropriate_flag).toBeUndefined();
+    expect(sps.video_signal_type_present_flag).toBe(1);
+    expect(sps.video_format).toBe(5);
+    expect(sps.video_full_range_flag).toBe(0);
+    expect(sps.color_description_present_flag).toBe(1);
+    expect(sps.color_primaries).toBe(1);
+    expect(sps.transfer_characteristics).toBe(1);
+    expect(sps.matrix_coefficients).toBe(1);
+    expect(sps.chroma_loc_info_present_flag).toBe(0);
+    expect(sps.chroma_sample_loc_type_top_field).toBeUndefined();
+    expect(sps.chroma_sample_loc_type_bottom_field).toBeUndefined();
+    expect(sps.timing_info_present_flag).toBe(1);
+    expect(sps.num_units_in_tick).toBe(1);
+    expect(sps.time_scale).toBe(50);
+    expect(sps.fixed_frame_rate_flag).toBe(0);
+    expect(sps.framesPerSecond).toBe(25);
+    expect(sps.nal_hrd_parameters_present_flag).toBe(0);
+
+    expect(sps.profileCompatibility()).toBe(0);
+    expect(sps.MIME()).toBe("avc1.64001E");
+  });
+});

--- a/packages/den/video/h264/SPS.ts
+++ b/packages/den/video/h264/SPS.ts
@@ -1,0 +1,366 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Bitstream } from "./Bitstream";
+
+const H264_PROFILE_NAMES: Map<number, string> = new Map([
+  [66, "BASELINE"],
+  [77, "MAIN"],
+  [88, "EXTENDED"],
+  [100, "FREXT_HP"],
+  [110, "FREXT_Hi10P"],
+  [122, "FREXT_Hi422"],
+  [244, "FREXT_Hi444"],
+  [44, "FREXT_CAVLC444"],
+]);
+
+const ASPECT_RATIO_IDC_VALUES: [number, number][] = [
+  [0, 0],
+  [1, 1],
+  [12, 11],
+  [10, 11],
+  [16, 11],
+  [40, 33],
+  [24, 11],
+  [20, 11],
+  [32, 11],
+  [80, 33],
+  [18, 11],
+  [15, 11],
+  [64, 33],
+  [160, 99],
+  [4, 3],
+  [3, 2],
+  [2, 1],
+];
+
+export class SPS {
+  public nal_ref_id: number;
+  public nal_unit_type: number | undefined;
+  public profile_idc: number;
+  public profileName: string;
+  public constraint_set0_flag: number;
+  public constraint_set1_flag: number;
+  public constraint_set2_flag: number;
+  public constraint_set3_flag: number;
+  public constraint_set4_flag: number;
+  public constraint_set5_flag: number;
+  public level_idc: number;
+  public seq_parameter_set_id: number;
+  public has_no_chroma_format_idc: boolean;
+  public chroma_format_idc: number | undefined;
+  public bit_depth_luma_minus8: number | undefined;
+  public separate_colour_plane_flag: number | undefined;
+  public chromaArrayType: number | undefined;
+  public bitDepthLuma: number | undefined;
+  public bit_depth_chroma_minus8: number | undefined;
+  public lossless_qpprime_flag: number | undefined;
+  public bitDepthChroma: number | undefined;
+  public seq_scaling_matrix_present_flag: number | undefined;
+  public seq_scaling_list_present_flag: Array<number> | undefined;
+  public seq_scaling_list: Array<number[]> | undefined;
+  public log2_max_frame_num_minus4: number | undefined;
+  public maxFrameNum: number;
+  public pic_order_cnt_type: number;
+  public log2_max_pic_order_cnt_lsb_minus4: number | undefined;
+  public maxPicOrderCntLsb: number | undefined;
+  public delta_pic_order_always_zero_flag: number | undefined;
+  public offset_for_non_ref_pic: number | undefined;
+  public offset_for_top_to_bottom_field: number | undefined;
+  public num_ref_frames_in_pic_order_cnt_cycle: number | undefined;
+  public offset_for_ref_frame: Array<number> | undefined;
+  public max_num_ref_frames: number;
+  public gaps_in_frame_num_value_allowed_flag: number;
+  public pic_width_in_mbs_minus_1: number;
+  public picWidth: number;
+  public pic_height_in_map_units_minus_1: number;
+  public frame_mbs_only_flag: number;
+  public interlaced: boolean;
+  public mb_adaptive_frame_field_flag: number | undefined;
+  public picHeight: number;
+  public direct_8x8_inference_flag: number;
+  public frame_cropping_flag: number;
+  public frame_cropping_rect_left_offset: number | undefined;
+  public frame_cropping_rect_right_offset: number | undefined;
+  public frame_cropping_rect_top_offset: number | undefined;
+  public frame_cropping_rect_bottom_offset: number | undefined;
+  public cropRect: { x: number; y: number; width: number; height: number };
+  public vui_parameters_present_flag: number;
+  public aspect_ratio_info_present_flag: number | undefined;
+  public aspect_ratio_idc: number | undefined;
+  public sar_width: number | undefined;
+  public sar_height: number | undefined;
+  public overscan_info_present_flag: number | undefined;
+  public overscan_appropriate_flag: number | undefined;
+  public video_signal_type_present_flag: number | undefined;
+  public video_format: number | undefined;
+  public video_full_range_flag: number | undefined;
+  public color_description_present_flag: number | undefined;
+  public color_primaries: number | undefined;
+  public transfer_characteristics: number | undefined;
+  public matrix_coefficients: number | undefined;
+  public chroma_loc_info_present_flag: number | undefined;
+  public chroma_sample_loc_type_top_field: number | undefined;
+  public chroma_sample_loc_type_bottom_field: number | undefined;
+  public timing_info_present_flag: number | undefined;
+  public num_units_in_tick: number | undefined;
+  public time_scale: number | undefined;
+  public fixed_frame_rate_flag: number | undefined;
+  public framesPerSecond: number | undefined;
+  public nal_hrd_parameters_present_flag: number | undefined;
+
+  public constructor(data: Uint8Array) {
+    const bitstream = new Bitstream(data);
+
+    const forbidden_zero_bit = bitstream.u_1();
+    if (forbidden_zero_bit !== 0) {
+      throw new Error("NALU error: invalid NALU header");
+    }
+    this.nal_ref_id = bitstream.u_2();
+    this.nal_unit_type = bitstream.u(5);
+    if (this.nal_unit_type !== 7) {
+      throw new Error("SPS error: not SPS");
+    }
+
+    this.profile_idc = bitstream.u_8()!;
+    if (H264_PROFILE_NAMES.has(this.profile_idc)) {
+      this.profileName = H264_PROFILE_NAMES.get(this.profile_idc)!;
+    } else {
+      throw new Error("SPS error: invalid profile_idc");
+    }
+
+    this.constraint_set0_flag = bitstream.u_1();
+    this.constraint_set1_flag = bitstream.u_1();
+    this.constraint_set2_flag = bitstream.u_1();
+    this.constraint_set3_flag = bitstream.u_1();
+    this.constraint_set4_flag = bitstream.u_1();
+    this.constraint_set5_flag = bitstream.u_1();
+    const reserved_zero_2bits = bitstream.u_2();
+    if (reserved_zero_2bits !== 0) {
+      throw new Error("SPS error: reserved_zero_2bits must be zero");
+    }
+
+    this.level_idc = bitstream.u_8()!;
+
+    this.seq_parameter_set_id = bitstream.ue_v();
+    if (this.seq_parameter_set_id > 31) {
+      throw new Error("SPS error: seq_parameter_set_id must be 31 or less");
+    }
+
+    this.has_no_chroma_format_idc =
+      this.profile_idc === 66 || this.profile_idc === 77 || this.profile_idc === 88;
+
+    if (!this.has_no_chroma_format_idc) {
+      this.chroma_format_idc = bitstream.ue_v();
+      if (this.chroma_format_idc > 3) {
+        throw new Error("SPS error: chroma_format_idc must be 3 or less");
+      }
+      if (this.chroma_format_idc === 3) {
+        /* 3 = YUV444 */
+        this.separate_colour_plane_flag = bitstream.u_1();
+        this.chromaArrayType = this.separate_colour_plane_flag !== 0 ? 0 : this.chroma_format_idc;
+      }
+      this.bit_depth_luma_minus8 = bitstream.ue_v();
+      if (this.bit_depth_luma_minus8 > 6) {
+        throw new Error("SPS error: bit_depth_luma_minus8 must be 6 or less");
+      }
+      this.bitDepthLuma = this.bit_depth_luma_minus8 + 8;
+      this.bit_depth_chroma_minus8 = bitstream.ue_v();
+      if (this.bit_depth_chroma_minus8 > 6) {
+        throw new Error("SPS error: bit_depth_chroma_minus8 must be 6 or less");
+      }
+      this.lossless_qpprime_flag = bitstream.u_1();
+      this.bitDepthChroma = this.bit_depth_chroma_minus8 + 8;
+      this.seq_scaling_matrix_present_flag = bitstream.u_1();
+      if (this.seq_scaling_matrix_present_flag !== 0) {
+        const n_ScalingList = this.chroma_format_idc !== 3 ? 8 : 12;
+        this.seq_scaling_list_present_flag = [];
+        this.seq_scaling_list = [];
+        for (let i = 0; i < n_ScalingList; i++) {
+          const seqScalingListPresentFlag = bitstream.u_1();
+          this.seq_scaling_list_present_flag.push(seqScalingListPresentFlag);
+          if (seqScalingListPresentFlag !== 0) {
+            const sizeOfScalingList = i < 6 ? 16 : 64;
+            let nextScale = 8;
+            let lastScale = 8;
+            const delta_scale = [];
+            for (let j = 0; j < sizeOfScalingList; j++) {
+              if (nextScale !== 0) {
+                const deltaScale = bitstream.se_v();
+                delta_scale.push(deltaScale);
+                nextScale = (lastScale + deltaScale + 256) % 256;
+              }
+              lastScale = nextScale === 0 ? lastScale : nextScale;
+              this.seq_scaling_list.push(delta_scale);
+            }
+          }
+        }
+      }
+    }
+
+    this.log2_max_frame_num_minus4 = bitstream.ue_v();
+    if (this.log2_max_frame_num_minus4 > 12) {
+      throw new Error("SPS error: log2_max_frame_num_minus4 must be 12 or less");
+    }
+    this.maxFrameNum = 1 << (this.log2_max_frame_num_minus4 + 4);
+
+    this.pic_order_cnt_type = bitstream.ue_v();
+    if (this.pic_order_cnt_type > 2) {
+      throw new Error("SPS error: pic_order_cnt_type must be 2 or less");
+    }
+
+    switch (this.pic_order_cnt_type) {
+      case 0:
+        this.log2_max_pic_order_cnt_lsb_minus4 = bitstream.ue_v();
+        if (this.log2_max_pic_order_cnt_lsb_minus4 > 12) {
+          throw new Error("SPS error: log2_max_pic_order_cnt_lsb_minus4 must be 12 or less");
+        }
+        this.maxPicOrderCntLsb = 1 << (this.log2_max_pic_order_cnt_lsb_minus4 + 4);
+        break;
+      case 1:
+        this.delta_pic_order_always_zero_flag = bitstream.u_1();
+        this.offset_for_non_ref_pic = bitstream.se_v();
+        this.offset_for_top_to_bottom_field = bitstream.se_v();
+        this.num_ref_frames_in_pic_order_cnt_cycle = bitstream.ue_v();
+        this.offset_for_ref_frame = [];
+        for (let i = 0; i < this.num_ref_frames_in_pic_order_cnt_cycle; i++) {
+          const offsetForRefFrame = bitstream.se_v();
+          this.offset_for_ref_frame.push(offsetForRefFrame);
+        }
+        break;
+      case 2:
+        /* there is nothing for case 2 */
+        break;
+    }
+
+    this.max_num_ref_frames = bitstream.ue_v();
+    this.gaps_in_frame_num_value_allowed_flag = bitstream.u_1();
+    this.pic_width_in_mbs_minus_1 = bitstream.ue_v();
+    this.picWidth = (this.pic_width_in_mbs_minus_1 + 1) << 4;
+    this.pic_height_in_map_units_minus_1 = bitstream.ue_v();
+    this.frame_mbs_only_flag = bitstream.u_1();
+    this.interlaced = this.frame_mbs_only_flag === 0;
+    if (this.frame_mbs_only_flag === 0) {
+      /* 1 if frames rather than fields (no interlacing) */
+      this.mb_adaptive_frame_field_flag = bitstream.u_1();
+    }
+    this.picHeight =
+      ((2 - this.frame_mbs_only_flag) * (this.pic_height_in_map_units_minus_1 + 1)) << 4;
+
+    this.direct_8x8_inference_flag = bitstream.u_1();
+    this.frame_cropping_flag = bitstream.u_1();
+    if (this.frame_cropping_flag !== 0) {
+      // Determine the chroma sample to luma sample ratio in each dimension
+      const chromaFormatIdc = this.chroma_format_idc ?? 1;
+      let subWidthC = 1;
+      let subHeightC = 1;
+      if (chromaFormatIdc === 0) {
+        // Monochrome
+      } else if (chromaFormatIdc === 1) {
+        // 4:2:0
+        subWidthC = 2;
+        subHeightC = 2;
+      } else if (chromaFormatIdc === 2) {
+        // 4:2:2
+        subWidthC = 2;
+        subHeightC = 1;
+      } else if (chromaFormatIdc === 3) {
+        // 4:4:4
+        subWidthC = 1;
+        subHeightC = 1;
+      }
+
+      this.frame_cropping_rect_left_offset = bitstream.ue_v();
+      this.frame_cropping_rect_right_offset = bitstream.ue_v();
+      this.frame_cropping_rect_top_offset = bitstream.ue_v();
+      this.frame_cropping_rect_bottom_offset = bitstream.ue_v();
+      const leftPixelCrop = this.frame_cropping_rect_left_offset * subWidthC;
+      const rightPixelCrop = this.frame_cropping_rect_right_offset * subWidthC;
+      const topPixelCrop = this.frame_cropping_rect_top_offset * subHeightC;
+      const bottomPixelCrop = this.frame_cropping_rect_bottom_offset * subHeightC;
+      this.cropRect = {
+        x: leftPixelCrop,
+        y: topPixelCrop,
+        width: this.picWidth - (leftPixelCrop + rightPixelCrop),
+        height: this.picHeight - (topPixelCrop + bottomPixelCrop),
+      };
+    } else {
+      this.cropRect = {
+        x: 0,
+        y: 0,
+        width: this.picWidth,
+        height: this.picHeight,
+      };
+    }
+    this.vui_parameters_present_flag = bitstream.u_1();
+    if (this.vui_parameters_present_flag !== 0) {
+      this.aspect_ratio_info_present_flag = bitstream.u_1();
+      if (this.aspect_ratio_info_present_flag !== 0) {
+        this.aspect_ratio_idc = bitstream.u_8();
+        if (this.aspect_ratio_idc === 255) {
+          this.sar_width = bitstream.u(16);
+          this.sar_height = bitstream.u(16);
+        } else if (this.aspect_ratio_idc > 0 && this.aspect_ratio_idc <= 16) {
+          const sar = ASPECT_RATIO_IDC_VALUES[this.aspect_ratio_idc]!;
+          this.sar_width = sar[0];
+          this.sar_height = sar[1];
+        }
+      }
+
+      this.overscan_info_present_flag = bitstream.u_1();
+      if (this.overscan_info_present_flag !== 0) {
+        this.overscan_appropriate_flag = bitstream.u_1();
+      }
+      this.video_signal_type_present_flag = bitstream.u_1();
+      if (this.video_signal_type_present_flag !== 0) {
+        this.video_format = bitstream.u(3);
+        this.video_full_range_flag = bitstream.u_1();
+        this.color_description_present_flag = bitstream.u_1();
+        if (this.color_description_present_flag !== 0) {
+          this.color_primaries = bitstream.u_8();
+          this.transfer_characteristics = bitstream.u_8();
+          this.matrix_coefficients = bitstream.u_8();
+        }
+      }
+      this.chroma_loc_info_present_flag = bitstream.u_1();
+      if (this.chroma_loc_info_present_flag !== 0) {
+        this.chroma_sample_loc_type_top_field = bitstream.ue_v();
+        this.chroma_sample_loc_type_bottom_field = bitstream.ue_v();
+      }
+      this.timing_info_present_flag = bitstream.u_1();
+      if (this.timing_info_present_flag !== 0) {
+        this.num_units_in_tick = bitstream.u(32);
+        this.time_scale = bitstream.u(32);
+        this.fixed_frame_rate_flag = bitstream.u_1();
+        if (this.num_units_in_tick !== 0 && this.time_scale !== 0 && this.num_units_in_tick !== 0) {
+          this.framesPerSecond = this.time_scale / (2 * this.num_units_in_tick);
+        }
+      }
+      this.nal_hrd_parameters_present_flag = bitstream.u_1();
+    }
+  }
+
+  public profileCompatibility(): number {
+    let v = this.constraint_set0_flag << 7;
+    v |= this.constraint_set1_flag << 6;
+    v |= this.constraint_set2_flag << 5;
+    v |= this.constraint_set3_flag << 4;
+    v |= this.constraint_set4_flag << 3;
+    v |= this.constraint_set5_flag << 1;
+    return v;
+  }
+
+  public MIME(): string {
+    const f = [];
+    f.push("avc1.");
+    f.push(byteToHex(this.profile_idc).toUpperCase());
+    f.push(byteToHex(this.profileCompatibility()).toUpperCase());
+    f.push(byteToHex(this.level_idc).toUpperCase());
+    return f.join("");
+  }
+}
+
+function byteToHex(val: number): string {
+  return ("00" + val.toString(16)).slice(-2);
+}

--- a/packages/den/video/h264/index.ts
+++ b/packages/den/video/h264/index.ts
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export * from "./H264";

--- a/packages/den/video/index.ts
+++ b/packages/den/video/index.ts
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export * from "./h264";
+export * from "./VideoPlayer";

--- a/packages/suite-base/src/panels/ThreeDeeRender/foxglove.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/foxglove.ts
@@ -23,6 +23,9 @@ addFoxgloveSchema(RAW_IMAGE_DATATYPES, "foxglove.RawImage");
 export const COMPRESSED_IMAGE_DATATYPES = new Set<string>();
 addFoxgloveSchema(COMPRESSED_IMAGE_DATATYPES, "foxglove.CompressedImage");
 
+export const COMPRESSED_VIDEO_DATATYPES = new Set<string>();
+addFoxgloveSchema(COMPRESSED_VIDEO_DATATYPES, "foxglove.CompressedVideo");
+
 export const CAMERA_CALIBRATION_DATATYPES = new Set<string>();
 addFoxgloveSchema(CAMERA_CALIBRATION_DATATYPES, "foxglove.CameraCalibration");
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.ts
@@ -28,10 +28,12 @@ import {
 import { ImageModeConfig } from "@lichtblick/suite-base/panels/ThreeDeeRender/IRenderer";
 import {
   AnyImage,
+  CompressedVideo,
   getTimestampFromImage,
 } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/Images/ImageTypes";
 import {
   normalizeCompressedImage,
+  normalizeCompressedVideo,
   normalizeRawImage,
   normalizeRosCompressedImage,
   normalizeRosImage,
@@ -203,6 +205,9 @@ export class MessageHandler implements IMessageHandler {
 
   public handleCompressedImage = (messageEvent: PartialMessageEvent<CompressedImage>): void => {
     this.handleImage(messageEvent, normalizeCompressedImage(messageEvent.message));
+  };
+  public handleCompressedVideo = (messageEvent: PartialMessageEvent<CompressedVideo>): void => {
+    this.handleImage(messageEvent, normalizeCompressedVideo(messageEvent.message));
   };
 
   protected handleImage(message: PartialMessageEvent<AnyImage>, image: AnyImage): void {
@@ -452,6 +457,7 @@ export interface IMessageHandler {
   handleRosCompressedImage: (messageEvent: PartialMessageEvent<RosCompressedImage>) => void;
   handleRawImage: (messageEvent: PartialMessageEvent<RawImage>) => void;
   handleCompressedImage: (messageEvent: PartialMessageEvent<CompressedImage>) => void;
+  handleCompressedVideo: (messageEvent: PartialMessageEvent<CompressedVideo>) => void;
   handleCameraInfo: (message: PartialMessageEvent<CameraInfo>) => void;
   handleAnnotations: (
     messageEvent: MessageEvent<FoxgloveImageAnnotations | RosImageMarker | RosImageMarkerArray>,

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -10,6 +10,7 @@ import * as THREE from "three";
 import { assert } from "ts-essentials";
 
 import { PinholeCameraModel } from "@lichtblick/den/image";
+import { VideoPlayer } from "@lichtblick/den/video";
 import Logger from "@lichtblick/log";
 import { toNanoSec } from "@lichtblick/rostime";
 import { IRenderer } from "@lichtblick/suite-base/panels/ThreeDeeRender/IRenderer";
@@ -19,8 +20,13 @@ import { WorkerImageDecoder } from "@lichtblick/suite-base/panels/ThreeDeeRender
 import { projectPixel } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/projections";
 import { RosValue } from "@lichtblick/suite-base/players/types";
 
-import { AnyImage } from "./ImageTypes";
-import { decodeCompressedImageToBitmap } from "./decodeImage";
+import { AnyImage, CompressedVideo } from "./ImageTypes";
+import {
+  decodeCompressedImageToBitmap,
+  decodeCompressedVideoToBitmap,
+  emptyVideoFrame,
+  getVideoDecoderConfig,
+} from "./decodeImage";
 import { CameraInfo } from "../../ros";
 import { DECODE_IMAGE_ERR_KEY, IMAGE_TOPIC_PATH } from "../ImageMode/constants";
 import { ColorModeSettings } from "../colorMode";
@@ -46,9 +52,13 @@ export const IMAGE_RENDERABLE_DEFAULT_SETTINGS: ImageRenderableSettings = {
   color: "#ffffff",
 };
 
+const IMAGE_FORMATS = new Set(["jpeg", "jpg", "png", "webp"]);
+const VIDEO_FORMATS = new Set(["h264"]);
+
 export type ImageUserData = BaseUserData & {
   topic: string;
   settings: ImageRenderableSettings;
+  firstMessageTime: bigint | undefined;
   cameraInfo: CameraInfo | undefined;
   cameraModel: PinholeCameraModel | undefined;
   image: AnyImage | undefined;
@@ -59,6 +69,9 @@ export type ImageUserData = BaseUserData & {
 };
 
 export class ImageRenderable extends Renderable<ImageUserData> {
+  // A lazily instantiated player for compressed video
+  public videoPlayer: VideoPlayer | undefined;
+
   // Make sure that everything is build the first time we render
   // set when camera info or image changes
   #geometryNeedsUpdate = true;
@@ -235,7 +248,60 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     resizeWidth?: number,
   ): Promise<ImageBitmap | ImageData> {
     if ("format" in image) {
-      return await decodeCompressedImageToBitmap(image, resizeWidth);
+      if (VIDEO_FORMATS.has(image.format)) {
+        const frameMsg = image as CompressedVideo;
+
+        if (frameMsg.data.byteLength === 0) {
+          const error = "Empty video frame";
+          log.error(error);
+          // show last frame instead of error image if available
+          if (this.videoPlayer?.lastImageBitmap) {
+            return this.videoPlayer.lastImageBitmap;
+          }
+          // show black image instead of error image
+          return await emptyVideoFrame(this.videoPlayer, resizeWidth);
+          // Raise error so the caller can catch it and display an error image
+          throw new Error(error);
+        }
+
+        if (!this.videoPlayer) {
+          this.videoPlayer = new VideoPlayer();
+          this.videoPlayer.on("error", (err) => {
+            log.error(err);
+            this.addError(DECODE_IMAGE_ERR_KEY, `Error decoding video: ${err.message}`);
+          });
+          this.videoPlayer.on("warn", (msg) => {
+            log.warn(msg);
+          });
+        }
+        const videoPlayer = this.videoPlayer;
+
+        // Initialize the video player if needed
+        if (!videoPlayer.isInitialized()) {
+          const decoderConfig = getVideoDecoderConfig(frameMsg);
+          if (decoderConfig) {
+            await videoPlayer.init(decoderConfig);
+          } else {
+            // Raise error so the caller can catch it
+            throw new Error("Waiting for keyframe");
+            return await emptyVideoFrame(this.videoPlayer, resizeWidth);
+          }
+        }
+
+        assert(this.userData.firstMessageTime != undefined, "firstMessageTime must be set");
+
+        return await decodeCompressedVideoToBitmap(
+          frameMsg,
+          videoPlayer,
+          this.userData.firstMessageTime,
+          resizeWidth,
+        );
+      } else if (IMAGE_FORMATS.has(image.format)) {
+        return await decodeCompressedImageToBitmap(image, resizeWidth);
+      } else {
+        // Raise error so the caller can catch it
+        throw new Error(`Unsupported format: "${image.format}"`);
+      }
     }
     return await (this.decoder ??= new WorkerImageDecoder()).decode(image, this.userData.settings);
   }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageTypes.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageTypes.ts
@@ -21,9 +21,17 @@ export const ALL_CAMERA_INFO_SCHEMAS = new Set([
   ...CAMERA_CALIBRATION_DATATYPES,
 ]);
 
+/** NOTE: Remove this definition once it is available in @foxglove/schemas */
+export type CompressedVideo = {
+  timestamp: Time;
+  frame_id: string;
+  data: Uint8Array;
+  format: string;
+};
+
 export type CompressedImageTypes = RosCompressedImage | CompressedImage;
 
-export type AnyImage = RosImage | RosCompressedImage | RawImage | CompressedImage;
+export type AnyImage = RosImage | RosCompressedImage | RawImage | CompressedImage | CompressedVideo;
 
 export function getFrameIdFromImage(image: AnyImage): string {
   if ("header" in image) {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
@@ -23,8 +23,10 @@ import {
   decodeUYVY,
   decodeYUYV,
 } from "@lichtblick/den/image";
+import { H264, VideoPlayer } from "@lichtblick/den/video";
+import { toMicroSec } from "@lichtblick/rostime";
 
-import { CompressedImageTypes } from "./ImageTypes";
+import { CompressedImageTypes, CompressedVideo } from "./ImageTypes";
 import { Image as RosImage } from "../../ros";
 import { ColorModeSettings, getColorConverter } from "../colorMode";
 
@@ -34,6 +36,55 @@ export async function decodeCompressedImageToBitmap(
 ): Promise<ImageBitmap> {
   const bitmapData = new Blob([image.data], { type: `image/${image.format}` });
   return await createImageBitmap(bitmapData, { resizeWidth });
+}
+
+export function isVideoKeyframe(frameMsg: CompressedVideo): boolean {
+  switch (frameMsg.format) {
+    case "h264": {
+      // Search for an IDR NAL unit to determine if this is a keyframe
+      return H264.IsKeyframe(frameMsg.data);
+    }
+  }
+  return false;
+}
+
+export function getVideoDecoderConfig(frameMsg: CompressedVideo): VideoDecoderConfig | undefined {
+  switch (frameMsg.format) {
+    case "h264": {
+      // Search for an SPS NAL unit to initialize the decoder. This should precede each keyframe
+      return H264.ParseDecoderConfig(frameMsg.data);
+    }
+  }
+
+  return undefined;
+}
+
+export async function decodeCompressedVideoToBitmap(
+  frameMsg: CompressedVideo,
+  videoPlayer: VideoPlayer,
+  firstMessageTime: bigint,
+  resizeWidth?: number,
+): Promise<ImageBitmap> {
+  if (!videoPlayer.isInitialized()) {
+    return await emptyVideoFrame(videoPlayer, resizeWidth);
+  }
+
+  // Get the timestamp of this frame as microseconds relative to the first frame
+  const firstTimestampMicros = Number(firstMessageTime / 1000n);
+  const timestampMicros = toMicroSec(frameMsg.timestamp) - firstTimestampMicros;
+
+  const videoFrame = await videoPlayer.decode(
+    frameMsg.data,
+    timestampMicros,
+    isVideoKeyframe(frameMsg) ? "key" : "delta",
+  );
+  if (videoFrame) {
+    const imageBitmap = await self.createImageBitmap(videoFrame, { resizeWidth });
+    videoPlayer.lastImageBitmap = imageBitmap;
+    videoFrame.close();
+    return imageBitmap;
+  }
+  return await emptyVideoFrame(videoPlayer, resizeWidth);
 }
 
 export const IMAGE_DEFAULT_COLOR_MODE_SETTINGS: Required<
@@ -133,4 +184,16 @@ export function decodeRawImage(
     default:
       throw new Error(`Unsupported encoding ${encoding}`);
   }
+}
+
+// Performance sensitive, skip the extra await when returning a blank image
+// eslint-disable-next-line @typescript-eslint/promise-function-async
+export function emptyVideoFrame(
+  videoPlayer?: VideoPlayer,
+  resizeWidth?: number,
+): Promise<ImageBitmap> {
+  const width = resizeWidth ?? 32;
+  const size = videoPlayer?.codedSize() ?? { width, height: width };
+  const data = new ImageData(size.width, size.height);
+  return createImageBitmap(data, { resizeWidth });
 }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/imageNormalizers.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/imageNormalizers.ts
@@ -9,6 +9,7 @@ import { CompressedImage, RawImage } from "@foxglove/schemas";
 
 import { PartialMessage } from "@lichtblick/suite-base/panels/ThreeDeeRender/SceneExtension";
 
+import { CompressedVideo } from "./ImageTypes";
 import { normalizeByteArray, normalizeHeader, normalizeTime } from "../../normalizeMessages";
 import { Image as RosImage, CompressedImage as RosCompressedImage } from "../../ros";
 
@@ -68,4 +69,10 @@ export function normalizeCompressedImage(
     format: message.format ?? "",
     data: normalizeByteArray(message.data),
   };
+}
+
+export function normalizeCompressedVideo(
+  message: PartialMessage<CompressedVideo>,
+): CompressedVideo {
+  return normalizeCompressedImage(message);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2880,6 +2880,7 @@ __metadata:
     "@lichtblick/comlink": 1.0.3
     "@lichtblick/tsconfig": 1.0.0
     async-mutex: 0.4.0
+    eventemitter3: 5.0.1
     xacro-parser: 0.3.9
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
**User-Facing Changes**
Added support for playback of compressedVideo messages H264

**Description**

Foxglove announced support for H264 playback when they were still open source but as a closed source feature. The funny thing is that we found a dangling commit (because they deleted everything) with a working implementation on the foxglove side https://github.com/foxglove/studio/commit/4975e65041299cc4cf04305f254c65eb12e48b5e (now deleted as well) which we tried and after some debugging managed to make it work. 

This is the port of that implementation to Lichtblick. Here's a Rosbag file to test the implementation:
[compressed_video.zip](https://github.com/user-attachments/files/18552947/compressed_video.zip)


<details>
<summary>On Generating the compressed video data</summary>

To generate the data we have used this package: https://github.com/ros-misc-utilities/ffmpeg_image_transport. For example:

```
ros2 run image_transport republish raw in:=/camera/color/image_raw --ros-args -p "ffmpeg_image_transport.preset:=ultrafast" --ros-args -p "ffmpeg_image_transport.qmax:=10"
```

which encodes the messages to h264 in output topic /out/ffmpeg.  To convert to foxglove message you can run this ROS2 node:

```python
import rclpy
from rclpy.node import Node
from ffmpeg_image_transport_msgs.msg import FFMPEGPacket
from foxglove_msgs.msg import CompressedVideo
from builtin_interfaces.msg import Time

class VideoConverterNode(Node):
    def __init__(self):
        super().__init__('video_converter_node')
        self.publisher_ = self.create_publisher(CompressedVideo, 'converted_video', 10)
        self.subscription = self.create_subscription(
            FFMPEGPacket,
            '/out/ffmpeg',
            self.listener_callback,
            10)

    def listener_callback(self, msg: FFMPEGPacket):
        video_msg = CompressedVideo()
        video_msg.timestamp = Time(sec=msg.header.stamp.sec, nanosec=msg.header.stamp.nanosec)
        video_msg.frame_id = msg.header.frame_id
        video_msg.data = msg.data
        video_msg.format = 'h264' 

        self.publisher_.publish(video_msg)
        self.get_logger().info('Publishing converted video frame')

def main(args=None):
    rclpy.init(args=args)
    video_converter_node = VideoConverterNode()
    rclpy.spin(video_converter_node)
    video_converter_node.destroy_node()
    rclpy.shutdown()

if __name__ == '__main__':
    main()
```

Another option is to use our fork of ffmpeg_image_transport that outputs directly Foxglove messages: https://github.com/kiwicampus/ffmpeg_image_transport/tree/feature/foxglove_compressed_video


</details>

One open question is whether to stick with the foxglove message type or change to the more standard ffmpeg_image_transport_msgs.FFMPEGPacket or to support both. What do you think?

**Checklist**

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
