### PR TITLE
Fixing bug related to right click menu on layouts

### DIFF
--- a/packages/suite-base/src/components/LayoutBrowser/LayoutRow.style.ts
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutRow.style.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+/* eslint-disable @lichtblick/no-restricted-imports */
+
+import { ListItem, MenuItem, styled as muiStyled } from "@mui/material";
+
+export const StyledListItem = muiStyled(ListItem, {
+  shouldForwardProp: (prop) =>
+    prop !== "hasModifications" && prop !== "deletedOnServer" && prop !== "editingName",
+})<{ editingName: boolean; hasModifications: boolean; deletedOnServer: boolean }>(
+  ({ editingName, hasModifications, deletedOnServer, theme }) => ({
+    ".MuiListItemSecondaryAction-root": {
+      right: theme.spacing(0.25),
+    },
+    ".MuiListItemButton-root": {
+      maxWidth: "100%",
+    },
+    "@media (pointer: fine)": {
+      ".MuiListItemButton-root": {
+        paddingRight: theme.spacing(4.5),
+      },
+      ".MuiListItemSecondaryAction-root": {
+        visibility: !hasModifications && !deletedOnServer && "hidden",
+      },
+      "&:hover .MuiListItemSecondaryAction-root": {
+        visibility: "visible",
+      },
+    },
+    ...(editingName && {
+      ".MuiListItemButton-root": {
+        paddingTop: theme.spacing(0.5),
+        paddingBottom: theme.spacing(0.5),
+        paddingLeft: theme.spacing(1),
+      },
+      ".MuiListItemText-root": {
+        margin: 0,
+      },
+    }),
+  }),
+);
+
+export const StyledMenuItem = muiStyled(MenuItem, {
+  shouldForwardProp: (prop) => prop !== "debug",
+})<{ debug?: boolean }>(({ theme, debug = false }) => ({
+  position: "relative",
+
+  ...(debug && {
+    "&:before": {
+      content: "''",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      bottom: 0,
+      width: 4,
+      backgroundColor: theme.palette.warning.main,
+      backgroundImage: `repeating-linear-gradient(${[
+        "-35deg",
+        "transparent",
+        "transparent 6px",
+        `${theme.palette.common.black} 6px`,
+        `${theme.palette.common.black} 12px`,
+      ].join(",")})`,
+    },
+  }),
+}));

