### PR TITLE
Add permissions to run pre build

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main # Trigger on push to main branch
 
+permissions:
+  actions: write
+
 jobs:
   bump:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description**
Add write permissions to actions, in order to enable pre-build workflow

Example of failing:
https://github.com/Lichtblick-Suite/lichtblick/actions/runs/13414502733/job/37471957916

To fix this Implementation:
https://github.com/Lichtblick-Suite/lichtblick/pull/368