### PR TITLE
Fix sample data

### DIFF
--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.test.ts
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+import * as Comlink from "@lichtblick/comlink";
+import { WorkerIterableSourceWorker } from "@lichtblick/suite-base/players/IterablePlayer/WorkerIterableSourceWorker";
+import { MultiIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/shared/MultiIterableSource";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+
+import { McapIterableSource } from "./McapIterableSource";
+import { initialize } from "./McapIterableSourceWorker.worker";
+
+jest.mock("@lichtblick/comlink", () => ({
+  expose: jest.fn((val) => val),
+  proxy: jest.fn((val) => val),
+  transferHandlers: {
+    set: jest.fn(),
+  },
+}));
+
+jest.mock("./McapIterableSource");
+jest.mock("@lichtblick/suite-base/players/IterablePlayer/WorkerIterableSourceWorker");
+jest.mock("@lichtblick/suite-base/players/IterablePlayer/shared/MultiIterableSource");
+
+describe("initialize", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should initialize with a single file", () => {
+    const filename = `${BasicBuilder.string()}.mcap`;
+    const file = new File(["data"], filename);
+
+    const result = initialize({ file });
+
+    expect(McapIterableSource).toHaveBeenCalledWith({ type: "file", file });
+    expect(WorkerIterableSourceWorker).toHaveBeenCalled();
+    expect(Comlink.proxy).toHaveBeenCalled();
+    expect(result).toBeInstanceOf(WorkerIterableSourceWorker);
+  });
+
+  it("should initialize with multiple files", () => {
+    const filename1 = `${BasicBuilder.string()}.mcap`;
+    const filename2 = `${BasicBuilder.string()}.mcap`;
+    const files = [new File(["data"], filename1), new File(["data"], filename2)];
+
+    const result = initialize({ files });
+
+    expect(MultiIterableSource).toHaveBeenCalledWith({ type: "files", files }, McapIterableSource);
+    expect(WorkerIterableSourceWorker).toHaveBeenCalled();
+    expect(Comlink.proxy).toHaveBeenCalled();
+    expect(result).toBeInstanceOf(WorkerIterableSourceWorker);
+  });
+
+  it("should initialize with a single URL", () => {
+    const url = `http://${BasicBuilder.string()}.com/${BasicBuilder.string()}.mcap`;
+
+    const result = initialize({ url });
+
+    expect(McapIterableSource).toHaveBeenCalledWith({ type: "url", url });
+    expect(WorkerIterableSourceWorker).toHaveBeenCalled();
+    expect(Comlink.proxy).toHaveBeenCalled();
+    expect(result).toBeInstanceOf(WorkerIterableSourceWorker);
+  });
+
+  it("should initialize with multiple URLs", () => {
+    const urls = [
+      `http://${BasicBuilder.string()}.com/${BasicBuilder.string()}.mcap`,
+      `http://${BasicBuilder.string()}.com/${BasicBuilder.string()}.mcap`,
+    ];
+
+    const result = initialize({ urls });
+
+    expect(MultiIterableSource).toHaveBeenCalledWith({ type: "urls", urls }, McapIterableSource);
+    expect(WorkerIterableSourceWorker).toHaveBeenCalled();
+    expect(Comlink.proxy).toHaveBeenCalled();
+    expect(result).toBeInstanceOf(WorkerIterableSourceWorker);
+  });
+
+  it("should throw an error if no valid input is provided", () => {
+    expect(() => initialize({})).toThrow("file or url required");
+  });
+});

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.ts
@@ -24,12 +24,11 @@ export function initialize(args: IterableSourceInitializeArgs): WorkerIterableSo
     );
     const wrapped = new WorkerIterableSourceWorker(source);
     return Comlink.proxy(wrapped);
-  } else if (args.urls?.length === 1) {
-    const singleUrl = args.urls[0]!;
-    const source = new McapIterableSource({ type: "url", url: singleUrl });
+  } else if (args.url) {
+    const source = new McapIterableSource({ type: "url", url: args.url });
     const wrapped = new WorkerIterableSourceWorker(source);
     return Comlink.proxy(wrapped);
-  } else if (args.urls && args.urls.length > 1) {
+  } else if (args.urls) {
     const source = new MultiIterableSource({ type: "urls", urls: args.urls }, McapIterableSource);
     const wrapped = new WorkerIterableSourceWorker(source);
     return Comlink.proxy(wrapped);


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
After the last updates related to loading multiple files via URLs, the sample data is not working. For that, the fix was made in the MCAP iterable worker, to attend only the proper cases when there is one URL or multiple URLs.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