--- a/packages/suite-base/src/components/LayoutBrowser/LayoutRow.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutRow.tsx
@@ -338,7 +338,7 @@ export default React.memo(function LayoutRow({
     },
   ];
 
-  if (hasModifications || anySelectedModifiedLayouts) {
+  if (hasModifications) {
     const sectionItems: LayoutActionMenuItem[] = [
       {
         type: "item",

--- a/packages/suite-base/src/components/LayoutBrowser/LayoutRow.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutRow.tsx
@@ -5,14 +5,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/* eslint-disable @lichtblick/no-restricted-imports */
-
 import ErrorIcon from "@mui/icons-material/Error";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import {
   Divider,
   IconButton,
-  ListItem,
   ListItemButton,
   ListItemText,
   Menu,
@@ -20,7 +17,6 @@ import {
   SvgIcon,
   TextField,
   Typography,
-  styled as muiStyled,
 } from "@mui/material";
 import {
   MouseEvent,
@@ -37,88 +33,8 @@ import { useLayoutManager } from "@lichtblick/suite-base/context/LayoutManagerCo
 import { useConfirm } from "@lichtblick/suite-base/hooks/useConfirm";
 import { Layout, layoutIsShared } from "@lichtblick/suite-base/services/ILayoutStorage";
 
-const StyledListItem = muiStyled(ListItem, {
-  shouldForwardProp: (prop) =>
-    prop !== "hasModifications" && prop !== "deletedOnServer" && prop !== "editingName",
-})<{ editingName: boolean; hasModifications: boolean; deletedOnServer: boolean }>(
-  ({ editingName, hasModifications, deletedOnServer, theme }) => ({
-    ".MuiListItemSecondaryAction-root": {
-      right: theme.spacing(0.25),
-    },
-    ".MuiListItemButton-root": {
-      maxWidth: "100%",
-    },
-    "@media (pointer: fine)": {
-      ".MuiListItemButton-root": {
-        paddingRight: theme.spacing(4.5),
-      },
-      ".MuiListItemSecondaryAction-root": {
-        visibility: !hasModifications && !deletedOnServer && "hidden",
-      },
-      "&:hover .MuiListItemSecondaryAction-root": {
-        visibility: "visible",
-      },
-    },
-    ...(editingName && {
-      ".MuiListItemButton-root": {
-        paddingTop: theme.spacing(0.5),
-        paddingBottom: theme.spacing(0.5),
-        paddingLeft: theme.spacing(1),
-      },
-      ".MuiListItemText-root": {
-        margin: 0,
-      },
-    }),
-  }),
-);
-
-const StyledMenuItem = muiStyled(MenuItem, {
-  shouldForwardProp: (prop) => prop !== "debug",
-})<{ debug?: boolean }>(({ theme, debug = false }) => ({
-  position: "relative",
-
-  ...(debug && {
-    "&:before": {
-      content: "''",
-      position: "absolute",
-      left: 0,
-      top: 0,
-      bottom: 0,
-      width: 4,
-      backgroundColor: theme.palette.warning.main,
-      backgroundImage: `repeating-linear-gradient(${[
-        "-35deg",
-        "transparent",
-        "transparent 6px",
-        `${theme.palette.common.black} 6px`,
-        `${theme.palette.common.black} 12px`,
-      ].join(",")})`,
-    },
-  }),
-}));
-
-export type LayoutActionMenuItem =
-  | {
-      type: "item";
-      text: string;
-      secondaryText?: string;
-      key: string;
-      onClick?: (event: React.MouseEvent<HTMLLIElement>) => void;
-      disabled?: boolean;
-      debug?: boolean;
-      "data-testid"?: string;
-    }
-  | {
-      type: "divider";
-      key: string;
-      debug?: boolean;
-    }
-  | {
-      type: "header";
-      key: string;
-      text: string;
-      debug?: boolean;
-    };
+import { StyledListItem, StyledMenuItem } from "./LayoutRow.style";
+import { LayoutActionMenuItem } from "./types";
 
 export default React.memo(function LayoutRow({
   layout,

--- a/packages/suite-base/src/components/LayoutBrowser/types.ts
+++ b/packages/suite-base/src/components/LayoutBrowser/types.ts
@@ -28,3 +28,26 @@ export type LayoutSelectionAction =
   | { type: "set-error"; value: undefined | Error }
   | { type: "set-online"; value: boolean }
   | { type: "shift-multi-action" };
+
+export type LayoutActionMenuItem =
+  | {
+      type: "item";
+      text: string;
+      secondaryText?: string;
+      key: string;
+      onClick?: (event: React.MouseEvent<HTMLLIElement>) => void;
+      disabled?: boolean;
+      debug?: boolean;
+      "data-testid"?: string;
+    }
+  | {
+      type: "divider";
+      key: string;
+      debug?: boolean;
+    }
+  | {
+      type: "header";
+      key: string;
+      text: string;
+      debug?: boolean;
+    };


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug on the Layouts tab where right-clicking any layout, while another layout with unsaved changes was selected, incorrectly showed `Save changes` and `Revert` options, which should only appear for layouts with unsaved changes.

![image](https://github.com/user-attachments/assets/94d086e8-18bd-497f-a84e-8182b64963e8)


**Description**
This bug occurred because the condition for adding the extra menu options relied on the `anySelectedModifiedLayouts` variable. As a result, whenever a modified layout was selected, the menu would include `Save changes` and `Revert`, even when right-clicking a different layout. This has been fixed by basing the menu options on the state of the layout that was right-clicked, rather than the selected one.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [X] The web version was tested and it is running ok
- [X] The desktop version was tested and it is running ok
- [X] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
