### PR TITLE
Fix plot sync

### DIFF
--- a/packages/suite-base/src/panels/Plot/Plot.tsx
+++ b/packages/suite-base/src/panels/Plot/Plot.tsx
@@ -146,6 +146,12 @@ const Plot = (props: PlotProps): React.JSX.Element => {
   }, [coordinator, getMessagePipelineState, subscribeMessagePipeline]);
 
   useEffect(() => {
+    if (coordinator) {
+      coordinator.setShouldSync({ shouldSync });
+    }
+  }, [coordinator, shouldSync]);
+
+  useEffect(() => {
     if (!renderer || !canvasDiv) {
       return;
     }

--- a/packages/suite-base/src/panels/Plot/PlotCoordinator.test.ts
+++ b/packages/suite-base/src/panels/Plot/PlotCoordinator.test.ts
@@ -216,6 +216,7 @@ describe("PlotCoordinator", () => {
 
     it("should emit 'timeseriesBounds' when updating limits", async () => {
       const listener = jest.fn();
+      plotCoordinator.setShouldSync({ shouldSync: true });
       plotCoordinator.on("timeseriesBounds", listener);
       const bounds: Bounds = {
         x: { min: BasicBuilder.number(), max: BasicBuilder.number() },
@@ -230,10 +231,29 @@ describe("PlotCoordinator", () => {
 
       await plotCoordinator["dispatchRender"]();
 
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
       expect(listener).toHaveBeenCalledTimes(1);
       expect(listener).toHaveBeenCalledWith(bounds.x);
+    });
+
+    it("should not emit 'timeseriesBounds' if shouldSync is false", async () => {
+      const listener = jest.fn();
+
+      plotCoordinator.setShouldSync({ shouldSync: false });
+      plotCoordinator.on("timeseriesBounds", listener);
+      const bounds: Bounds = {
+        x: { min: BasicBuilder.number(), max: BasicBuilder.number() },
+        y: { min: BasicBuilder.number(), max: BasicBuilder.number() },
+      };
+      (renderer.update as jest.Mock).mockResolvedValue(bounds);
+      plotCoordinator.addInteractionEvent({
+        type: "zoom",
+        scaleX: BasicBuilder.number(),
+        scaleY: BasicBuilder.number(),
+      } as unknown as InteractionEvent);
+
+      await plotCoordinator["dispatchRender"]();
+
+      expect(listener).not.toHaveBeenCalled();
     });
   });
 
@@ -377,6 +397,15 @@ describe("PlotCoordinator", () => {
       expect(plotCoordinator["globalBounds"]).toBeUndefined();
       expect(plotCoordinator["shouldResetY"]).toBe(true);
       queueDispatchRenderSpy.mockRestore();
+    });
+  });
+
+  describe("setShouldSync", () => {
+    // eslint-disable-next-line @lichtblick/no-boolean-parameters
+    it.each([true, false])("should update shouldSync property", (shouldSync: boolean) => {
+      plotCoordinator.setShouldSync({ shouldSync });
+
+      expect(plotCoordinator["shouldSync"]).toBe(shouldSync);
     });
   });
 

--- a/packages/suite-base/src/panels/Plot/PlotCoordinator.ts
+++ b/packages/suite-base/src/panels/Plot/PlotCoordinator.ts
@@ -61,6 +61,7 @@ const replaceUndefinedWithEmptyDataset = (dataset: Dataset | undefined) => datas
 export class PlotCoordinator extends EventEmitter<PlotCoordinatorEventTypes> {
   private renderer: OffscreenCanvasRenderer;
   private datasetsBuilder: IDatasetsBuilder;
+  private shouldSync: boolean = false;
   private configBounds: ConfigBounds = { x: {}, y: {} };
   private globalBounds?: Immutable<Partial<Bounds1D>>;
   private datasetRange?: Bounds1D;
@@ -98,6 +99,10 @@ export class PlotCoordinator extends EventEmitter<PlotCoordinatorEventTypes> {
   /** Stop the coordinator from sending any future updates to the renderer. */
   public destroy(): void {
     this.destroyed = true;
+  }
+
+  public setShouldSync({ shouldSync }: { shouldSync: boolean }): void {
+    this.shouldSync = shouldSync;
   }
 
   public handlePlayerState(state: Immutable<PlayerState>): void {
@@ -430,9 +435,10 @@ export class PlotCoordinator extends EventEmitter<PlotCoordinatorEventTypes> {
       this.interactionBounds = bounds;
     }
 
-    if (haveInteractionEvents && bounds) {
+    if (haveInteractionEvents && bounds && this.shouldSync) {
       this.emit("timeseriesBounds", bounds.x);
     }
+
     this.emit("viewportChange", this.canReset());
 
     // The viewport has changed from some render interactions so we need to consider new datasets


### PR DESCRIPTION
**User-Facing Changes**
Plot panels will now only synchronize when both have the "Sync with other plots" option enabled. This ensures that users have finer control over synchronization behavior, preventing unwanted updates when only one plot has syncing activated.

**Description**
Introduced the `shouldSync` variable into the `plotCoordinator` to manage when the `timeseriesBounds` event is emitted. This guarantees that only plots with `shouldSync = true` will trigger and receive synchronization events, preventing unnecessary updates for plots that do not have syncing enabled.

**Checklist**
- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
