### PR TITLE
Add camera models for cylinder and deformed cylinder

### DIFF
--- a/packages/den/image/CylinderCameraModel.test.ts
+++ b/packages/den/image/CylinderCameraModel.test.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { CameraInfo } from "./CameraInfo";
+import { CylinderCameraModel } from "./CylinderCameraModel";
+
+function makeCameraInfo(
+  fx: number,
+  fy: number,
+  cx: number,
+  cy: number,
+  cut_angle: number,
+): CameraInfo {
+  return {
+    D: [0, 0, 0, 0, 0, cut_angle],
+    // prettier-ignore
+    K: [
+      fx, 0, cx,
+      0, fy, cy,
+      0, 0, 1,
+    ],
+    R: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    // prettier-ignore
+    P: [
+      fx, 0, cx, 0,
+      0, fy, cy, 0,
+      0,  0,  1, 0,
+    ],
+    width: 2 * cx,
+    height: 2 * cy,
+    binning_x: 0,
+    binning_y: 0,
+    distortion_model: "cylindrical",
+    roi: { x_offset: 0, y_offset: 0, do_rectify: false, height: 0, width: 0 },
+  };
+}
+
+describe("CylinderCameraModel", () => {
+  it("projectPixelTo3dRay", () => {
+    const model = new CylinderCameraModel(
+      makeCameraInfo(100.0, 100.0, 150.0, 150.0, 0.3490658503988659),
+    );
+    const point = { x: 0, y: 0, z: 0 };
+
+    model.projectPixelTo3dRay(point, { x: 150, y: 150 });
+    expect(point).toEqual({ x: 0, y: 0, z: 1 });
+
+    model.projectPixelTo3dRay(point, { x: 225.71869, y: 217.82079 });
+    expect(point).toEqual({
+      x: expect.closeTo(0.568472300538615),
+      y: expect.closeTo(0.561295395936576),
+      z: expect.closeTo(0.601487092148067),
+    });
+    model.projectPixelTo3dRay(point, { x: 74.2813, y: 217.82079 });
+    expect(point).toEqual({
+      x: expect.closeTo(-0.568472300538615),
+      y: expect.closeTo(0.561295395936576),
+      z: expect.closeTo(0.601487092148067),
+    });
+    model.projectPixelTo3dRay(point, { x: 225.71869, y: 82.179214 });
+    expect(point).toEqual({
+      x: expect.closeTo(0.568472300538615),
+      y: expect.closeTo(-0.561295395936576),
+      z: expect.closeTo(0.601487092148067),
+    });
+    model.projectPixelTo3dRay(point, { x: 74.2813, y: 82.179214 });
+    expect(point).toEqual({
+      x: expect.closeTo(-0.568472300538615),
+      y: expect.closeTo(-0.561295395936576),
+      z: expect.closeTo(0.601487092148067),
+    });
+    model.projectPixelTo3dRay(point, { x: 297.1128, y: 150.0 });
+    expect(point).toEqual({
+      x: expect.closeTo(0.995037222617926),
+      y: expect.closeTo(0),
+      z: expect.closeTo(0.09950339494109685),
+    });
+    model.projectPixelTo3dRay(point, { x: 2.8872223, y: 150.0 });
+    expect(point).toEqual({
+      x: expect.closeTo(-0.9950372004286443),
+      y: expect.closeTo(0),
+      z: expect.closeTo(0.09950361683439482),
+    });
+    model.projectPixelTo3dRay(point, { x: 150.0, y: 329.8874 });
+    expect(point).toEqual({
+      x: expect.closeTo(0),
+      y: expect.closeTo(0.874028213322798),
+      z: expect.closeTo(0.4858751715366379),
+    });
+    model.projectPixelTo3dRay(point, { x: 150.0, y: -29.887375 });
+    expect(point).toEqual({
+      x: expect.closeTo(0),
+      y: expect.closeTo(-0.874028213322798),
+      z: expect.closeTo(0.4858751715366379),
+    });
+  });
+});

--- a/packages/den/image/CylinderCameraModel.ts
+++ b/packages/den/image/CylinderCameraModel.ts
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import type { CameraInfo } from "./CameraInfo";
+
+type Vector2 = { x: number; y: number };
+
+type Vector3 = { x: number; y: number; z: number };
+
+type Matrix3 = [number, number, number, number, number, number, number, number, number];
+
+// prettier-ignore
+type Matrix3x4 = [
+  number, number, number, number,
+  number, number, number, number,
+  number, number, number, number,
+];
+
+type Vec8 = [number, number, number, number, number, number, number, number];
+
+/**
+ * A cylindrical camera model that can be used to rectify, unrectify, and project pixel coordinates.
+ *
+ * In this model the image is assumed to be formed by projecting the scene onto a cylindrical surface.
+ * The intrinsic matrix `K` represents the parameters of the raw (cylindrically distorted) image,
+ * while the projection matrix `P` relates to the processed cylindrical projection.
+ */
+export class CylinderCameraModel {
+  /**
+   * Distortion parameters `[k1, k2, p1, p2, k3, k4, k5, k6]`. All eight parameters shall be set to zero.
+   */
+  public D: Readonly<Vec8>;
+  /**
+   * Intrinsic camera matrix for the raw (distorted) images. 3x3 row-major matrix.
+   * ```
+   *     [fx  0 cx]
+   * K = [ 0 fy cy]
+   *     [ 0  0  1]
+   * ```
+   * Projects 3D points in the camera coordinate frame to 2D pixel coordinates using the focal
+   * lengths `(fx, fy)` and principal point `(cx, cy)`.
+   */
+  public K: Readonly<Matrix3>;
+  /**
+   * Projection matrix (not applicable for cylindrical model)
+   */
+  public P: Readonly<Matrix3x4>;
+  /**
+   * Rectification matrix (stereo cameras only). 3x3 row-major matrix.
+   * A rotation matrix aligning the camera coordinate system to the ideal stereo image plane so
+   * that epipolar lines in both stereo images are parallel.
+   */
+  public R: Readonly<Matrix3>;
+  /** The full camera image width in pixels. */
+  public readonly width: number;
+  /** The full camera image height in pixels. */
+  public readonly height: number;
+
+  // Mostly copied from `fromCameraInfo`
+  // <http://docs.ros.org/diamondback/api/image_geometry/html/c++/pinhole__camera__model_8cpp_source.html#l00064>
+  public constructor(info: CameraInfo) {
+    const { binning_x, binning_y, roi, distortion_model: model, D, K, P, R, width, height } = info;
+    const fx = K[0];
+    const fy = K[4];
+
+    if (width <= 0 || height <= 0) {
+      throw new Error(`Invalid image size ${width}x${height}`);
+    }
+    if (model.length > 0 && model !== "cylindrical") {
+      throw new Error(`Unrecognized distortion_model "${model}"`);
+    }
+    if (K.length !== 0 && K.length !== 9) {
+      throw new Error(`K.length=${K.length}, expected 9`);
+    }
+    if (fx === 0 || fy === 0) {
+      throw new Error(`Invalid focal length (fx=${fx}, fy=${fy})`);
+    }
+
+    const D8 = [...D];
+    while (D8.length < 8) {
+      D8.push(0);
+    }
+    this.D = D8 as Vec8;
+    this.K = K.length === 9 ? (K as Matrix3) : [1, 0, 0, 0, 1, 0, 0, 0, 1];
+    this.P = P as Matrix3x4;
+    this.R = R.length === 9 ? (R as Matrix3) : [1, 0, 0, 0, 1, 0, 0, 0, 1];
+    this.width = width;
+    this.height = height;
+
+    // Binning = 0 is considered the same as binning = 1 (no binning).
+    const binningX = binning_x !== 0 ? binning_x : 1;
+    const binningY = binning_y !== 0 ? binning_y : 1;
+
+    const adjustBinning = binningX > 1 || binningY > 1;
+    const adjustRoi = roi.x_offset !== 0 || roi.y_offset !== 0;
+
+    if (adjustBinning || adjustRoi) {
+      throw new Error(
+        "Failed to initialize camera model: unable to handle adjusted binning and adjusted roi camera models.",
+      );
+    }
+  }
+
+  /**
+   * Projects a 2D image pixel onto a 3D point on the unit cylinder.
+   *
+   * This function first removes the effect of the intrinsic parameters to obtain normalized
+   * coordinates. It then maps the horizontal coordinate to an angle (in radians) around the
+   * cylinder and computes the corresponding 3D point on a cylindrical surface at unit distance.
+   *
+   * @param out - The output vector to receive the 3D point coordinates.
+   * @param pixel - The 2D image pixel coordinate.
+   * @returns The 3D point on the unit cylinder corresponding to the input pixel.
+   */
+  public projectPixelTo3dPlane(out: Vector3, pixel: Readonly<Vector2>): Vector3 {
+    const { K } = this;
+    const fx = K[0];
+    const fy = K[4];
+    const cx = K[2];
+    const cy = K[5];
+
+    // Undo K to get normalized coordinates
+    out.x = (pixel.x - cx) / fx;
+    out.y = (pixel.y - cy) / fy;
+    out.z = 1.0;
+
+    const theta = out.x;
+    out.x = Math.sin(theta);
+    out.z = Math.cos(theta);
+
+    return out;
+  }
+
+  /**
+   * Projects a 2D image pixel into a normalized 3D ray direction for the cylindrical camera model.
+   *
+   * This function first maps the pixel to a point on the unit cylinder using the intrinsic
+   * parameters and cylindrical geometry, then normalizes the resulting vector to yield a
+   * unit-length direction.
+   *
+   * @param out - The output vector to receive the 3D ray direction.
+   * @param pixel - The 2D image pixel coordinate.
+   * @returns The normalized 3D ray direction corresponding to the input pixel.
+   */
+  public projectPixelTo3dRay(out: Vector3, pixel: Readonly<Vector2>): Vector3 {
+    this.projectPixelTo3dPlane(out, pixel);
+
+    // Normalize the ray direction
+    const invNorm = 1.0 / Math.sqrt(out.x * out.x + out.y * out.y + out.z * out.z);
+    out.x *= invNorm;
+    out.y *= invNorm;
+    out.z *= invNorm;
+
+    return out;
+  }
+}

