### PR TITLE
Adding descriptive messages when no readme or changelog are found

### DIFF
--- a/packages/suite-base/src/components/ExtensionDetails.test.tsx
+++ b/packages/suite-base/src/components/ExtensionDetails.test.tsx
@@ -159,8 +159,7 @@ describe("ExtensionDetails Component", () => {
     it("displays message indicating readme is not found when readme is undefined", async () => {
       (isDesktopApp as jest.Mock).mockReturnValue(true);
 
-      const readmeContent = undefined;
-      mockExtension.readme = readmeContent;
+      mockExtension.readme = undefined;
 
       render(<ExtensionDetails extension={mockExtension} onClose={() => {}} installed={true} />);
       const readmeButton = screen.getByRole("tab", {
@@ -193,8 +192,7 @@ describe("ExtensionDetails Component", () => {
     it("displays message indicating changelog is not found when changelog is undefined", async () => {
       (isDesktopApp as jest.Mock).mockReturnValue(true);
 
-      const changelogContent = undefined;
-      mockExtension.changelog = changelogContent;
+      mockExtension.changelog = undefined;
 
       render(<ExtensionDetails extension={mockExtension} onClose={() => {}} installed={true} />);
       const changelogButton = screen.getByRole("tab", {

--- a/packages/suite-base/src/components/ExtensionDetails.test.tsx
+++ b/packages/suite-base/src/components/ExtensionDetails.test.tsx
@@ -145,7 +145,7 @@ describe("ExtensionDetails Component", () => {
       const readmeContent = BasicBuilder.string();
       mockExtension.readme = readmeContent;
 
-      render(<ExtensionDetails extension={mockExtension} onClose={() => {}} installed={false} />);
+      render(<ExtensionDetails extension={mockExtension} onClose={() => {}} installed={true} />);
       const readmeButton = screen.getByRole("tab", {
         name: /readme/i,
       });
@@ -162,7 +162,7 @@ describe("ExtensionDetails Component", () => {
       const readmeContent = undefined;
       mockExtension.readme = readmeContent;
 
-      render(<ExtensionDetails extension={mockExtension} onClose={() => {}} installed={false} />);
+      render(<ExtensionDetails extension={mockExtension} onClose={() => {}} installed={true} />);
       const readmeButton = screen.getByRole("tab", {
         name: /readme/i,
       });
@@ -179,7 +179,7 @@ describe("ExtensionDetails Component", () => {
       const changelogContent = BasicBuilder.string();
       mockExtension.changelog = changelogContent;
 
-      render(<ExtensionDetails extension={mockExtension} onClose={() => {}} installed={false} />);
+      render(<ExtensionDetails extension={mockExtension} onClose={() => {}} installed={true} />);
       const changelogButton = screen.getByRole("tab", {
         name: /changelog/i,
       });
@@ -196,7 +196,7 @@ describe("ExtensionDetails Component", () => {
       const changelogContent = undefined;
       mockExtension.changelog = changelogContent;
 
-      render(<ExtensionDetails extension={mockExtension} onClose={() => {}} installed={false} />);
+      render(<ExtensionDetails extension={mockExtension} onClose={() => {}} installed={true} />);
       const changelogButton = screen.getByRole("tab", {
         name: /changelog/i,
       });

--- a/packages/suite-base/src/components/ExtensionDetails.test.tsx
+++ b/packages/suite-base/src/components/ExtensionDetails.test.tsx
@@ -156,6 +156,23 @@ describe("ExtensionDetails Component", () => {
       });
     });
 
+    it("displays message indicating readme is not found when readme is undefined", async () => {
+      (isDesktopApp as jest.Mock).mockReturnValue(true);
+
+      const readmeContent = undefined;
+      mockExtension.readme = readmeContent;
+
+      render(<ExtensionDetails extension={mockExtension} onClose={() => {}} installed={false} />);
+      const readmeButton = screen.getByRole("tab", {
+        name: /readme/i,
+      });
+
+      fireEvent.click(readmeButton);
+      await waitFor(() => {
+        expect(screen.getByText(/No readme found/i)).toBeInTheDocument();
+      });
+    });
+
     it("displays changelog correctly", async () => {
       (isDesktopApp as jest.Mock).mockReturnValue(true);
 
@@ -170,6 +187,23 @@ describe("ExtensionDetails Component", () => {
       fireEvent.click(changelogButton);
       await waitFor(() => {
         expect(screen.getByText(changelogContent)).toBeInTheDocument();
+      });
+    });
+
+    it("displays message indicating changelog is not found when changelog is undefined", async () => {
+      (isDesktopApp as jest.Mock).mockReturnValue(true);
+
+      const changelogContent = undefined;
+      mockExtension.changelog = changelogContent;
+
+      render(<ExtensionDetails extension={mockExtension} onClose={() => {}} installed={false} />);
+      const changelogButton = screen.getByRole("tab", {
+        name: /changelog/i,
+      });
+
+      fireEvent.click(changelogButton);
+      await waitFor(() => {
+        expect(screen.getByText(/No changelog found/i)).toBeInTheDocument();
       });
     });
 

--- a/packages/suite-base/src/components/ExtensionDetails.tsx
+++ b/packages/suite-base/src/components/ExtensionDetails.tsx
@@ -82,14 +82,14 @@ export function ExtensionDetails({
     async () =>
       readme != undefined && isValidUrl(readme)
         ? await marketplace.getMarkdown(readme)
-        : DOMPurify.sanitize(readme ?? ""),
+        : DOMPurify.sanitize(readme ?? "No readme found."),
     [marketplace, readme],
   );
   const { value: changelogContent } = useAsync(
     async () =>
       changelog != undefined && isValidUrl(changelog)
         ? await marketplace.getMarkdown(changelog)
-        : DOMPurify.sanitize(changelog ?? ""),
+        : DOMPurify.sanitize(changelog ?? "No changelog found."),
     [marketplace, changelog],
   );
 


### PR DESCRIPTION
**User-Facing Changes**
Added a descriptive message when Lichtblick doesn't found a `readme` for `changelog` file, instead of just an empty string that wouldn't give any feedback to the user.
![image](https://github.com/user-attachments/assets/63967db3-6af2-4545-b303-f274e3c68459)

**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [X] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
