### PR TITLE
Add RGBA color mode for messages converted to valid pointcloud datatypes

### DIFF
--- a/packages/suite-base/src/components/PanelExtensionAdapter/renderState.test.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/renderState.test.ts
@@ -132,7 +132,7 @@ describe("renderState", () => {
     const state = buildRenderState(input);
 
     expect(state).toEqual({
-      topics: [{ name: "test", schemaName: "schema", datatype: "schema", convertibleTo: ["more"] }],
+      topics: [{ name: "test", schemaName: "schema", convertibleTo: ["more"] }],
     });
   });
 
@@ -148,7 +148,7 @@ describe("renderState", () => {
     const state = buildRenderState(input);
 
     expect(state).toEqual({
-      topics: [{ name: "test", schemaName: "schema", datatype: "schema" }],
+      topics: [{ name: "test", schemaName: "schema" }],
     });
   });
 
@@ -196,7 +196,7 @@ describe("renderState", () => {
       endTime: { sec: 100, nsec: 1 },
       startTime: { sec: 1, nsec: 1 },
       previewTime: 3.500000001,
-      topics: [{ datatype: "schema", name: "test", schemaName: "schema" }],
+      topics: [{ name: "test", schemaName: "schema" }],
     });
   });
 
@@ -225,7 +225,7 @@ describe("renderState", () => {
     });
 
     expect(state).toEqual({
-      topics: [{ name: "test", schemaName: "schema", datatype: "schema" }],
+      topics: [{ name: "test", schemaName: "schema" }],
       currentFrame: [
         {
           topic: "test",
@@ -274,8 +274,8 @@ describe("renderState", () => {
 
     expect(state).toEqual({
       topics: [
-        { name: "another", schemaName: "schema", datatype: "schema" },
-        { name: "test", schemaName: "schema", datatype: "schema" },
+        { name: "another", schemaName: "schema" },
+        { name: "test", schemaName: "schema" },
       ],
       currentFrame: [
         {
@@ -338,8 +338,8 @@ describe("renderState", () => {
 
     expect(state).toEqual({
       topics: [
-        { name: "test1", schemaName: "schema", datatype: "schema" },
-        { name: "test2", schemaName: "schema", datatype: "schema" },
+        { name: "test1", schemaName: "schema" },
+        { name: "test2", schemaName: "schema" },
       ],
       allFrames: [
         makeBlock("test1", { nsec: 0, sec: 1 }),
@@ -416,9 +416,7 @@ describe("renderState", () => {
     });
 
     expect(state).toEqual({
-      topics: [
-        { name: "test", schemaName: "schema", datatype: "schema", convertibleTo: ["otherSchema"] },
-      ],
+      topics: [{ name: "test", schemaName: "schema", convertibleTo: ["otherSchema"] }],
       currentFrame: [
         {
           topic: "test",
@@ -623,7 +621,6 @@ describe("renderState", () => {
         {
           name: "test",
           schemaName: "schema",
-          datatype: "schema",
           convertibleTo: ["otherSchema", "anotherSchema"],
         },
       ],
@@ -764,9 +761,7 @@ describe("renderState", () => {
     });
 
     expect(state).toEqual({
-      topics: [
-        { name: "test", schemaName: "schema", datatype: "schema", convertibleTo: ["otherSchema"] },
-      ],
+      topics: [{ name: "test", schemaName: "schema", convertibleTo: ["otherSchema"] }],
       currentFrame: [
         {
           topic: "test",
@@ -848,13 +843,11 @@ describe("renderState", () => {
         {
           name: "test",
           schemaName: "schema",
-          datatype: "schema",
           convertibleTo: ["otherSchema", "anotherSchema"],
         },
         {
           name: "test2",
           schemaName: "schema2",
-          datatype: "schema2",
         },
       ],
       currentFrame: expect.any(Array),

--- a/packages/suite-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -194,7 +194,6 @@ function initRenderStateBuilder(): BuildRenderStateFn {
         const topics = sortedTopics.map((topic): Topic => {
           const newTopic: Topic = {
             name: topic.name,
-            datatype: topic.schemaName ?? "",
             schemaName: topic.schemaName ?? "",
           };
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.test.ts
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { SettingsTreeField, Topic } from "@lichtblick/suite";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+
+import { pointSettingsNode } from "./pointExtensionUtils";
+
+type SettingsTreeFieldWithOptions = SettingsTreeField & {
+  options: { label: string; value: string };
+};
+
+// Foxglove messages
+const RGBA_OPTION = { label: "RGBA (separate fields)", value: "rgba-fields" };
+const FOXGLOVE_POINTCLOUD_DATATYPE = "foxglove.PointCloud";
+const VALID_MESSAGE_FIELDS = ["red", "blue", "green", "alpha"];
+
+// ROS messages
+const BGR_OPTION_ROS = { label: "BGR (packed)", value: "rgb" };
+const BGRA_OPTION_ROS = { label: "BGRA (packed)", value: "rgba" };
+const ROS_POINTCLOUD_DATATYPE = "sensor_msgs/PointCloud2";
+
+describe("pointExtensionUtils", () => {
+  describe("colorModeFields", () => {
+    const createTopic = (topicArgs?: Partial<Topic>): Topic => {
+      return {
+        name: BasicBuilder.string(),
+        datatype: BasicBuilder.string(), // will be deprecated soon
+        schemaName: BasicBuilder.string(),
+        ...topicArgs,
+      };
+    };
+
+    it("should include RGBA color mode when topic schema is valid and contains RGBA fields", () => {
+      const mockTopic = createTopic({ schemaName: FOXGLOVE_POINTCLOUD_DATATYPE });
+
+      const panelSettings = pointSettingsNode(mockTopic, VALID_MESSAGE_FIELDS, {});
+      const colorMode = panelSettings.fields!.colorMode! as SettingsTreeFieldWithOptions;
+
+      expect(colorMode.options).toEqual(expect.arrayContaining([RGBA_OPTION]));
+      expect(colorMode.options).toEqual(
+        expect.not.arrayContaining([BGR_OPTION_ROS, BGRA_OPTION_ROS]),
+      );
+    });
+
+    it("should include RGBA color mode when topic is convertible to a valid schema and contains RGBA fields", () => {
+      const mockTopic = createTopic({ convertibleTo: [FOXGLOVE_POINTCLOUD_DATATYPE] });
+
+      const panelSettings = pointSettingsNode(mockTopic, VALID_MESSAGE_FIELDS, {});
+      const colorMode = panelSettings.fields!.colorMode! as SettingsTreeFieldWithOptions;
+
+      expect(colorMode.options).toEqual(expect.arrayContaining([RGBA_OPTION]));
+      expect(colorMode.options).toEqual(
+        expect.not.arrayContaining([BGR_OPTION_ROS, BGRA_OPTION_ROS]),
+      );
+    });
+
+    it("should not include RGBA color mode when topic has no RGBA fields", () => {
+      const mockTopic = createTopic({ convertibleTo: [FOXGLOVE_POINTCLOUD_DATATYPE] });
+
+      const panelSettings = pointSettingsNode(mockTopic, [], {});
+      const colorMode = panelSettings.fields!.colorMode! as SettingsTreeFieldWithOptions;
+
+      expect(colorMode.options).toEqual(expect.not.arrayContaining([RGBA_OPTION]));
+      expect(colorMode.options).toEqual(
+        expect.not.arrayContaining([BGR_OPTION_ROS, BGRA_OPTION_ROS]),
+      );
+    });
+
+    it("should not include RGBA color mode when topic schema is invalid, even with valid RGBA fields", () => {
+      const mockTopic = createTopic();
+
+      const panelSettings = pointSettingsNode(mockTopic, VALID_MESSAGE_FIELDS, {});
+      const colorMode = panelSettings.fields!.colorMode! as SettingsTreeFieldWithOptions;
+
+      expect(colorMode.options).toEqual(expect.not.arrayContaining([RGBA_OPTION]));
+      expect(colorMode.options).toEqual(
+        expect.not.arrayContaining([BGR_OPTION_ROS, BGRA_OPTION_ROS]),
+      );
+    });
+
+    it("should include BGR and BGRA color modes for ROS PointCloud2 messages", () => {
+      const mockTopic = createTopic({ schemaName: ROS_POINTCLOUD_DATATYPE });
+
+      const panelSettings = pointSettingsNode(mockTopic, BasicBuilder.strings(), {});
+      const colorMode = panelSettings.fields!.colorMode! as SettingsTreeFieldWithOptions;
+
+      expect(colorMode.options).toEqual(expect.arrayContaining([BGR_OPTION_ROS, BGRA_OPTION_ROS]));
+      expect(colorMode.options).toEqual(expect.not.arrayContaining([RGBA_OPTION]));
+    });
+
+    it("should include BGR and BGRA color modes for ROS PointCloud2 messages from message converter", () => {
+      const mockTopic = createTopic({ convertibleTo: [ROS_POINTCLOUD_DATATYPE] });
+
+      const panelSettings = pointSettingsNode(mockTopic, BasicBuilder.strings(), {});
+      const colorMode = panelSettings.fields!.colorMode! as SettingsTreeFieldWithOptions;
+
+      expect(colorMode.options).toEqual(expect.arrayContaining([BGR_OPTION_ROS, BGRA_OPTION_ROS]));
+      expect(colorMode.options).toEqual(expect.not.arrayContaining([RGBA_OPTION]));
+    });
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.test.ts
@@ -25,7 +25,6 @@ describe("pointExtensionUtils", () => {
     const createTopic = (topicArgs?: Partial<Topic>): Topic => {
       return {
         name: BasicBuilder.string(),
-        datatype: BasicBuilder.string(), // will be deprecated soon
         schemaName: BasicBuilder.string(),
         ...topicArgs,
       };

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
@@ -82,13 +82,20 @@ export function pointSettingsNode(
   const pointShape = config.pointShape ?? "circle";
   const decayTime = config.decayTime;
 
+  const checkColorsForDatatypes = (pointCloudDatatypes: Set<string>): boolean => {
+    return (
+      pointCloudDatatypes.has(topic.schemaName) ||
+      (topic.convertibleTo ?? []).some((item) => pointCloudDatatypes.has(item))
+    );
+  };
+
   const colorModeFields = colorModeSettingsFields({
     msgFields: messageFields,
     config,
     defaults: defaultSettings,
     modifiers: {
-      supportsPackedRgbModes: ROS_POINTCLOUD_DATATYPES.has(topic.schemaName),
-      supportsRgbaFieldsMode: LICHTBLICK_POINTCLOUD_DATATYPES.has(topic.schemaName),
+      supportsPackedRgbModes: checkColorsForDatatypes(ROS_POINTCLOUD_DATATYPES),
+      supportsRgbaFieldsMode: checkColorsForDatatypes(LICHTBLICK_POINTCLOUD_DATATYPES),
     },
   });
 

--- a/packages/suite/src/index.ts
+++ b/packages/suite/src/index.ts
@@ -48,10 +48,6 @@ export type Topic = {
    */
   name: string;
   /**
-   * @deprecated Renamed to `schemaName`. `datatype` will be removed in a future release.
-   */
-  datatype: string;
-  /**
    * The schema name is an identifier for the types of messages on this topic. Typically this is the
    * fully-qualified name of the message schema. The fully-qualified name depends on the data source
    * and data loaded by the data source.


### PR DESCRIPTION
## User-Facing Changes
Users can now create messages using the `PointCloud` schema through custom message converters and apply custom RGBA values to the messages, enhancing customization options for visualizing point clouds.

## Description 
Previously, Lichtblick only supported coloring PointCloud messages if the topic contained original messages with the PointCloud schema. With this update, users can now filter messages by RGBA values through custom message converters. This extension significantly increases the flexibility of message customization, enabling users to define custom colors for point clouds, even if the messages don't originally conform to the PointCloud schema.

The change introduces the ability to add color to messages that contain simple `x`, `y`, `z` coordinates (like the `Point3` topic). Through the use of a message converter, these coordinates can be assigned RGBA color values, allowing them to be rendered as colored point clouds. After packaging and converting the messages according to the PointCloud schema, users will be able to see both the original `Point3` topic (now renderable with colors) and the native `PointCloud` topic in a 3D panel.

In the screenshot below, we demonstrate two topics:

- `/point_cloud/colored`, which is natively in the `PointCloud` schema.
- `/point_3`, which initially contained only `x`, `y`, `z` coordinates and was not renderable in the 3D panel.

After applying the message converter, the `Point3` topic is now renderable, and the RGBA color mode is enabled. The green-colored squares represent the converted `Point3` points, and the red half-transparent circle represents the original `/point_cloud/colored` messages.

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/12f2e6b4-aaf9-4e28-807b-c56aefa8b475" />

### Test Plan
To ensure the functionality works as expected, we conducted tests with the following resources:

Files used (MCAP and .foxe custom extension): 
[mcap and extension for PointCloud.zip](https://github.com/user-attachments/files/19449007/mcap.and.extension.for.PointCloud.zip)

The code for the message converter used in the tests is as follows:

```
extensionContext.registerMessageConverter({
    fromSchemaName: "foxglove.Point3",
    toSchemaName: "foxglove.PointCloud",
    converter: (msg: Point3, event): PointCloud => {
      const r = Math.floor(Math.random() * 150);
      const g = 255;
      const b = Math.floor(Math.random() * 150);

      // POINTS PROCESS
      const pointStride = 16; // 3 floats (x, y, z) + 4 bytes for RGBA

      // Packing data for the point cloud with colors (16 bytes: 3 floats for x, y, z + 4 bytes for RGBA)
      const pointColoredData = new Uint8Array(pointStride);

      new DataView(pointColoredData.buffer).setFloat32(0, msg.x, true);
      new DataView(pointColoredData.buffer).setFloat32(4, msg.y, true);
      new DataView(pointColoredData.buffer).setFloat32(8, msg.z, true);
      pointColoredData[12] = r; // red
      pointColoredData[13] = g; // green
      pointColoredData[14] = b; // blue
      pointColoredData[15] = 255; // alpha (fully opaque, for simplicity)

      return {
        timestamp: event.receiveTime,
        point_stride: pointStride,
        frame_id: "cloud",
        fields: [
          { name: "x", offset: 0, type: 7 },
          { name: "y", offset: 4, type: 7 },
          { name: "z", offset: 8, type: 7 },
          { name: "red", offset: 12, type: 1 },
          { name: "green", offset: 13, type: 1 },
          { name: "blue", offset: 14, type: 1 },
          { name: "alpha", offset: 15, type: 1 },
        ],
        pose: {
          position: { x: 0, y: 0, z: 0 },
          orientation: { x: 0, y: 0, z: 0, w: 1 },
        },
        data: pointColoredData,
      };
    },
  });
```

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests

