### PR TITLE
Enable all x axis to sync in plot panel

### DIFF
--- a/packages/suite-base/src/panels/Plot/Plot.tsx
+++ b/packages/suite-base/src/panels/Plot/Plot.tsx
@@ -64,7 +64,7 @@ const Plot = (props: PlotProps): React.JSX.Element => {
   const [subscriberId] = useState(() => uuidv4());
   const [canvasDiv, setCanvasDiv] = useState<HTMLDivElement | ReactNull>(ReactNull);
   const [coordinator, setCoordinator] = useState<PlotCoordinator | undefined>(undefined);
-  const shouldSync = config.xAxisVal === "timestamp" && config.isSynced;
+  const shouldSync = config.isSynced;
   const renderer = useRenderer(canvasDiv, theme);
   const { globalVariables } = useGlobalVariables();
   const getMessagePipelineState = useMessagePipelineGetter();


### PR DESCRIPTION
### **User-Facing Changes**
Plot panels can now be synchronized across all X Axis modes, not just when "timestamp" is selected.

**Description**
- The restriction that limited plot panel synchronization to the "timestamp" X Axis mode has been removed. Users can now sync plot panels regardless of the selected X Axis mode.

Note: An alternative approach could have involved injecting the selected X Axis path into change events, allowing synchronization only between panels with the same X Axis configuration. However, the team chose to first test a global synchronization method.

**Checklist**
- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
