### PR TITLE
Apply new operators to filters

### DIFF
--- a/packages/message-path/src/grammar.ne
+++ b/packages/message-path/src/grammar.ne
@@ -40,6 +40,14 @@ value -> integer  {% (d) => d[0] %}
        | "false" {% (d) => ({ value: false, repr: "false" }) %}
 	   | variable {% (d) => d[0] %}
 
+#Comparison operators
+comparisonOperator -> "==" {% () => "==" %}
+                    | "!=" {% () => "!=" %}
+                    | ">=" {% () => ">=" %}
+                    | "<=" {% () => "<=" %}
+                    | ">"  {% () => ">" %}
+                    | "<"  {% () => "<" %}
+
 ## Topic part. Basically an id but with (optional) slashes.
 topicName -> slashID:+     {% (d) => ({ value: d[0].join(""), repr: d[0].join("") }) %}
            | id slashID:*  {% (d) => ({ value: d[0] + d[1].join(""), repr: d[0] + d[1].join("") }) %}
@@ -112,15 +120,16 @@ filter -> "{" simplePath:? "}"
                 repr: (d[1] || []).join("."),
               })
             %}
-        | "{" simplePath:? "==" value "}"
+        | "{" simplePath:? comparisonOperator value "}"
             {%
               (d, loc) => ({
                 type: "filter",
                 path: d[1] || [],
+                operator: d[2],
                 value: d[3].value,
                 nameLoc: loc+1,
                 valueLoc: loc+1+(d[1] || []).join(".").length+d[2].length,
-                repr: `${(d[1] || []).join(".")}==${d[3].repr}`,
+                repr: `${(d[1] || []).join(".")}${d[2]}${d[3].repr}`,
               })
             %}
 

--- a/packages/message-path/src/grammar.ne
+++ b/packages/message-path/src/grammar.ne
@@ -120,16 +120,16 @@ filter -> "{" simplePath:? "}"
                 repr: (d[1] || []).join("."),
               })
             %}
-        | "{" simplePath:? comparisonOperator:? value "}"
+        | "{" simplePath:? comparisonOperator value "}"
             {%
               (d, loc) => ({
                 type: "filter",
                 path: d[1] || [],
-                operator: d[2] || "",
+                operator: d[2],
                 value: d[3].value,
                 nameLoc: loc+1,
-                valueLoc: loc+1+(d[1] || []).join(".").length+(d[2] || "").length,
-                repr: `${(d[1] || []).join(".")}${d[2] || ""}${d[3].repr}`,
+                valueLoc: loc+1+(d[1] || []).join(".").length+d[2].length,
+                repr: `${(d[1] || []).join(".")}${d[2]}${d[3].repr}`,
               })
             %}
 

--- a/packages/message-path/src/grammar.ne
+++ b/packages/message-path/src/grammar.ne
@@ -120,16 +120,16 @@ filter -> "{" simplePath:? "}"
                 repr: (d[1] || []).join("."),
               })
             %}
-        | "{" simplePath:? comparisonOperator value "}"
+        | "{" simplePath:? comparisonOperator:? value "}"
             {%
               (d, loc) => ({
                 type: "filter",
                 path: d[1] || [],
-                operator: d[2],
+                operator: d[2] || "",
                 value: d[3].value,
                 nameLoc: loc+1,
-                valueLoc: loc+1+(d[1] || []).join(".").length+d[2].length,
-                repr: `${(d[1] || []).join(".")}${d[2]}${d[3].repr}`,
+                valueLoc: loc+1+(d[1] || []).join(".").length+(d[2] || "").length,
+                repr: `${(d[1] || []).join(".")}${d[2] || ""}${d[3].repr}`,
               })
             %}
 

--- a/packages/message-path/src/parseMessagePath.test.ts
+++ b/packages/message-path/src/parseMessagePath.test.ts
@@ -293,6 +293,7 @@ describe("parseRosPath", () => {
           nameLoc: "/topic.foo{".length,
           valueLoc: "/topic.foo{bar==".length,
           repr: "bar=='baz'",
+          operator: "==",
         },
         { type: "name", name: "a", repr: "a" },
         {
@@ -302,6 +303,7 @@ describe("parseRosPath", () => {
           nameLoc: "/topic.foo{bar=='baz'}.a{".length,
           valueLoc: "/topic.foo{bar=='baz'}.a{bar==".length,
           repr: 'bar=="baz"',
+          operator: "==",
         },
         { type: "name", name: "b", repr: "b" },
         {
@@ -311,6 +313,7 @@ describe("parseRosPath", () => {
           nameLoc: "/topic.foo{bar=='baz'}.a{bar==\"baz\"}.b{".length,
           valueLoc: "/topic.foo{bar=='baz'}.a{bar==\"baz\"}.b{bar==".length,
           repr: "bar==3",
+          operator: "==",
         },
         { type: "name", name: "c", repr: "c" },
         {
@@ -320,6 +323,7 @@ describe("parseRosPath", () => {
           nameLoc: "/topic.foo{bar=='baz'}.a{bar==\"baz\"}.b{bar==3}.c{".length,
           valueLoc: "/topic.foo{bar=='baz'}.a{bar==\"baz\"}.b{bar==3}.c{bar==".length,
           repr: "bar==-1",
+          operator: "==",
         },
         { type: "name", name: "d", repr: "d" },
         {
@@ -329,6 +333,7 @@ describe("parseRosPath", () => {
           nameLoc: "/topic.foo{bar=='baz'}.a{bar==\"baz\"}.b{bar==3}.c{bar==-1}.d{".length,
           valueLoc: "/topic.foo{bar=='baz'}.a{bar==\"baz\"}.b{bar==3}.c{bar==-1}.d{bar==".length,
           repr: "bar==false",
+          operator: "==",
         },
         { type: "name", name: "e", repr: "e" },
         { type: "slice", start: 0, end: Infinity },
@@ -342,6 +347,7 @@ describe("parseRosPath", () => {
             "/topic.foo{bar=='baz'}.a{bar==\"baz\"}.b{bar==3}.c{bar==-1}.d{bar==false}.e[:]{bar.baz=="
               .length,
           repr: "bar.baz==true",
+          operator: "==",
         },
       ],
       modifier: MISSING,
@@ -360,6 +366,7 @@ describe("parseRosPath", () => {
           nameLoc: "/topic{".length,
           valueLoc: "/topic{foo==".length,
           repr: "foo=='bar'",
+          operator: "==",
         },
         {
           type: "filter",
@@ -368,6 +375,7 @@ describe("parseRosPath", () => {
           nameLoc: "/topic{foo=='bar'}{".length,
           valueLoc: "/topic{foo=='bar'}{baz==".length,
           repr: "baz==2",
+          operator: "==",
         },
         { type: "name", name: "a", repr: "a" },
         { type: "slice", start: 3, end: 3 },
@@ -379,6 +387,7 @@ describe("parseRosPath", () => {
           nameLoc: "/topic{foo=='bar'}{baz==2}.a[3].b{".length,
           valueLoc: "/topic{foo=='bar'}{baz==2}.a[3].b{x==".length,
           repr: "x=='y'",
+          operator: "==",
         },
       ],
       modifier: MISSING,
@@ -398,6 +407,7 @@ describe("parseRosPath", () => {
           nameLoc: "/topic.foo{".length,
           valueLoc: "/topic.foo{bar==".length,
           repr: "bar==$",
+          operator: "==",
         },
         { type: "name", name: "a", repr: "a" },
         {
@@ -407,6 +417,7 @@ describe("parseRosPath", () => {
           nameLoc: "/topic.foo{bar==$}.a{".length,
           valueLoc: "/topic.foo{bar==$}.a{bar==".length,
           repr: "bar==$my_var_1",
+          operator: "==",
         },
       ],
       modifier: MISSING,
@@ -485,6 +496,7 @@ describe("parseRosPath", () => {
           nameLoc: "/topic.foo{".length,
           valueLoc: "/topic.foo{==".length,
           repr: "==1",
+          operator: "==",
         },
       ],
       modifier: MISSING,
@@ -501,6 +513,7 @@ describe("parseRosPath", () => {
           nameLoc: "/topic.foo{".length,
           valueLoc: "/topic.foo{==".length,
           repr: "==-3",
+          operator: "==",
         },
       ],
       modifier: MISSING,

--- a/packages/message-path/src/types.ts
+++ b/packages/message-path/src/types.ts
@@ -28,6 +28,8 @@ export type PrimitiveType =
   | "float64"
   | "string";
 
+export type OperatorType = "==" | "!=" | "<=" | ">=" | "<" | ">";
+
 export type MessagePathFilter = {
   type: "filter";
   path: string[];
@@ -35,6 +37,7 @@ export type MessagePathFilter = {
   nameLoc: number;
   valueLoc: number;
   repr: string; // the original string representation of the filter
+  operator?: OperatorType;
 };
 
 // A parsed version of paths.

--- a/packages/message-path/src/types.ts
+++ b/packages/message-path/src/types.ts
@@ -37,7 +37,7 @@ export type MessagePathFilter = {
   nameLoc: number;
   valueLoc: number;
   repr: string; // the original string representation of the filter
-  operator?: OperatorType;
+  operator: OperatorType;
 };
 
 // A parsed version of paths.

--- a/packages/suite-base/src/components/MessagePathSyntax/MessagePathInput.test.tsx
+++ b/packages/suite-base/src/components/MessagePathSyntax/MessagePathInput.test.tsx
@@ -59,6 +59,7 @@ describe("tryToSetDefaultGlobalVar", () => {
 describe("getFirstInvalidVariableFromRosPath", () => {
   it("returns all possible message paths when not passing in `validTypes`", () => {
     const setGlobalVars = jest.fn();
+    const defaultOperator = "==";
     const rosPath: MessagePath = {
       topicName: "/some_topic",
       topicNameRepr: "/some_topic",
@@ -72,6 +73,7 @@ describe("getFirstInvalidVariableFromRosPath", () => {
           nameLoc: 11,
           valueLoc: 10,
           repr: "myId==$not_yet_set_global_var",
+          operator: defaultOperator,
         },
       ],
       modifier: undefined,

--- a/packages/suite-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/suite-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -359,7 +359,9 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
         for (const name of Object.keys(structureTraversalResult.structureItem.nextByName)) {
           const item = structureTraversalResult.structureItem.nextByName[name];
           if (item?.structureType === "primitive") {
-            items.push(`${name}==${getExamplePrimitive(item.primitiveType)}`);
+            for (const operator of ["==", "!=", ">", ">=", "<", "<="]) {
+              items.push(`${name}${operator}${getExamplePrimitive(item.primitiveType)}`);
+            }
           }
         }
 

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -24,68 +24,109 @@ describe("filterMatches", () => {
     };
   }
 
-  it("returns false for undefined filter value", () => {
-    const filter = setup();
-    expect(filterMatches(filter, { a: 1 })).toBe(false);
+  describe("basic value matching", () => {
+    it("returns false for undefined filter value", () => {
+      const filter = setup();
+      expect(filterMatches(filter, { a: 1 })).toBe(false);
+    });
+
+    it("returns false for non-matching value", () => {
+      const filter = setup({ value: 2 });
+      expect(filterMatches(filter, { a: 1 })).toBe(false);
+    });
+
+    it("returns true for matching value", () => {
+      const filter = setup({ value: 1 });
+      expect(filterMatches(filter, { a: 1 })).toBe(true);
+    });
+
+    it("returns false for currentValue == undefined", () => {
+      const filter = setup({ value: 1 });
+      expect(filterMatches(filter, { a: undefined })).toBe(false);
+    });
   });
 
-  it("returns false for non-matching value", () => {
-    const filter = setup({ value: 2 });
-    expect(filterMatches(filter, { a: 1 })).toBe(false);
+  describe("nested value matching", () => {
+    it("returns false for non-matching nested value", () => {
+      const filter = setup({ path: ["a", "b"], value: 2 });
+      expect(filterMatches(filter, { a: { b: 1 } })).toBe(false);
+    });
+
+    it("returns true for matching nested value", () => {
+      const filter = setup({ path: ["a", "b"], value: 1 });
+      expect(filterMatches(filter, { a: { b: 1 } })).toBe(true);
+    });
+
+    it("returns false for undefined nested value", () => {
+      const filter = setup({ path: ["a", "b"], value: 1 });
+      expect(filterMatches(filter, { a: {} })).toBe(false);
+    });
   });
 
-  it("returns true for matching value", () => {
-    const filter = setup({ value: 1 });
-    expect(filterMatches(filter, { a: 1 })).toBe(true);
-  });
+  describe("operator matching", () => {
+    it("returns false for invalid operator", () => {
+      const filter = setup({ value: 1, operator: "invalid" as any });
+      expect(filterMatches(filter, { a: 1 })).toBe(false);
+    });
 
-  it("returns false for non-matching nested value", () => {
-    const filter = setup({ path: ["a", "b"], value: 2 });
-    expect(filterMatches(filter, { a: { b: 1 } })).toBe(false);
-  });
+    it("returns false for non-matching value with <", () => {
+      const filter = setup({ value: 1 }, "<");
+      expect(filterMatches(filter, { a: 2 })).toBe(false);
+    });
 
-  it("returns true for matching nested value", () => {
-    const filter = setup({ path: ["a", "b"], value: 1 });
-    expect(filterMatches(filter, { a: { b: 1 } })).toBe(true);
-  });
+    it("returns true for matching value with <", () => {
+      const filter = setup({ value: 2 }, "<");
+      expect(filterMatches(filter, { a: 1 })).toBe(true);
+    });
 
-  it("returns false for undefined nested value", () => {
-    const filter = setup({ path: ["a", "b"], value: 1 });
-    expect(filterMatches(filter, { a: {} })).toBe(false);
-  });
+    it("returns false for non-matching value with >", () => {
+      const filter = setup({ value: 2 }, ">");
+      expect(filterMatches(filter, { a: 1 })).toBe(false);
+    });
 
-  it("returns false for invalid operator", () => {
-    const filter = setup({ value: 1, operator: "invalid" as any });
-    expect(filterMatches(filter, { a: 1 })).toBe(false);
-  });
+    it("returns true for matching value with >", () => {
+      const filter = setup({ value: 1 }, ">");
+      expect(filterMatches(filter, { a: 2 })).toBe(true);
+    });
 
-  it("returns false for non-matching value with <", () => {
-    const filter = setup({ value: 1 }, "<");
-    expect(filterMatches(filter, { a: 2 })).toBe(false);
-  });
+    it("returns false for matching value with !=", () => {
+      const filter = setup({ value: 1 }, "!=");
+      expect(filterMatches(filter, { a: 1 })).toBe(false);
+    });
 
-  it("returns true for matching value with <", () => {
-    const filter = setup({ value: 2 }, "<");
-    expect(filterMatches(filter, { a: 1 })).toBe(true);
-  });
+    it("returns true for non-matching value with !=", () => {
+      const filter = setup({ value: 1 }, "!=");
+      expect(filterMatches(filter, { a: 2 })).toBe(true);
+    });
 
-  it("returns false for non-matching value with >", () => {
-    const filter = setup({ value: 2 }, ">");
-    expect(filterMatches(filter, { a: 1 })).toBe(false);
-  });
+    it("returns false for non-matching value with >=", () => {
+      const filter = setup({ value: 2 }, ">=");
+      expect(filterMatches(filter, { a: 1 })).toBe(false);
+    });
 
-  it("returns true for matching value with >", () => {
-    const filter = setup({ value: 1 }, ">");
-    expect(filterMatches(filter, { a: 2 })).toBe(true);
-  });
+    it("returns true for matching value with >=", () => {
+      const filter = setup({ value: 1 }, ">=");
+      expect(filterMatches(filter, { a: 1 })).toBe(true);
+    });
 
-  it("returns false for matching value with !=", () => {
-    const filter = setup({ value: 1 }, "!=");
-    expect(filterMatches(filter, { a: 1 })).toBe(false);
-  });
+    it("returns true for greater value with >=", () => {
+      const filter = setup({ value: 1 }, ">=");
+      expect(filterMatches(filter, { a: 2 })).toBe(true);
+    });
 
-  it("returns true for non-matching value with !=", () => {
-    const filter = setup({ value: 1 }, "!=");
-    expect(filterMatches(filter, { a: 2 })).toBe(true);
+    it("returns false for non-matching value with <=", () => {
+      const filter = setup({ value: 1 }, "<=");
+      expect(filterMatches(filter, { a: 2 })).toBe(false);
+    });
+
+    it("returns true for matching value with <=", () => {
+      const filter = setup({ value: 1 }, "<=");
+      expect(filterMatches(filter, { a: 1 })).toBe(true);
+    });
+
+    it("returns true for lesser value with <=", () => {
+      const filter = setup({ value: 2 }, "<=");
+      expect(filterMatches(filter, { a: 1 })).toBe(true);
+    });
   });
 });

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { MessagePathFilter, OperatorType } from "@lichtblick/message-path";
+import { Immutable } from "@lichtblick/suite";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+
+import { filterMatches } from "./filterMatches";
+
+describe("filterMatches", () => {
+  function setup(
+    overrides: Partial<MessagePathFilter> = {},
+    operator: OperatorType = "==",
+  ): Immutable<MessagePathFilter> {
+    return {
+      path: ["a"],
+      value: undefined,
+      operator,
+      type: "filter",
+      nameLoc: BasicBuilder.number(),
+      valueLoc: BasicBuilder.number(),
+      repr: "",
+      ...overrides,
+    };
+  }
+
+  it("returns false for undefined filter value", () => {
+    const filter = setup();
+    expect(filterMatches(filter, { a: 1 })).toBe(false);
+  });
+
+  it("returns false for non-matching value", () => {
+    const filter = setup({ value: 2 });
+    expect(filterMatches(filter, { a: 1 })).toBe(false);
+  });
+
+  it("returns true for matching value", () => {
+    const filter = setup({ value: 1 });
+    expect(filterMatches(filter, { a: 1 })).toBe(true);
+  });
+
+  it("returns false for non-matching nested value", () => {
+    const filter = setup({ path: ["a", "b"], value: 2 });
+    expect(filterMatches(filter, { a: { b: 1 } })).toBe(false);
+  });
+
+  it("returns true for matching nested value", () => {
+    const filter = setup({ path: ["a", "b"], value: 1 });
+    expect(filterMatches(filter, { a: { b: 1 } })).toBe(true);
+  });
+
+  it("returns false for undefined nested value", () => {
+    const filter = setup({ path: ["a", "b"], value: 1 });
+    expect(filterMatches(filter, { a: {} })).toBe(false);
+  });
+
+  it("returns false for invalid operator", () => {
+    const filter = setup({ value: 1, operator: "invalid" as any });
+    expect(filterMatches(filter, { a: 1 })).toBe(false);
+  });
+
+  it("returns false for non-matching value with <", () => {
+    const filter = setup({ value: 1 }, "<");
+    expect(filterMatches(filter, { a: 2 })).toBe(false);
+  });
+
+  it("returns true for matching value with <", () => {
+    const filter = setup({ value: 2 }, "<");
+    expect(filterMatches(filter, { a: 1 })).toBe(true);
+  });
+
+  it("returns false for non-matching value with >", () => {
+    const filter = setup({ value: 2 }, ">");
+    expect(filterMatches(filter, { a: 1 })).toBe(false);
+  });
+
+  it("returns true for matching value with >", () => {
+    const filter = setup({ value: 1 }, ">");
+    expect(filterMatches(filter, { a: 2 })).toBe(true);
+  });
+
+  it("returns false for matching value with !=", () => {
+    const filter = setup({ value: 1 }, "!=");
+    expect(filterMatches(filter, { a: 1 })).toBe(false);
+  });
+
+  it("returns true for non-matching value with !=", () => {
+    const filter = setup({ value: 1 }, "!=");
+    expect(filterMatches(filter, { a: 2 })).toBe(true);
+  });
+});

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -88,7 +88,7 @@ describe("filterMatches", () => {
   describe("handling undefined or empty values", () => {
     it("returns false when currentValue is undefined or an empty object", () => {
       const filter = setup({}, "==");
-      expect(filterMatches(filter, { a: undefined })).toBe(false);
+      expect(filterMatches(filter, {})).toBe(false);
       expect(filterMatches(filter, { a: {} })).toBe(false);
     });
 

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -42,6 +42,11 @@ describe("filterMatches", () => {
       const filter = setup({ value }, "==");
       expect(filterMatches(filter, { a: value })).toBe(true);
     });
+
+    it("returns false for undefined currentValue in path", () => {
+      const filter = setup({ path: ["a", "b"], value: BasicBuilder.number() }, "==");
+      expect(filterMatches(filter, { a: undefined })).toBe(false);
+    });
   });
 
   describe("nested value matching", () => {
@@ -56,6 +61,11 @@ describe("filterMatches", () => {
       const value = BasicBuilder.number();
       const filter = setup({ path: ["a", "b"], value }, "==");
       expect(filterMatches(filter, { a: { b: value } })).toBe(true);
+    });
+
+    it("returns false for undefined currentValue in nested path", () => {
+      const filter = setup({ path: ["a", "b"], value: BasicBuilder.number() }, "==");
+      expect(filterMatches(filter, { a: { b: undefined } })).toBe(false);
     });
   });
 
@@ -82,6 +92,11 @@ describe("filterMatches", () => {
     it("returns false for invalid operator", () => {
       const filter = setup({ value: BasicBuilder.number(), operator: "invalid" as any }, "==");
       expect(filterMatches(filter, { a: BasicBuilder.number() })).toBe(false);
+    });
+
+    it("returns false for undefined currentValue", () => {
+      const filter = setup({ value: BasicBuilder.number() }, "==");
+      expect(filterMatches(filter, { a: undefined })).toBe(false);
     });
   });
 

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -129,4 +129,26 @@ describe("filterMatches", () => {
       expect(filterMatches(filter, { a: 1 })).toBe(true);
     });
   });
+  describe("currentValue type checking", () => {
+    it("returns false for currentValue being a primitive type", () => {
+      const filter = setup({ value: 1 });
+      expect(filterMatches(filter, { a: "string" })).toBe(false);
+      expect(filterMatches(filter, { a: null })).toBe(false);
+    });
+
+    it("returns false for currentValue being undefined", () => {
+      const filter = setup({ value: 1 });
+      expect(filterMatches(filter, { a: undefined })).toBe(false);
+    });
+
+    it("returns true for currentValue being a valid object", () => {
+      const filter = setup({ path: ["a", "b"], value: 1 });
+      expect(filterMatches(filter, { a: { b: 1 } })).toBe(true);
+    });
+
+    it("returns false for currentValue being an empty object", () => {
+      const filter = setup({ path: ["a", "b"], value: 1 });
+      expect(filterMatches(filter, { a: { b: {} } })).toBe(false);
+    });
+  });
 });

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -85,17 +85,4 @@ describe("filterMatches", () => {
     });
   });
 
-  describe("handling undefined or empty values", () => {
-    it("returns false when currentValue is undefined or an empty object", () => {
-      const filter = setup({}, "==");
-      expect(filterMatches(filter, {})).toBe(false);
-      expect(filterMatches(filter, { a: {} })).toBe(false);
-    });
-
-    it("returns true when currentValue is a valid nested object", () => {
-      const value = BasicBuilder.number();
-      const filter = setup({ path: ["a", "b"], value }, "==");
-      expect(filterMatches(filter, { a: { b: value } })).toBe(true);
-    });
-  });
 });

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -91,9 +91,9 @@ describe("filterMatches", () => {
       ["<=", 1, 2, true],
       ["<=", 1, 1, true],
       ["<=", 2, 1, false],
-    ])("returns %s for %s %s %s", (operator, testValue, filterValue, expected) => {
+    ])("returns %s for %s %s %s", (operator, testValue, filterValue, expectedResult) => {
       const filter = setup({ value: filterValue, operator: operator as OperatorType });
-      expect(filterMatches(filter, { a: testValue })).toBe(expected);
+      expect(filterMatches(filter, { a: testValue })).toBe(expectedResult);
     });
 
     it("returns false for invalid operator", () => {

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -22,6 +22,11 @@ describe("filterMatches", () => {
   }
 
   describe("value matching", () => {
+    it("returns false for undefined value", () => {
+      const filter = setup();
+      expect(filterMatches(filter, undefined)).toBe(false);
+    });
+
     it("returns false for undefined filter value", () => {
       const filter = setup({ value: undefined });
       expect(filterMatches(filter, { a: BasicBuilder.number() })).toBe(false);
@@ -43,8 +48,9 @@ describe("filterMatches", () => {
 
   describe("nested value matching", () => {
     it("returns false for non-matching or missing nested value", () => {
-      const filter = setup({ path: ["a", "b"], value: BasicBuilder.number() });
-      expect(filterMatches(filter, { a: { b: BasicBuilder.number() } })).toBe(false);
+      const value = BasicBuilder.number();
+      const filter = setup({ path: ["a", "b"], value });
+      expect(filterMatches(filter, { a: { b: value + 1 } })).toBe(false);
       expect(filterMatches(filter, { a: {} })).toBe(false);
       expect(filterMatches(filter, { a: { b: {} } })).toBe(false);
     });

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -10,7 +10,7 @@ import { filterMatches } from "./filterMatches";
 describe("filterMatches", () => {
   function setup(
     overrides: Partial<MessagePathFilter> = {},
-    operator: OperatorType,
+    operator?: OperatorType,
   ): Immutable<MessagePathFilter> {
     return {
       path: ["a"],
@@ -26,7 +26,7 @@ describe("filterMatches", () => {
 
   describe("value matching", () => {
     it("returns false for undefined filter value", () => {
-      const filter = setup({ value: undefined }, "==");
+      const filter = setup({ value: undefined });
       expect(filterMatches(filter, { a: BasicBuilder.number() })).toBe(false);
     });
 
@@ -46,7 +46,7 @@ describe("filterMatches", () => {
 
   describe("nested value matching", () => {
     it("returns false for non-matching or missing nested value", () => {
-      const filter = setup({ path: ["a", "b"], value: BasicBuilder.number() }, "==");
+      const filter = setup({ path: ["a", "b"], value: BasicBuilder.number() });
       expect(filterMatches(filter, { a: { b: BasicBuilder.number() } })).toBe(false);
       expect(filterMatches(filter, { a: {} })).toBe(false);
       expect(filterMatches(filter, { a: { b: {} } })).toBe(false);
@@ -80,7 +80,7 @@ describe("filterMatches", () => {
     });
 
     it("returns false for invalid operator", () => {
-      const filter = setup({ value: BasicBuilder.number(), operator: "invalid" as any }, "==");
+      const filter = setup({ value: BasicBuilder.number(), operator: "invalid" as any });
       expect(filterMatches(filter, { a: BasicBuilder.number() })).toBe(false);
     });
   });

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -84,5 +84,4 @@ describe("filterMatches", () => {
       expect(filterMatches(filter, { a: BasicBuilder.number() })).toBe(false);
     });
   });
-
 });

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -27,6 +27,20 @@ describe("filterMatches", () => {
       expect(filterMatches(filter, undefined)).toBe(false);
     });
 
+    it("returns false for empty path and undefined value", () => {
+      const filter = setup({ path: [] });
+      expect(filterMatches(filter, undefined)).toBe(false);
+    });
+
+    it("returns error when filter value is an object", () => {
+      const filter = setup({
+        value: { variableName: BasicBuilder.string(), startLoc: BasicBuilder.number() },
+      });
+      expect(() => filterMatches(filter, { a: BasicBuilder.number() })).toThrow(
+        new Error("filterMatches only works on paths where global variables have been filled in"),
+      );
+    });
+
     it("returns false for undefined filter value", () => {
       const filter = setup({ value: undefined });
       expect(filterMatches(filter, { a: BasicBuilder.number() })).toBe(false);

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -8,14 +8,11 @@ import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
 import { filterMatches } from "./filterMatches";
 
 describe("filterMatches", () => {
-  function setup(
-    overrides: Partial<MessagePathFilter> = {},
-    operator?: OperatorType,
-  ): Immutable<MessagePathFilter> {
+  function setup(overrides: Partial<MessagePathFilter> = {}): Immutable<MessagePathFilter> {
     return {
       path: ["a"],
       value: BasicBuilder.number(),
-      operator,
+      operator: "==",
       type: "filter",
       nameLoc: BasicBuilder.number(),
       valueLoc: BasicBuilder.number(),
@@ -33,13 +30,13 @@ describe("filterMatches", () => {
     it("returns false for non-matching value", () => {
       const value = BasicBuilder.number();
       const secondValue = value + 1;
-      const filter = setup({ value }, "==");
+      const filter = setup({ value });
       expect(filterMatches(filter, { a: secondValue })).toBe(false);
     });
 
     it("returns true for matching value", () => {
       const value = BasicBuilder.number();
-      const filter = setup({ value }, "==");
+      const filter = setup({ value });
       expect(filterMatches(filter, { a: value })).toBe(true);
     });
   });
@@ -54,7 +51,7 @@ describe("filterMatches", () => {
 
     it("returns true for matching nested value", () => {
       const value = BasicBuilder.number();
-      const filter = setup({ path: ["a", "b"], value }, "==");
+      const filter = setup({ path: ["a", "b"], value });
       expect(filterMatches(filter, { a: { b: value } })).toBe(true);
     });
   });
@@ -75,7 +72,7 @@ describe("filterMatches", () => {
       ["<=", 1, 1, true],
       ["<=", 2, 1, false],
     ])("returns %s for %s %s %s", (operator, testValue, filterValue, expected) => {
-      const filter = setup({ value: filterValue }, operator as OperatorType);
+      const filter = setup({ value: filterValue, operator: operator as OperatorType });
       expect(filterMatches(filter, { a: testValue })).toBe(expected);
     });
 

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -42,11 +42,6 @@ describe("filterMatches", () => {
       const filter = setup({ value }, "==");
       expect(filterMatches(filter, { a: value })).toBe(true);
     });
-
-    it("returns false for undefined currentValue in path", () => {
-      const filter = setup({ path: ["a", "b"], value: BasicBuilder.number() }, "==");
-      expect(filterMatches(filter, { a: undefined })).toBe(false);
-    });
   });
 
   describe("nested value matching", () => {
@@ -61,11 +56,6 @@ describe("filterMatches", () => {
       const value = BasicBuilder.number();
       const filter = setup({ path: ["a", "b"], value }, "==");
       expect(filterMatches(filter, { a: { b: value } })).toBe(true);
-    });
-
-    it("returns false for undefined currentValue in nested path", () => {
-      const filter = setup({ path: ["a", "b"], value: BasicBuilder.number() }, "==");
-      expect(filterMatches(filter, { a: { b: undefined } })).toBe(false);
     });
   });
 
@@ -92,11 +82,6 @@ describe("filterMatches", () => {
     it("returns false for invalid operator", () => {
       const filter = setup({ value: BasicBuilder.number(), operator: "invalid" as any }, "==");
       expect(filterMatches(filter, { a: BasicBuilder.number() })).toBe(false);
-    });
-
-    it("returns false for undefined currentValue", () => {
-      const filter = setup({ value: BasicBuilder.number() }, "==");
-      expect(filterMatches(filter, { a: undefined })).toBe(false);
     });
   });
 

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.test.ts
@@ -32,7 +32,7 @@ describe("filterMatches", () => {
 
     it("returns false for non-matching value", () => {
       const value = BasicBuilder.number();
-      const secondValue = BasicBuilder.number();
+      const secondValue = value + 1;
       const filter = setup({ value }, "==");
       expect(filterMatches(filter, { a: secondValue })).toBe(false);
     });

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.ts
@@ -16,7 +16,6 @@ export function filterMatches(filter: Immutable<MessagePathFilter>, value: unkno
     return false;
   }
   let currentValue = value;
-  console.log("currentValue line 19:", currentValue);
   for (const name of filter.path) {
     if (typeof currentValue !== "object" || currentValue == undefined) {
       return false;
@@ -31,7 +30,6 @@ export function filterMatches(filter: Immutable<MessagePathFilter>, value: unkno
   // comparing numbers with strings, bigints with numbers, and so on.
 
   if (currentValue != undefined) {
-    console.log("currentValue line 34:", currentValue);
     switch (filter.operator) {
       case "==":
         // eslint-disable-next-line @lichtblick/strict-equality

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.ts
@@ -51,4 +51,5 @@ export function filterMatches(filter: Immutable<MessagePathFilter>, value: unkno
         return false;
     }
   }
+  return false;
 }

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.ts
@@ -21,14 +21,34 @@ export function filterMatches(filter: Immutable<MessagePathFilter>, value: unkno
     if (typeof currentValue !== "object" || currentValue == undefined) {
       return false;
     }
+
     currentValue = (currentValue as Record<string, unknown>)[name];
     if (currentValue == undefined) {
       return false;
     }
   }
 
-  // Test equality using `==` so we can be forgiving for comparing booleans with integers,
+  // Test equality using non strict operators so we can be forgiving for comparing booleans with integers,
   // comparing numbers with strings, bigints with numbers, and so on.
-  // eslint-disable-next-line @lichtblick/strict-equality
-  return currentValue != undefined && currentValue == filter.value;
+
+  if (currentValue != undefined) {
+    switch (filter.operator) {
+      case "==":
+        // eslint-disable-next-line @lichtblick/strict-equality
+        return currentValue == filter.value;
+      case "!=":
+        // eslint-disable-next-line @lichtblick/strict-equality
+        return currentValue != filter.value;
+      case ">=":
+        return currentValue >= filter.value;
+      case "<=":
+        return currentValue <= filter.value;
+      case ">":
+        return currentValue > filter.value;
+      case "<":
+        return currentValue < filter.value;
+      default:
+        return false;
+    }
+  }
 }

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.ts
@@ -21,7 +21,6 @@ export function filterMatches(filter: Immutable<MessagePathFilter>, value: unkno
     if (typeof currentValue !== "object" || currentValue == undefined) {
       return false;
     }
-
     currentValue = (currentValue as Record<string, unknown>)[name];
     if (currentValue == undefined) {
       return false;

--- a/packages/suite-base/src/components/MessagePathSyntax/filterMatches.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/filterMatches.ts
@@ -15,8 +15,8 @@ export function filterMatches(filter: Immutable<MessagePathFilter>, value: unkno
   if (filter.value == undefined) {
     return false;
   }
-
   let currentValue = value;
+  console.log("currentValue line 19:", currentValue);
   for (const name of filter.path) {
     if (typeof currentValue !== "object" || currentValue == undefined) {
       return false;
@@ -31,6 +31,7 @@ export function filterMatches(filter: Immutable<MessagePathFilter>, value: unkno
   // comparing numbers with strings, bigints with numbers, and so on.
 
   if (currentValue != undefined) {
+    console.log("currentValue line 34:", currentValue);
     switch (filter.operator) {
       case "==":
         // eslint-disable-next-line @lichtblick/strict-equality

--- a/packages/suite-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
@@ -15,7 +15,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { unwrap } from "@lichtblick/den/monads";
-import { parseMessagePath } from "@lichtblick/message-path";
+import { OperatorType, parseMessagePath } from "@lichtblick/message-path";
 import { RosDatatypes } from "@lichtblick/suite-base/types/RosDatatypes";
 
 import {
@@ -592,6 +592,9 @@ describe("validTerminatingStructureItem", () => {
 });
 
 describe("traverseStructure", () => {
+  const equal: OperatorType = "==";
+  const notEqual: OperatorType = "!=";
+  const greaterThan: OperatorType = ">=";
   it("returns whether the path is valid for the structure, plus some metadata", () => {
     const structure = messagePathStructures(datatypes)["pose_msgs/PoseDebug"];
 
@@ -627,7 +630,7 @@ describe("traverseStructure", () => {
           nameLoc: 123,
           valueLoc: 0,
           repr: "",
-          operator: "==",
+          operator: equal,
         },
         { type: "name", name: "dummy_array", repr: "dummy_array" },
         { type: "slice", start: 50, end: 100 },
@@ -647,7 +650,7 @@ describe("traverseStructure", () => {
           nameLoc: 123,
           valueLoc: 0,
           repr: "",
-          operator: "==",
+          operator: equal,
         },
       ]),
     ).toEqual({
@@ -690,7 +693,7 @@ describe("traverseStructure", () => {
           nameLoc: 123,
           valueLoc: 0,
           repr: "",
-          operator: "==",
+          operator: notEqual,
         },
       ]),
     ).toEqual({
@@ -702,7 +705,7 @@ describe("traverseStructure", () => {
         nameLoc: 123,
         valueLoc: 0,
         repr: "",
-        operator: "==",
+        operator: notEqual,
       },
       structureItem: messagePathStructures(datatypes)["pose_msgs/SomePose"],
     });
@@ -716,7 +719,7 @@ describe("traverseStructure", () => {
           nameLoc: 123,
           valueLoc: 0,
           repr: "",
-          operator: "==",
+          operator: greaterThan,
         },
       ]),
     ).toEqual({
@@ -728,7 +731,7 @@ describe("traverseStructure", () => {
         nameLoc: 123,
         valueLoc: 0,
         repr: "",
-        operator: "==",
+        operator: greaterThan,
       },
       structureItem: messagePathStructures(datatypes)["pose_msgs/SomePose"],
     });

--- a/packages/suite-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
@@ -620,7 +620,15 @@ describe("traverseStructure", () => {
     expect(
       traverseStructure(structure, [
         { type: "name", name: "some_pose", repr: "some_pose" },
-        { type: "filter", path: ["x"], value: 10, nameLoc: 123, valueLoc: 0, repr: "" },
+        {
+          type: "filter",
+          path: ["x"],
+          value: 10,
+          nameLoc: 123,
+          valueLoc: 0,
+          repr: "",
+          operator: "==",
+        },
         { type: "name", name: "dummy_array", repr: "dummy_array" },
         { type: "slice", start: 50, end: 100 },
       ]),
@@ -632,7 +640,15 @@ describe("traverseStructure", () => {
     expect(
       traverseStructure(structure, [
         { type: "name", name: "some_pose", repr: "some_pose" },
-        { type: "filter", path: ["header", "seq"], value: 10, nameLoc: 123, valueLoc: 0, repr: "" },
+        {
+          type: "filter",
+          path: ["header", "seq"],
+          value: 10,
+          nameLoc: 123,
+          valueLoc: 0,
+          repr: "",
+          operator: "==",
+        },
       ]),
     ).toEqual({
       valid: true,
@@ -667,17 +683,41 @@ describe("traverseStructure", () => {
     expect(
       traverseStructure(structure, [
         { type: "name", name: "some_pose", repr: "some_pose" },
-        { type: "filter", path: ["y"], value: 10, nameLoc: 123, valueLoc: 0, repr: "" },
+        {
+          type: "filter",
+          path: ["y"],
+          value: 10,
+          nameLoc: 123,
+          valueLoc: 0,
+          repr: "",
+          operator: "==",
+        },
       ]),
     ).toEqual({
       valid: false,
-      msgPathPart: { type: "filter", path: ["y"], value: 10, nameLoc: 123, valueLoc: 0, repr: "" },
+      msgPathPart: {
+        type: "filter",
+        path: ["y"],
+        value: 10,
+        nameLoc: 123,
+        valueLoc: 0,
+        repr: "",
+        operator: "==",
+      },
       structureItem: messagePathStructures(datatypes)["pose_msgs/SomePose"],
     });
     expect(
       traverseStructure(structure, [
         { type: "name", name: "some_pose", repr: "some_pose" },
-        { type: "filter", path: ["header", "y"], value: 10, nameLoc: 123, valueLoc: 0, repr: "" },
+        {
+          type: "filter",
+          path: ["header", "y"],
+          value: 10,
+          nameLoc: 123,
+          valueLoc: 0,
+          repr: "",
+          operator: "==",
+        },
       ]),
     ).toEqual({
       valid: false,
@@ -688,6 +728,7 @@ describe("traverseStructure", () => {
         nameLoc: 123,
         valueLoc: 0,
         repr: "",
+        operator: "==",
       },
       structureItem: messagePathStructures(datatypes)["pose_msgs/SomePose"],
     });

--- a/packages/suite-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
+++ b/packages/suite-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
@@ -18,7 +18,7 @@
 import { renderHook } from "@testing-library/react";
 import * as _ from "lodash-es";
 
-import { parseMessagePath } from "@lichtblick/message-path";
+import { OperatorType, parseMessagePath } from "@lichtblick/message-path";
 import { messagePathStructures } from "@lichtblick/suite-base/components/MessagePathSyntax/messagePathsForDatatype";
 import MockMessagePipelineProvider from "@lichtblick/suite-base/components/MessagePipeline/MockMessagePipelineProvider";
 import { MessageEvent, Topic } from "@lichtblick/suite-base/players/types";
@@ -618,6 +618,9 @@ describe("useCachedGetMessagePathDataItems", () => {
 });
 
 describe("fillInGlobalVariablesInPath", () => {
+  const equal: OperatorType = "==";
+  const notEqual: OperatorType = "!=";
+
   it("fills in global variables in slices", () => {
     expect(
       fillInGlobalVariablesInPath(
@@ -687,7 +690,7 @@ describe("fillInGlobalVariablesInPath", () => {
               nameLoc: 0,
               valueLoc: 0,
               repr: "",
-              operator: "==",
+              operator: equal,
             },
           ],
           modifier: undefined,
@@ -705,7 +708,7 @@ describe("fillInGlobalVariablesInPath", () => {
           nameLoc: 0,
           valueLoc: 0,
           repr: "",
-          operator: "==",
+          operator: equal,
         },
       ],
     });
@@ -726,7 +729,7 @@ describe("fillInGlobalVariablesInPath", () => {
               nameLoc: 0,
               valueLoc: 0,
               repr: "",
-              operator: "==",
+              operator: notEqual,
             },
           ],
           modifier: undefined,
@@ -744,7 +747,7 @@ describe("fillInGlobalVariablesInPath", () => {
           nameLoc: 0,
           valueLoc: 0,
           repr: "",
-          operator: "==",
+          operator: notEqual,
         },
       ],
     });

--- a/packages/suite-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
+++ b/packages/suite-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
@@ -737,7 +737,15 @@ describe("fillInGlobalVariablesInPath", () => {
       topicName: "/foo",
       topicNameRepr: "/foo",
       messagePath: [
-        { type: "filter", path: ["bar"], value: undefined, nameLoc: 0, valueLoc: 0, repr: "", operator:"==" },
+        {
+          type: "filter",
+          path: ["bar"],
+          value: undefined,
+          nameLoc: 0,
+          valueLoc: 0,
+          repr: "",
+          operator: "==",
+        },
       ],
     });
   });

--- a/packages/suite-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
+++ b/packages/suite-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
@@ -687,6 +687,7 @@ describe("fillInGlobalVariablesInPath", () => {
               nameLoc: 0,
               valueLoc: 0,
               repr: "",
+              operator: "==",
             },
           ],
           modifier: undefined,
@@ -697,7 +698,15 @@ describe("fillInGlobalVariablesInPath", () => {
       topicName: "/foo",
       topicNameRepr: "/foo",
       messagePath: [
-        { type: "filter", path: ["bar"], value: 123, nameLoc: 0, valueLoc: 0, repr: "" },
+        {
+          type: "filter",
+          path: ["bar"],
+          value: 123,
+          nameLoc: 0,
+          valueLoc: 0,
+          repr: "",
+          operator: "==",
+        },
       ],
     });
   });
@@ -717,6 +726,7 @@ describe("fillInGlobalVariablesInPath", () => {
               nameLoc: 0,
               valueLoc: 0,
               repr: "",
+              operator: "==",
             },
           ],
           modifier: undefined,
@@ -727,7 +737,7 @@ describe("fillInGlobalVariablesInPath", () => {
       topicName: "/foo",
       topicNameRepr: "/foo",
       messagePath: [
-        { type: "filter", path: ["bar"], value: undefined, nameLoc: 0, valueLoc: 0, repr: "" },
+        { type: "filter", path: ["bar"], value: undefined, nameLoc: 0, valueLoc: 0, repr: "", operator:"==" },
       ],
     });
   });


### PR DESCRIPTION
**User-Facing Changes**
This change adds the possibiity of using comparison operators to filter messages on Raw Messages Panel and Plot Panel.

E.g.:
```
/my_books.readers[:]{id==1}{isCurrentlyReading==true}.name =>
  "Ashley" // message 1
  // No value returned for message 2

/my_books.readers[:]{id==1}{isCurrentlyReading==false}.name =>
  // No value returned for message 1
  // No value returned for message 2

/my_books.readers[:]{id==5}{isCurrentlyReading==false}.name =>
  // No value returned for message 1
  "Ethan" // message 2
```


**Description**
This PR aims to add the possibility of using not just ==, but the remaining comparators. It will be possible to use: `"==" | "!=" | "<=" | ">=" | "<" | ">"` in order to compare messages.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests