### PR TITLE
Fix settings API undefined behaviour

### DIFF
--- a/packages/suite-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -119,6 +119,8 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       config,
     } = input;
 
+    const configTopics = config?.topics ?? {};
+
     const topicToSchemaNameMap = _.mapValues(
       _.keyBy(sortedTopics, "name"),
       ({ schemaName }) => schemaName,
@@ -235,7 +237,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
           const schemaName = topicToSchemaNameMap[messageEvent.topic];
           if (schemaName) {
             convertMessage(
-              { ...messageEvent, topicConfig: config?.topics[messageEvent.topic] },
+              { ...messageEvent, topicConfig: configTopics[messageEvent.topic] },
               topicSchemaConverters,
               postProcessedFrame,
             );
@@ -252,7 +254,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
           const schemaName = topicToSchemaNameMap[messageEvent.topic];
           if (schemaName) {
             convertMessage(
-              { ...messageEvent, topicConfig: config?.topics[messageEvent.topic] },
+              { ...messageEvent, topicConfig: configTopics[messageEvent.topic] },
               newConverters,
               postProcessedFrame,
             );
@@ -308,7 +310,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
               const schemaName = topicToSchemaNameMap[messageEvent.topic];
               if (schemaName) {
                 convertMessage(
-                  { ...messageEvent, topicConfig: config?.topics[messageEvent.topic] },
+                  { ...messageEvent, topicConfig: configTopics[messageEvent.topic] },
                   topicSchemaConverters,
                   frames,
                 );


### PR DESCRIPTION
**User-Facing Changes**
Users can use Settings API without error

**Description**
It was properly treated how to access the config.topics on message converters.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
