### PR TITLE
Add dont show this again on initial dialog

### DIFF
--- a/packages/suite-base/src/components/DataSourceDialog/DontShowThisAgainCheckbox.test.tsx
+++ b/packages/suite-base/src/components/DataSourceDialog/DontShowThisAgainCheckbox.test.tsx
@@ -1,0 +1,57 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import "@testing-library/jest-dom";
+
+import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks";
+
+import DontShowThisAgainCheckbox from "./DontShowThisAgainCheckbox";
+
+jest.mock("@lichtblick/suite-base/hooks", () => ({
+  useAppConfigurationValue: jest.fn(),
+}));
+
+describe("DontShowThisAgainCheckbox", () => {
+  it("renders the checkbox with the correct label", () => {
+    // GIVEN
+    (useAppConfigurationValue as jest.Mock).mockReturnValue([true, jest.fn()]);
+
+    // WHEN
+    render(<DontShowThisAgainCheckbox />);
+
+    // THEN
+    const label = screen.getByText("Don't show this again");
+    const checkbox = screen.getByRole("checkbox");
+
+    expect(label).toBeInTheDocument();
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it.each([
+    [true, false],
+    [false, true],
+    [undefined, false],
+  ])(
+    "renders the checkbox with configValue=$configValue, expects checked=$expectedChecked and newValue=$expectedNewValue",
+    (configValue, expectedChecked) => {
+      // GIVEN
+      const setCheckedMock = jest.fn();
+      (useAppConfigurationValue as jest.Mock).mockReturnValue([configValue, setCheckedMock]);
+
+      // WHEN
+      render(<DontShowThisAgainCheckbox />);
+
+      // THEN
+      const checkbox = screen.getByRole("checkbox");
+      expect((checkbox as HTMLInputElement).checked).toBe(expectedChecked);
+
+      fireEvent.click(checkbox);
+      expect(setCheckedMock).toHaveBeenCalledWith(expectedChecked);
+    },
+  );
+});

--- a/packages/suite-base/src/components/DataSourceDialog/DontShowThisAgainCheckbox.test.tsx
+++ b/packages/suite-base/src/components/DataSourceDialog/DontShowThisAgainCheckbox.test.tsx
@@ -24,7 +24,7 @@ describe("DontShowThisAgainCheckbox", () => {
     render(<DontShowThisAgainCheckbox />);
 
     // THEN
-    const label = screen.getByText("Don't show this again");
+    const label = screen.getByText("Don't show this again on startup");
     const checkbox = screen.getByRole("checkbox");
 
     expect(label).toBeInTheDocument();

--- a/packages/suite-base/src/components/DataSourceDialog/DontShowThisAgainCheckbox.tsx
+++ b/packages/suite-base/src/components/DataSourceDialog/DontShowThisAgainCheckbox.tsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { Checkbox, FormControlLabel } from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+import { AppSetting } from "@lichtblick/suite-base/AppSetting";
+import Stack from "@lichtblick/suite-base/components/Stack";
+import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks";
+
+const DontShowThisAgainCheckbox = (): React.JSX.Element => {
+  const { t } = useTranslation("openDialog");
+
+  const [checked = true, setChecked] = useAppConfigurationValue<boolean>(
+    AppSetting.SHOW_OPEN_DIALOG_ON_STARTUP,
+  );
+
+  const handleChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    await setChecked(!event.target.checked);
+  };
+
+  const LabelComponent = <span style={{ fontSize: "0.7rem" }}>{t("dontShowThisAgain")}</span>;
+
+  return (
+    <Stack direction="row" justifyContent="right">
+      <FormControlLabel
+        label={LabelComponent}
+        control={<Checkbox size="small" checked={!checked} onChange={handleChange} />}
+      />
+    </Stack>
+  );
+};
+
+export default DontShowThisAgainCheckbox;

--- a/packages/suite-base/src/components/DataSourceDialog/SidebarItems.test.tsx
+++ b/packages/suite-base/src/components/DataSourceDialog/SidebarItems.test.tsx
@@ -5,11 +5,12 @@
 
 import { render, screen, fireEvent } from "@testing-library/react";
 import { useTranslation } from "react-i18next";
+import "@testing-library/jest-dom";
 
 import { LICHTBLICK_DOCUMENTATION_LINK } from "@lichtblick/suite-base/constants/documentation";
 import { useAnalytics } from "@lichtblick/suite-base/context/AnalyticsContext";
 import { useCurrentUser } from "@lichtblick/suite-base/context/BaseUserContext";
-import "@testing-library/jest-dom";
+import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks";
 
 import SidebarItems from "./SidebarItems";
 
@@ -29,6 +30,10 @@ jest.mock("@lichtblick/suite-base/components/DataSourceDialog/index.style", () =
   useStyles: () => ({ classes: { button: "mock-button-class" } }),
 }));
 
+jest.mock("@lichtblick/suite-base/hooks", () => ({
+  useAppConfigurationValue: jest.fn(),
+}));
+
 describe("SidebarItems", () => {
   const mockOnSelectView = jest.fn();
   const mockLogEvent = jest.fn();
@@ -39,6 +44,7 @@ describe("SidebarItems", () => {
   beforeEach(() => {
     (useTranslation as jest.Mock).mockReturnValue(mockTranslation);
     (useAnalytics as jest.Mock).mockReturnValue({ logEvent: mockLogEvent });
+    (useAppConfigurationValue as jest.Mock).mockReturnValue([true, jest.fn()]);
     jest.clearAllMocks();
   });
 
@@ -51,6 +57,7 @@ describe("SidebarItems", () => {
     expect(screen.getByText("newToLichtblickDescription")).toBeInTheDocument();
     expect(screen.getByText("exploreSampleData")).toBeInTheDocument();
     expect(screen.getByText("viewDocumentation")).toBeInTheDocument();
+    expect(screen.getByText("dontShowThisAgain")).toBeInTheDocument();
   });
 
   it("renders items for authenticated-free users", () => {
@@ -62,6 +69,7 @@ describe("SidebarItems", () => {
     expect(screen.getByText("startCollaboratingDescription")).toBeInTheDocument();
     expect(screen.getByText("uploadToDataPlatform")).toBeInTheDocument();
     expect(screen.getByText("shareLayouts")).toBeInTheDocument();
+    expect(screen.getByText("dontShowThisAgain")).toBeInTheDocument();
   });
 
   it("renders items for authenticated-team users", () => {
@@ -73,6 +81,7 @@ describe("SidebarItems", () => {
     expect(screen.getByText("needHelp")).toBeInTheDocument();
     expect(screen.getByText("needHelpDescription")).toBeInTheDocument();
     expect(screen.getByText("seeTutorials")).toBeInTheDocument();
+    expect(screen.getByText("dontShowThisAgain")).toBeInTheDocument();
   });
 
   it("handles button clicks correctly", () => {

--- a/packages/suite-base/src/components/DataSourceDialog/SidebarItems.tsx
+++ b/packages/suite-base/src/components/DataSourceDialog/SidebarItems.tsx
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { DataSourceDialogItem } from "@lichtblick/suite-base/components/DataSourceDialog/DataSourceDialog";
+import DontShowThisAgainCheckbox from "@lichtblick/suite-base/components/DataSourceDialog/DontShowThisAgainCheckbox";
 import { useStyles } from "@lichtblick/suite-base/components/DataSourceDialog/index.style";
 import { SidebarItem } from "@lichtblick/suite-base/components/DataSourceDialog/types";
 import Stack from "@lichtblick/suite-base/components/Stack";
@@ -132,23 +133,26 @@ const SidebarItems = (props: {
   }, [analytics, classes.button, currentUserType, freeUser, teamOrEnterpriseUser, t]);
 
   return (
-    <>
-      {sidebarItems.map((item) => (
-        <Stack key={item.id}>
-          <Typography variant="h5" gutterBottom>
-            {item.title}
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {item.text}
-          </Typography>
-          {item.actions != undefined && (
-            <Stack direction="row" flexWrap="wrap" alignItems="center" gap={1} paddingTop={1.5}>
-              {item.actions}
-            </Stack>
-          )}
-        </Stack>
-      ))}
-    </>
+    <Stack fullHeight direction="column" justifyContent="space-between">
+      <Stack>
+        {sidebarItems.map((item) => (
+          <Stack key={item.id}>
+            <Typography variant="h5" gutterBottom>
+              {item.title}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {item.text}
+            </Typography>
+            {item.actions != undefined && (
+              <Stack direction="row" flexWrap="wrap" alignItems="center" gap={1} paddingTop={1.5}>
+                {item.actions}
+              </Stack>
+            )}
+          </Stack>
+        ))}
+      </Stack>
+      <DontShowThisAgainCheckbox />
+    </Stack>
   );
 };
 

--- a/packages/suite-base/src/components/DataSourceDialog/Start.test.tsx
+++ b/packages/suite-base/src/components/DataSourceDialog/Start.test.tsx
@@ -30,6 +30,10 @@ jest.mock("@lichtblick/suite-base/context/Workspace/useWorkspaceActions", () => 
   useWorkspaceActions: jest.fn(),
 }));
 
+jest.mock("@lichtblick/suite-base/hooks", () => ({
+  useAppConfigurationValue: jest.fn().mockImplementation(() => [true, jest.fn()]),
+}));
+
 jest.mock("@lichtblick/suite-base/components/DataSourceDialog/index.style", () => ({
   useStyles: () => ({
     classes: {

--- a/packages/suite-base/src/i18n/en/openDialog.ts
+++ b/packages/suite-base/src/i18n/en/openDialog.ts
@@ -11,7 +11,7 @@ export const openDialog = {
   convenientWebInterface:
     "Use a convenient web interface to tag, search, and retrieve data at lightning speed",
   createAFreeAccount: "Create a free account",
-  dontShowThisAgain: "Don't show this again",
+  dontShowThisAgain: "Don't show this again on startup",
   exploreSampleData: "Explore sample data",
   viewDocumentation: "View documentation",
   learnMore: "Learn more",

--- a/packages/suite-base/src/i18n/en/openDialog.ts
+++ b/packages/suite-base/src/i18n/en/openDialog.ts
@@ -11,6 +11,7 @@ export const openDialog = {
   convenientWebInterface:
     "Use a convenient web interface to tag, search, and retrieve data at lightning speed",
   createAFreeAccount: "Create a free account",
+  dontShowThisAgain: "Don't show this again",
   exploreSampleData: "Explore sample data",
   viewDocumentation: "View documentation",
   learnMore: "Learn more",


### PR DESCRIPTION
## User-Facing Changes
Users can now select "don't show this again" and don't see the initial dialog when starting Lichtblick.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/e9bf0482-1add-4d9e-82ca-2d3672dd2ed8" />

## Description
- Used the useAppConfigurationValue hook to store the value.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