--- a/packages/den/image/DeformedCylinderCameraModel.test.ts
+++ b/packages/den/image/DeformedCylinderCameraModel.test.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { CameraInfo } from "./CameraInfo";
+import { DeformedCylinderCameraModel } from "./DeformedCylinderCameraModel";
+
+function makeCameraInfo(
+  fx: number,
+  fy: number,
+  cx: number,
+  cy: number,
+  cut_angle: number,
+): CameraInfo {
+  return {
+    D: [0, 0, 0, 0, 0, cut_angle],
+    // prettier-ignore
+    K: [
+      fx, 0, cx,
+      0, fy, cy,
+      0, 0, 1,
+    ],
+    R: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    // prettier-ignore
+    P: [
+      fx, 0, cx, 0,
+      0, fy, cy, 0,
+      0,  0,  1, 0,
+    ],
+    width: 2 * cx,
+    height: 2 * cy,
+    binning_x: 0,
+    binning_y: 0,
+    distortion_model: "deformed_cylinder",
+    roi: { x_offset: 0, y_offset: 0, do_rectify: false, height: 0, width: 0 },
+  };
+}
+
+describe("DeformedCylinderCameraModel", () => {
+  it("projectPixelTo3dRay", () => {
+    const model = new DeformedCylinderCameraModel(
+      makeCameraInfo(100.0, 100.0, 150.0, 150.0, 0.3490658503988659),
+    );
+    const point = { x: 0, y: 0, z: 0 };
+
+    model.projectPixelTo3dRay(point, { x: 150, y: 150 });
+    expect(point).toEqual({ x: 0, y: 0, z: 1 });
+
+    model.projectPixelTo3dRay(point, { x: 225.71869, y: 217.82079 });
+    expect(point).toEqual({
+      x: expect.closeTo(0.5774),
+      y: expect.closeTo(0.5774),
+      z: expect.closeTo(0.5774),
+    });
+    model.projectPixelTo3dRay(point, { x: 74.2813, y: 217.82079 });
+    expect(point).toEqual({
+      x: expect.closeTo(-0.5774),
+      y: expect.closeTo(0.5774),
+      z: expect.closeTo(0.5774),
+    });
+    model.projectPixelTo3dRay(point, { x: 225.71869, y: 82.179214 });
+    expect(point).toEqual({
+      x: expect.closeTo(0.5774),
+      y: expect.closeTo(-0.5774),
+      z: expect.closeTo(0.5774),
+    });
+    model.projectPixelTo3dRay(point, { x: 74.2813, y: 82.179214 });
+    expect(point).toEqual({
+      x: expect.closeTo(-0.5774),
+      y: expect.closeTo(-0.5774),
+      z: expect.closeTo(0.5774),
+    });
+    model.projectPixelTo3dRay(point, { x: 297.1128, y: 150.0 });
+    expect(point).toEqual({
+      x: expect.closeTo(0.995),
+      y: expect.closeTo(0),
+      z: expect.closeTo(0.0995),
+    });
+    model.projectPixelTo3dRay(point, { x: 2.8872223, y: 150.0 });
+    expect(point).toEqual({
+      x: expect.closeTo(-0.995),
+      y: expect.closeTo(0),
+      z: expect.closeTo(0.0995),
+    });
+    model.projectPixelTo3dRay(point, { x: 150.0, y: 329.8874 });
+    expect(point).toEqual({
+      x: expect.closeTo(0),
+      y: expect.closeTo(0.995),
+      z: expect.closeTo(0.0995),
+    });
+    model.projectPixelTo3dRay(point, { x: 150.0, y: -29.887375 });
+    expect(point).toEqual({
+      x: expect.closeTo(0),
+      y: expect.closeTo(-0.995),
+      z: expect.closeTo(0.0995),
+    });
+  });
+});

