### PR TITLE
Fix filter of topics not working in NodeEditor

### DIFF
--- a/desktop/integration-test/filterOfTopicsNodeEditor.test.ts
+++ b/desktop/integration-test/filterOfTopicsNodeEditor.test.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { AppType, launchApp } from "./launchApp";
+import { loadFile } from "./utils/loadFile";
+
+describe("filterOfTopics", () => {
+  const closeDataSourceDialogAfterAppLaunch = async (app: AppType) => {
+    await expect(app.renderer.getByTestId("DataSourceDialog").isVisible()).resolves.toBe(true);
+    await app.renderer.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+    await expect(app.renderer.getByTestId("DataSourceDialog").isVisible()).resolves.toBe(false);
+  };
+
+  it("should filter the visible and invisible", async () => {
+    await using app = await launchApp();
+    await closeDataSourceDialogAfterAppLaunch(app);
+
+    /**
+     * Load a file with 4 topics on 3D panel:
+     * /image_raw
+     * /radar/points
+     * /velodyne_packets
+     * /velodyne_points
+     **/
+    await loadFile(app, "../../../packages/suite-base/src/test/fixtures/demo-shuffled.bag");
+
+    // Open settings menu
+    const settingsIcon = app.renderer.getByTestId("SettingsIcon").nth(0);
+    await settingsIcon.click();
+
+    // Make the first topic visible
+    const visibilityButtons = app.renderer.getByTitle("Toggle visibility");
+    await visibilityButtons.nth(0).click();
+
+    expect(await visibilityButtons.count()).toBe(4);
+
+    // Select only visibles
+    await app.renderer.getByRole("button", { name: "List all" }).click();
+    await app.renderer.locator("#menu-").getByText("List visible").click();
+    expect(await app.renderer.getByTitle("Toggle visibility").count()).toBe(1);
+
+    // Select only invisibles
+    await app.renderer.getByRole("button", { name: "List visible" }).click();
+    await app.renderer.locator("#menu-").getByText("List invisible").click();
+    expect(await app.renderer.getByTitle("Toggle visibility").count()).toBe(3);
+
+    // Select all
+    await app.renderer.getByRole("button", { name: "List invisible" }).click();
+    await app.renderer.locator("#menu-").getByText("List all").click();
+    expect(await app.renderer.getByTitle("Toggle visibility").count()).toBe(4);
+  }, 20_000);
+});

--- a/desktop/integration-test/mapPanel.test.ts
+++ b/desktop/integration-test/mapPanel.test.ts
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-import path from "path";
-
 import { AppType, launchApp } from "./launchApp";
 import { loadFile } from "./utils/loadFile";
 

--- a/desktop/integration-test/mapPanel.test.ts
+++ b/desktop/integration-test/mapPanel.test.ts
@@ -4,6 +4,7 @@
 import path from "path";
 
 import { AppType, launchApp } from "./launchApp";
+import { loadFile } from "./utils/loadFile";
 
 describe("mapPanel", () => {
   const closeDataSourceDialogAfterAppLaunch = async (app: AppType) => {
@@ -15,14 +16,8 @@ describe("mapPanel", () => {
   it("should open map panel when loading a file", async () => {
     await using app = await launchApp();
     await closeDataSourceDialogAfterAppLaunch(app);
-    //Add rosbag file from source
-    const filePath = path.resolve(
-      __dirname,
-      "../../packages/suite-base/src/test/fixtures/example.bag",
-    );
-    //Drag and drop file
-    const fileInput = app.renderer.locator("[data-puppeteer-file-upload]");
-    await fileInput.setInputFiles(filePath);
+
+    await loadFile(app, "../../../packages/suite-base/src/test/fixtures/example.bag");
 
     //Click on add panel and select Map
     await app.renderer.getByTestId("AddPanelButton").click();

--- a/desktop/integration-test/open-extension.test.ts
+++ b/desktop/integration-test/open-extension.test.ts
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-import path from "path";
-
 import { launchApp } from "./launchApp";
 import { loadFile } from "./utils/loadFile";
 

--- a/desktop/integration-test/open-extension.test.ts
+++ b/desktop/integration-test/open-extension.test.ts
@@ -4,6 +4,7 @@
 import path from "path";
 
 import { launchApp } from "./launchApp";
+import { loadFile } from "./utils/loadFile";
 
 describe("open extension", () => {
   it("should import .foxe extension correctly", async () => {
@@ -11,13 +12,10 @@ describe("open extension", () => {
 
     await app.renderer.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
 
-    const extensionPath = path.resolve(
-      __dirname,
-      "../../packages/suite-base/src/test/fixtures/lichtblick.suite-extension-turtlesim-0.0.1.foxe",
+    await loadFile(
+      app,
+      "../../../packages/suite-base/src/test/fixtures/lichtblick.suite-extension-turtlesim-0.0.1.foxe",
     );
-
-    const fileInput = app.renderer.locator("[data-puppeteer-file-upload]");
-    await fileInput.setInputFiles(extensionPath);
 
     // Add turtlesim extension
     await app.renderer.getByLabel("Add panel button").click();

--- a/desktop/integration-test/openFile.test.ts
+++ b/desktop/integration-test/openFile.test.ts
@@ -4,6 +4,7 @@
 import path from "path";
 
 import { AppType, launchApp } from "./launchApp";
+import { loadFile } from "./utils/loadFile";
 
 describe("openFiles", () => {
   const closeDataSourceDialogAfterAppLaunch = async (app: AppType) => {
@@ -16,34 +17,19 @@ describe("openFiles", () => {
     await using app = await launchApp();
     await closeDataSourceDialogAfterAppLaunch(app);
 
-    //Add bag file from source
-    const filePath = path.resolve(
-      __dirname,
-      "../../packages/suite-base/src/test/fixtures/example.bag",
-    );
-
     //Expect that there are not preloaded files
     await expect(
       app.renderer.getByText("No data source", { exact: true }).innerText(),
     ).resolves.toBe("No data source");
 
-    //Drag and drop the bag file
-    const fileInput = app.renderer.locator("[data-puppeteer-file-upload]");
-    await fileInput.setInputFiles(filePath);
+    await loadFile(app, "../../../packages/suite-base/src/test/fixtures/example.bag");
 
     //Expect that the bag file is being shown
     await expect(
       app.renderer.getByText("example.bag", { exact: true }).innerText(),
     ).resolves.toBeDefined();
 
-    //Add mcap file from source
-    const filePathMcap = path.resolve(
-      __dirname,
-      "../../packages/suite-base/src/test/fixtures/example.mcap",
-    );
-
-    //Drag and drop the mcap file
-    await fileInput.setInputFiles(filePathMcap);
+    await loadFile(app, "../../../packages/suite-base/src/test/fixtures/example.mcap");
 
     //Expect that the mcap file is being shown
     await expect(

--- a/desktop/integration-test/openFile.test.ts
+++ b/desktop/integration-test/openFile.test.ts
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-import path from "path";
-
 import { AppType, launchApp } from "./launchApp";
 import { loadFile } from "./utils/loadFile";
 

--- a/desktop/integration-test/utils/loadFile.ts
+++ b/desktop/integration-test/utils/loadFile.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import path from "path";
+
+import { AppType } from "../launchApp";
+
+export const loadFile = async (app: AppType, filePath: string): Promise<void> => {
+  // Adjust file path
+  const filePathAdjusted = path.resolve(__dirname, filePath);
+
+  // Select the file input
+  const fileInput = app.renderer.locator("[data-puppeteer-file-upload]");
+
+  // Drag and drop the file
+  await fileInput.setInputFiles(filePathAdjusted);
+};

--- a/packages/suite-base/src/components/SettingsTreeEditor/NodeEditor.test.tsx
+++ b/packages/suite-base/src/components/SettingsTreeEditor/NodeEditor.test.tsx
@@ -1,0 +1,101 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import "@testing-library/jest-dom";
+
+import { Immutable, SettingsTreeAction, SettingsTreeNode } from "@lichtblick/suite";
+import { NodeEditor } from "@lichtblick/suite-base/components/SettingsTreeEditor/NodeEditor";
+import {
+  FieldEditorProps,
+  SelectVisibilityFilterValue,
+} from "@lichtblick/suite-base/components/SettingsTreeEditor/types";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+
+let capturedActionHandler: (action: SettingsTreeAction) => void;
+
+jest.mock("@lichtblick/suite-base/components/SettingsTreeEditor/FieldEditor", () => ({
+  FieldEditor: (props: FieldEditorProps) => {
+    capturedActionHandler = props.actionHandler;
+    return <div />; // Simple mock because UI does not matter here
+  },
+}));
+
+const changeVisibilityFilter = (visibility: SelectVisibilityFilterValue) => {
+  capturedActionHandler({
+    action: "update",
+    payload: { input: "select", value: visibility, path: ["topics", "visibilityFilter"] },
+  });
+};
+
+describe("NodeEditor childNodes filtering", () => {
+  const nodes: [string, string, string] = BasicBuilder.strings({ count: 3 }) as [
+    string,
+    string,
+    string,
+  ];
+
+  const tree: Immutable<SettingsTreeNode> = {
+    enableVisibilityFilter: true,
+    children: {
+      [nodes[0]]: { visible: true, label: nodes[0] },
+      [nodes[1]]: { visible: false, label: nodes[1] },
+      [nodes[2]]: { label: nodes[2] }, // undefined visibility is always shown
+    },
+  };
+
+  const renderComponent = async () => {
+    const ui: React.ReactElement = (
+      <NodeEditor actionHandler={() => undefined} path={[]} settings={tree} />
+    );
+
+    return {
+      ...render(ui),
+      user: userEvent.setup(),
+    };
+  };
+
+  it("all nodes should be visible at start", async () => {
+    await renderComponent();
+
+    expect(screen.queryByText(nodes[0])).toBeInTheDocument();
+    expect(screen.queryByText(nodes[1])).toBeInTheDocument();
+    expect(screen.queryByText(nodes[2])).toBeInTheDocument();
+  });
+
+  it("should list only the selected option filter", async () => {
+    await renderComponent();
+
+    expect(screen.queryByText(nodes[0])).toBeInTheDocument();
+    expect(screen.queryByText(nodes[1])).toBeInTheDocument();
+    expect(screen.queryByText(nodes[2])).toBeInTheDocument();
+
+    act(() => {
+      changeVisibilityFilter("visible");
+    });
+
+    expect(screen.queryByText(nodes[0])).toBeInTheDocument();
+    expect(screen.queryByText(nodes[1])).not.toBeInTheDocument();
+    expect(screen.queryByText(nodes[2])).toBeInTheDocument();
+
+    act(() => {
+      changeVisibilityFilter("invisible");
+    });
+
+    expect(screen.queryByText(nodes[0])).not.toBeInTheDocument();
+    expect(screen.queryByText(nodes[1])).toBeInTheDocument();
+    expect(screen.queryByText(nodes[2])).toBeInTheDocument();
+
+    act(() => {
+      changeVisibilityFilter("all");
+    });
+
+    expect(screen.queryByText(nodes[0])).toBeInTheDocument();
+    expect(screen.queryByText(nodes[1])).toBeInTheDocument();
+    expect(screen.queryByText(nodes[2])).toBeInTheDocument();
+  });
+});

--- a/packages/suite-base/src/components/SettingsTreeEditor/NodeEditor.test.tsx
+++ b/packages/suite-base/src/components/SettingsTreeEditor/NodeEditor.test.tsx
@@ -33,11 +33,7 @@ const changeVisibilityFilter = (visibility: SelectVisibilityFilterValue) => {
 };
 
 describe("NodeEditor childNodes filtering", () => {
-  const nodes: [string, string, string] = BasicBuilder.strings({ count: 3 }) as [
-    string,
-    string,
-    string,
-  ];
+  const nodes = BasicBuilder.strings({ count: 3 }) as [string, string, string];
 
   const tree: Immutable<SettingsTreeNode> = {
     enableVisibilityFilter: true,

--- a/packages/suite-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/suite-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -186,24 +186,21 @@ function NodeEditorComponent(props: NodeEditorProps): React.JSX.Element {
     if (!filterFn) {
       return preparedNodes;
     }
-    return filterMap(preparedNodes, ([, child]) => filterFn(child));
+    return preparedNodes.filter(([, child]) => filterFn(child));
   }, [preparedNodes, filterFn]);
 
   const childNodes = useMemo(() => {
-    return filterMap(
-      filteredNodes as Immutable<Array<[string, SettingsTreeNode]>>,
-      ([key, child]) => (
-        <NodeEditor
-          actionHandler={actionHandler}
-          defaultOpen={child.defaultExpansionState !== "collapsed"}
-          filter={filter}
-          focusedPath={focusedPath}
-          key={key}
-          settings={child}
-          path={makeStablePath(props.path, key)}
-        />
-      ),
-    );
+    return filterMap(filteredNodes, ([key, child]) => (
+      <NodeEditor
+        actionHandler={actionHandler}
+        defaultOpen={child.defaultExpansionState !== "collapsed"}
+        filter={filter}
+        focusedPath={focusedPath}
+        key={key}
+        settings={child}
+        path={makeStablePath(props.path, key)}
+      />
+    ));
   }, [filteredNodes, actionHandler, filter, focusedPath, props.path]);
 
   const IconComponent = settings.icon ? icons[settings.icon] : undefined;

--- a/packages/suite-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/suite-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -28,6 +28,10 @@ import {
 } from "@lichtblick/suite";
 import { HighlightedText } from "@lichtblick/suite-base/components/HighlightedText";
 import { useStyles } from "@lichtblick/suite-base/components/SettingsTreeEditor/NodeEditor.style";
+import {
+  NodeEditorProps,
+  SelectVisibilityFilterValue,
+} from "@lichtblick/suite-base/components/SettingsTreeEditor/types";
 import Stack from "@lichtblick/suite-base/components/Stack";
 import { useAppContext } from "@lichtblick/suite-base/context/AppContext";
 
@@ -36,15 +40,6 @@ import { NodeActionsMenu } from "./NodeActionsMenu";
 import { VisibilityToggle } from "./VisibilityToggle";
 import { icons } from "./icons";
 import { prepareSettingsNodes } from "./utils";
-
-type NodeEditorProps = {
-  actionHandler: (action: SettingsTreeAction) => void;
-  defaultOpen?: boolean;
-  filter?: string;
-  focusedPath?: readonly string[];
-  path: readonly string[];
-  settings?: Immutable<SettingsTreeNode>;
-};
 
 function ExpansionArrow({ expanded }: { expanded: boolean }): React.JSX.Element {
   const { classes } = useStyles();
@@ -59,7 +54,6 @@ function ExpansionArrow({ expanded }: { expanded: boolean }): React.JSX.Element 
 
 const makeStablePath = memoizeWeak((path: readonly string[], key: string) => [...path, key]);
 
-type SelectVisibilityFilterValue = "all" | "visible" | "invisible";
 const SelectVisibilityFilterOptions: (t: TFunction<"settingsEditor">) => {
   label: string;
   value: SelectVisibilityFilterValue;
@@ -165,8 +159,7 @@ function NodeEditorComponent(props: NodeEditorProps): React.JSX.Element {
   );
 
   const fieldEditors = useMemo(
-    () =>
-      entries.filter(([, field]) => field).map(([key, field]) => renderFieldEditor(key, field!)),
+    () => entries.filter(([, field]) => field).map(([key, field]) => renderFieldEditor(key, field)),
     [entries, renderFieldEditor],
   );
 

--- a/packages/suite-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/suite-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -159,7 +159,8 @@ function NodeEditorComponent(props: NodeEditorProps): React.JSX.Element {
   );
 
   const fieldEditors = useMemo(
-    () => entries.filter(([, field]) => field).map(([key, field]) => renderFieldEditor(key, field)),
+    () =>
+      entries.filter(([, field]) => field).map(([key, field]) => renderFieldEditor(key, field!)),
     [entries, renderFieldEditor],
   );
 

--- a/packages/suite-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/suite-base/src/components/SettingsTreeEditor/types.ts
@@ -1,8 +1,32 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
-import { SettingsTreeNodeAction } from "@lichtblick/suite";
+import { Immutable } from "immer";
+
+import {
+  SettingsTreeAction,
+  SettingsTreeField,
+  SettingsTreeNode,
+  SettingsTreeNodeAction,
+} from "@lichtblick/suite";
 
 export type NodeActionsMenuProps = {
   actions: readonly SettingsTreeNodeAction[];
   onSelectAction: (actionId: string) => void;
+};
+
+export type NodeEditorProps = {
+  actionHandler: (action: SettingsTreeAction) => void;
+  defaultOpen?: boolean;
+  filter?: string;
+  focusedPath?: readonly string[];
+  path: readonly string[];
+  settings?: Immutable<SettingsTreeNode>;
+};
+
+export type SelectVisibilityFilterValue = "all" | "visible" | "invisible";
+
+export type FieldEditorProps = {
+  actionHandler: (action: SettingsTreeAction) => void;
+  field: Immutable<SettingsTreeField>;
+  path: readonly string[];
 };


### PR DESCRIPTION
**User-Facing Changes**
Users can now filter topics based on their visibility (visible/invisible) without encountering errors.

**Description**
A recent modification in [PR #272](https://github.com/lichtblick-suite/lichtblick/pull/272) changed how child nodes were filtered, replacing an array of nodes with an array of booleans. This led to errors when filtering valid topics, while empty arrays behaved correctly.

This PR resolves the issue by properly handling the filtering logic. Additionally, new end-to-end (e2e) tests were added to validate the fix and standardize file-opening methods across our e2e tests.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
