### PR TITLE
Enable Sonar checks for story branches

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 


### PR DESCRIPTION
Remove branch restriction for pull requests to enable Sonar checks for story branches.
