### PR TITLE
Sonar lint connected mode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,5 +31,9 @@
   "eslint.lintTask.enable": true,
   "[shellscript]": {
     "editor.defaultFormatter": "foxundermoon.shell-format"
+  },
+  "sonarlint.connectedMode.project": {
+    "connectionId": "lichtblick-suite",
+    "projectKey": "Lichtblick-Suite_lichtblick"
   }
 }


### PR DESCRIPTION
**User-Facing Changes**
Updating settings.json to be able to link local VS Code project to SonarQube server + project, making SonarLint act like a smart, server-synced linter.

