### PR TITLE
add pre-build workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -3,7 +3,7 @@ name: Auto Bump Version
 on:
   push:
     branches:
-      - main  # Trigger on push to main branch
+      - main # Trigger on push to main branch
 
 jobs:
   bump:
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: "14"
 
       - run: corepack enable
 
@@ -59,3 +59,11 @@ jobs:
       - name: Push changes
         run: |
           git push origin main
+
+      - name: Trigger pre-build workflow
+        run: |
+          curl -X POST -H "Accept: application/vnd.github+json" \
+               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+               -H "X-GitHub-Api-Version: 2022-11-28" \
+               -d '{"ref":"main"}' \
+               https://api.github.com/repos/${{ github.repository }}/actions/workflows/pre-build.yml/dispatches

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,64 @@
+name: Pre-Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.1.1
+        with:
+          token: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}
+          lfs: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 16.17
+
+      - name: Enable corepack
+        run: corepack enable yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Read version from package.json
+        id: package_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+
+      - name: Build prod files
+        run: |
+          yarn run desktop:build:prod
+
+      - name: Build Windows version
+        run: yarn run package:win
+
+      - name: Build Linux version
+        run: yarn run package:linux
+
+      - name: Build macOS version
+        run: yarn run package:darwin
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lichtblick-${{ env.version }}-windows
+          path: dist/lichtblick-${{ env.version }}-win.exe
+          retention-days: 30
+
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lichtblick-${{ env.version }}-debian-amd64
+          path: dist/lichtblick-${{ env.version }}-linux-amd64.deb
+          retention-days: 30
+
+      - name: Upload MacOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lichtblick-${{ env.version }}-macos
+          path: dist/lichtblick-${{ env.version }}-mac-universal.dmg
+          retention-days: 30


### PR DESCRIPTION
**User-Facing Changes**
Developers will now have access to pre-built binaries for every merged PR. This allows for faster testing of changes and ensures that the release workflow functions correctly before an actual release.

**Description**
A new workflow, "pre-build", has been introduced. This workflow automatically builds binaries for macOS, Linux, and Windows, mirroring the release process. Each build artifact is uploaded to GitHub's Artifactory, where it remains available for 30 days, enabling developers to test new changes efficiently.

***Why this is important?***
- Faster testing: Developers can quickly validate their changes with pre-built binaries.
- Early build verification: Ensures that the release workflow works as expected before an official release.
- Cross-platform validation: Builds for all major OSes are generated automatically.
