### PR TITLE
Remove duplicated window button actions for Linux

### DIFF
--- a/packages/suite-desktop/src/main/StudioWindow.ts
+++ b/packages/suite-desktop/src/main/StudioWindow.ts
@@ -37,8 +37,6 @@ import { LICHTBLICK_PRODUCT_NAME } from "../common/webpackDefines";
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 
 const isMac = process.platform === "darwin";
-const isLinux = process.platform === "linux";
-const isWindows = process.platform === "win32";
 const isProduction = process.env.NODE_ENV === "production";
 const rendererPath = MAIN_WINDOW_WEBPACK_ENTRY;
 
@@ -54,7 +52,7 @@ function getWindowBackgroundColor(): string | undefined {
 
 function getTitleBarOverlayOptions(): TitleBarOverlayOptions {
   const theme = palette[nativeTheme.shouldUseDarkColors ? "dark" : "light"];
-  if (isWindows) {
+  if (!isMac) {
     return {
       height: APP_BAR_HEIGHT,
       color: theme.appBar.main,
@@ -79,7 +77,6 @@ function newStudioWindow(deepLinks: string[] = [], reloadMainWindow: () => void)
     minHeight: 250,
     autoHideMenuBar: true,
     title: LICHTBLICK_PRODUCT_NAME,
-    frame: isLinux ? false : true,
     titleBarStyle: "hidden",
     trafficLightPosition: isMac ? { x: macTrafficLightInset, y: macTrafficLightInset } : undefined,
     titleBarOverlay: getTitleBarOverlayOptions(),
@@ -109,7 +106,7 @@ function newStudioWindow(deepLinks: string[] = [], reloadMainWindow: () => void)
 
   const browserWindow = new BrowserWindow(windowOptions);
   nativeTheme.on("updated", () => {
-    if (isWindows) {
+    if (!isMac) {
       // Although the TS types say this function is always available, it is undefined on non-Windows platforms
       browserWindow.setTitleBarOverlay(getTitleBarOverlayOptions());
     }

--- a/packages/suite-desktop/src/renderer/Root.tsx
+++ b/packages/suite-desktop/src/renderer/Root.tsx
@@ -165,7 +165,6 @@ export default function Root(props: RootProps): React.JSX.Element {
       onAppBarDoubleClick={() => {
         nativeWindow.handleTitleBarDoubleClick();
       }}
-      showCustomWindowControls={ctxbridge?.platform === "linux"}
       isMaximized={isMaximized}
       onMinimizeWindow={onMinimizeWindow}
       onMaximizeWindow={onMaximizeWindow}


### PR DESCRIPTION
**User-Facing Changes**
On Linux, users currently see two sets of window control buttons—one provided by the OS and another added by a Lichtblick component.

**Description**
This PR disables the additional set of window control buttons added by the Lichtblick component, ensuring that only the native Linux buttons are displayed.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests (N/A)
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated (N/A)
