### PR TITLE
Fix repetitive loading extensions for desktop version

### DIFF
--- a/packages/suite-desktop/src/preload/extensions.test.ts
+++ b/packages/suite-desktop/src/preload/extensions.test.ts
@@ -8,6 +8,7 @@ import { join as pathJoin } from "path";
 import randomString from "randomstring";
 
 import {
+  getExtension,
   getExtensions,
   getPackageDirname,
   getPackageId,
@@ -166,6 +167,132 @@ describe("parsePackageName", () => {
     expect(result).toEqual({
       name: "",
     });
+  });
+});
+
+describe("getExtension", () => {
+  const rootFolder = "/mock/extensions";
+
+  it("should return undefined if the root folder does not exist", async () => {
+    // Given
+    const extensionId = genericString();
+    (existsSync as jest.Mock).mockReturnValue(false);
+
+    // When
+    const result = await getExtension(extensionId, rootFolder);
+
+    // Then
+    expect(result).toBeUndefined();
+    expect(existsSync).toHaveBeenCalledWith(rootFolder);
+  });
+
+  it("should return undefined if no matching extension is found", async () => {
+    // Given
+    const extensionId = genericString();
+    const extensionName = genericString();
+    (existsSync as jest.Mock).mockReturnValue(true);
+    (readdir as jest.Mock).mockResolvedValue([{ name: extensionName, isDirectory: () => true }]);
+    (readFile as jest.Mock).mockImplementation(async (path: string) => {
+      if (path.endsWith("package.json")) {
+        const otherPackageJson = generateExtensionPackageJSon({ publisher: genericString() });
+        return JSON.stringify(otherPackageJson);
+      }
+      return "";
+    });
+
+    // When
+    const result = await getExtension(extensionId, rootFolder);
+
+    // Then
+    expect(result).toBeUndefined();
+    expect(readdir).toHaveBeenCalledWith(rootFolder, { withFileTypes: true });
+  });
+
+  it("should return the extension if a matching id is found", async () => {
+    // Given
+    const mockReadmeContent = genericString();
+    const mockChangelogContent = genericString();
+    const publisher = genericString();
+    const extensionName = genericString();
+    const mockPackageJson = generateExtensionPackageJSon({
+      name: extensionName,
+      publisher,
+    });
+    const extensionId = `${publisher}.${extensionName}`;
+
+    (existsSync as jest.Mock).mockReturnValue(true);
+    (readdir as jest.Mock).mockResolvedValue([{ name: extensionName, isDirectory: () => true }]);
+    (readFile as jest.Mock).mockImplementation(async (path: string) => {
+      if (path.endsWith("package.json")) {
+        return JSON.stringify(mockPackageJson);
+      }
+      if (path.endsWith("README.md")) {
+        return mockReadmeContent;
+      }
+      if (path.endsWith("CHANGELOG.md")) {
+        return mockChangelogContent;
+      }
+      return "";
+    });
+
+    // When
+    const result = await getExtension(extensionId, rootFolder);
+    console.log("GOLDBERG getExtension result:", result);
+
+    // Then
+    expect(result).toMatchObject({
+      id: extensionId,
+      packageJson: mockPackageJson,
+      directory: `${rootFolder}/${extensionName}`,
+      readme: mockReadmeContent,
+      changelog: mockChangelogContent,
+    });
+  });
+
+  it("should return the extension with empty readme and changelog if those files are missing", async () => {
+    // Given
+    const publisher = genericString();
+    const extensionName = genericString();
+    const mockPackageJson = generateExtensionPackageJSon({
+      name: extensionName,
+      publisher,
+    });
+    const extensionId = `${publisher}.${extensionName}`;
+    (existsSync as jest.Mock).mockReturnValue(true);
+    (readdir as jest.Mock).mockResolvedValue([{ name: extensionName, isDirectory: () => true }]);
+    (readFile as jest.Mock).mockImplementation(async (path: string) => {
+      if (path.endsWith("package.json")) {
+        return JSON.stringify(mockPackageJson);
+      }
+      throw new Error("File not found");
+    });
+
+    // When
+    const result = await getExtension(extensionId, rootFolder);
+
+    // Then
+    expect(result).toMatchObject({
+      id: extensionId,
+      packageJson: mockPackageJson,
+      directory: `${rootFolder}/${extensionName}`,
+      readme: "",
+      changelog: "",
+    });
+  });
+
+  it("should skip directories that are not directories", async () => {
+    // Given
+    const publisher = genericString();
+    const extensionName = genericString();
+    const extensionId = `${publisher}.${extensionName}`;
+    (existsSync as jest.Mock).mockReturnValue(true);
+    (readdir as jest.Mock).mockResolvedValue([{ name: "notadir", isDirectory: () => false }]);
+
+    // When
+    const result = await getExtension(extensionId, rootFolder);
+
+    // Then
+    expect(result).toBeUndefined();
   });
 });
 