--- a/packages/den/image/DeformedCylinderCameraModel.ts
+++ b/packages/den/image/DeformedCylinderCameraModel.ts
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import type { CameraInfo } from "./CameraInfo";
+
+type Vector2 = { x: number; y: number };
+
+type Vector3 = { x: number; y: number; z: number };
+
+type Matrix3 = [number, number, number, number, number, number, number, number, number];
+
+// prettier-ignore
+type Matrix3x4 = [
+  number, number, number, number,
+  number, number, number, number,
+  number, number, number, number,
+];
+
+type Vec8 = [number, number, number, number, number, number, number, number];
+
+/**
+ * A deformable cylindrical camera model that can be used to rectify, unrectify, and project pixel coordinates.
+ *
+ * This model extends the basic cylindrical projection by introducing a deformation that adapts
+ * to image regions near the top and bottom. In these regions, a spherical projection is applied,
+ * with the transition determined by a "cut" parameter extracted from the distortion parameters.
+ */
+export class DeformedCylinderCameraModel {
+  /**
+   * Distortion parameters for the deformable cylindrical model.
+   *
+   * The parameters `[k1, k2, p1, p2, k3, k4, k5, k6]` encode both the standard cylindrical distortion
+   * and the additional deformation. In many cases, the sixth parameter (`k4`) represents the cut angle
+   * that separates the cylindrical region from the spherical (deformed) regions at the top and bottom.
+   * Unused parameters are set to zero.
+   */
+  public D: Readonly<Vec8>;
+  /**
+   * Intrinsic camera matrix for the raw (distorted) images. 3x3 row-major matrix.
+   * ```
+   *     [fx  0 cx]
+   * K = [ 0 fy cy]
+   *     [ 0  0  1]
+   * ```
+   * Projects 3D points in the camera coordinate frame to 2D pixel coordinates using the focal
+   * lengths `(fx, fy)` and principal point `(cx, cy)`.
+   */
+  public K: Readonly<Matrix3>;
+  /**
+   * Projection matrix (not applicable for cylindrical model)
+   */
+  public P: Readonly<Matrix3x4>;
+  /**
+   * Rectification matrix (stereo cameras only). 3x3 row-major matrix.
+   * A rotation matrix aligning the camera coordinate system to the ideal stereo image plane so
+   * that epipolar lines in both stereo images are parallel.
+   */
+  public R: Readonly<Matrix3>;
+  /** The full camera image width in pixels. */
+  public readonly width: number;
+  /** The full camera image height in pixels. */
+  public readonly height: number;
+
+  // Mostly copied from `fromCameraInfo`
+  // <http://docs.ros.org/diamondback/api/image_geometry/html/c++/pinhole__camera__model_8cpp_source.html#l00064>
+  public constructor(info: CameraInfo) {
+    const { binning_x, binning_y, roi, distortion_model: model, D, K, P, R, width, height } = info;
+    const fx = K[0];
+    const fy = K[4];
+
+    if (width <= 0 || height <= 0) {
+      throw new Error(`Invalid image size ${width}x${height}`);
+    }
+    if (model.length > 0 && model !== "deformed_cylinder") {
+      throw new Error(`Unrecognized distortion_model "${model}"`);
+    }
+    if (K.length !== 0 && K.length !== 9) {
+      throw new Error(`K.length=${K.length}, expected 9`);
+    }
+    if (P.length !== 12) {
+      throw new Error(`P.length=${P.length}, expected 12`);
+    }
+    if (R.length !== 0 && R.length !== 9) {
+      throw new Error(`R.length=${R.length}, expected 9`);
+    }
+    if (fx === 0 || fy === 0) {
+      throw new Error(`Invalid focal length (fx=${fx}, fy=${fy})`);
+    }
+
+    const D8 = [...D];
+    while (D8.length < 8) {
+      D8.push(0);
+    }
+    this.D = D8 as Vec8;
+    this.K = K.length === 9 ? (K as Matrix3) : [1, 0, 0, 0, 1, 0, 0, 0, 1];
+    this.P = P as Matrix3x4;
+    this.R = R.length === 9 ? (R as Matrix3) : [1, 0, 0, 0, 1, 0, 0, 0, 1];
+    this.width = width;
+    this.height = height;
+
+    // Binning = 0 is considered the same as binning = 1 (no binning).
+    const binningX = binning_x !== 0 ? binning_x : 1;
+    const binningY = binning_y !== 0 ? binning_y : 1;
+
+    const adjustBinning = binningX > 1 || binningY > 1;
+    const adjustRoi = roi.x_offset !== 0 || roi.y_offset !== 0;
+
+    if (adjustBinning || adjustRoi) {
+      throw new Error(
+        "Failed to initialize camera model: unable to handle adjusted binning and adjusted roi camera models.",
+      );
+    }
+  }
+
+  /**
+   * Projects a 2D image pixel to a 3D point on the unit deformed cylinder.
+   *
+   * This function first determines whether the pixel is in the central cylindrical region
+   * or in one of the deformed (spherical) regions at the top or bottom of the image. For the
+   * cylindrical region, the horizontal coordinate is interpreted as an angle (theta) around the
+   * cylinder. For pixels in the top or bottom deformed regions, a spherical inverse projection is applied.
+   *
+   * @param out - The output vector to receive the 3D point coordinates.
+   * @param pixel - The 2D image pixel coordinate.
+   * @returns The 3D point on the deformed cylindrical surface corresponding to the input pixel.
+   */
+  public projectPixelTo3dPlane(out: Vector3, pixel: Readonly<Vector2>): Vector3 {
+    const { K, D } = this;
+    const fx = K[0];
+    const fy = K[4];
+    const cx = K[2];
+    const cy = K[5];
+    const cut_angle = D[5];
+
+    const cut_height = Math.tan(cut_angle);
+    const cut_height_pixels = cut_height * fy;
+
+    if (pixel.y < cy - cut_height_pixels) {
+      // top
+      out = this.sphericalProjectionInverse(out, pixel, -cut_height);
+      //   out.x = 0;
+      //   out.y = 0;
+      //   out.z = -1;
+    } else if (pixel.y > cy + cut_height_pixels) {
+      // bottom
+      out = this.sphericalProjectionInverse(out, pixel, cut_height);
+      //   out.x = 0;
+      //   out.y = 0;
+      //   out.z = -1;
+    } else {
+      // Undo K to get normalized coordinates
+      out.x = (pixel.x - cx) / fx;
+      out.y = (pixel.y - cy) / fy;
+      out.z = 1.0;
+
+      const inverse_ray_length = 1 / Math.sqrt(out.y * out.y + 1);
+
+      const theta = out.x;
+      out.x = Math.sin(theta) * inverse_ray_length;
+      out.y = out.y * inverse_ray_length;
+      out.z = Math.cos(theta) * inverse_ray_length;
+    }
+
+    return out;
+  }
+
+  /**
+   * Applies the inverse spherical projection for pixels in the deformed regions.
+   *
+   * This helper function is used for pixels near the top or bottom of the image. It "unsqueezes"
+   * the image coordinates based on a pixel-dependent squeeze factor and applies a spherical
+   * projection inverse to recover the corresponding 3D point.
+   *
+   * @param out - The output vector to receive the 3D point.
+   * @param pixel - The 2D image pixel coordinate.
+   * @param cut_height - The vertical offset (in normalized units) corresponding to the cut.
+   * @returns The 3D point derived from the inverse spherical projection.
+   */
+  private sphericalProjectionInverse(
+    out: Vector3,
+    pixel: Readonly<Vector2>,
+    cut_height: number,
+  ): Vector3 {
+    const { K } = this;
+    const fx = K[0];
+    const fy = K[4];
+    const cx = K[2];
+    const cy = K[5];
+
+    const pixel_ratio = 1.0 - pixel.x / cx;
+    const squeeze_factor = 1.0 - 0.375 * pixel_ratio ** 2;
+
+    out.x = (pixel.x - cx) / fx;
+    out.y = (pixel.y - (cy + fy * cut_height)) / (fy * squeeze_factor);
+
+    const theta = Math.hypot(out.x, out.y);
+    const phi = Math.atan2(out.y, out.x);
+    const sin_theta = Math.sin(theta);
+
+    out.x = sin_theta * Math.cos(phi);
+    out.y = sin_theta * Math.sin(phi) + cut_height;
+    out.z = Math.cos(theta);
+
+    return out;
+  }
+
+  /**
+   * Projects a 2D image pixel into a normalized 3D ray direction for the deformable cylindrical camera model.
+   *
+   * This function maps the pixel to a point on the deformed cylindrical (or spherical) surface using the
+   * intrinsic parameters and the deformation model, then normalizes the resulting vector to yield a
+   * unit-length direction.
+   *
+   * @param out - The output vector to receive the 3D ray direction.
+   * @param pixel - The 2D image pixel coordinate.
+   * @returns The normalized 3D ray direction corresponding to the input pixel.
+   */
+  public projectPixelTo3dRay(out: Vector3, pixel: Readonly<Vector2>): Vector3 {
+    this.projectPixelTo3dPlane(out, pixel);
+
+    // Normalize the ray direction
+    const invNorm = 1.0 / Math.sqrt(out.x * out.x + out.y * out.y + out.z * out.z);
+    out.x *= invNorm;
+    out.y *= invNorm;
+    out.z *= invNorm;
+
+    return out;
+  }
+}

