### PR TITLE
Load and initialise multiple MCAP files via UI

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -29,7 +29,7 @@ settings:
 
 rules:
   "@lichtblick/license-header": error
-  "@lichtblick/prefer-hash-private": error
+  "@lichtblick/prefer-hash-private": off
 
   tss-unused-classes/unused-classes: error
 

--- a/eslint-test.ts
+++ b/eslint-test.ts
@@ -33,13 +33,11 @@
 function useEffectOnce() {} // eslint-disable-line id-denylist, @typescript-eslint/no-unused-vars
 
 class Foo {
-  private bar = 1; // eslint-disable-line @lichtblick/prefer-hash-private
-  private static baz = 1; // eslint-disable-line @lichtblick/prefer-hash-private
-  // eslint-disable-next-line @lichtblick/prefer-hash-private
+  private bar = 1;
+  private static baz = 1;
   private foo() {
     this.bar = 2;
   }
-  // eslint-disable-next-line @lichtblick/prefer-hash-private
   private static getBaz() {
     this.baz = 3;
     void this.baz;

--- a/packages/suite-base/package.json
+++ b/packages/suite-base/package.json
@@ -116,6 +116,7 @@
     "geojson": "0.5.0",
     "gl-matrix": "3.4.3",
     "hammerjs": "2.0.8",
+    "heap-js": "2.6.0",
     "i18next": "23.7.18",
     "i18next-browser-languagedetector": "7.1.0",
     "idb": "7.1.1",

--- a/packages/suite-base/src/context/Workspace/useOpenFile.tsx
+++ b/packages/suite-base/src/context/Workspace/useOpenFile.tsx
@@ -52,7 +52,6 @@ export function useOpenFile(sources: readonly IDataSourceFactory[]): () => Promi
       filesHandles.map(async (handle) => {
         const file = await handle.getFile();
         return {
-          handle,
           file,
           extension: path.extname(file.name),
         };

--- a/packages/suite-base/src/context/Workspace/useOpenFile.tsx
+++ b/packages/suite-base/src/context/Workspace/useOpenFile.tsx
@@ -34,7 +34,7 @@ export function useOpenFile(sources: readonly IDataSourceFactory[]): () => Promi
   }, [sources]);
 
   return useCallback(async () => {
-    const filesHandles = await showOpenFilePicker({
+    const filesHandle = await showOpenFilePicker({
       multiple: true,
       types: [
         {
@@ -44,12 +44,12 @@ export function useOpenFile(sources: readonly IDataSourceFactory[]): () => Promi
       ],
     });
 
-    if (filesHandles.length === 0) {
+    if (filesHandle.length === 0) {
       return;
     }
 
     const processedFiles = await Promise.all(
-      filesHandles.map(async (handle) => {
+      filesHandle.map(async (handle) => {
         const file = await handle.getFile();
         return {
           file,

--- a/packages/suite-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/suite-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -21,10 +21,15 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
   public displayName = "MCAP";
   public iconName: IDataSourceFactory["iconName"] = "OpenFile";
   public supportedFileTypes = [".mcap"];
+  public supportsMultiFile = true;
 
   public initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
-    const file = args.file;
-    if (!file) {
+    const files = args.files ?? [];
+
+    if (args.file) {
+      files.push(args.file);
+    }
+    if (files.length === 0) {
       return;
     }
 
@@ -38,13 +43,13 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
           ),
         );
       },
-      initArgs: { file },
+      initArgs: { files },
     });
 
     return new IterablePlayer({
       metricsCollector: args.metricsCollector,
       source,
-      name: file.name,
+      name: files.map((file) => file.name).join(),
       sourceId: this.id,
     });
   }

--- a/packages/suite-base/src/i18n/en/appBar.ts
+++ b/packages/suite-base/src/i18n/en/appBar.ts
@@ -20,7 +20,7 @@ export const appBar = {
   open: "Open…",
   openConnection: "Open connection…",
   openDataSources: "Open data sources",
-  openLocalFile: "Open local file…",
+  openLocalFile: "Open local files…",
   recentDataSources: "Recent data sources",
   recentlyViewed: "Recently viewed",
   settings: "Visualization settings",

--- a/packages/suite-base/src/i18n/en/openDialog.ts
+++ b/packages/suite-base/src/i18n/en/openDialog.ts
@@ -22,7 +22,7 @@ export const openDialog = {
   openConnection: "Open connection",
   openConnectionDescription: "Connect to a live robot or server.",
   openDataSource: "Open data source",
-  openLocalFile: "Open local file",
+  openLocalFile: "Open local files",
   openLocalFileDescription: "Visualize data directly from your local filesystem.",
   openUrl: "Upload and share data",
   openUrlDescription: "Use Foxglove Data Platform to share data with your team.",

--- a/packages/suite-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IIterableSource.ts
@@ -191,6 +191,8 @@ export interface IIterableSource {
     args: Immutable<MessageIteratorArgs> & { abort?: AbortSignal },
   ) => IMessageCursor;
 
+  getStart?: () => Time;
+
   /**
    * Optional method a data source can implement to cleanup resources. The player will call this
    * method when the source will no longer be used.

--- a/packages/suite-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IIterableSource.ts
@@ -191,7 +191,7 @@ export interface IIterableSource {
     args: Immutable<MessageIteratorArgs> & { abort?: AbortSignal },
   ) => IMessageCursor;
 
-  getStart?: () => Time;
+  getStart?: () => Time | undefined;
 
   /**
    * Optional method a data source can implement to cleanup resources. The player will call this

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -293,8 +293,8 @@ export class McapIndexedIterableSource implements IIterableSource {
     return sizeEstimate;
   }
 
-  public getStart(): Time {
-    return this.#start!;
+  public getStart(): Time | undefined {
+    return this.#start;
   }
 }
 

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -277,7 +277,7 @@ export class McapIndexedIterableSource implements IIterableSource {
 
   /**
    * Returns the cached size estimate for the given {@link subscriptionHash}. Estimates the size
-   * of the given {@link msg} object and updates the cache if no such cache entry existsp.
+   * of the given {@link msg} object and updates the cache if no such cache entry exists.
    * @param subscriptionHash Subscription hash
    * @param msg Deserialized message object
    * @returns Size estimate in bytes

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -277,7 +277,7 @@ export class McapIndexedIterableSource implements IIterableSource {
 
   /**
    * Returns the cached size estimate for the given {@link subscriptionHash}. Estimates the size
-   * of the given {@link msg} object and updates the cache if no such cache entry exists.
+   * of the given {@link msg} object and updates the cache if no such cache entry existsp.
    * @param subscriptionHash Subscription hash
    * @param msg Deserialized message object
    * @returns Size estimate in bytes
@@ -291,6 +291,10 @@ export class McapIndexedIterableSource implements IIterableSource {
     const sizeEstimate = estimateObjectSize(msg);
     this.#messageSizeEstimateByHash[subscriptionHash] = sizeEstimate;
     return sizeEstimate;
+  }
+
+  public getStart(): Time {
+    return this.#start!;
   }
 }
 

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -9,6 +9,7 @@ import { McapIndexedReader, McapTypes } from "@mcap/core";
 
 import Log from "@lichtblick/log";
 import { loadDecompressHandlers } from "@lichtblick/mcap-support";
+import { Time } from "@lichtblick/rostime";
 import { MessageEvent } from "@lichtblick/suite-base/players/types";
 
 import { BlobReadable } from "./BlobReadable";
@@ -120,5 +121,9 @@ export class McapIterableSource implements IIterableSource {
     }
 
     return await this.#sourceImpl.getBackfillMessages(args);
+  }
+
+  public getStart(): Time {
+    return this.#sourceImpl!.getStart!();
   }
 }

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -123,7 +123,7 @@ export class McapIterableSource implements IIterableSource {
     return await this.#sourceImpl.getBackfillMessages(args);
   }
 
-  public getStart(): Time {
+  public getStart(): Time | undefined {
     return this.#sourceImpl!.getStart!();
   }
 }

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.ts
@@ -8,12 +8,20 @@
 import * as Comlink from "@lichtblick/comlink";
 import { IterableSourceInitializeArgs } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import { WorkerIterableSourceWorker } from "@lichtblick/suite-base/players/IterablePlayer/WorkerIterableSourceWorker";
+import { MultiIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/shared/MultiIterableSource";
 
 import { McapIterableSource } from "./McapIterableSource";
 
 export function initialize(args: IterableSourceInitializeArgs): WorkerIterableSourceWorker {
   if (args.file) {
     const source = new McapIterableSource({ type: "file", file: args.file });
+    const wrapped = new WorkerIterableSourceWorker(source);
+    return Comlink.proxy(wrapped);
+  } else if (args.files) {
+    const source = new MultiIterableSource(
+      { type: "files", files: args.files },
+      McapIterableSource,
+    );
     const wrapped = new WorkerIterableSourceWorker(source);
     return Comlink.proxy(wrapped);
   } else if (args.url) {

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
@@ -91,7 +91,7 @@ export class MultiIterableSource<T extends IIterableSource, P> implements IItera
     }
 
     resultInit.topics = Array.from(uniqueTopics.values());
-    this.sourceImpl.sort((a, b) => compare(a.getStart!(), b.getStart!()));
+    this.sourceImpl.sort((a, b) => compare(a.getStart!()!, b.getStart!()!));
 
     return resultInit;
   }

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { compare, Time } from "@lichtblick/rostime";
+import { Topic } from "@lichtblick/suite";
+import { mergeAsyncIterators } from "@lichtblick/suite-base/players/IterablePlayer/shared/mergeAsyncIterators";
+import { MessageEvent, TopicStats } from "@lichtblick/suite-base/players/types";
+import { OptionalMessageDefinition } from "@lichtblick/suite-base/types/RosDatatypes";
+
+import {
+  IIterableSource,
+  IteratorResult,
+  Initalization,
+  MessageIteratorArgs,
+  GetBackfillMessagesArgs,
+} from "../IIterableSource";
+
+type MultiSource = { type: "files"; files: Blob[] } | { type: "urls"; urls: string[] };
+
+type IterableSourceConstructor<T extends IIterableSource, P> = new (args: P) => T;
+
+type Metadata = Initalization["metadata"];
+
+type TopicStatsMap = Initalization["topicStats"];
+
+export class MultiIterableSource<T extends IIterableSource, P> implements IIterableSource {
+  private SourceConstructor: IterableSourceConstructor<T, P>;
+  private dataSource: MultiSource;
+  private sourceImpl: IIterableSource[] = [];
+
+  public constructor(dataSource: MultiSource, SourceConstructor: IterableSourceConstructor<T, P>) {
+    this.dataSource = dataSource;
+    this.SourceConstructor = SourceConstructor;
+  }
+
+  private async loadMultipleSources(): Promise<Initalization[]> {
+    const { type } = this.dataSource;
+
+    const sources: IIterableSource[] =
+      type === "files"
+        ? this.dataSource.files.map(
+            (file) => new this.SourceConstructor({ type: "file", file } as P),
+          )
+        : this.dataSource.urls.map((url) => new this.SourceConstructor({ type: "url", url } as P));
+
+    this.sourceImpl = [...this.sourceImpl, ...sources];
+
+    const initializations: Initalization[] = await Promise.all(
+      sources.map(async (source) => await source.initialize()),
+    );
+
+    return initializations;
+  }
+
+  public async initialize(): Promise<Initalization> {
+    const initializations: Initalization[] = await this.loadMultipleSources();
+
+    const resultInit: Initalization = {
+      start: { sec: Number.MAX_SAFE_INTEGER, nsec: Number.MAX_SAFE_INTEGER },
+      end: { sec: Number.MIN_SAFE_INTEGER, nsec: Number.MIN_SAFE_INTEGER },
+      datatypes: new Map<string, OptionalMessageDefinition>(),
+      metadata: [],
+      name: "",
+      problems: [],
+      profile: "",
+      publishersByTopic: new Map<string, Set<string>>(),
+      topics: [],
+      topicStats: new Map<string, TopicStats>(),
+    };
+
+    const uniqueTopics = new Map<string, Topic>();
+
+    for (const init of initializations) {
+      resultInit.start = this.setStartTime(resultInit.start, init.start);
+      resultInit.end = this.setEndTime(resultInit.end, init.end);
+      resultInit.name ??= init.name;
+      resultInit.profile ??= init.profile;
+      resultInit.datatypes = this.accumulateMap(resultInit.datatypes, init.datatypes);
+      resultInit.publishersByTopic = this.accumulateMap(
+        resultInit.publishersByTopic,
+        init.publishersByTopic,
+      );
+      resultInit.topicStats = this.mergeTopicStats(resultInit.topicStats, init.topicStats);
+      resultInit.metadata = this.mergeMetadata(resultInit.metadata, init.metadata);
+      resultInit.problems = [...resultInit.problems, ...init.problems];
+
+      init.topics.forEach((topic) => uniqueTopics.set(topic.name, topic as Topic));
+    }
+
+    resultInit.topics = Array.from(uniqueTopics.values());
+    this.sourceImpl.sort((a, b) => compare(a.getStart!(), b.getStart!()));
+
+    return resultInit;
+  }
+
+  public async *messageIterator(
+    opt: MessageIteratorArgs,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> {
+    const iterators = this.sourceImpl.map((source) => source.messageIterator(opt));
+    yield* mergeAsyncIterators(iterators);
+  }
+
+  public async getBackfillMessages(args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
+    const backfillMessages = await Promise.all(
+      this.sourceImpl.map(async (source) => await source.getBackfillMessages(args)),
+    );
+
+    return backfillMessages.flat();
+  }
+
+  private setStartTime(accumulated: Time, current: Time): Time {
+    return compare(current, accumulated) < 0 ? current : accumulated;
+  }
+
+  private setEndTime(accumulated: Time, current: Time): Time {
+    return compare(current, accumulated) > 0 ? current : accumulated;
+  }
+
+  private mergeMetadata(accumulated: Metadata, current: Metadata): Metadata {
+    return [...(accumulated ?? []), ...(current ?? [])];
+  }
+
+  private accumulateMap<V>(accumulated: Map<string, V>, current: Map<string, V>): Map<string, V> {
+    return new Map<string, V>([...accumulated, ...current]);
+  }
+
+  private mergeTopicStats(accumulated: TopicStatsMap, current: TopicStatsMap): TopicStatsMap {
+    for (const [topic, stats] of current) {
+      if (!accumulated.has(topic)) {
+        accumulated.set(topic, { numMessages: 0 });
+      }
+      accumulated.get(topic)!.numMessages += stats.numMessages;
+    }
+    return accumulated;
+  }
+}

--- a/packages/suite-base/src/players/IterablePlayer/shared/mergeAsyncIterators.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/mergeAsyncIterators.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { Heap } from "heap-js";
+
+import { toMillis } from "@lichtblick/rostime";
+import { IteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
+
+export async function* mergeAsyncIterators<T extends IteratorResult>(
+  iterators: AsyncIterableIterator<T>[],
+): AsyncIterableIterator<T> {
+  const heap = new Heap<{ value: T; iterator: AsyncIterableIterator<T> }>(
+    (a, b) => getTime(a.value) - getTime(b.value),
+  );
+
+  await Promise.all(
+    iterators.map(async (iterator) => {
+      const result = await iterator.next();
+      if (!(result.done ?? false)) {
+        heap.push({ value: result.value, iterator });
+      }
+    }),
+  );
+
+  while (!heap.isEmpty()) {
+    const node = heap.pop()!;
+    yield node.value;
+
+    const nextResult = await node.iterator.next();
+    if (!(nextResult.done ?? false)) {
+      heap.push({ value: nextResult.value, iterator: node.iterator });
+    }
+  }
+}
+
+function getTime(event: IteratorResult): number {
+  if (event.type === "message-event") {
+    return toMillis(event.msgEvent.receiveTime);
+  }
+  if (event.type === "stamp") {
+    return toMillis(event.stamp);
+  }
+  return Number.MAX_SAFE_INTEGER;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3219,6 +3219,7 @@ __metadata:
     geojson: 0.5.0
     gl-matrix: 3.4.3
     hammerjs: 2.0.8
+    heap-js: 2.6.0
     i18next: 23.7.18
     i18next-browser-languagedetector: 7.1.0
     idb: 7.1.1
@@ -12341,6 +12342,13 @@ __metadata:
   bin:
     he: bin/he
   checksum: 3d4d6babccccd79c5c5a3f929a68af33360d6445587d628087f39a965079d84f18ce9c3d3f917ee1e3978916fc833bb8b29377c3b403f919426f91bc6965e7a7
+  languageName: node
+  linkType: hard
+
+"heap-js@npm:2.6.0":
+  version: 2.6.0
+  resolution: "heap-js@npm:2.6.0"
+  checksum: c89d8fc4794e580abdfd5ab2937fdef6fef0d4f48428484ac2665b50873237ebcf60e02b453b2b448a89607a9af6270d8a71aa79f5890a3dc0e52d62b6119e1c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12345,17 +12345,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"heap-js@npm:2.6.0":
+"heap-js@npm:2.6.0, heap-js@npm:^2.2.0":
   version: 2.6.0
   resolution: "heap-js@npm:2.6.0"
   checksum: c89d8fc4794e580abdfd5ab2937fdef6fef0d4f48428484ac2665b50873237ebcf60e02b453b2b448a89607a9af6270d8a71aa79f5890a3dc0e52d62b6119e1c
-  languageName: node
-  linkType: hard
-
-"heap-js@npm:^2.2.0":
-  version: 2.5.0
-  resolution: "heap-js@npm:2.5.0"
-  checksum: 2705f4c94ee89fe6aee274117abc8caa3da18eefaf7586dcc0cad4386ff75fc7a7025474b20240b12fb12cf18ef569e51d1959ee3a00a5b6ec0831b6974f2c42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->


**Description**
Transferred initialisation of multi MCAP files from PoC into story branch.
This PR has no unit tests because there is another ticket just to implement the tests. This is done just to unblock the others sub-tasks of the story.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
