### PR TITLE
Fixing multiple message converters not being registered when installing an extension

### DIFF
--- a/packages/suite-base/src/providers/ExtensionCatalogProvider.tsx
+++ b/packages/suite-base/src/providers/ExtensionCatalogProvider.tsx
@@ -101,14 +101,12 @@ function createExtensionRegistryStore(
       set((state) => ({
         installedExtensions: _.uniqBy([...(state.installedExtensions ?? []), info], "id"),
         installedPanels: { ...state.installedPanels, ...panels },
-        installedMessageConverters: _.uniqBy(
-          [...state.installedMessageConverters!, ...messageConverters],
-          "extensionId",
-        ),
-        installedTopicAliasFunctions: _.uniqBy(
-          [...state.installedTopicAliasFunctions!, ...topicAliasFunctions],
-          "extensionId",
-        ),
+        installedMessageConverters: [...state.installedMessageConverters!, ...messageConverters],
+
+        installedTopicAliasFunctions: [
+          ...state.installedTopicAliasFunctions!,
+          ...topicAliasFunctions,
+        ],
         panelSettings: { ...state.panelSettings, ...panelSettings },
 
         installedCameraModels: new Map([

--- a/packages/suite-base/src/providers/ExtensionCatalogProvider.tsx
+++ b/packages/suite-base/src/providers/ExtensionCatalogProvider.tsx
@@ -102,13 +102,11 @@ function createExtensionRegistryStore(
         installedExtensions: _.uniqBy([...(state.installedExtensions ?? []), info], "id"),
         installedPanels: { ...state.installedPanels, ...panels },
         installedMessageConverters: [...state.installedMessageConverters!, ...messageConverters],
-
         installedTopicAliasFunctions: [
           ...state.installedTopicAliasFunctions!,
           ...topicAliasFunctions,
         ],
         panelSettings: { ...state.panelSettings, ...panelSettings },
-
         installedCameraModels: new Map([
           ...state.installedCameraModels,
           ...Array.from(cameraModels.entries()),


### PR DESCRIPTION
**User-Facing Changes**
All message converters and alias functions will be registered on the installation process as expected and as it was done when loading an extension.

**Description**
Mainly, the problem is that during the installation of extensions, after creating the contribution points, it gets filtered by unique extensionId. Meaning that message converters and alias functions can be registered only once per extension (which is wrong). Ideally, installing an extension should register all message converters and alias functions. This doesn't happen when loaading extensions, meaning that on reload, after installing an extension, all message converters would be registered as expected.
It was identified in the code in the `ExtensionCatalogProvider`, in the mergeState function that `installedMessageConverters` and `installedTopicAliasFunctions` have this filter `_.uniqBy` that was causing the problem, by removing it it's guaranteed that all converters and alias functions from an extension are registered. 

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [X] The web version was tested and it is running ok
- [X] The desktop version was tested and it is running ok
- [X] This change is covered by unit tests
- [X] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated