### PR TITLE
Fixing overlay error when extensions are installed

### DIFF
--- a/packages/suite-base/src/components/PanelLayout.tsx
+++ b/packages/suite-base/src/components/PanelLayout.tsx
@@ -141,7 +141,6 @@ export function UnconnectedPanelLayout(props: Readonly<Props>): React.ReactEleme
               </EmptyState>
             }
           >
-            {loadingComponent}
             <MosaicPathContext.Provider value={path}>
               <PanelRemounter id={id} tabId={tabId}>
                 {panel}
@@ -155,7 +154,7 @@ export function UnconnectedPanelLayout(props: Readonly<Props>): React.ReactEleme
       }
       return mosaicWindow;
     },
-    [panelComponents, createTile, loadingComponent, tabId],
+    [panelComponents, createTile, tabId],
   );
 
   const bodyToRender = useMemo(
@@ -177,7 +176,12 @@ export function UnconnectedPanelLayout(props: Readonly<Props>): React.ReactEleme
     [layout, mosaicId, onChange, renderTile, tabId],
   );
 
-  return <ErrorBoundary>{bodyToRender}</ErrorBoundary>;
+  return (
+    <ErrorBoundary>
+      {loadingComponent}
+      {bodyToRender}
+    </ErrorBoundary>
+  );
 }
 
 function ExtensionsLoadingState(): React.JSX.Element {


### PR DESCRIPTION
**User-Facing Changes**
Overlay for when the extensions are installed should now behave as expected.

**Description**
Changing the abstraction level where the overlay that is called when extensions are being installed, so it doesn't appear on every single panel and instead be a single one.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
