### PR TITLE
Fix the LB desktop version after breaking change of the Electron

### DIFF
--- a/packages/suite-desktop/src/main/index.ts
+++ b/packages/suite-desktop/src/main/index.ts
@@ -74,6 +74,7 @@ export async function main(): Promise<void> {
 
   // https://github.com/electron/electron/issues/28422#issuecomment-987504138
   app.commandLine.appendSwitch("enable-experimental-web-platform-features");
+  app.commandLine.appendSwitch("gtk-version", "3");
 
   const start = Date.now();
   log.info(`${LICHTBLICK_PRODUCT_NAME} ${LICHTBLICK_PRODUCT_VERSION}`);


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
Fixed issue using the workaround, forcing GTK version to 3 when initialising the application.

[Electron issue](https://github.com/electron/electron/issues/46538)
How to fix: https://github.com/electron/electron/issues/46538#issuecomment-2808806722


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The desktop version was tested and it is running ok
