### PR TITLE
chore: update Node.js version to 20 in SonarCloud workflow

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4.0.3
         with:
-          node-version: 16.17
+          node-version: 20
 
       - name: Enable corepack
         run: corepack enable yarn


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
N/A

**Description**
Updated node version from 16 to 20 in Sonar Github workflow to fix issues in #542 related to os.availableParallelism(), which is available since node v18.

See error details:
https://github.com/lichtblick-suite/lichtblick/actions/runs/16057013472/job/45313815729#step:8:12

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