--- a/packages/den/image/index.ts
+++ b/packages/den/image/index.ts
@@ -8,3 +8,5 @@
 export * from "./CameraInfo";
 export * from "./decodings";
 export * from "./PinholeCameraModel";
+export * from "./CylinderCameraModel";
+export * from "./DeformedCylinderCameraModel";

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Cameras.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Cameras.ts
@@ -8,7 +8,11 @@
 import { CameraCalibration } from "@foxglove/schemas";
 import { t } from "i18next";
 
-import { PinholeCameraModel } from "@lichtblick/den/image";
+import {
+  PinholeCameraModel,
+  CylinderCameraModel,
+  DeformedCylinderCameraModel,
+} from "@lichtblick/den/image";
 import Logger from "@lichtblick/log";
 import { toNanoSec } from "@lichtblick/rostime";
 import { SettingsTreeAction, SettingsTreeFields } from "@lichtblick/suite";
@@ -70,7 +74,7 @@ export type CameraInfoUserData = BaseUserData & {
   topic: string;
   cameraInfo: CameraInfo | undefined;
   originalMessage: Record<string, RosValue> | undefined;
-  cameraModel: PinholeCameraModel | undefined;
+  cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel | undefined;
   lines: RenderableLineList | undefined;
 };
 
@@ -314,7 +318,7 @@ function vec3(): Vector3 {
 
 function createLineListMarker(
   cameraInfo: CameraInfo,
-  cameraModel: PinholeCameraModel,
+  cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel,
   settings: LayerSettingsCameraInfo,
   steps = 10,
 ): Marker {
@@ -380,7 +384,7 @@ function horizontalLine(
   output: Vector3[],
   y: number,
   cameraInfo: CameraInfo,
-  cameraModel: PinholeCameraModel,
+  cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel,
   steps: number,
   settings: LayerSettingsCameraInfo,
 ): void {
@@ -397,7 +401,7 @@ function verticalLine(
   output: Vector3[],
   x: number,
   cameraInfo: CameraInfo,
-  cameraModel: PinholeCameraModel,
+  cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel,
   steps: number,
   settings: LayerSettingsCameraInfo,
 ): void {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
@@ -7,7 +7,11 @@
 
 import * as THREE from "three";
 
-import { PinholeCameraModel } from "@lichtblick/den/image";
+import {
+  PinholeCameraModel,
+  CylinderCameraModel,
+  DeformedCylinderCameraModel,
+} from "@lichtblick/den/image";
 
 const DEFAULT_CAMERA_STATE = {
   near: 0.001,
@@ -18,7 +22,7 @@ const MIN_USER_ZOOM = 0.5;
 const MAX_USER_ZOOM = 50;
 
 export class ImageModeCamera extends THREE.PerspectiveCamera {
-  #model?: PinholeCameraModel;
+  #model?: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel;
   readonly #cameraState = DEFAULT_CAMERA_STATE;
   #rotation: 0 | 90 | 180 | 270 = 0;
   #flipHorizontal = false;
@@ -33,7 +37,9 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
   /** Amount the user has zoomed with the scroll wheel */
   #userZoom = 1;
 
-  public updateCamera(cameraModel: PinholeCameraModel | undefined): void {
+  public updateCamera(
+    cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel | undefined,
+  ): void {
     this.#model = cameraModel;
     this.#updateProjection();
   }
@@ -119,7 +125,10 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
    *
    * @returns the projection matrix for the current camera model, or undefined if no camera model is available
    */
-  #getProjection(out: THREE.Matrix4, model: PinholeCameraModel) {
+  #getProjection(
+    out: THREE.Matrix4,
+    model: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel,
+  ) {
     const { width, height } = model;
 
     // focal lengths

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -11,7 +11,11 @@ import * as THREE from "three";
 import { Opaque } from "ts-essentials";
 
 import { filterMap } from "@lichtblick/den/collection";
-import { PinholeCameraModel } from "@lichtblick/den/image";
+import {
+  CylinderCameraModel,
+  PinholeCameraModel,
+  DeformedCylinderCameraModel,
+} from "@lichtblick/den/image";
 import { Immutable, MessageEvent, SettingsTreeAction, Topic } from "@lichtblick/suite";
 import { Path } from "@lichtblick/suite-base/panels/ThreeDeeRender/LayerErrors";
 import { onlyLastByTopicMessage } from "@lichtblick/suite-base/panels/ThreeDeeRender/SceneExtension";
@@ -73,7 +77,7 @@ export class ImageAnnotations extends THREE.Object3D {
   #context: ImageAnnotationsContext;
 
   #renderablesByTopic = new Map<TopicName, RenderableTopicAnnotations>();
-  #cameraModel?: PinholeCameraModel;
+  #cameraModel?: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel;
 
   #scale: number;
   #canvasWidth: number;
@@ -160,7 +164,9 @@ export class ImageAnnotations extends THREE.Object3D {
     }
   }
 
-  public updateCameraModel(cameraModel: PinholeCameraModel): void {
+  public updateCameraModel(
+    cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel,
+  ): void {
     this.#cameraModel = cameraModel;
     for (const renderable of this.#renderablesByTopic.values()) {
       renderable.setCameraModel(cameraModel);

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
@@ -11,7 +11,11 @@ import { LineGeometry } from "three/examples/jsm/lines/LineGeometry";
 import { LineSegments2 } from "three/examples/jsm/lines/LineSegments2";
 import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
 
-import { PinholeCameraModel } from "@lichtblick/den/image";
+import {
+  PinholeCameraModel,
+  CylinderCameraModel,
+  DeformedCylinderCameraModel,
+} from "@lichtblick/den/image";
 import { RosObject, RosValue } from "@lichtblick/suite-base/players/types";
 
 import {
@@ -89,7 +93,7 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
   #annotation?: NormalizedPointsAnnotation & { style: LineStyle };
   #annotationNeedsUpdate = false;
 
-  #cameraModel?: PinholeCameraModel;
+  #cameraModel?: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel;
   #cameraModelNeedsUpdate = false;
 
   public constructor(topicName: string) {
@@ -176,7 +180,9 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
     this.#canvasHeight = canvasHeight;
   }
 
-  public setCameraModel(cameraModel: PinholeCameraModel | undefined): void {
+  public setCameraModel(
+    cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel | undefined,
+  ): void {
     this.#cameraModelNeedsUpdate ||= this.#cameraModel !== cameraModel;
     this.#cameraModel = cameraModel;
   }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderablePointsAnnotation.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderablePointsAnnotation.ts
@@ -7,7 +7,11 @@
 
 import * as THREE from "three";
 
-import { PinholeCameraModel } from "@lichtblick/den/image";
+import {
+  PinholeCameraModel,
+  CylinderCameraModel,
+  DeformedCylinderCameraModel,
+} from "@lichtblick/den/image";
 import { RosObject, RosValue } from "@lichtblick/suite-base/players/types";
 
 import {
@@ -59,7 +63,7 @@ export class RenderablePointsAnnotation extends Renderable<BaseUserData, /*TRend
   #annotation?: NormalizedPointsAnnotation & { style: "points" };
   #annotationNeedsUpdate = false;
 
-  #cameraModel?: PinholeCameraModel;
+  #cameraModel?: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel;
   #cameraModelNeedsUpdate = false;
 
   public constructor(topicName: string) {
@@ -117,7 +121,9 @@ export class RenderablePointsAnnotation extends Renderable<BaseUserData, /*TRend
     this.#pixelRatio = pixelRatio;
   }
 
-  public setCameraModel(cameraModel: PinholeCameraModel | undefined): void {
+  public setCameraModel(
+    cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel | undefined,
+  ): void {
     this.#cameraModelNeedsUpdate ||= this.#cameraModel !== cameraModel;
     this.#cameraModel = cameraModel;
   }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableTextAnnotation.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableTextAnnotation.ts
@@ -5,7 +5,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { PinholeCameraModel } from "@lichtblick/den/image";
+import {
+  PinholeCameraModel,
+  CylinderCameraModel,
+  DeformedCylinderCameraModel,
+} from "@lichtblick/den/image";
 import { RosObject, RosValue } from "@lichtblick/suite-base/players/types";
 import { Label, LabelPool } from "@lichtblick/three-text";
 
@@ -30,7 +34,7 @@ export class RenderableTextAnnotation extends Renderable<BaseUserData, /*TRender
   #annotation?: NormalizedTextAnnotation;
   #annotationNeedsUpdate = false;
 
-  #cameraModel?: PinholeCameraModel;
+  #cameraModel?: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel;
   #cameraModelNeedsUpdate = false;
 
   public constructor(topicName: string, labelPool: LabelPool) {
@@ -81,7 +85,9 @@ export class RenderableTextAnnotation extends Renderable<BaseUserData, /*TRender
     this.#scale = scale;
   }
 
-  public setCameraModel(cameraModel: PinholeCameraModel | undefined): void {
+  public setCameraModel(
+    cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel | undefined,
+  ): void {
     this.#cameraModelNeedsUpdate ||= this.#cameraModel !== cameraModel;
     this.#cameraModel = cameraModel;
   }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableTopicAnnotations.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableTopicAnnotations.ts
@@ -7,7 +7,11 @@
 
 import * as THREE from "three";
 
-import { PinholeCameraModel } from "@lichtblick/den/image";
+import {
+  CylinderCameraModel,
+  PinholeCameraModel,
+  DeformedCylinderCameraModel,
+} from "@lichtblick/den/image";
 import { RosObject } from "@lichtblick/suite-base/players/types";
 import { LabelPool } from "@lichtblick/three-text";
 
@@ -34,7 +38,7 @@ export class RenderableTopicAnnotations extends THREE.Object3D {
   #annotations: NormalizedAnnotation[] = [];
   #annotationsNeedsUpdate = false;
 
-  #cameraModel?: PinholeCameraModel;
+  #cameraModel?: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel;
   #cameraModelNeedsUpdate = false;
 
   #originalMessage?: RosObject;
@@ -72,7 +76,9 @@ export class RenderableTopicAnnotations extends THREE.Object3D {
     this.#originalMessage = originalMessage;
   }
 
-  public setCameraModel(cameraModel: PinholeCameraModel | undefined): void {
+  public setCameraModel(
+    cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel | undefined,
+  ): void {
     this.#cameraModelNeedsUpdate ||= this.#cameraModel !== cameraModel;
     this.#cameraModel = cameraModel;
   }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -9,7 +9,11 @@ import * as _ from "lodash-es";
 import * as THREE from "three";
 import { assert } from "ts-essentials";
 
-import { PinholeCameraModel } from "@lichtblick/den/image";
+import {
+  CylinderCameraModel,
+  PinholeCameraModel,
+  DeformedCylinderCameraModel,
+} from "@lichtblick/den/image";
 import Logger from "@lichtblick/log";
 import { toNanoSec } from "@lichtblick/rostime";
 import { IRenderer } from "@lichtblick/suite-base/panels/ThreeDeeRender/IRenderer";
@@ -50,7 +54,7 @@ export type ImageUserData = BaseUserData & {
   topic: string;
   settings: ImageRenderableSettings;
   cameraInfo: CameraInfo | undefined;
-  cameraModel: PinholeCameraModel | undefined;
+  cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel | undefined;
   image: AnyImage | undefined;
   texture: THREE.Texture | undefined;
   material: THREE.MeshBasicMaterial | undefined;
@@ -129,7 +133,9 @@ export class ImageRenderable extends Renderable<ImageUserData> {
   }
 
   // Renderable should only need to care about the model
-  public setCameraModel(cameraModel: PinholeCameraModel): void {
+  public setCameraModel(
+    cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel,
+  ): void {
     this.#geometryNeedsUpdate ||= this.userData.cameraModel !== cameraModel;
     this.userData.cameraModel = cameraModel;
   }
@@ -448,7 +454,7 @@ function createDataTexture(imageData: ImageData): THREE.DataTexture {
 }
 
 function createGeometry(
-  cameraModel: PinholeCameraModel,
+  cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel,
   settings: ImageRenderableSettings,
 ): THREE.PlaneGeometry {
   const WIDTH_SEGMENTS = 10;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/projections.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/projections.ts
@@ -7,7 +7,11 @@
 
 import { CameraCalibration } from "@foxglove/schemas";
 
-import { PinholeCameraModel } from "@lichtblick/den/image";
+import {
+  CylinderCameraModel,
+  PinholeCameraModel,
+  DeformedCylinderCameraModel,
+} from "@lichtblick/den/image";
 
 import { PartialMessage } from "../SceneExtension";
 import { normalizeHeader, normalizeTime } from "../normalizeMessages";
@@ -27,7 +31,7 @@ const tempVec2 = { x: 0, y: 0, z: 0 };
 export function projectPixel(
   out: Vector3,
   uv: Readonly<Vector2>,
-  cameraModel: PinholeCameraModel,
+  cameraModel: PinholeCameraModel | CylinderCameraModel | DeformedCylinderCameraModel,
   settings: { distance: number; planarProjectionFactor: number },
 ): Vector3 {
   if (settings.planarProjectionFactor === 0) {


### PR DESCRIPTION
**User-Facing Changes**
Two new camera models are added: `cylindrical` and `deformed_cylinder´ which have become popular recently with wide-angle and fisheye cameras.

![image](https://github.com/user-attachments/assets/fd05ffd3-1d6b-4d6c-b863-7195f6dc2a11)

**Description**

The camera models can be selected by populating the  `distortion_model` and the corresponding parameters.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
