### PR TITLE
[bugfix] Show enumerator value when array in Raw Message panel

### DIFF
--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -333,7 +333,10 @@ function RawMessages(props: Props) {
             );
           }
 
-          let constantName: string | undefined;
+          let constantName: string | undefined =
+            typeof label === "number" && queriedData[label]
+              ? queriedData[label]?.constantName
+              : undefined;
           if (structureItem) {
             const childStructureItem = getStructureItemForPath(
               structureItem,

--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -64,7 +64,12 @@ import {
   getValueActionForValue,
 } from "./getValueActionForValue";
 import { NodeState, RawMessagesPanelConfig } from "./types";
-import { DATA_ARRAY_PREVIEW_LIMIT, generateDeepKeyPaths, toggleExpansion } from "./utils";
+import {
+  DATA_ARRAY_PREVIEW_LIMIT,
+  generateDeepKeyPaths,
+  getConstantNameFromQueriedData,
+  toggleExpansion,
+} from "./utils";
 
 type Props = {
   config: Immutable<RawMessagesPanelConfig>;
@@ -333,10 +338,7 @@ function RawMessages(props: Props) {
             );
           }
 
-          let constantName: string | undefined =
-            typeof label === "number" && queriedData[label]
-              ? queriedData[label]?.constantName
-              : undefined;
+          let constantName: string | undefined = getConstantNameFromQueriedData(label, queriedData);
           if (structureItem) {
             const childStructureItem = getStructureItemForPath(
               structureItem,

--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -68,7 +68,6 @@ import {
   DATA_ARRAY_PREVIEW_LIMIT,
   generateDeepKeyPaths,
   getConstantNameByKeyPath,
-  getConstantNameFromQueriedData,
   toggleExpansion,
 } from "./utils";
 

--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -67,6 +67,7 @@ import { NodeState, RawMessagesPanelConfig } from "./types";
 import {
   DATA_ARRAY_PREVIEW_LIMIT,
   generateDeepKeyPaths,
+  getConstantNameByKeyPath,
   getConstantNameFromQueriedData,
   toggleExpansion,
 } from "./utils";
@@ -338,7 +339,7 @@ function RawMessages(props: Props) {
             );
           }
 
-          let constantName: string | undefined = getConstantNameFromQueriedData(label, queriedData);
+          let constantName: string | undefined = getConstantNameByKeyPath(keyPath, queriedData);
           if (structureItem) {
             const childStructureItem = getStructureItemForPath(
               structureItem,

--- a/packages/suite-base/src/panels/RawMessages/utils.test.ts
+++ b/packages/suite-base/src/panels/RawMessages/utils.test.ts
@@ -8,7 +8,7 @@
 import { MessagePathDataItem } from "@lichtblick/suite-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { NodeExpansion, NodeState } from "@lichtblick/suite-base/panels/RawMessages/types";
 import {
-  getConstantNameFromQueriedData,
+  getConstantNameByKeyPath,
   getMessageDocumentationLink,
   toggleExpansion,
 } from "@lichtblick/suite-base/panels/RawMessages/utils";
@@ -77,51 +77,61 @@ describe("toggleExpansion", () => {
   });
 });
 
-describe("getConstantNameFromQueriedData", () => {
-  it("returns undefined if label is not a number", () => {
-    const label = BasicBuilder.string();
+describe("getConstantNameByKeyPath", () => {
+  it("should return undefined when keyPath is empty", () => {
+    const keyPath: (string | number)[] = [];
     const queriedData: MessagePathDataItem[] = [];
 
-    const result = getConstantNameFromQueriedData(label, queriedData);
+    const result = getConstantNameByKeyPath(keyPath, queriedData);
 
     expect(result).toBeUndefined();
   });
 
-  it("returns undefined if queriedData at position does not exist", () => {
-    const label = BasicBuilder.number();
+  it("should return undefined when keyPath is not a number", () => {
+    const keyPath: (string | number)[] = [BasicBuilder.string()];
     const queriedData: MessagePathDataItem[] = [];
 
-    const result = getConstantNameFromQueriedData(label, queriedData);
+    const result = getConstantNameByKeyPath(keyPath, queriedData);
 
     expect(result).toBeUndefined();
   });
 
-  it("returns constantName correctly when present", () => {
+  it("should return undefined when queriedData at keyPath does not exist", () => {
+    const keyPath: (string | number)[] = [BasicBuilder.number()];
+    const queriedData: MessagePathDataItem[] = [];
+
+    const result = getConstantNameByKeyPath(keyPath, queriedData);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined if constantName is missing from item", () => {
+    const keyPath: (string | number)[] = [0];
     const queriedData: MessagePathDataItem[] = [
       {
-        constantName: BasicBuilder.string(),
         path: BasicBuilder.string(),
         value: BasicBuilder.number(),
       },
     ];
-    const label = queriedData.length - 1;
 
-    const result = getConstantNameFromQueriedData(label, queriedData);
-
-    expect(result).toBe(queriedData[label]?.constantName);
-  });
-
-  it("returns undefined if constantName is missing from item", () => {
-    const label = 0;
-    const queriedData: MessagePathDataItem[] = [
-      {
-        path: "foo.bar",
-        value: 42,
-      },
-    ];
-
-    const result = getConstantNameFromQueriedData(label, queriedData);
+    const result = getConstantNameByKeyPath(keyPath, queriedData);
 
     expect(result).toBeUndefined();
+  });
+
+  it("should return constantName correctly when present", () => {
+    const constantName = BasicBuilder.string();
+    const queriedData: MessagePathDataItem[] = [
+      {
+        constantName,
+        path: BasicBuilder.string(),
+        value: BasicBuilder.number(),
+      },
+    ];
+    const keyPath: (string | number)[] = [0];
+
+    const result = getConstantNameByKeyPath(keyPath, queriedData);
+
+    expect(result).toBe(constantName);
   });
 });

--- a/packages/suite-base/src/panels/RawMessages/utils.test.ts
+++ b/packages/suite-base/src/panels/RawMessages/utils.test.ts
@@ -5,11 +5,14 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { MessagePathDataItem } from "@lichtblick/suite-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { NodeExpansion, NodeState } from "@lichtblick/suite-base/panels/RawMessages/types";
 import {
+  getConstantNameFromQueriedData,
   getMessageDocumentationLink,
   toggleExpansion,
 } from "@lichtblick/suite-base/panels/RawMessages/utils";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
 
 describe("getMessageDocumentationLink", () => {
   it("links to ROS and Foxglove docs", () => {
@@ -71,5 +74,54 @@ describe("toggleExpansion", () => {
       [`grandchild${PATH_NAME_AGGREGATOR}child${PATH_NAME_AGGREGATOR}key1`]: NodeState.Expanded,
       key2: NodeState.Collapsed,
     });
+  });
+});
+
+describe("getConstantNameFromQueriedData", () => {
+  it("returns undefined if label is not a number", () => {
+    const label = BasicBuilder.string();
+    const queriedData: MessagePathDataItem[] = [];
+
+    const result = getConstantNameFromQueriedData(label, queriedData);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined if queriedData at position does not exist", () => {
+    const label = BasicBuilder.number();
+    const queriedData: MessagePathDataItem[] = [];
+
+    const result = getConstantNameFromQueriedData(label, queriedData);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns constantName correctly when present", () => {
+    const queriedData: MessagePathDataItem[] = [
+      {
+        constantName: BasicBuilder.string(),
+        path: BasicBuilder.string(),
+        value: BasicBuilder.number(),
+      },
+    ];
+    const label = queriedData.length - 1;
+
+    const result = getConstantNameFromQueriedData(label, queriedData);
+
+    expect(result).toBe(queriedData[label]?.constantName);
+  });
+
+  it("returns undefined if constantName is missing from item", () => {
+    const label = 0;
+    const queriedData: MessagePathDataItem[] = [
+      {
+        path: "foo.bar",
+        value: 42,
+      },
+    ];
+
+    const result = getConstantNameFromQueriedData(label, queriedData);
+
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/suite-base/src/panels/RawMessages/utils.ts
+++ b/packages/suite-base/src/panels/RawMessages/utils.ts
@@ -153,11 +153,11 @@ export function getMessageDocumentationLink(datatype: string): string | undefine
   return undefined;
 }
 
-export function getConstantNameFromQueriedData(
-  label: string | number,
+export function getConstantNameByKeyPath(
+  keyPath: (string | number)[],
   queriedData: MessagePathDataItem[],
 ): string | undefined {
-  return typeof label === "number" && queriedData[label]
-    ? queriedData[label]?.constantName
+  return keyPath.length > 0 && typeof keyPath[0] === "number"
+    ? queriedData[keyPath[0]]?.constantName
     : undefined;
 }

--- a/packages/suite-base/src/panels/RawMessages/utils.ts
+++ b/packages/suite-base/src/panels/RawMessages/utils.ts
@@ -157,7 +157,9 @@ export function getConstantNameByKeyPath(
   keyPath: (string | number)[],
   queriedData: MessagePathDataItem[],
 ): string | undefined {
-  return keyPath.length > 0 && typeof keyPath[0] === "number"
-    ? queriedData[keyPath[0]]?.constantName
-    : undefined;
+  if (keyPath.length > 0 && typeof keyPath[0] === "number") {
+    return queriedData[keyPath[0]]?.constantName;
+  }
+
+  return undefined;
 }

--- a/packages/suite-base/src/panels/RawMessages/utils.ts
+++ b/packages/suite-base/src/panels/RawMessages/utils.ts
@@ -18,6 +18,7 @@ import { foxgloveMessageSchemas } from "@foxglove/schemas/internal";
 import * as _ from "lodash-es";
 
 import { ros1 } from "@lichtblick/rosmsg-msgs-common";
+import { MessagePathDataItem } from "@lichtblick/suite-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { diffLabels, DiffObject } from "@lichtblick/suite-base/panels/RawMessages/getDiff";
 
 import { PATH_NAME_AGGREGATOR } from "./constants";
@@ -150,4 +151,13 @@ export function getMessageDocumentationLink(datatype: string): string | undefine
   }
 
   return undefined;
+}
+
+export function getConstantNameFromQueriedData(
+  label: string | number,
+  queriedData: MessagePathDataItem[],
+): string | undefined {
+  return typeof label === "number" && queriedData[label]
+    ? queriedData[label]?.constantName
+    : undefined;
 }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
Before:
![Screenshot 2025-03-24 at 18 31 47](https://github.com/user-attachments/assets/1cfb86b2-4da7-4f7a-977c-819a8ffd7e54)

Current:
![Screenshot 2025-03-24 at 18 31 03](https://github.com/user-attachments/assets/eaed5690-1861-4aed-bc30-5a1974cc7f85)

**Description**
Added `constantName` to be displayed in Raw Message panel when the value has a representation like enumerators.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
