### PR TITLE
Fix empty 'before object' on RawMessage panel

### DIFF
--- a/packages/suite-base/src/panels/RawMessages/getDiff.test.ts
+++ b/packages/suite-base/src/panels/RawMessages/getDiff.test.ts
@@ -263,4 +263,19 @@ describe("getDiff", () => {
       },
     ]);
   });
+
+  it("returns {} fallback when before[key] has not key and showFullMessageForDiff is true", () => {
+    const before = {};
+    const after = { someKey: undefined };
+
+    const result = getDiff({
+      before,
+      after,
+      showFullMessageForDiff: true,
+    });
+
+    expect(result).toEqual({
+      someKey: {},
+    });
+  });
 });

--- a/packages/suite-base/src/panels/RawMessages/getDiff.ts
+++ b/packages/suite-base/src/panels/RawMessages/getDiff.ts
@@ -146,7 +146,7 @@ export default function getDiff({
     const allKeys = Object.keys(before).concat(Object.keys(after));
     for (const key of _.uniq(allKeys)) {
       const innerDiff = getDiff({
-        before: (before as DiffObject)[key] ?? {},
+        before: (before as DiffObject)[key],
         after: (after as DiffObject)[key],
         idLabel: undefined,
         showFullMessageForDiff,

--- a/packages/suite-base/src/panels/RawMessages/getDiff.ts
+++ b/packages/suite-base/src/panels/RawMessages/getDiff.ts
@@ -146,7 +146,7 @@ export default function getDiff({
     const allKeys = Object.keys(before).concat(Object.keys(after));
     for (const key of _.uniq(allKeys)) {
       const innerDiff = getDiff({
-        before: (before as DiffObject)[key],
+        before: (before as DiffObject)[key] ?? {},
         after: (after as DiffObject)[key],
         idLabel: undefined,
         showFullMessageForDiff,
@@ -154,7 +154,7 @@ export default function getDiff({
       if (!_.isEmpty(innerDiff)) {
         diff[key] = innerDiff;
       } else if (showFullMessageForDiff) {
-        diff[key] = (before as DiffObject)[key];
+        diff[key] = (before as DiffObject)[key] ?? {};
       }
     }
     return diff;


### PR DESCRIPTION
## User-Facing Changes
Users can now activate "Show full message" when comparing messages in the Raw Message Panel, even if the "before" object is missing, without encountering errors.

## Description
- This change adds a fallback mechanism to handle cases where the `before` object is `undefined` or `null`, ensuring the diff comparison feature works reliably without runtime errors.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