--- a/packages/suite-desktop/src/preload/extensions.test.ts
+++ b/packages/suite-desktop/src/preload/extensions.test.ts
@@ -237,7 +237,6 @@ describe("getExtension", () => {
 
     // When
     const result = await getExtension(extensionId, rootFolder);
-    console.log("GOLDBERG getExtension result:", result);
 
     // Then
     expect(result).toMatchObject({

--- a/packages/suite-desktop/src/preload/extensions.ts
+++ b/packages/suite-desktop/src/preload/extensions.ts
@@ -97,7 +97,9 @@ export async function getExtension(
 
   const rootFolderContents = await readdir(rootFolder, { withFileTypes: true });
   for (const entry of rootFolderContents) {
-    if (!entry.isDirectory()) continue;
+    if (!entry.isDirectory()) {
+      continue;
+    }
 
     const extensionRootPath = pathJoin(rootFolder, entry.name);
     const packagePath = pathJoin(extensionRootPath, "package.json");
@@ -106,7 +108,9 @@ export async function getExtension(
       const packageData = await readFile(packagePath, { encoding: "utf8" });
       const packageJson = JSON.parse(packageData) as ExtensionPackageJson;
 
-      if (getPackageId(packageJson) !== id) continue;
+      if (getPackageId(packageJson) !== id) {
+        continue;
+      }
 
       const [readme, changelog] = await Promise.all([
         safeReadFile(pathJoin(extensionRootPath, "README.md")),

--- a/packages/suite-desktop/src/preload/extensions.ts
+++ b/packages/suite-desktop/src/preload/extensions.ts
@@ -87,6 +87,47 @@ const safeReadFile = async (filePath: string): Promise<string> => {
   }
 };
 
+export async function getExtension(
+  id: string,
+  rootFolder: string,
+): Promise<DesktopExtension | undefined> {
+  if (!existsSync(rootFolder)) {
+    return undefined;
+  }
+
+  const rootFolderContents = await readdir(rootFolder, { withFileTypes: true });
+  for (const entry of rootFolderContents) {
+    if (!entry.isDirectory()) continue;
+
+    const extensionRootPath = pathJoin(rootFolder, entry.name);
+    const packagePath = pathJoin(extensionRootPath, "package.json");
+
+    try {
+      const packageData = await readFile(packagePath, { encoding: "utf8" });
+      const packageJson = JSON.parse(packageData) as ExtensionPackageJson;
+
+      if (getPackageId(packageJson) !== id) continue;
+
+      const [readme, changelog] = await Promise.all([
+        safeReadFile(pathJoin(extensionRootPath, "README.md")),
+        safeReadFile(pathJoin(extensionRootPath, "CHANGELOG.md")),
+      ]);
+
+      return {
+        id,
+        packageJson,
+        directory: extensionRootPath,
+        readme,
+        changelog,
+      };
+    } catch (err: unknown) {
+      log.error(`Failed to load extension at ${extensionRootPath}:`, err);
+      continue;
+    }
+  }
+  return undefined;
+}
+
 export async function getExtensions(rootFolder: string): Promise<DesktopExtension[]> {
   const extensions: DesktopExtension[] = [];
 
@@ -124,14 +165,11 @@ export async function getExtensions(rootFolder: string): Promise<DesktopExtensio
 }
 
 export async function loadExtension(id: string, rootFolder: string): Promise<string> {
-  // Find this extension
-  const userExtensions = await getExtensions(rootFolder);
-  const extension = userExtensions.find(
-    (ext) => getPackageId(ext.packageJson as ExtensionPackageJson) === id,
-  );
-  if (extension == undefined) {
-    log.error(`Extension ${id} was not found, searched ${userExtensions.length} extensions`);
-    return "";
+  log.debug(`Loading extension ${id} from ${rootFolder}`);
+
+  const extension = await getExtension(id, rootFolder);
+  if (!extension) {
+    throw new Error(`Extension ${id} not found in ${rootFolder}`);
   }
 
   const packagePath = pathJoin(extension.directory, "package.json");
@@ -201,20 +239,14 @@ export async function installExtension(
 }
 
 export async function uninstallExtension(id: string, rootFolder: string): Promise<boolean> {
-  log.debug(`Searching for extension ${id} in ${rootFolder} to uninstall`);
+  log.debug(`Uninstalling extension ${id} from ${rootFolder}`);
 
-  // Find this extension
-  const userExtensions = await getExtensions(rootFolder);
-  const extension = userExtensions.find(
-    (ext) => getPackageId(ext.packageJson as ExtensionPackageJson) === id,
-  );
-  if (extension == undefined) {
-    log.error(`Extension ${id} was not found, searched ${userExtensions.length} extensions`);
+  const extension = await getExtension(id, rootFolder);
+  if (!extension) {
+    log.warn(`Extension ${id} not found in ${rootFolder}`);
     return false;
   }
 
-  // Delete the extension directory and contents
-  log.info(`Deleting extension directory ${extension.directory}`);
   await rm(extension.directory, { recursive: true, force: true });
   return true;
 }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
N/A
**Description**
Fixed the loading extensions process for the Desktop version. To load properly, we just need to get the proper extension instead of getting all extensions from FS.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
