### PR TITLE
Remove unified navigation from experimental features

### DIFF
--- a/packages/suite-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/suite-base/src/components/ExperimentalFeatureSettings.tsx
@@ -44,11 +44,6 @@ function useFeatures(): Feature[] {
 
   const features: Feature[] = [
     {
-      key: AppSetting.ENABLE_UNIFIED_NAVIGATION,
-      name: t("newAppMenu"),
-      description: <>{t("newAppMenuDescription")}</>,
-    },
-    {
       key: AppSetting.ENABLE_MEMORY_USE_INDICATOR,
       name: t("memoryUseIndicator"),
       description: <>{t("memoryUseIndicatorDescription")}</>,

--- a/packages/suite-base/src/i18n/en/appSettings.ts
+++ b/packages/suite-base/src/i18n/en/appSettings.ts
@@ -26,8 +26,6 @@ export const appSettings = {
   messageRate: "Message rate",
   memoryUseIndicator: "Memory use indicator",
   memoryUseIndicatorDescription: "Show the app memory use in the sidebar.",
-  newAppMenu: "Enable unified navigation",
-  newAppMenuDescription: "Show the new menu and navigation.",
   noExperimentalFeatures: "Currently there are no experimental features.",
   openLinksIn: "Open links in",
   ros: "ROS",


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
Removed the option in Settings > Experimental features.

**Description**
Remove the obsolete option to enable unified navigation from experimental features in Settings > Experimental features.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
