### PR TITLE
Fixing name change revert if layout had new changes right after

### DIFF
--- a/packages/suite-base/src/hooks/useLayoutActions.test.tsx
+++ b/packages/suite-base/src/hooks/useLayoutActions.test.tsx
@@ -1,0 +1,74 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { renderHook, act } from "@testing-library/react";
+
+import { useAnalytics } from "@lichtblick/suite-base/context/AnalyticsContext";
+import { useCurrentLayoutActions } from "@lichtblick/suite-base/context/CurrentLayoutContext";
+import { useLayoutManager } from "@lichtblick/suite-base/context/LayoutManagerContext";
+import { useLayoutActions } from "@lichtblick/suite-base/hooks/useLayoutActions";
+import { AppEvent } from "@lichtblick/suite-base/services/IAnalytics";
+import MockLayoutManager from "@lichtblick/suite-base/services/LayoutManager/MockLayoutManager";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+import LayoutBuilder from "@lichtblick/suite-base/testing/builders/LayoutBuilder";
+
+jest.mock("@lichtblick/suite-base/context/LayoutManagerContext", () => ({
+  useLayoutManager: jest.fn(),
+}));
+
+jest.mock("@lichtblick/suite-base/context/AnalyticsContext", () => ({
+  useAnalytics: jest.fn(),
+}));
+
+jest.mock("@lichtblick/suite-base/context/CurrentLayoutContext", () => ({
+  useCurrentLayoutActions: jest.fn(),
+  useCurrentLayoutSelector: jest.fn(),
+}));
+
+describe("useLayoutActions", () => {
+  let analyticsMock: any;
+  let setSelectedLayoutIdMock: any;
+  const mockLayoutManager = new MockLayoutManager();
+
+  beforeEach(() => {
+    mockLayoutManager.updateLayout = jest.fn().mockResolvedValue(undefined);
+    analyticsMock = {
+      logEvent: jest.fn(),
+    };
+    setSelectedLayoutIdMock = jest.fn();
+
+    (useLayoutManager as jest.Mock).mockReturnValue(mockLayoutManager);
+    (useAnalytics as jest.Mock).mockReturnValue(analyticsMock);
+    (useCurrentLayoutActions as jest.Mock).mockReturnValue({
+      setSelectedLayoutId: setSelectedLayoutIdMock,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should rename the layout", async () => {
+    const { result } = renderHook(() => useLayoutActions());
+    const newName = BasicBuilder.string();
+
+    const mockLayout = LayoutBuilder.layout();
+
+    await act(async () => {
+      await result.current.onRenameLayout(mockLayout, newName);
+    });
+
+    expect(mockLayoutManager.updateLayout).toHaveBeenCalledWith({
+      id: mockLayout.id,
+      name: newName,
+    });
+
+    expect(setSelectedLayoutIdMock).toHaveBeenCalledWith(mockLayout.id);
+
+    expect(analyticsMock.logEvent).toHaveBeenCalledWith(AppEvent.LAYOUT_RENAME, {
+      permission: mockLayout.permission,
+    });
+  });
+});

--- a/packages/suite-base/src/hooks/useLayoutActions.test.tsx
+++ b/packages/suite-base/src/hooks/useLayoutActions.test.tsx
@@ -54,7 +54,7 @@ describe("useLayoutActions", () => {
     const { result } = renderHook(() => useLayoutActions());
     const newName = BasicBuilder.string();
 
-    const mockLayout = LayoutBuilder.layout();
+    const mockLayout = LayoutBuilder.layout({ permission: "CREATOR_WRITE" });
 
     await act(async () => {
       await result.current.onRenameLayout(mockLayout, newName);

--- a/packages/suite-base/src/hooks/useLayoutActions.tsx
+++ b/packages/suite-base/src/hooks/useLayoutActions.tsx
@@ -44,9 +44,10 @@ export function useLayoutActions(): UseLayoutActions {
   const onRenameLayout = useCallbackWithToast(
     async (item: Layout, newName: string) => {
       await layoutManager.updateLayout({ id: item.id, name: newName });
+      setSelectedLayoutId(item.id);
       void analytics.logEvent(AppEvent.LAYOUT_RENAME, { permission: item.permission });
     },
-    [analytics, layoutManager],
+    [analytics, layoutManager, setSelectedLayoutId],
   );
 
   const onDuplicateLayout = useCallbackWithToast(

--- a/packages/suite-base/src/players/TopicAliasingPlayer/aliasing.test.ts
+++ b/packages/suite-base/src/players/TopicAliasingPlayer/aliasing.test.ts
@@ -236,6 +236,7 @@ describe("mapPlayerState", () => {
         {
           extensionId: "any",
           aliasFunction: (args: Parameters<TopicAliasFunction>[0]) => [
+            // eslint-disable-next-line @typescript-eslint/no-base-to-string
             { sourceTopicName: "/topic_1", name: `/renamed_topic_${args.globalVariables["foo"]}` },
           ],
         },

--- a/packages/suite-base/src/players/TopicAliasingPlayer/aliasing.test.ts
+++ b/packages/suite-base/src/players/TopicAliasingPlayer/aliasing.test.ts
@@ -236,7 +236,6 @@ describe("mapPlayerState", () => {
         {
           extensionId: "any",
           aliasFunction: (args: Parameters<TopicAliasFunction>[0]) => [
-            // eslint-disable-next-line @typescript-eslint/no-base-to-string
             { sourceTopicName: "/topic_1", name: `/renamed_topic_${args.globalVariables["foo"]}` },
           ],
         },

--- a/packages/suite-base/src/services/ILayoutStorage.ts
+++ b/packages/suite-base/src/services/ILayoutStorage.ts
@@ -20,6 +20,17 @@ export type LayoutSyncStatus =
   | "tracked"
   | "locally-deleted"
   | "remotely-deleted";
+
+export type LayoutBaseline = {
+  data: LayoutData;
+  savedAt: ISO8601Timestamp | undefined;
+};
+
+export type LayoutSyncInfo = {
+  status: LayoutSyncStatus;
+  lastRemoteSavedAt: ISO8601Timestamp | undefined;
+};
+
 export type Layout = {
   id: LayoutID;
   name: string;
@@ -32,28 +43,16 @@ export type Layout = {
   state?: LayoutData;
 
   /** The last explicitly saved version of this layout. */
-  baseline: {
-    data: LayoutData;
-    savedAt: ISO8601Timestamp | undefined;
-  };
+  baseline: LayoutBaseline;
 
   /**
    * The working copy of this layout, if it has been edited since the last explicit save.
    */
-  working:
-    | {
-        data: LayoutData;
-        savedAt: ISO8601Timestamp | undefined;
-      }
-    | undefined;
+  working: LayoutBaseline | undefined;
 
   /** Info about this layout from remote storage. */
   syncInfo:
-    | {
-        status: LayoutSyncStatus;
-        /** The last savedAt time returned by the server. */
-        lastRemoteSavedAt: ISO8601Timestamp | undefined;
-      }
+    | LayoutSyncInfo
     | undefined;
 };
 

--- a/packages/suite-base/src/services/ILayoutStorage.ts
+++ b/packages/suite-base/src/services/ILayoutStorage.ts
@@ -51,9 +51,7 @@ export type Layout = {
   working: LayoutBaseline | undefined;
 
   /** Info about this layout from remote storage. */
-  syncInfo:
-    | LayoutSyncInfo
-    | undefined;
+  syncInfo: LayoutSyncInfo | undefined;
 };
 
 export interface ILayoutStorage {

--- a/packages/suite-base/src/testing/builders/LayoutBuilder.ts
+++ b/packages/suite-base/src/testing/builders/LayoutBuilder.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { LayoutData, LayoutID } from "@lichtblick/suite-base/context/CurrentLayoutContext";
+import {
+  Layout,
+  LayoutPermission,
+  LayoutSyncStatus,
+} from "@lichtblick/suite-base/services/ILayoutStorage";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+import { defaults } from "@lichtblick/suite-base/testing/builders/utilities";
+import { PlaybackConfig } from "@lichtblick/suite-base/types/panels";
+
+const defaultPlaybackConfigValue: PlaybackConfig = {
+  speed: 1.0,
+};
+
+const DEFAULT_LAYOUT_FOR_TESTS: LayoutData = {
+  configById: {},
+  globalVariables: {},
+  userNodes: {},
+  playbackConfig: defaultPlaybackConfigValue,
+};
+
+function randomLayoutPermission(): LayoutPermission {
+  const layoutPermissions: LayoutPermission[] = ["CREATOR_WRITE", "ORG_READ", "ORG_WRITE"];
+  const randomSelector = BasicBuilder.number({ min: 0, max: layoutPermissions.length - 1 });
+  return layoutPermissions[randomSelector]!;
+}
+
+function randomLayoutSyncStatus(): LayoutSyncStatus {
+  const layoutSyncStatuses: LayoutSyncStatus[] = [
+    "new",
+    "updated",
+    "tracked",
+    "locally-deleted",
+    "remotely-deleted",
+  ];
+  const randomSelector = BasicBuilder.number({ min: 0, max: layoutSyncStatuses.length - 1 });
+  return layoutSyncStatuses[randomSelector]!;
+}
+
+export default class LayoutBuilder {
+  public static layout(props: Partial<Layout> = {}): Layout {
+    return defaults<Layout>(props, {
+      id: BasicBuilder.string() as LayoutID,
+      name: BasicBuilder.string(),
+      from: BasicBuilder.string(),
+      permission: randomLayoutPermission(),
+      baseline: { data: DEFAULT_LAYOUT_FOR_TESTS, savedAt: undefined },
+      working: { data: DEFAULT_LAYOUT_FOR_TESTS, savedAt: undefined },
+      syncInfo: { status: randomLayoutSyncStatus(), lastRemoteSavedAt: undefined },
+    });
+  }
+}

--- a/packages/suite-base/src/testing/builders/LayoutBuilder.ts
+++ b/packages/suite-base/src/testing/builders/LayoutBuilder.ts
@@ -13,7 +13,7 @@ import {
 import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
 import GlobalVariableBuilder from "@lichtblick/suite-base/testing/builders/GlobalVariableBuilder";
 import { defaults } from "@lichtblick/suite-base/testing/builders/utilities";
-import { PlaybackConfig, UserScripts } from "@lichtblick/suite-base/types/panels";
+import { PlaybackConfig, UserScript, UserScripts } from "@lichtblick/suite-base/types/panels";
 
 export default class LayoutBuilder {
   public static playbackConfig(props: Partial<PlaybackConfig> = {}): PlaybackConfig {
@@ -22,10 +22,15 @@ export default class LayoutBuilder {
     });
   }
 
-  public static userScripts(props: Partial<UserScripts> = {}): UserScripts {
-    return defaults<UserScripts>(props, {
-      scriptId: { name: BasicBuilder.string(), sourceCode: BasicBuilder.string() },
+  public static userScript(props: Partial<UserScript> = {}): UserScript {
+    return defaults<UserScript>(props, {
+      name: BasicBuilder.string(),
+      sourceCode: BasicBuilder.string(),
     });
+  }
+
+  public static userScripts(count = 3): UserScripts {
+    return BasicBuilder.genericDictionary(LayoutBuilder.userScript, { count });
   }
 
   public static data(props: Partial<LayoutData> = {}): LayoutData {

--- a/packages/suite-base/src/testing/builders/LayoutBuilder.ts
+++ b/packages/suite-base/src/testing/builders/LayoutBuilder.ts
@@ -44,7 +44,7 @@ export default class LayoutBuilder {
         "locally-deleted",
         "remotely-deleted",
       ]),
-      lastRemoteSavedAt: new Date(BasicBuilder.number()).toISOString() as ISO8601Timestamp
+      lastRemoteSavedAt: new Date(BasicBuilder.number()).toISOString() as ISO8601Timestamp,
     });
   }
 

--- a/packages/suite-base/src/testing/builders/LayoutBuilder.ts
+++ b/packages/suite-base/src/testing/builders/LayoutBuilder.ts
@@ -6,36 +6,45 @@ import {
   ISO8601Timestamp,
   Layout,
   LayoutBaseline,
+  LayoutPermission,
   LayoutSyncInfo,
+  LayoutSyncStatus,
 } from "@lichtblick/suite-base/services/ILayoutStorage";
 import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+import GlobalVariableBuilder from "@lichtblick/suite-base/testing/builders/GlobalVariableBuilder";
 import { defaults } from "@lichtblick/suite-base/testing/builders/utilities";
-import { PlaybackConfig } from "@lichtblick/suite-base/types/panels";
+import { PlaybackConfig, UserScripts } from "@lichtblick/suite-base/types/panels";
 
 export default class LayoutBuilder {
-  public static layoutPlaybackConfig(props: Partial<PlaybackConfig> = {}): PlaybackConfig {
+  public static playbackConfig(props: Partial<PlaybackConfig> = {}): PlaybackConfig {
     return defaults<PlaybackConfig>(props, {
       speed: BasicBuilder.float(),
     });
   }
 
-  public static layoutData(props: Partial<LayoutData> = {}): LayoutData {
-    return defaults<LayoutData>(props, {
-      configById: {},
-      globalVariables: {},
-      userNodes: {},
-      playbackConfig: LayoutBuilder.layoutPlaybackConfig(),
+  public static userScripts(props: Partial<UserScripts> = {}): UserScripts {
+    return defaults<UserScripts>(props, {
+      scriptId: { name: BasicBuilder.string(), sourceCode: BasicBuilder.string() },
     });
   }
 
-  public static layoutBaseline(props: Partial<LayoutBaseline> = {}): LayoutBaseline {
+  public static data(props: Partial<LayoutData> = {}): LayoutData {
+    return defaults<LayoutData>(props, {
+      configById: BasicBuilder.genericDictionary(Object),
+      globalVariables: GlobalVariableBuilder.globalVariables(),
+      userNodes: LayoutBuilder.userScripts(),
+      playbackConfig: LayoutBuilder.playbackConfig(),
+    });
+  }
+
+  public static baseline(props: Partial<LayoutBaseline> = {}): LayoutBaseline {
     return defaults<LayoutBaseline>(props, {
-      data: LayoutBuilder.layoutData(),
+      data: LayoutBuilder.data(),
       savedAt: new Date(BasicBuilder.number()).toISOString() as ISO8601Timestamp,
     });
   }
 
-  public static layoutSyncInfo(props: Partial<LayoutSyncInfo> = {}): LayoutSyncInfo {
+  public static syncInfo(props: Partial<LayoutSyncInfo> = {}): LayoutSyncInfo {
     return defaults<LayoutSyncInfo>(props, {
       status: BasicBuilder.sample([
         "new",
@@ -43,7 +52,7 @@ export default class LayoutBuilder {
         "tracked",
         "locally-deleted",
         "remotely-deleted",
-      ]),
+      ]) as LayoutSyncStatus,
       lastRemoteSavedAt: new Date(BasicBuilder.number()).toISOString() as ISO8601Timestamp,
     });
   }
@@ -53,13 +62,14 @@ export default class LayoutBuilder {
       id: BasicBuilder.string() as LayoutID,
       name: BasicBuilder.string(),
       from: BasicBuilder.string(),
-      permission: BasicBuilder.sample(["CREATOR_WRITE", "ORG_READ", "ORG_WRITE"]),
-      baseline: LayoutBuilder.layoutBaseline(),
-      working: LayoutBuilder.layoutBaseline(),
-      syncInfo: LayoutBuilder.layoutSyncInfo(),
-      //Deprecated fields
-      data: LayoutBuilder.layoutData(),
-      state: LayoutBuilder.layoutData(),
+      permission: BasicBuilder.sample([
+        "CREATOR_WRITE",
+        "ORG_READ",
+        "ORG_WRITE",
+      ]) as LayoutPermission,
+      baseline: LayoutBuilder.baseline(),
+      working: LayoutBuilder.baseline(),
+      syncInfo: LayoutBuilder.syncInfo(),
     });
   }
 }

--- a/packages/suite-base/src/testing/builders/LayoutBuilder.ts
+++ b/packages/suite-base/src/testing/builders/LayoutBuilder.ts
@@ -3,53 +3,63 @@
 
 import { LayoutData, LayoutID } from "@lichtblick/suite-base/context/CurrentLayoutContext";
 import {
+  ISO8601Timestamp,
   Layout,
-  LayoutPermission,
-  LayoutSyncStatus,
+  LayoutBaseline,
+  LayoutSyncInfo,
 } from "@lichtblick/suite-base/services/ILayoutStorage";
 import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
 import { defaults } from "@lichtblick/suite-base/testing/builders/utilities";
 import { PlaybackConfig } from "@lichtblick/suite-base/types/panels";
 
-const defaultPlaybackConfigValue: PlaybackConfig = {
-  speed: 1.0,
-};
-
-const DEFAULT_LAYOUT_FOR_TESTS: LayoutData = {
-  configById: {},
-  globalVariables: {},
-  userNodes: {},
-  playbackConfig: defaultPlaybackConfigValue,
-};
-
-function randomLayoutPermission(): LayoutPermission {
-  const layoutPermissions: LayoutPermission[] = ["CREATOR_WRITE", "ORG_READ", "ORG_WRITE"];
-  const randomSelector = BasicBuilder.number({ min: 0, max: layoutPermissions.length - 1 });
-  return layoutPermissions[randomSelector]!;
-}
-
-function randomLayoutSyncStatus(): LayoutSyncStatus {
-  const layoutSyncStatuses: LayoutSyncStatus[] = [
-    "new",
-    "updated",
-    "tracked",
-    "locally-deleted",
-    "remotely-deleted",
-  ];
-  const randomSelector = BasicBuilder.number({ min: 0, max: layoutSyncStatuses.length - 1 });
-  return layoutSyncStatuses[randomSelector]!;
-}
-
 export default class LayoutBuilder {
+  public static layoutPlaybackConfig(props: Partial<PlaybackConfig> = {}): PlaybackConfig {
+    return defaults<PlaybackConfig>(props, {
+      speed: BasicBuilder.float(),
+    });
+  }
+
+  public static layoutData(props: Partial<LayoutData> = {}): LayoutData {
+    return defaults<LayoutData>(props, {
+      configById: {},
+      globalVariables: {},
+      userNodes: {},
+      playbackConfig: LayoutBuilder.layoutPlaybackConfig(),
+    });
+  }
+
+  public static layoutBaseline(props: Partial<LayoutBaseline> = {}): LayoutBaseline {
+    return defaults<LayoutBaseline>(props, {
+      data: LayoutBuilder.layoutData(),
+      savedAt: new Date(BasicBuilder.number()).toISOString() as ISO8601Timestamp,
+    });
+  }
+
+  public static layoutSyncInfo(props: Partial<LayoutSyncInfo> = {}): LayoutSyncInfo {
+    return defaults<LayoutSyncInfo>(props, {
+      status: BasicBuilder.sample([
+        "new",
+        "updated",
+        "tracked",
+        "locally-deleted",
+        "remotely-deleted",
+      ]),
+      lastRemoteSavedAt: new Date(BasicBuilder.number()).toISOString() as ISO8601Timestamp
+    });
+  }
+
   public static layout(props: Partial<Layout> = {}): Layout {
     return defaults<Layout>(props, {
       id: BasicBuilder.string() as LayoutID,
       name: BasicBuilder.string(),
       from: BasicBuilder.string(),
-      permission: randomLayoutPermission(),
-      baseline: { data: DEFAULT_LAYOUT_FOR_TESTS, savedAt: undefined },
-      working: { data: DEFAULT_LAYOUT_FOR_TESTS, savedAt: undefined },
-      syncInfo: { status: randomLayoutSyncStatus(), lastRemoteSavedAt: undefined },
+      permission: BasicBuilder.sample(["CREATOR_WRITE", "ORG_READ", "ORG_WRITE"]),
+      baseline: LayoutBuilder.layoutBaseline(),
+      working: LayoutBuilder.layoutBaseline(),
+      syncInfo: LayoutBuilder.layoutSyncInfo(),
+      //Deprecated fields
+      data: LayoutBuilder.layoutData(),
+      state: LayoutBuilder.layoutData(),
     });
   }
 }


### PR DESCRIPTION
**User-Facing Changes**
Layouts will no longer revert the name change if an user applies changes to it, like changing panels or readjusting panels height.

**Description**
Basically the error was occurring because, despite the layout state being correctly updated when the name was changed, the layout in question was still selected and that selection would keep the older state,, so when an user tried to make any change to the layout, that change would be done with the `layoutState` of what was selected, and therefore not the updated version. 
My fix to this issue was simply refresh the selected layout by grabbing its id after the name was updated and therefore updating its `layoutState`.

**Checklist**

- [X] The web version was tested and it is running ok
- [X] The desktop version was tested and it is running ok
- [X] This change is covered by unit tests
- [X] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
