### PR TITLE
Adding brightness and contrast adjustment settings to Image panel

### DIFF
--- a/e2e/tests/desktop/extension/custom-camera-model.desktop.spec.ts
+++ b/e2e/tests/desktop/extension/custom-camera-model.desktop.spec.ts
@@ -46,7 +46,7 @@ test("custom camera model", async ({ mainWindow }) => {
   await mainWindow.getByRole("option", { name: "/camera_calibration", exact: true }).click();
 
   // THEN
-  await mainWindow.waitForTimeout(10); // await for the sidebar to update
+  await mainWindow.waitForTimeout(100); // await for the sidebar to update
   expect(await sidebarLeft.getByTestId("ErrorIcon").count()).toBe(0);
 
   // WHEN
@@ -72,6 +72,6 @@ test("custom camera model", async ({ mainWindow }) => {
   await mainWindow.getByTestId("play-button").click();
 
   // THEN
-  await mainWindow.waitForTimeout(10); // await for the sidebar to update
+  await mainWindow.waitForTimeout(100); // await for the sidebar to update
   expect(await sidebarLeft.getByTestId("ErrorIcon").count()).toBe(0);
 });

--- a/e2e/tests/desktop/extension/custom-camera-model.desktop.spec.ts
+++ b/e2e/tests/desktop/extension/custom-camera-model.desktop.spec.ts
@@ -46,6 +46,7 @@ test("custom camera model", async ({ mainWindow }) => {
   await mainWindow.getByRole("option", { name: "/camera_calibration", exact: true }).click();
 
   // THEN
+  await mainWindow.waitForTimeout(10); // await for the sidebar to update
   expect(await sidebarLeft.getByTestId("ErrorIcon").count()).toBe(0);
 
   // WHEN
@@ -68,13 +69,9 @@ test("custom camera model", async ({ mainWindow }) => {
     mainWindow,
     filename: foxeFile,
   });
-  await sidebarLeft
-    .getByRole("button", { name: "/camera_calibration/custom", exact: true })
-    .nth(0)
-    .click();
-  await mainWindow.getByRole("option", { name: "/camera_calibration/custom", exact: true }).click();
   await mainWindow.getByTestId("play-button").click();
 
   // THEN
+  await mainWindow.waitForTimeout(10); // await for the sidebar to update
   expect(await sidebarLeft.getByTestId("ErrorIcon").count()).toBe(0);
 });

--- a/packages/suite-base/src/components/SettingsTreeEditor/FieldEditor.style.ts
+++ b/packages/suite-base/src/components/SettingsTreeEditor/FieldEditor.style.ts
@@ -72,4 +72,17 @@ export const useStyles = makeStyles<void, "error">()((theme, _params, classes) =
       },
     },
   },
+  slider: {
+    color: theme.palette.secondary.main,
+    top: "2px",
+    height: 3,
+    width: "calc(100% - 30px)",
+    left: "10px",
+
+    "& .MuiSlider-thumb": {
+      "&:focus, &:hover, &.Mui-active, &.Mui-focusVisible": {
+        boxShadow: "none",
+      },
+    },
+  },
 }));

