### PR TITLE
Migrate CI pipelines to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
         config:
           # Specify names so that the GitHub branch protection settings for
           # required checks don't need to change if we ever change the commands used.
@@ -68,14 +68,9 @@ jobs:
       - run: ${{ matrix.config.command }}
 
   integration:
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-20.04]
+    runs-on: ubuntu-latest
 
-    name: integration (${{ matrix.os }})
+    name: integration (ubuntu-latest)
 
     steps:
       - uses: actions/checkout@v4.1.1
@@ -98,24 +93,22 @@ jobs:
 
       - run: yarn install --immutable
 
-      - name: test:integration (ubuntu)
-        if: matrix.os == 'ubuntu-20.04'
+      - name: Apply AppArmor Fix (Ubuntu)
+        # Required for Playwright on Ubuntu to work properly
+        # See: https://github.com/microsoft/playwright/issues/34251
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: test:integration (ubuntu-latest)
         uses: coactions/setup-xvfb@v1
         with:
           working-directory: ./
           run: yarn run test:integration
 
-      - name: test:integration (windows and macOS)
-        if: matrix.os != 'ubuntu-20.04'
-        run: yarn run test:integration
-
       # New version of playwright requires to install new browsers
       - name: Install Playwright browsers
-        if: matrix.os == 'ubuntu-20.04'
         run: |
           cd web
           yarn playwright install
 
       - name: test:web-integration
-        if: matrix.os == 'ubuntu-20.04'
         run: yarn run test:web-integration

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to Cloudflare Pages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       # Environment variables that are injected into the build

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   npm:
     name: Publish to NPM
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout ${{ github.event.release.tag_name }}
@@ -32,7 +32,7 @@ jobs:
 
   docker:
     name: Publish to GHCR
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**

This PR updates the GitHub Actions workflows to use the ubuntu-latest runner image, in anticipation of the [deprecation of Ubuntu 20.04 in GitHub Actions environments.](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/) This migration ensures that our CI pipelines remain functional and compatible with the latest GitHub Actions runner images, avoiding any potential issues as Ubuntu 20.04 reaches its end of support.

Id also like to note that on our CI pipeline I had to add another step for our integration tests to run by adding:
`sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`

In essence this modification disables the restriction on unprivileged user namespaces, which is necessary for Playwright to create isolated environments for the browsers it launches.
I was able to reach to this solution after some investigation and coming across https://github.com/microsoft/playwright/issues/34251 

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->


