### PR TITLE
Fix duplicated header

### DIFF
--- a/packages/suite-base/src/PanelAPI/useConfigById.ts
+++ b/packages/suite-base/src/PanelAPI/useConfigById.ts
@@ -32,10 +32,10 @@ import { getPanelTypeFromId } from "../util/layout";
 export default function useConfigById<Config extends Record<string, unknown>>(
   panelId: string | undefined,
 ): [
-    Config | undefined,
-    SaveConfig<Config>,
-    Record<string, Record<string, PanelSettings<unknown>>>,
-  ] {
+  Config | undefined,
+  SaveConfig<Config>,
+  Record<string, Record<string, PanelSettings<unknown>>>,
+] {
   const { getCurrentLayoutState, savePanelConfigs } = useCurrentLayoutActions();
   const extensionSettings = useExtensionCatalog(getExtensionPanelSettings);
   const sortedTopics = useMessagePipeline((state) => state.sortedTopics);

--- a/packages/suite-base/src/PanelAPI/useConfigById.ts
+++ b/packages/suite-base/src/PanelAPI/useConfigById.ts
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
-// SPDX-License-Identifier: MPL-2.0
-
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
@@ -35,10 +32,10 @@ import { getPanelTypeFromId } from "../util/layout";
 export default function useConfigById<Config extends Record<string, unknown>>(
   panelId: string | undefined,
 ): [
-  Config | undefined,
-  SaveConfig<Config>,
-  Record<string, Record<string, PanelSettings<unknown>>>,
-] {
+    Config | undefined,
+    SaveConfig<Config>,
+    Record<string, Record<string, PanelSettings<unknown>>>,
+  ] {
   const { getCurrentLayoutState, savePanelConfigs } = useCurrentLayoutActions();
   const extensionSettings = useExtensionCatalog(getExtensionPanelSettings);
   const sortedTopics = useMessagePipeline((state) => state.sortedTopics);


### PR DESCRIPTION
**Description**

Removing a duplicated header on [useConfigById.ts](https://github.com/Lichtblick-Suite/lichtblick/pull/369/files#diff-2a165df1d3757fe7c604ff4fa4d1a9a83772f0ffbbfe3c48259c652c2657d4b7).