### PR TITLE
Update useHandleFiles and apply useRef for usage

### DIFF
--- a/packages/suite-base/src/Workspace.tsx
+++ b/packages/suite-base/src/Workspace.tsx
@@ -179,12 +179,14 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
   );
 
   const { dialogActions, sidebarActions } = useWorkspaceActions();
-  const { handleFiles } = useHandleFiles({
+  const handleFiles = useHandleFiles({
     availableSources,
     selectSource,
     isPlaying,
     playerEvents: { play, pause },
   });
+
+  const handleFilesRef = useRef(handleFiles);
 
   // file types we support for drag/drop
   const allowedDropExtensions = useMemo(() => {
@@ -245,11 +247,16 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
 
   // files the main thread told us to open
   const filesToOpen = useElectronFilesToOpen();
+
   useEffect(() => {
-    if (filesToOpen) {
-      void handleFiles(Array.from(filesToOpen));
+    handleFilesRef.current = handleFiles;
+  }, [handleFiles]);
+
+  useEffect(() => {
+    if (filesToOpen && filesToOpen.length > 0) {
+      void handleFilesRef.current(Array.from(filesToOpen));
     }
-  }, [filesToOpen, handleFiles]);
+  }, [filesToOpen]);
 
   const dropHandler = useCallback(
     async ({ files, handles }: { files?: File[]; handles?: FileSystemFileHandle[] }) => {

--- a/packages/suite-base/src/Workspace.tsx
+++ b/packages/suite-base/src/Workspace.tsx
@@ -179,14 +179,18 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
   );
 
   const { dialogActions, sidebarActions } = useWorkspaceActions();
-  const handleFiles = useHandleFiles({
+  const { handleFiles } = useHandleFiles({
     availableSources,
     selectSource,
     isPlaying,
     playerEvents: { play, pause },
   });
 
-  const handleFilesRef = useRef(handleFiles);
+  // Store stable reference to avoid re-running effects unnecessarily
+  const handleFilesRef = useRef<typeof handleFiles>(handleFiles);
+  useLayoutEffect(() => {
+    handleFilesRef.current = handleFiles;
+  }, [handleFiles]);
 
   // file types we support for drag/drop
   const allowedDropExtensions = useMemo(() => {

--- a/packages/suite-base/src/hooks/useHandleFiles.test.tsx
+++ b/packages/suite-base/src/hooks/useHandleFiles.test.tsx
@@ -33,7 +33,7 @@ type Setup = {
   filesOverride?: File[];
 };
 
-describe("useHandleFilesProps", () => {
+describe("useHandleFiles", () => {
   const installFoxeExtensionsMock = jest.fn();
   const availableSources: IDataSourceFactory[] = [
     {
@@ -74,8 +74,9 @@ describe("useHandleFilesProps", () => {
         );
     });
 
+    const { result } = renderHook(() => useHandleFiles(useHandleFilesProps));
     return {
-      ...renderHook(() => useHandleFiles(useHandleFilesProps)),
+      handleFiles: result.current,
       files,
     };
   }
@@ -91,10 +92,12 @@ describe("useHandleFilesProps", () => {
   });
 
   it("should call pause and install .foxe extension", async () => {
-    const { result, files } = setup({ filesOverride: [fileBuilder(".foxe", FILE_ACCEPT_TYPE)] });
+    const { handleFiles, files } = setup({
+      filesOverride: [fileBuilder("foxe", FILE_ACCEPT_TYPE)],
+    });
 
     await act(async () => {
-      await result.current.handleFiles(files);
+      await handleFiles(files);
     });
 
     expect(playerEvents.pause).toHaveBeenCalled();
@@ -102,10 +105,10 @@ describe("useHandleFilesProps", () => {
   });
 
   it("does nothing when passed an empty file array", async () => {
-    const { result, files } = setup({ filesOverride: [] });
+    const { handleFiles, files } = setup({ filesOverride: [] });
 
     await act(async () => {
-      await result.current.handleFiles(files);
+      await handleFiles(files);
     });
 
     expect(playerEvents.pause).not.toHaveBeenCalled();
@@ -119,9 +122,8 @@ describe("useHandleFilesProps", () => {
       writable: false,
     });
 
-    const { result, files } = setup({
-      filesOverride: [brokenFile],
-    });
+    const { handleFiles, files } = setup({ filesOverride: [brokenFile] });
+
     files.forEach((file) => {
       (file as any).arrayBuffer = () => {
         throw new Error("Read failed");
@@ -131,7 +133,7 @@ describe("useHandleFilesProps", () => {
     const logSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
     await act(async () => {
-      await result.current.handleFiles(files);
+      await handleFiles(files);
     });
 
     expect(logSpy).toHaveBeenCalledWith(
@@ -142,21 +144,21 @@ describe("useHandleFilesProps", () => {
     logSpy.mockRestore();
   });
 
-  it("handles and selects source for non foxe files", async () => {
-    const { result, files } = setup();
+  it("handles and selects source for non-foxe files", async () => {
+    const { handleFiles, files } = setup();
 
     await act(async () => {
-      await result.current.handleFiles(files);
+      await handleFiles(files);
     });
 
     expect(selectSource).toHaveBeenCalled();
   });
 
   it("does not select source if no file type matches availableSources", async () => {
-    const { result, files } = setup({ filesOverride: [fileBuilder("csv", FILE_ACCEPT_TYPE)] });
+    const { handleFiles, files } = setup({ filesOverride: [fileBuilder("csv", FILE_ACCEPT_TYPE)] });
 
     await act(async () => {
-      await result.current.handleFiles(files);
+      await handleFiles(files);
     });
 
     expect(selectSource).not.toHaveBeenCalled();

--- a/packages/suite-base/src/hooks/useHandleFiles.test.tsx
+++ b/packages/suite-base/src/hooks/useHandleFiles.test.tsx
@@ -76,7 +76,7 @@ describe("useHandleFiles", () => {
 
     const { result } = renderHook(() => useHandleFiles(useHandleFilesProps));
     return {
-      handleFiles: result.current,
+      handleFiles: result.current.handleFiles,
       files,
     };
   }

--- a/packages/suite-base/src/hooks/useHandleFiles.tsx
+++ b/packages/suite-base/src/hooks/useHandleFiles.tsx
@@ -11,7 +11,9 @@ import {
 } from "@lichtblick/suite-base/context/PlayerSelectionContext";
 import { useInstallingExtensionsState } from "@lichtblick/suite-base/hooks/useInstallingExtensionsState";
 
-type UseHandleFiles = (files: File[]) => Promise<void>;
+type UseHandleFiles = {
+  handleFiles: (files: File[]) => Promise<void>;
+};
 
 type UseHandleFilesProps = {
   availableSources: readonly IDataSourceFactory[];
@@ -76,5 +78,5 @@ export function useHandleFiles({
     [availableSources, installFoxeExtensions, pause, selectSource],
   );
 
-  return handleFiles;
+  return { handleFiles };
 }

--- a/packages/suite-base/src/hooks/useHandleFiles.tsx
+++ b/packages/suite-base/src/hooks/useHandleFiles.tsx
@@ -11,9 +11,7 @@ import {
 } from "@lichtblick/suite-base/context/PlayerSelectionContext";
 import { useInstallingExtensionsState } from "@lichtblick/suite-base/hooks/useInstallingExtensionsState";
 
-type UseHandleFiles = {
-  handleFiles: (files: File[]) => Promise<void>;
-};
+type UseHandleFiles = (files: File[]) => Promise<void>;
 
 type UseHandleFilesProps = {
   availableSources: readonly IDataSourceFactory[];
@@ -78,5 +76,5 @@ export function useHandleFiles({
     [availableSources, installFoxeExtensions, pause, selectSource],
   );
 
-  return { handleFiles };
+  return handleFiles;
 }


### PR DESCRIPTION
**User-Facing Changes**
Opening .mcap files via double-click or command line no longer works after updating Lichtblick from 1.11.0 to 1.12.0.

**Description**
The issue was resolved by storing the handleFiles function in a useRef to maintain a stable reference across renders.
This change prevented the useEffect from re-triggering unnecessarily due to function identity changes.

This PR resolves https://github.com/lichtblick-suite/lichtblick/issues/493
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [ ] The web version was tested and it is running ok (N/A)
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated (N/A)
