### PR TITLE
Add title field to customize panels

### DIFF
--- a/packages/suite-base/src/components/PanelRoot.tsx
+++ b/packages/suite-base/src/components/PanelRoot.tsx
@@ -12,7 +12,7 @@ import { makeStyles } from "tss-react/mui";
 
 import { APP_BAR_HEIGHT } from "@lichtblick/suite-base/components/AppBar/constants";
 
-export const PANEL_ROOT_CLASS_NAME = "FoxglovePanelRoot-root";
+export const PANEL_ROOT_CLASS_NAME = "LichtblickPanelRoot-root";
 
 type PanelRootProps = {
   fullscreenState: TransitionStatus;

--- a/packages/suite-base/src/components/PanelSettings/index.tsx
+++ b/packages/suite-base/src/components/PanelSettings/index.tsx
@@ -227,7 +227,7 @@ export default function PanelSettings({
             <SettingsTreeEditor
               key={selectedPanelId}
               settings={settingsTree ?? EMPTY_SETTINGS_TREE}
-              variant="log"
+              variant="panel"
             />
           ) : (
             <Stack

--- a/packages/suite-base/src/dataSources/SampleNuscenesLayout.json
+++ b/packages/suite-base/src/dataSources/SampleNuscenesLayout.json
@@ -342,7 +342,7 @@
       "legendDisplay": "floating",
       "showPlotValuesInLegend": false,
       "sidebarDimension": 240,
-      "foxglovePanelTitle": "Plot"
+      "lichtblickPanelTitle": "Plot"
     },
     "Plot!4792hqu": {
       "paths": [
@@ -377,7 +377,7 @@
       "legendDisplay": "floating",
       "showPlotValuesInLegend": false,
       "sidebarDimension": 240,
-      "foxglovePanelTitle": "Plot"
+      "lichtblickPanelTitle": "Plot"
     },
     "StateTransitions!3i4dk1l": {
       "paths": [

--- a/packages/suite-base/src/testing/builders/PlotBuilder.ts
+++ b/packages/suite-base/src/testing/builders/PlotBuilder.ts
@@ -53,7 +53,7 @@ export default class PlotBuilder {
   public static config(props: Partial<PlotConfig> = {}): PlotConfig {
     return defaults<PlotConfig>(props, {
       followingViewWidth: BasicBuilder.number(),
-      foxglovePanelTitle: BasicBuilder.string(),
+      lichtblickPanelTitle: BasicBuilder.string(),
       isSynced: BasicBuilder.boolean(),
       legendDisplay: "floating",
       maxXValue: BasicBuilder.number(),

--- a/packages/suite-base/src/util/layout.ts
+++ b/packages/suite-base/src/util/layout.ts
@@ -44,7 +44,7 @@ import { TAB_PANEL_TYPE } from "@lichtblick/suite-base/util/globalConstants";
 const log = Logger.getLogger(__filename);
 
 /** Key injected into panel configs for user-selected title (overrides setDefaultPanelTitle) */
-export const PANEL_TITLE_CONFIG_KEY = "foxglovePanelTitle";
+export const PANEL_TITLE_CONFIG_KEY = "lichtblickPanelTitle";
 
 // given a panel type, create a unique id for a panel
 // with the type embedded within the id


### PR DESCRIPTION
# User-Facing Changes
Users will be able to modify the name of panels for more customization.

<img width="874" alt="image" src="https://github.com/user-attachments/assets/4556db77-64c1-44e4-8eb8-d37a83013430" />

# Description
There was a flag misplace on PR #8, where instead of "log" it should be "panel"

https://github.com/lichtblick-suite/lichtblick/blob/5de27ab7620143223295ab4eb020bea516fa806f/packages/studio-base/src/components/PanelSettings/index.tsx#L213-L217

# Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