--- a/packages/suite-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/suite-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -13,6 +13,7 @@ import {
   MenuList,
   MenuListProps,
   Select,
+  Slider,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
@@ -333,6 +334,23 @@ function FieldInput({
           max={field.max}
           onChange={(value) => {
             actionHandler({ action: "update", payload: { path, input: "vec2", value } });
+          }}
+        />
+      );
+    case "slider":
+      return (
+        <Slider
+          className={classes.slider}
+          value={field.value}
+          min={field.min}
+          max={field.max}
+          size="small"
+          valueLabelDisplay="auto"
+          onChange={(_, value) => {
+            actionHandler({
+              action: "update",
+              payload: { path, input: "slider", value: value as number },
+            });
           }}
         />
       );

--- a/packages/suite-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/suite-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -344,6 +344,7 @@ function FieldInput({
           value={field.value}
           min={field.min}
           max={field.max}
+          step={field.step}
           size="small"
           valueLabelDisplay="auto"
           onChange={(_, value) => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -97,6 +97,8 @@ export type ImageModeConfig = Partial<ColorModeSettings> & {
   synchronize?: boolean;
   /** Rotation */
   rotation?: 0 | 90 | 180 | 270;
+  brightness?: number;
+  contrast?: number;
   flipHorizontal?: boolean;
   flipVertical?: boolean;
   /** Minimum (black) value for single-channel images */

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -29,6 +29,12 @@ import { Path } from "@lichtblick/suite-base/panels/ThreeDeeRender/LayerErrors";
 import {
   IMAGE_MODE_HUD_GROUP_ID,
   IMAGE_TOPIC_PATH,
+  MAX_BRIGHTNESS,
+  MAX_CONTRAST,
+  MID_BRIGHTNESS,
+  MID_CONTRAST,
+  MIN_BRIGHTNESS,
+  MIN_CONTRAST,
 } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/constants";
 import {
   IMAGE_RENDERABLE_DEFAULT_SETTINGS,
@@ -129,8 +135,8 @@ const DEFAULT_CONFIG = {
   flipHorizontal: false,
   flipVertical: false,
   rotation: 0 as 0 | 90 | 180 | 270,
-  brightness: 50,
-  contrast: 50,
+  brightness: MID_BRIGHTNESS,
+  contrast: MID_CONTRAST,
   ...IMAGE_DEFAULT_COLOR_MODE_SETTINGS,
 };
 
@@ -548,15 +554,15 @@ export class ImageMode
     fields.brightness = {
       input: "slider",
       label: "Brightness",
-      min: 0,
-      max: 100,
+      min: MIN_BRIGHTNESS,
+      max: MAX_BRIGHTNESS,
       value: brightness,
     };
     fields.contrast = {
       input: "slider",
       label: "Contrast",
-      min: 0,
-      max: 100,
+      min: MIN_CONTRAST,
+      max: MAX_CONTRAST,
       value: contrast,
     };
 
@@ -659,6 +665,8 @@ export class ImageMode
       explicitAlpha: config.explicitAlpha,
       minValue: config.minValue,
       maxValue: config.maxValue,
+      brightness: config.brightness,
+      contrast: config.contrast,
     });
     if (config.synchronize !== prevImageModeConfig.synchronize) {
       this.hud.removeGroup(IMAGE_MODE_HUD_GROUP_ID);

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -27,6 +27,7 @@ import { DraggedMessagePath } from "@lichtblick/suite-base/components/PanelExten
 import { Path } from "@lichtblick/suite-base/panels/ThreeDeeRender/LayerErrors";
 import {
   COMPRESSED_VIDEO_DATATYPES,
+  COMPRESSED_IMAGE_DATATYPES,
   RAW_IMAGE_DATATYPES,
 } from "@lichtblick/suite-base/panels/ThreeDeeRender/foxglove";
 import {
@@ -93,7 +94,6 @@ import {
   IMAGE_DATATYPES as ROS_IMAGE_DATATYPES,
   COMPRESSED_IMAGE_DATATYPES as ROS_COMPRESSED_IMAGE_DATATYPES,
   CameraInfo,
-  COMPRESSED_IMAGE_DATATYPES,
 } from "../../ros";
 import { topicIsConvertibleToSchema } from "../../topicIsConvertibleToSchema";
 import { ICameraHandler } from "../ICameraHandler";

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -557,6 +557,7 @@ export class ImageMode
       min: MIN_BRIGHTNESS,
       max: MAX_BRIGHTNESS,
       value: brightness,
+      step: 5,
     };
     fields.contrast = {
       input: "slider",
@@ -564,6 +565,7 @@ export class ImageMode
       min: MIN_CONTRAST,
       max: MAX_CONTRAST,
       value: contrast,
+      step: 5,
     };
 
     const imageTopic =

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -24,18 +24,36 @@ import {
 } from "@lichtblick/suite";
 import { PanelContextMenuItem } from "@lichtblick/suite-base/components/PanelContextMenu";
 import { DraggedMessagePath } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
-import { HUDItem } from "@lichtblick/suite-base/panels/ThreeDeeRender/HUDItemManager";
 import { Path } from "@lichtblick/suite-base/panels/ThreeDeeRender/LayerErrors";
 import {
+  COMPRESSED_VIDEO_DATATYPES,
+  RAW_IMAGE_DATATYPES,
+} from "@lichtblick/suite-base/panels/ThreeDeeRender/foxglove";
+import {
+  ALL_SUPPORTED_CALIBRATION_SCHEMAS,
+  ALL_SUPPORTED_IMAGE_SCHEMAS,
+  CALIBRATION_TOPIC_PATH,
+  CALIBRATION_TOPIC_UNAVAILABLE,
+  CAMERA_MODEL,
+  DEFAULT_FOCAL_LENGTH,
+  DEFAULT_IMAGE_CONFIG,
   IMAGE_MODE_HUD_GROUP_ID,
+  IMAGE_TOPIC_DIFFERENT_FRAME,
   IMAGE_TOPIC_PATH,
+  IMAGE_TOPIC_UNAVAILABLE,
   MAX_BRIGHTNESS,
   MAX_CONTRAST,
-  MID_BRIGHTNESS,
-  MID_CONTRAST,
   MIN_BRIGHTNESS,
   MIN_CONTRAST,
+  MISSING_CAMERA_INFO,
+  NO_IMAGE_TOPICS_HUD_ITEM,
+  REMOVE_IMAGE_TIMEOUT_MS,
+  SUPPORTED_RAW_IMAGE_SCHEMAS,
 } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/constants";
+import {
+  ConfigWithDefaults,
+  ImageModeEventMap,
+} from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/types";
 import {
   IMAGE_RENDERABLE_DEFAULT_SETTINGS,
   ImageRenderable,
@@ -46,7 +64,6 @@ import {
   AnyImage,
   getFrameIdFromImage,
 } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/Images/ImageTypes";
-import { IMAGE_DEFAULT_COLOR_MODE_SETTINGS } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/Images/decodeImage";
 import {
   cameraInfosEqual,
   normalizeCameraInfo,
@@ -73,16 +90,10 @@ import type {
 import { PartialMessageEvent, SceneExtension } from "../../SceneExtension";
 import { SettingsTreeEntry } from "../../SettingsManager";
 import {
-  CAMERA_CALIBRATION_DATATYPES,
-  COMPRESSED_IMAGE_DATATYPES,
-  COMPRESSED_VIDEO_DATATYPES,
-  RAW_IMAGE_DATATYPES,
-} from "../../foxglove";
-import {
   IMAGE_DATATYPES as ROS_IMAGE_DATATYPES,
   COMPRESSED_IMAGE_DATATYPES as ROS_COMPRESSED_IMAGE_DATATYPES,
-  CAMERA_INFO_DATATYPES,
   CameraInfo,
+  COMPRESSED_IMAGE_DATATYPES,
 } from "../../ros";
 import { topicIsConvertibleToSchema } from "../../topicIsConvertibleToSchema";
 import { ICameraHandler } from "../ICameraHandler";
@@ -91,56 +102,6 @@ import { colorModeSettingsFields } from "../colorMode";
 
 const log = Logger.getLogger(__filename);
 
-const CALIBRATION_TOPIC_PATH = ["imageMode", "calibrationTopic"];
-
-const IMAGE_TOPIC_UNAVAILABLE = "IMAGE_TOPIC_UNAVAILABLE";
-const CALIBRATION_TOPIC_UNAVAILABLE = "CALIBRATION_TOPIC_UNAVAILABLE";
-
-const MISSING_CAMERA_INFO = "MISSING_CAMERA_INFO";
-const IMAGE_TOPIC_DIFFERENT_FRAME = "IMAGE_TOPIC_DIFFERENT_FRAME";
-
-const CAMERA_MODEL = "CameraModel";
-
-const DEFAULT_FOCAL_LENGTH = 500;
-
-const REMOVE_IMAGE_TIMEOUT_MS = 50;
-
-const NO_IMAGE_TOPICS_HUD_ITEM: HUDItem = {
-  id: "NO_IMAGE_TOPICS",
-  group: IMAGE_MODE_HUD_GROUP_ID,
-  getMessage: () => t3D("noImageTopicsAvailable"),
-  displayType: "empty",
-};
-interface ImageModeEventMap extends THREE.Object3DEventMap {
-  hasModifiedViewChanged: object;
-}
-
-export const ALL_SUPPORTED_IMAGE_SCHEMAS = new Set([
-  ...ROS_IMAGE_DATATYPES,
-  ...ROS_COMPRESSED_IMAGE_DATATYPES,
-  ...RAW_IMAGE_DATATYPES,
-  ...COMPRESSED_IMAGE_DATATYPES,
-  ...COMPRESSED_VIDEO_DATATYPES,
-]);
-
-const SUPPORTED_RAW_IMAGE_SCHEMAS = new Set([...RAW_IMAGE_DATATYPES, ...ROS_IMAGE_DATATYPES]);
-
-const ALL_SUPPORTED_CALIBRATION_SCHEMAS = new Set([
-  ...CAMERA_INFO_DATATYPES,
-  ...CAMERA_CALIBRATION_DATATYPES,
-]);
-
-const DEFAULT_CONFIG = {
-  synchronize: false,
-  flipHorizontal: false,
-  flipVertical: false,
-  rotation: 0 as 0 | 90 | 180 | 270,
-  brightness: MID_BRIGHTNESS,
-  contrast: MID_CONTRAST,
-  ...IMAGE_DEFAULT_COLOR_MODE_SETTINGS,
-};
-
-type ConfigWithDefaults = ImageModeConfig & typeof DEFAULT_CONFIG;
 export class ImageMode
   extends SceneExtension<ImageRenderable, ImageModeEventMap>
   implements ICameraHandler
@@ -580,7 +541,7 @@ export class ImageMode
         config: settings as ImageModeConfig,
 
         defaults: {
-          gradient: DEFAULT_CONFIG.gradient,
+          gradient: DEFAULT_IMAGE_CONFIG.gradient,
         },
         modifiers: {
           supportsPackedRgbModes: false,
@@ -894,12 +855,12 @@ export class ImageMode
 
     const colorMode =
       config.colorMode === "rgba-fields"
-        ? DEFAULT_CONFIG.colorMode
-        : config.colorMode ?? DEFAULT_CONFIG.colorMode;
+        ? DEFAULT_IMAGE_CONFIG.colorMode
+        : config.colorMode ?? DEFAULT_IMAGE_CONFIG.colorMode;
 
     // Ensures that no required fields are left undefined
     // rightmost values are applied last and have the most precedence
-    return _.merge({}, DEFAULT_CONFIG, { colorMode }, config);
+    return _.merge({}, DEFAULT_IMAGE_CONFIG, { colorMode }, config);
   }
 
   /**

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -129,6 +129,8 @@ const DEFAULT_CONFIG = {
   flipHorizontal: false,
   flipVertical: false,
   rotation: 0 as 0 | 90 | 180 | 270,
+  brightness: 50,
+  contrast: 50,
   ...IMAGE_DEFAULT_COLOR_MODE_SETTINGS,
 };
 
@@ -427,6 +429,8 @@ export class ImageMode
       flipHorizontal,
       flipVertical,
       rotation,
+      brightness,
+      contrast,
     } = settings;
 
     const imageTopics = filterMap(this.renderer.topics ?? [], (topic) => {
@@ -540,6 +544,20 @@ export class ImageMode
         { label: "180°", value: 180 },
         { label: "270°", value: 270 },
       ],
+    };
+    fields.brightness = {
+      input: "slider",
+      label: "Brightness",
+      min: 0,
+      max: 100,
+      value: brightness,
+    };
+    fields.contrast = {
+      input: "slider",
+      label: "Contrast",
+      min: 0,
+      max: 100,
+      value: contrast,
     };
 
     const imageTopic =

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/constants.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/constants.ts
@@ -71,9 +71,13 @@ export const MIN_CONTRAST = 0;
 export const MAX_CONTRAST = 100;
 export const INITIAL_CONTRAST = (MAX_CONTRAST + MIN_CONTRAST) / 2;
 
+// Contrast should be in the range of -1 and 1.
+// It was trimmed by 0.4 to improve visualization.
 export const LOWER_BRIGHTNESS_LIMIT = -0.6;
 export const UPPER_BRIGHTNESS_LIMIT = 0.6;
 
+// Contrast should be in the range of 0 and 2.
+// It was trimmed by 0.1 to improve visualization.
 export const LOWER_CONTRAST_LIMIT = 0.1;
 export const UPPER_CONTRAST_LIMIT = 1.9;
 
@@ -102,6 +106,8 @@ export const VERTEX_SHADER = `
     }
 `;
 
+// Custom GLSL scrpit to apply brightness, contrast and other properties to the image texture
+// Source: https://github.com/mrdoob/three.js/blob/master/src/materials/ShaderMaterial.js
 export const FRAGMENT_SHADER = `
     uniform sampler2D map;
     uniform float brightness;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/constants.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/constants.ts
@@ -5,6 +5,22 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { HUDItem } from "@lichtblick/suite-base/panels/ThreeDeeRender/HUDItemManager";
+import { IMAGE_DEFAULT_COLOR_MODE_SETTINGS } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/Images/decodeImage";
+import { t3D } from "@lichtblick/suite-base/panels/ThreeDeeRender/t3D";
+
+import {
+  CAMERA_CALIBRATION_DATATYPES,
+  COMPRESSED_IMAGE_DATATYPES,
+  COMPRESSED_VIDEO_DATATYPES,
+  RAW_IMAGE_DATATYPES,
+} from "../../foxglove";
+import {
+  IMAGE_DATATYPES as ROS_IMAGE_DATATYPES,
+  COMPRESSED_IMAGE_DATATYPES as ROS_COMPRESSED_IMAGE_DATATYPES,
+  CAMERA_INFO_DATATYPES,
+} from "../../ros";
+
 export const IMAGE_TOPIC_PATH = ["imageMode", "imageTopic"];
 export const DECODE_IMAGE_ERR_KEY = "CreateBitmap";
 
@@ -20,6 +36,33 @@ export const WAITING_FOR_BOTH_MESSAGES_HUD_ID = "WAITING_FOR_BOTH_MESSAGES";
 export const WAITING_FOR_CALIBRATION_HUD_ID = "WAITING_FOR_CALIBRATION";
 export const WAITING_FOR_IMAGES_NOTICE_ID = "WAITING_FOR_IMAGES_NOTICE";
 
+export const CALIBRATION_TOPIC_PATH = ["imageMode", "calibrationTopic"];
+export const IMAGE_TOPIC_UNAVAILABLE = "IMAGE_TOPIC_UNAVAILABLE";
+export const CALIBRATION_TOPIC_UNAVAILABLE = "CALIBRATION_TOPIC_UNAVAILABLE";
+export const MISSING_CAMERA_INFO = "MISSING_CAMERA_INFO";
+export const IMAGE_TOPIC_DIFFERENT_FRAME = "IMAGE_TOPIC_DIFFERENT_FRAME";
+export const CAMERA_MODEL = "CameraModel";
+export const DEFAULT_FOCAL_LENGTH = 500;
+export const REMOVE_IMAGE_TIMEOUT_MS = 50;
+
+export const ALL_SUPPORTED_IMAGE_SCHEMAS = new Set([
+  ...ROS_IMAGE_DATATYPES,
+  ...ROS_COMPRESSED_IMAGE_DATATYPES,
+  ...RAW_IMAGE_DATATYPES,
+  ...COMPRESSED_IMAGE_DATATYPES,
+  ...COMPRESSED_VIDEO_DATATYPES,
+]);
+
+export const SUPPORTED_RAW_IMAGE_SCHEMAS = new Set([
+  ...RAW_IMAGE_DATATYPES,
+  ...ROS_IMAGE_DATATYPES,
+]);
+
+export const ALL_SUPPORTED_CALIBRATION_SCHEMAS = new Set([
+  ...CAMERA_INFO_DATATYPES,
+  ...CAMERA_CALIBRATION_DATATYPES,
+]);
+
 export const MIN_BRIGHTNESS = 0;
 export const MAX_BRIGHTNESS = 100;
 export const MID_BRIGHTNESS = (MAX_BRIGHTNESS + MIN_BRIGHTNESS) / 2;
@@ -33,6 +76,23 @@ export const UPPER_BRIGHTNESS_LIMIT = 0.6;
 
 export const LOWER_CONTRAST_LIMIT = 0.1;
 export const UPPER_CONTRAST_LIMIT = 1.9;
+
+export const NO_IMAGE_TOPICS_HUD_ITEM: HUDItem = {
+  id: "NO_IMAGE_TOPICS",
+  group: IMAGE_MODE_HUD_GROUP_ID,
+  getMessage: () => t3D("noImageTopicsAvailable"),
+  displayType: "empty",
+};
+
+export const DEFAULT_IMAGE_CONFIG = {
+  synchronize: false,
+  flipHorizontal: false,
+  flipVertical: false,
+  rotation: 0 as 0 | 90 | 180 | 270,
+  brightness: MID_BRIGHTNESS,
+  contrast: MID_CONTRAST,
+  ...IMAGE_DEFAULT_COLOR_MODE_SETTINGS,
+};
 
 export const VERTEX_SHADER = `
     varying vec2 vUv;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/constants.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/constants.ts
@@ -19,3 +19,50 @@ export const WAITING_FOR_IMAGES_EMPTY_HUD_ID = "WAITING_FOR_IMAGES_EMPTY";
 export const WAITING_FOR_BOTH_MESSAGES_HUD_ID = "WAITING_FOR_BOTH_MESSAGES";
 export const WAITING_FOR_CALIBRATION_HUD_ID = "WAITING_FOR_CALIBRATION";
 export const WAITING_FOR_IMAGES_NOTICE_ID = "WAITING_FOR_IMAGES_NOTICE";
+
+export const MIN_BRIGHTNESS = 0;
+export const MAX_BRIGHTNESS = 100;
+export const MID_BRIGHTNESS = (MAX_BRIGHTNESS + MIN_BRIGHTNESS) / 2;
+
+export const MIN_CONTRAST = 0;
+export const MAX_CONTRAST = 100;
+export const MID_CONTRAST = (MAX_CONTRAST + MIN_CONTRAST) / 2;
+
+export const LOWER_BRIGHTNESS_LIMIT = -0.6;
+export const UPPER_BRIGHTNESS_LIMIT = 0.6;
+
+export const LOWER_CONTRAST_LIMIT = 0.1;
+export const UPPER_CONTRAST_LIMIT = 1.9;
+
+export const VERTEX_SHADER = `
+    varying vec2 vUv;
+    void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+`;
+
+export const FRAGMENT_SHADER = `
+    uniform sampler2D map;
+    uniform float brightness;
+    uniform float contrast;
+    uniform vec3 color;
+    uniform float opacity;
+    varying vec2 vUv;
+
+    void main() {
+    vec4 texColor = texture2D(map, vUv);
+
+    // Apply brightness
+    texColor.rgb += brightness;
+
+    // Apply contrast
+    texColor.rgb = ((texColor.rgb - 0.5) * contrast) + 0.5;
+
+    // Apply tint color and opacity
+    texColor.rgb *= color;
+    texColor.a *= opacity;
+
+    gl_FragColor = texColor;
+    }
+`;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/constants.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/constants.ts
@@ -71,7 +71,7 @@ export const MIN_CONTRAST = 0;
 export const MAX_CONTRAST = 100;
 export const INITIAL_CONTRAST = (MAX_CONTRAST + MIN_CONTRAST) / 2;
 
-// Contrast should be in the range of -1 and 1.
+// Brightness should be in the range of -1 and 1.
 // It was trimmed by 0.4 to improve visualization.
 export const LOWER_BRIGHTNESS_LIMIT = -0.6;
 export const UPPER_BRIGHTNESS_LIMIT = 0.6;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/constants.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/constants.ts
@@ -37,8 +37,8 @@ export const UPPER_CONTRAST_LIMIT = 1.9;
 export const VERTEX_SHADER = `
     varying vec2 vUv;
     void main() {
-    vUv = uv;
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        vUv = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
     }
 `;
 
@@ -51,18 +51,18 @@ export const FRAGMENT_SHADER = `
     varying vec2 vUv;
 
     void main() {
-    vec4 texColor = texture2D(map, vUv);
+        vec4 texColor = texture2D(map, vUv);
 
-    // Apply brightness
-    texColor.rgb += brightness;
+        // Apply brightness
+        texColor.rgb += brightness;
 
-    // Apply contrast
-    texColor.rgb = ((texColor.rgb - 0.5) * contrast) + 0.5;
+        // Apply contrast
+        texColor.rgb = ((texColor.rgb - 0.5) * contrast) + 0.5;
 
-    // Apply tint color and opacity
-    texColor.rgb *= color;
-    texColor.a *= opacity;
+        // Apply tint color and opacity
+        texColor.rgb *= color;
+        texColor.a *= opacity;
 
-    gl_FragColor = texColor;
+        gl_FragColor = texColor;
     }
 `;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/constants.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/constants.ts
@@ -65,11 +65,11 @@ export const ALL_SUPPORTED_CALIBRATION_SCHEMAS = new Set([
 
 export const MIN_BRIGHTNESS = 0;
 export const MAX_BRIGHTNESS = 100;
-export const MID_BRIGHTNESS = (MAX_BRIGHTNESS + MIN_BRIGHTNESS) / 2;
+export const INITIAL_BRIGHTNESS = (MAX_BRIGHTNESS + MIN_BRIGHTNESS) / 2;
 
 export const MIN_CONTRAST = 0;
 export const MAX_CONTRAST = 100;
-export const MID_CONTRAST = (MAX_CONTRAST + MIN_CONTRAST) / 2;
+export const INITIAL_CONTRAST = (MAX_CONTRAST + MIN_CONTRAST) / 2;
 
 export const LOWER_BRIGHTNESS_LIMIT = -0.6;
 export const UPPER_BRIGHTNESS_LIMIT = 0.6;
@@ -89,8 +89,8 @@ export const DEFAULT_IMAGE_CONFIG = {
   flipHorizontal: false,
   flipVertical: false,
   rotation: 0 as 0 | 90 | 180 | 270,
-  brightness: MID_BRIGHTNESS,
-  contrast: MID_CONTRAST,
+  brightness: INITIAL_BRIGHTNESS,
+  contrast: INITIAL_CONTRAST,
   ...IMAGE_DEFAULT_COLOR_MODE_SETTINGS,
 };
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/types.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/types.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { ImageModeConfig } from "@lichtblick/suite-base/panels/ThreeDeeRender/IRenderer";
+import { DEFAULT_IMAGE_CONFIG } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/constants";
+
+export interface ImageModeEventMap extends THREE.Object3DEventMap {
+  hasModifiedViewChanged: object;
+}
+
+export type ConfigWithDefaults = ImageModeConfig & typeof DEFAULT_IMAGE_CONFIG;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.test.ts
@@ -13,84 +13,56 @@ import {
 } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/constants";
 import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
 
-import { mapRange, clampBrightness, clampContrast } from "./utils";
-
-describe("mapRange", () => {
-  it("maps value correctly within range", () => {
-    const result = mapRange(50, 0, 100, 0, 200);
-    expect(result).toBe(100);
-  });
-
-  it("clamps value to inMax if above", () => {
-    const result = mapRange(150, 0, 100, 0, 200);
-    expect(result).toBe(200);
-  });
-
-  it("clamps value to inMin if below", () => {
-    const result = mapRange(-50, 0, 100, 0, 200);
-    expect(result).toBe(0);
-  });
-
-  it("returns outMin if inMin === inMax to avoid division by zero", () => {
-    const result = mapRange(50, 100, 100, 0, 200);
-    expect(result).toBe(0);
-  });
-
-  it("maps correctly when in range", () => {
-    const result = mapRange(25, 0, 100, 0, 50);
-    expect(result).toBe(12.5);
-  });
-
-  it("should return outMin value when inMin and inMax are equal", () => {
-    const repeatedValue = BasicBuilder.number();
-    const outMin = BasicBuilder.number();
-    const result = mapRange(75, repeatedValue, repeatedValue, outMin, 200);
-    expect(result).toBe(outMin);
-  });
-});
+import { clampBrightness, clampContrast } from "./utils";
 
 describe("clampBrightness", () => {
   it("maps brightness within limits", () => {
-    const result = mapRange(
-      50,
-      MIN_BRIGHTNESS,
-      MAX_BRIGHTNESS,
-      LOWER_BRIGHTNESS_LIMIT,
-      UPPER_BRIGHTNESS_LIMIT,
-    );
-    expect(clampBrightness(50)).toBe(result);
+    const randomBrightness = BasicBuilder.number({ min: MIN_BRIGHTNESS, max: MAX_BRIGHTNESS });
+    expect(clampBrightness(randomBrightness)).toBeGreaterThanOrEqual(LOWER_BRIGHTNESS_LIMIT);
+    expect(clampBrightness(randomBrightness)).toBeLessThanOrEqual(UPPER_BRIGHTNESS_LIMIT);
   });
 
-  it("clamps brightness bclampBrightness(-10)elow minimum", () => {
-    const result = clampBrightness(-10);
+  it("clamps brightness below minimum", () => {
+    const lowRandomBrightness = BasicBuilder.number({
+      min: MIN_BRIGHTNESS - 100,
+      max: MIN_BRIGHTNESS - 1,
+    });
+    const result = clampBrightness(lowRandomBrightness);
     expect(result).toBe(LOWER_BRIGHTNESS_LIMIT);
   });
 
   it("clamps brightness above maximum", () => {
-    const result = clampBrightness(150);
+    const highRandomBrightness = BasicBuilder.number({
+      min: MAX_BRIGHTNESS + 1,
+      max: MAX_BRIGHTNESS + 100,
+    });
+    const result = clampBrightness(highRandomBrightness);
     expect(result).toBe(UPPER_BRIGHTNESS_LIMIT);
   });
 });
 
 describe("clampContrast", () => {
   it("maps contrast within limits", () => {
-    const result = mapRange(
-      50,
-      MIN_CONTRAST,
-      MAX_CONTRAST,
-      LOWER_CONTRAST_LIMIT,
-      UPPER_CONTRAST_LIMIT,
-    );
-    expect(clampContrast(50)).toBe(result);
+    const randomContrast = BasicBuilder.number({ min: MIN_CONTRAST, max: MAX_CONTRAST });
+    expect(clampContrast(randomContrast)).toBeGreaterThanOrEqual(LOWER_CONTRAST_LIMIT);
+    expect(clampContrast(randomContrast)).toBeLessThanOrEqual(UPPER_CONTRAST_LIMIT);
   });
 
   it("clamps contrast below minimum", () => {
-    const result = clampContrast(-20);
+    const lowRandomContrast = BasicBuilder.number({
+      min: MIN_CONTRAST - 100,
+      max: MIN_CONTRAST - 1,
+    });
+    const result = clampContrast(lowRandomContrast);
     expect(result).toBe(LOWER_CONTRAST_LIMIT);
   });
 
   it("clamps contrast above maximum", () => {
-    const result = clampContrast(120);
+    const highRandomContrast = BasicBuilder.number({
+      min: MAX_CONTRAST + 1,
+      max: MAX_CONTRAST + 100,
+    });
+    const result = clampContrast(highRandomContrast);
     expect(result).toBe(UPPER_CONTRAST_LIMIT);
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.test.ts
@@ -11,28 +11,41 @@ import {
   UPPER_BRIGHTNESS_LIMIT,
   UPPER_CONTRAST_LIMIT,
 } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/constants";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
 
 import { mapRange, clampBrightness, clampContrast } from "./utils";
 
 describe("mapRange", () => {
   it("maps value correctly within range", () => {
-    expect(mapRange(50, 0, 100, 0, 200)).toBe(100);
+    const result = mapRange(50, 0, 100, 0, 200);
+    expect(result).toBe(100);
   });
 
   it("clamps value to inMax if above", () => {
-    expect(mapRange(150, 0, 100, 0, 200)).toBe(200);
+    const result = mapRange(150, 0, 100, 0, 200);
+    expect(result).toBe(200);
   });
 
   it("clamps value to inMin if below", () => {
-    expect(mapRange(-50, 0, 100, 0, 200)).toBe(0);
+    const result = mapRange(-50, 0, 100, 0, 200);
+    expect(result).toBe(0);
   });
 
   it("returns outMin if inMin === inMax to avoid division by zero", () => {
-    expect(mapRange(50, 100, 100, 0, 200)).toBe(0);
+    const result = mapRange(50, 100, 100, 0, 200);
+    expect(result).toBe(0);
   });
 
   it("maps correctly when in range", () => {
-    expect(mapRange(25, 0, 100, 0, 50)).toBe(12.5);
+    const result = mapRange(25, 0, 100, 0, 50);
+    expect(result).toBe(12.5);
+  });
+
+  it("should return outMin value when inMin and inMax are equal", () => {
+    const repeatedValue = BasicBuilder.number();
+    const outMin = BasicBuilder.number();
+    const result = mapRange(75, repeatedValue, repeatedValue, outMin, 200);
+    expect(result).toBe(outMin);
   });
 });
 
@@ -48,12 +61,14 @@ describe("clampBrightness", () => {
     expect(clampBrightness(50)).toBe(result);
   });
 
-  it("clamps brightness below minimum", () => {
-    expect(clampBrightness(-10)).toBe(LOWER_BRIGHTNESS_LIMIT);
+  it("clamps brightness bclampBrightness(-10)elow minimum", () => {
+    const result = clampBrightness(-10);
+    expect(result).toBe(LOWER_BRIGHTNESS_LIMIT);
   });
 
   it("clamps brightness above maximum", () => {
-    expect(clampBrightness(150)).toBe(UPPER_BRIGHTNESS_LIMIT);
+    const result = clampBrightness(150);
+    expect(result).toBe(UPPER_BRIGHTNESS_LIMIT);
   });
 });
 
@@ -70,10 +85,12 @@ describe("clampContrast", () => {
   });
 
   it("clamps contrast below minimum", () => {
-    expect(clampContrast(-20)).toBe(LOWER_CONTRAST_LIMIT);
+    const result = clampContrast(-20);
+    expect(result).toBe(LOWER_CONTRAST_LIMIT);
   });
 
   it("clamps contrast above maximum", () => {
-    expect(clampContrast(120)).toBe(UPPER_CONTRAST_LIMIT);
+    const result = clampContrast(120);
+    expect(result).toBe(UPPER_CONTRAST_LIMIT);
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.test.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import {
+  LOWER_BRIGHTNESS_LIMIT,
+  LOWER_CONTRAST_LIMIT,
+  MAX_BRIGHTNESS,
+  MAX_CONTRAST,
+  MIN_BRIGHTNESS,
+  MIN_CONTRAST,
+  UPPER_BRIGHTNESS_LIMIT,
+  UPPER_CONTRAST_LIMIT,
+} from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/constants";
+
+import { mapRange, clampBrightness, clampContrast } from "./utils";
+
+describe("mapRange", () => {
+  it("maps value correctly within range", () => {
+    expect(mapRange(50, 0, 100, 0, 200)).toBe(100);
+  });
+
+  it("clamps value to inMax if above", () => {
+    expect(mapRange(150, 0, 100, 0, 200)).toBe(200);
+  });
+
+  it("clamps value to inMin if below", () => {
+    expect(mapRange(-50, 0, 100, 0, 200)).toBe(0);
+  });
+
+  it("returns outMin if inMin === inMax to avoid division by zero", () => {
+    expect(mapRange(50, 100, 100, 0, 200)).toBe(0);
+  });
+
+  it("maps correctly when in range", () => {
+    expect(mapRange(25, 0, 100, 0, 50)).toBe(12.5);
+  });
+});
+
+describe("clampBrightness", () => {
+  it("maps brightness within limits", () => {
+    const result = mapRange(
+      50,
+      MIN_BRIGHTNESS,
+      MAX_BRIGHTNESS,
+      LOWER_BRIGHTNESS_LIMIT,
+      UPPER_BRIGHTNESS_LIMIT,
+    );
+    expect(clampBrightness(50)).toBe(result);
+  });
+
+  it("clamps brightness below minimum", () => {
+    expect(clampBrightness(-10)).toBe(LOWER_BRIGHTNESS_LIMIT);
+  });
+
+  it("clamps brightness above maximum", () => {
+    expect(clampBrightness(150)).toBe(UPPER_BRIGHTNESS_LIMIT);
+  });
+});
+
+describe("clampContrast", () => {
+  it("maps contrast within limits", () => {
+    const result = mapRange(
+      50,
+      MIN_CONTRAST,
+      MAX_CONTRAST,
+      LOWER_CONTRAST_LIMIT,
+      UPPER_CONTRAST_LIMIT,
+    );
+    expect(clampContrast(50)).toBe(result);
+  });
+
+  it("clamps contrast below minimum", () => {
+    expect(clampContrast(-20)).toBe(LOWER_CONTRAST_LIMIT);
+  });
+
+  it("clamps contrast above maximum", () => {
+    expect(clampContrast(120)).toBe(UPPER_CONTRAST_LIMIT);
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.test.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import {
+  INITIAL_BRIGHTNESS,
+  INITIAL_CONTRAST,
   LOWER_BRIGHTNESS_LIMIT,
   LOWER_CONTRAST_LIMIT,
   MAX_BRIGHTNESS,
@@ -64,5 +66,21 @@ describe("clampContrast", () => {
     });
     const result = clampContrast(highRandomContrast);
     expect(result).toBe(UPPER_CONTRAST_LIMIT);
+  });
+});
+
+describe("brightness and contrast limits", () => {
+  it("guarantee that brightness are ok", () => {
+    expect(MIN_BRIGHTNESS).toBeLessThan(MAX_BRIGHTNESS);
+    expect(INITIAL_BRIGHTNESS).toBeGreaterThanOrEqual(MIN_BRIGHTNESS);
+    expect(INITIAL_BRIGHTNESS).toBeLessThanOrEqual(MAX_BRIGHTNESS);
+    expect(LOWER_BRIGHTNESS_LIMIT).toBeLessThan(UPPER_BRIGHTNESS_LIMIT);
+  });
+
+  it("guarantee that contrast are ok", () => {
+    expect(MIN_CONTRAST).toBeLessThan(MAX_CONTRAST);
+    expect(INITIAL_CONTRAST).toBeGreaterThanOrEqual(MIN_CONTRAST);
+    expect(INITIAL_CONTRAST).toBeLessThanOrEqual(MAX_CONTRAST);
+    expect(LOWER_CONTRAST_LIMIT).toBeLessThan(UPPER_CONTRAST_LIMIT);
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.ts
@@ -12,7 +12,7 @@ import {
   UPPER_CONTRAST_LIMIT,
 } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/constants";
 
-function mapRange(
+export function mapRange(
   value: number,
   inMin: number,
   inMax: number,

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import {
+  LOWER_BRIGHTNESS_LIMIT,
+  LOWER_CONTRAST_LIMIT,
+  MAX_BRIGHTNESS,
+  MAX_CONTRAST,
+  MIN_BRIGHTNESS,
+  MIN_CONTRAST,
+  UPPER_BRIGHTNESS_LIMIT,
+  UPPER_CONTRAST_LIMIT,
+} from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/constants";
+
+function mapRange(
+  value: number,
+  inMin: number,
+  inMax: number,
+  outMin: number,
+  outMax: number,
+): number {
+  // Avoid division by 0
+  if (inMin === inMax) {
+    return outMin;
+  }
+
+  const clamped = Math.min(Math.max(value, inMin), inMax);
+  return ((clamped - inMin) / (inMax - inMin)) * (outMax - outMin) + outMin;
+}
+
+export function clampBrightness(value: number): number {
+  return mapRange(
+    value,
+    MIN_BRIGHTNESS,
+    MAX_BRIGHTNESS,
+    LOWER_BRIGHTNESS_LIMIT,
+    UPPER_BRIGHTNESS_LIMIT,
+  );
+}
+
+export function clampContrast(value: number): number {
+  return mapRange(value, MIN_CONTRAST, MAX_CONTRAST, LOWER_CONTRAST_LIMIT, UPPER_CONTRAST_LIMIT);
+}

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.ts
@@ -12,20 +12,20 @@ import {
   UPPER_CONTRAST_LIMIT,
 } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/constants";
 
-export function mapRange(
+function mapRange(
   value: number,
-  inMin: number,
-  inMax: number,
-  outMin: number,
-  outMax: number,
+  inputMin: number,
+  inputMax: number,
+  outputMin: number,
+  outputMax: number,
 ): number {
   // Avoid division by 0
-  if (inMin === inMax) {
-    return outMin;
+  if (inputMin === inputMax) {
+    return outputMin;
   }
 
-  const clamped = Math.min(Math.max(value, inMin), inMax);
-  return ((clamped - inMin) / (inMax - inMin)) * (outMax - outMin) + outMin;
+  const clamped = Math.min(Math.max(value, inputMin), inputMax);
+  return ((clamped - inputMin) / (inputMax - inputMin)) * (outputMax - outputMin) + outputMin;
 }
 
 export function clampBrightness(value: number): number {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/utils.ts
@@ -19,11 +19,6 @@ function mapRange(
   outputMin: number,
   outputMax: number,
 ): number {
-  // Avoid division by 0
-  if (inputMin === inputMax) {
-    return outputMin;
-  }
-
   const clamped = Math.min(Math.max(value, inputMin), inputMax);
   return ((clamped - inputMin) / (inputMax - inputMin)) * (outputMax - outputMin) + outputMin;
 }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -15,7 +15,7 @@ import { CameraModelsMap } from "@lichtblick/den/image/types";
 import Logger from "@lichtblick/log";
 import { toNanoSec } from "@lichtblick/rostime";
 import { SettingsTreeAction, SettingsTreeFields } from "@lichtblick/suite";
-import { ALL_SUPPORTED_IMAGE_SCHEMAS } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/ImageMode";
+import { ALL_SUPPORTED_IMAGE_SCHEMAS } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/constants";
 
 import {
   IMAGE_RENDERABLE_DEFAULT_SETTINGS,

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -98,6 +98,30 @@ describe("ImageRenderable", () => {
     expect(renderable.isDisposed()).toBe(true);
   });
 
+  it("should set a new brightness value", () => {
+    const newBrightnessValue = BasicBuilder.number();
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+
+    renderable.userData.texture = new THREE.Texture();
+    renderable.userData.material = new THREE.ShaderMaterial();
+    renderable.setSettings({ ...renderable.userData.settings, brightness: newBrightnessValue });
+    renderable.userData.geometry = new THREE.PlaneGeometry();
+
+    expect(renderable.userData.settings.brightness).toBe(newBrightnessValue);
+  });
+
+  it("should set a new contrast value", () => {
+    const newContrastValue = BasicBuilder.number();
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+
+    renderable.userData.texture = new THREE.Texture();
+    renderable.userData.material = new THREE.ShaderMaterial();
+    renderable.setSettings({ ...renderable.userData.settings, contrast: newContrastValue });
+    renderable.userData.geometry = new THREE.PlaneGeometry();
+
+    expect(renderable.userData.settings.contrast).toBe(newContrastValue);
+  });
+
   it("should set camera model", () => {
     const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
     const model = new PinholeCameraModel({

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -86,7 +86,7 @@ describe("ImageRenderable", () => {
   it("should dispose resources", () => {
     const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
     renderable.userData.texture = new THREE.Texture();
-    renderable.userData.material = new THREE.MeshBasicMaterial();
+    renderable.userData.material = new THREE.ShaderMaterial();
     renderable.userData.geometry = new THREE.PlaneGeometry();
 
     // @ts-expect-error isDisposed is protected, but ok to use on tests

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -179,7 +179,11 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       this.#geometryNeedsUpdate = true;
     }
 
-    if (newSettings.color !== prevSettings.color) {
+    if (
+      newSettings.color !== prevSettings.color ||
+      newSettings.brightness !== prevSettings.brightness ||
+      newSettings.contrast !== prevSettings.contrast
+    ) {
       this.#materialNeedsUpdate = true;
     }
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -179,11 +179,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       this.#geometryNeedsUpdate = true;
     }
 
-    if (
-      newSettings.color !== prevSettings.color ||
-      newSettings.brightness !== prevSettings.brightness ||
-      newSettings.contrast !== prevSettings.contrast
-    ) {
+    if (newSettings.color !== prevSettings.color) {
       this.#materialNeedsUpdate = true;
     }
 
@@ -193,7 +189,9 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       !_.isEqual(prevSettings.gradient, newSettings.gradient) ||
       prevSettings.colorMap !== newSettings.colorMap ||
       prevSettings.minValue !== newSettings.minValue ||
-      prevSettings.maxValue !== newSettings.maxValue
+      prevSettings.maxValue !== newSettings.maxValue ||
+      prevSettings.brightness !== newSettings.brightness ||
+      prevSettings.contrast !== newSettings.contrast
     ) {
       this.userData.settings = newSettings;
       // Decode the current image again, which takes into account the new options

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -78,6 +78,7 @@ export type ImageUserData = BaseUserData & {
   cameraModel: ICameraModel | undefined;
   image: AnyImage | undefined;
   texture: THREE.Texture | undefined;
+  // The material should use ShaderMaterial so we can use custom shaders to apply effects like brightness and contrast
   material: THREE.ShaderMaterial | undefined;
   geometry: THREE.PlaneGeometry | undefined;
   mesh: THREE.Mesh | undefined;
@@ -520,6 +521,7 @@ function createCanvasTexture(bitmap: ImageBitmap): THREE.CanvasTexture {
     THREE.UnsignedByteType,
   );
   texture.generateMipmaps = false;
+  // Color space needs to be set to LinearSRGBColorSpace for correct color rendering on custom Shader
   texture.colorSpace = THREE.LinearSRGBColorSpace;
   return texture;
 }
@@ -537,6 +539,7 @@ function createDataTexture(imageData: ImageData): THREE.DataTexture {
     THREE.NearestFilter,
     THREE.LinearFilter,
     1,
+    // Color space needs to be set to LinearSRGBColorSpace for correct color rendering on custom Shader
     THREE.LinearSRGBColorSpace,
   );
   dataTexture.needsUpdate = true; // ensure initial image data is displayed

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -36,8 +36,8 @@ import {
   DECODE_IMAGE_ERR_KEY,
   FRAGMENT_SHADER,
   IMAGE_TOPIC_PATH,
-  MID_BRIGHTNESS,
-  MID_CONTRAST,
+  INITIAL_BRIGHTNESS,
+  INITIAL_CONTRAST,
   VERTEX_SHADER,
 } from "../ImageMode/constants";
 import { ColorModeSettings } from "../colorMode";
@@ -63,8 +63,8 @@ export const IMAGE_RENDERABLE_DEFAULT_SETTINGS: ImageRenderableSettings = {
   distance: DEFAULT_DISTANCE,
   planarProjectionFactor: DEFAULT_PLANAR_PROJECTION_FACTOR,
   color: "#ffffff",
-  brightness: MID_BRIGHTNESS,
-  contrast: MID_CONTRAST,
+  brightness: INITIAL_BRIGHTNESS,
+  contrast: INITIAL_CONTRAST,
 };
 
 const IMAGE_FORMATS = new Set(["jpeg", "jpg", "png", "webp"]);

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -16,6 +16,10 @@ import { ICameraModel } from "@lichtblick/suite";
 import { IRenderer } from "@lichtblick/suite-base/panels/ThreeDeeRender/IRenderer";
 import { BaseUserData, Renderable } from "@lichtblick/suite-base/panels/ThreeDeeRender/Renderable";
 import { stringToRgba } from "@lichtblick/suite-base/panels/ThreeDeeRender/color";
+import {
+  clampBrightness,
+  clampContrast,
+} from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/ImageMode/utils";
 import { WorkerImageDecoder } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder";
 import { projectPixel } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/projections";
 import { RosValue } from "@lichtblick/suite-base/players/types";
@@ -28,7 +32,14 @@ import {
   getVideoDecoderConfig,
 } from "./decodeImage";
 import { CameraInfo } from "../../ros";
-import { DECODE_IMAGE_ERR_KEY, IMAGE_TOPIC_PATH } from "../ImageMode/constants";
+import {
+  DECODE_IMAGE_ERR_KEY,
+  FRAGMENT_SHADER,
+  IMAGE_TOPIC_PATH,
+  MID_BRIGHTNESS,
+  MID_CONTRAST,
+  VERTEX_SHADER,
+} from "../ImageMode/constants";
 import { ColorModeSettings } from "../colorMode";
 
 const log = Logger.getLogger(__filename);
@@ -39,6 +50,8 @@ export interface ImageRenderableSettings extends Partial<ColorModeSettings> {
   distance: number;
   planarProjectionFactor: number;
   color: string;
+  brightness: number;
+  contrast: number;
 }
 
 const DEFAULT_DISTANCE = 1;
@@ -50,6 +63,8 @@ export const IMAGE_RENDERABLE_DEFAULT_SETTINGS: ImageRenderableSettings = {
   distance: DEFAULT_DISTANCE,
   planarProjectionFactor: DEFAULT_PLANAR_PROJECTION_FACTOR,
   color: "#ffffff",
+  brightness: MID_BRIGHTNESS,
+  contrast: MID_CONTRAST,
 };
 
 const IMAGE_FORMATS = new Set(["jpeg", "jpg", "png", "webp"]);
@@ -63,7 +78,7 @@ export type ImageUserData = BaseUserData & {
   cameraModel: ICameraModel | undefined;
   image: AnyImage | undefined;
   texture: THREE.Texture | undefined;
-  material: THREE.MeshBasicMaterial | undefined;
+  material: THREE.ShaderMaterial | undefined;
   geometry: THREE.PlaneGeometry | undefined;
   mesh: THREE.Mesh | undefined;
 };
@@ -404,13 +419,17 @@ export class ImageRenderable extends Renderable<ImageUserData> {
 
     const texture = this.userData.texture;
     if (texture) {
-      material.map = texture;
+      material.uniforms.map = { value: texture };
     }
 
     tempColor = stringToRgba(tempColor, this.userData.settings.color);
     const transparent = tempColor.a < 1;
     const color = new THREE.Color(tempColor.r, tempColor.g, tempColor.b);
-    material.color.set(color);
+    const { brightness, contrast } = this.userData.settings;
+    material.uniforms.color = { value: color };
+    material.uniforms.brightness = { value: clampBrightness(brightness) };
+    material.uniforms.contrast = { value: clampContrast(contrast) };
+    material.uniforms.opacity = { value: tempColor.a };
     material.opacity = tempColor.a;
     material.transparent = transparent;
     material.depthWrite = !transparent;
@@ -429,13 +448,23 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     stringToRgba(tempColor, this.userData.settings.color);
     const transparent = tempColor.a < 1;
     const color = new THREE.Color(tempColor.r, tempColor.g, tempColor.b);
-    this.userData.material = new THREE.MeshBasicMaterial({
+    const { brightness, contrast } = this.userData.settings;
+    const uniforms = {
+      map: { value: this.userData.texture },
+      color: { value: color },
+      opacity: { value: tempColor.a },
+      brightness: { value: clampBrightness(brightness) },
+      contrast: { value: clampContrast(contrast) },
+    };
+    this.userData.material = new THREE.ShaderMaterial({
       name: `${this.userData.topic}:Material`,
-      color,
+      uniforms,
       side: THREE.DoubleSide,
       opacity: tempColor.a,
       transparent,
       depthWrite: !transparent,
+      vertexShader: VERTEX_SHADER,
+      fragmentShader: FRAGMENT_SHADER,
     });
   }
 
@@ -487,7 +516,7 @@ function createCanvasTexture(bitmap: ImageBitmap): THREE.CanvasTexture {
     THREE.UnsignedByteType,
   );
   texture.generateMipmaps = false;
-  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.colorSpace = THREE.LinearSRGBColorSpace;
   return texture;
 }
 
@@ -504,7 +533,7 @@ function createDataTexture(imageData: ImageData): THREE.DataTexture {
     THREE.NearestFilter,
     THREE.LinearFilter,
     1,
-    THREE.SRGBColorSpace,
+    THREE.LinearSRGBColorSpace,
   );
   dataTexture.needsUpdate = true; // ensure initial image data is displayed
   return dataTexture;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -179,7 +179,11 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       this.#geometryNeedsUpdate = true;
     }
 
-    if (newSettings.color !== prevSettings.color) {
+    if (
+      newSettings.color !== prevSettings.color ||
+      prevSettings.brightness !== newSettings.brightness ||
+      prevSettings.contrast !== newSettings.contrast
+    ) {
       this.#materialNeedsUpdate = true;
     }
 
@@ -189,9 +193,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       !_.isEqual(prevSettings.gradient, newSettings.gradient) ||
       prevSettings.colorMap !== newSettings.colorMap ||
       prevSettings.minValue !== newSettings.minValue ||
-      prevSettings.maxValue !== newSettings.maxValue ||
-      prevSettings.brightness !== newSettings.brightness ||
-      prevSettings.contrast !== newSettings.contrast
+      prevSettings.maxValue !== newSettings.maxValue
     ) {
       this.userData.settings = newSettings;
       // Decode the current image again, which takes into account the new options

--- a/packages/suite/src/index.ts
+++ b/packages/suite/src/index.ts
@@ -687,6 +687,7 @@ export type SettingsTreeFieldSlider = {
   value?: number;
   min?: number;
   max?: number;
+  step?: number;
 };
 
 export type SettingsTreeFieldVec3 = {

--- a/packages/suite/src/index.ts
+++ b/packages/suite/src/index.ts
@@ -682,6 +682,13 @@ export type SettingsTreeFieldToggleNumber = {
   options: number[] | Array<{ label: string; value: undefined | number }>;
 };
 
+export type SettingsTreeFieldSlider = {
+  input: "slider";
+  value?: number;
+  min?: number;
+  max?: number;
+};
+
 export type SettingsTreeFieldVec3 = {
   input: "vec3";
   value?: [undefined | number, undefined | number, undefined | number];
@@ -717,6 +724,7 @@ export type SettingsTreeFieldValue =
   | SettingsTreeFieldString
   | SettingsTreeFieldToggleString
   | SettingsTreeFieldToggleNumber
+  | SettingsTreeFieldSlider
   | SettingsTreeFieldVec3
   | SettingsTreeFieldVec2;
 


### PR DESCRIPTION
## User-Facing Changes

This pull request introduces new settings for the Image Panel, providing Lichtblick users with greater control over image visualization. Specifically, we are adding two new sliders that allow users to adjust brightness and contrast directly within the panel.

These enhancements enable users to make minor visual adjustments to improve image clarity and visibility, ultimately enhancing the overall user experience when working with the Image Panel.

![image](https://github.com/user-attachments/assets/2968ec02-7641-422c-bd84-09c0bc42a75c)

## Description

### Summary of Changes

- **Replaced `THREE.MeshBasicMaterial` with `THREE.ShaderMaterial`**  
  This allows the use of custom GLSL shaders for rendering, giving us full control over pixel manipulation (e.g. brightness, contrast). Unlike built-in materials, `ShaderMaterial` requires manual handling of color processing, which leads to the next change.

- **Set texture color space to `THREE.LinearSRGBColorSpace`**  
  When using `ShaderMaterial`, Three.js does not automatically linearize sRGB textures. To avoid manual sRGB-to-linear conversion in the shader (which is more costly and complex), we set the texture’s `colorSpace` to `LinearSRGBColorSpace`, assuming the texture data is already linear. This ensures correct color rendering and improves performance. Without that, it was noticed that the image is darker.

References:
- [ShaderMaterial – Three.js docs](https://threejs.org/docs/#api/en/materials/ShaderMaterial)
- [Color Management in Three.js](https://threejs.org/docs/#manual/en/introduction/Color-management)
- [Shader GLSL](https://www.khronos.org/files/opengles_shading_language.pdf)


**Checklist**

- [X] The web version was tested and it is running ok
- [X] The desktop version was tested and it is running ok
- [X] This change is covered by unit tests
- [X] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
