### PR TITLE
Fix user script panel by wrapping on error boundary

### DIFF
--- a/packages/suite-base/src/components/Panel.test.tsx
+++ b/packages/suite-base/src/components/Panel.test.tsx
@@ -63,7 +63,6 @@ describe("Panel", () => {
     expect(renderFn.mock.calls).toEqual([
       [{ config: { someString: "hello world" }, saveConfig: expect.any(Function) }],
       [{ config: { someString: "hello world" }, saveConfig: expect.any(Function) }],
-      [{ config: { someString: "hello world" }, saveConfig: expect.any(Function) }],
     ]);
 
     expect(actions).toEqual([
@@ -94,7 +93,6 @@ describe("Panel", () => {
 
     expect(renderFn.mock.calls).toEqual([
       [{ config: { someString }, saveConfig: expect.any(Function) }],
-      [{ config: { someString }, saveConfig: expect.any(Function) }],
     ]);
 
     expect(actions).toEqual([
@@ -122,7 +120,6 @@ describe("Panel", () => {
     );
 
     expect(renderFn.mock.calls).toEqual([
-      [{ config: { someNumber: 42, someString: "hello world" }, saveConfig: expect.any(Function) }],
       [{ config: { someNumber: 42, someString: "hello world" }, saveConfig: expect.any(Function) }],
       [{ config: { someNumber: 42, someString: "hello world" }, saveConfig: expect.any(Function) }],
     ]);
@@ -160,7 +157,6 @@ describe("Panel", () => {
 
     expect(renderFn.mock.calls).toEqual([
       [{ config: { someNumber: 42, someString }, saveConfig: expect.any(Function) }],
-      [{ config: { someNumber: 42, someString }, saveConfig: expect.any(Function) }],
     ]);
 
     expect(actions).toEqual([
@@ -189,10 +185,10 @@ describe("Panel", () => {
       },
     });
 
-    expect(renderFn.mock.calls.length).toEqual(3);
+    expect(renderFn.mock.calls.length).toEqual(2);
     act(() => {
       actions.current.savePanelConfigs({ configs: [{ id: "someOtherId", config: {} }] });
     });
-    expect(renderFn.mock.calls.length).toEqual(3);
+    expect(renderFn.mock.calls.length).toEqual(2);
   });
 });

--- a/packages/suite-base/src/components/Panel.tsx
+++ b/packages/suite-base/src/components/Panel.tsx
@@ -21,7 +21,7 @@ import {
   TableSimple20Regular,
 } from "@fluentui/react-icons";
 import * as _ from "lodash-es";
-import React, {
+import {
   ComponentType,
   MouseEventHandler,
   Profiler,
@@ -668,7 +668,7 @@ export default function Panel<
                   />
                 )}
                 <PanelErrorBoundary onRemovePanel={removePanel} onResetPanel={resetPanel}>
-                  <React.StrictMode>{child}</React.StrictMode>
+                  {child}
                 </PanelErrorBoundary>
                 {process.env.NODE_ENV !== "production" && (
                   <div className={classes.perfInfo} ref={perfInfo} />

--- a/packages/suite-base/src/components/PanelLayout.test.tsx
+++ b/packages/suite-base/src/components/PanelLayout.test.tsx
@@ -114,8 +114,8 @@ describe("UnconnectedPanelLayout", () => {
     expect(moduleA).toHaveBeenCalledTimes(1);
     expect(moduleB).toHaveBeenCalledTimes(1);
     expect(moduleC).toHaveBeenCalledTimes(0);
-    expect(renderA).toHaveBeenCalledTimes(4);
-    expect(renderB).toHaveBeenCalledTimes(4);
+    expect(renderA).toHaveBeenCalledTimes(2);
+    expect(renderB).toHaveBeenCalledTimes(2);
     expect(renderC).toHaveBeenCalledTimes(0);
 
     rerender(
@@ -125,15 +125,15 @@ describe("UnconnectedPanelLayout", () => {
       />,
     );
     await waitFor(() => {
-      expect(renderC).toHaveBeenCalledTimes(4);
+      expect(renderC).toHaveBeenCalledTimes(2);
     });
     // Each panel module should have only been loaded once; panels A and B should not render again
     expect(moduleA).toHaveBeenCalledTimes(1);
     expect(moduleB).toHaveBeenCalledTimes(1);
     expect(moduleC).toHaveBeenCalledTimes(1);
-    expect(renderA).toHaveBeenCalledTimes(4);
-    expect(renderB).toHaveBeenCalledTimes(4);
-    expect(renderC).toHaveBeenCalledTimes(4);
+    expect(renderA).toHaveBeenCalledTimes(2);
+    expect(renderB).toHaveBeenCalledTimes(2);
+    expect(renderC).toHaveBeenCalledTimes(2);
 
     unmount();
   });

--- a/packages/suite-base/src/panels/UserScriptEditor/Editor.tsx
+++ b/packages/suite-base/src/panels/UserScriptEditor/Editor.tsx
@@ -21,8 +21,7 @@ import * as monacoApi from "monaco-editor/esm/vs/editor/editor.api";
 // @ts-expect-error StandaloneService does not have type information in the monaco-editor package
 import { StandaloneServices } from "monaco-editor/esm/vs/editor/standalone/browser/standaloneServices";
 import * as path from "path";
-import React, { Suspense } from "react";
-import { ReactElement, useCallback, useEffect, useRef } from "react";
+import React, { Suspense, ReactElement, useCallback, useEffect, useRef } from "react";
 import MonacoEditor, { EditorDidMount, EditorWillMount } from "react-monaco-editor";
 import { ResizePayload, useResizeDetector } from "react-resize-detector";
 import { useLatest } from "react-use";

--- a/packages/suite-base/src/panels/UserScriptEditor/Editor.tsx
+++ b/packages/suite-base/src/panels/UserScriptEditor/Editor.tsx
@@ -21,12 +21,14 @@ import * as monacoApi from "monaco-editor/esm/vs/editor/editor.api";
 // @ts-expect-error StandaloneService does not have type information in the monaco-editor package
 import { StandaloneServices } from "monaco-editor/esm/vs/editor/standalone/browser/standaloneServices";
 import * as path from "path";
+import React, { Suspense } from "react";
 import { ReactElement, useCallback, useEffect, useRef } from "react";
 import MonacoEditor, { EditorDidMount, EditorWillMount } from "react-monaco-editor";
 import { ResizePayload, useResizeDetector } from "react-resize-detector";
 import { useLatest } from "react-use";
 import { ModuleResolutionKind } from "typescript";
 
+import ErrorBoundary from "@lichtblick/suite-base/components/ErrorBoundary";
 import getPrettifiedCode from "@lichtblick/suite-base/panels/UserScriptEditor/getPrettifiedCode";
 import { Script } from "@lichtblick/suite-base/panels/UserScriptEditor/script";
 import { getUserScriptProjectConfig } from "@lichtblick/suite-base/players/UserScriptPlayer/transformerWorker/typescript/projectConfig";
@@ -353,16 +355,23 @@ const Editor = ({
     return ReactNull;
   }
 
+  // The ErrorBoundary is required to properly capture runtime errors from Monaco Editor.
+  // Without it, TypeScript or Monaco-related errors (e.g., type mismatches or input availability issues)
+  // may not appear in the "Problems" tab. Do not remove this wrapper.
   return (
     <div ref={sizeRef} style={{ width: "100%", height: "100%" }}>
-      <MonacoEditor
-        language="typescript"
-        theme={editorTheme}
-        editorWillMount={willMount}
-        editorDidMount={didMount}
-        options={options}
-        onChange={onChange}
-      />
+      <ErrorBoundary>
+        <Suspense fallback={<p>Loading user script editor</p>}>
+          <MonacoEditor
+            language="typescript"
+            theme={editorTheme}
+            editorWillMount={willMount}
+            editorDidMount={didMount}
+            options={options}
+            onChange={onChange}
+          />
+        </Suspense>
+      </ErrorBoundary>
     </div>
   );
 };


### PR DESCRIPTION
**User-Facing Changes**
Improved stability of the `User Script panel` during development. Errors related to user scripts are now properly shown in the Problems tab.

**Description**
`React.StrictMode` was removed from editor panels to avoid rendering issues with Monaco Editor. To ensure proper error reporting and a stable developer experience, the `User Script panel` is now wrapped in an `ErrorBoundary`. This allows runtime and type errors in scripts to be correctly displayed in the Problems tab.

This PR resolves #460 

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok