### PR TITLE
Fix loading of mesh resources over ROS_PACKAGE_PATH in desktop version and also loading of *.glb meshes over the foxglove web socket/bridge

### DIFF
--- a/packages/suite-desktop/src/main/rosPackageResources.ts
+++ b/packages/suite-desktop/src/main/rosPackageResources.ts
@@ -9,6 +9,7 @@ import { protocol, net } from "electron";
 import { promises as fs } from "fs";
 import path from "path";
 import { PNG } from "pngjs";
+import { pathToFileURL } from "url";
 import UTIF from "utif";
 
 import Logger from "@lichtblick/log";
@@ -157,7 +158,9 @@ export function registerRosPackageProtocolHandlers(): void {
 
       const resolvedResourcePath = path.join(pkgRoot, ...relPath.split("/"));
       log.info(`Resolved: ${resolvedResourcePath}`);
-      return await net.fetch(resolvedResourcePath);
+      // prepend the file:// protocol to the path
+      const fileUrl = pathToFileURL(resolvedResourcePath).toString();
+      return await net.fetch(fileUrl);
     } catch (err: unknown) {
       log.error("Error loading from ROS package url", request.url, err);
       return Response.error();


### PR DESCRIPTION
**User-Facing Changes**
Fix loading of mesh resources over ROS_PACKAGE_PATH in desktop version and also loading of *.glb meshes over the foxglove web socket/bridge

**Description**

- 1. Fix ROS_PACKAGE_PATH in desktop version:
In newer electron versions it seems to be necessary to prepend the 'file://' protocol handle to local files. Before it was tried to load the resources by the raw file path, which fails in my scenario (Ubuntu 24.04. LTS ARM64)

- 2. Fix fetching of *.glb meshes over web socket (via 'fetchAsset' feature):
Foxglove Bridge (or more specifically the web socket protocol) supports to fetch those meshes from the server side (where the ROS2 workspace is located). For some reason (I don't know) *.glb files were loaded differently by the URL specified in the URDF file. This fails for URLs like (package://path/to/some/mesh.glb). Now the mesh is loaded like all the others (STL, COLLADA, OBJ, ...). It is not fetched a second time based on the URL, but based on the ArrayBuffer already obtained from the Foxglove Web Socket (in case of a package:// URL) or from the web (for regular https:// URLs).

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
