### PR TITLE
Buffer messages as UInt8Array

### DIFF
--- a/benchmark/src/dataSources/McapLocalBenchmarkDataSourceFactory.ts
+++ b/benchmark/src/dataSources/McapLocalBenchmarkDataSourceFactory.ts
@@ -9,6 +9,7 @@ import {
   IDataSourceFactory,
   DataSourceFactoryInitializeArgs,
 } from "@lichtblick/suite-base/context/PlayerSelectionContext";
+import { DeserializingIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/DeserializingIterableSource";
 import { McapIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/Mcap/McapIterableSource";
 import { Player } from "@lichtblick/suite-base/players/types";
 
@@ -28,7 +29,8 @@ class McapLocalBenchmarkDataSourceFactory implements IDataSourceFactory {
     }
 
     const mcapProvider = new McapIterableSource({ type: "file", file });
-    return new BenchmarkPlayer(file.name, mcapProvider);
+    const source = new DeserializingIterableSource(mcapProvider);
+    return new BenchmarkPlayer(file.name, source);
   }
 }
 

--- a/benchmark/src/players/BenchmarkPlayer.ts
+++ b/benchmark/src/players/BenchmarkPlayer.ts
@@ -11,7 +11,7 @@ import { toRFC3339String } from "@lichtblick/rostime";
 import { MessageEvent } from "@lichtblick/suite";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
 import { BlockLoader } from "@lichtblick/suite-base/players/IterablePlayer/BlockLoader";
-import { IIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
+import { IDeserializedIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import PlayerAlertManager from "@lichtblick/suite-base/players/PlayerAlertManager";
 import { PLAYER_CAPABILITIES } from "@lichtblick/suite-base/players/constants";
 import {
@@ -29,18 +29,18 @@ const log = Log.getLogger(__filename);
 
 const DEFAULT_CACHE_SIZE_BYTES = 1.0e9;
 const MIN_MEM_CACHE_BLOCK_SIZE_NS = 0.1e9;
-const MAX_BLOCKS = 400;
+const MAX_BLOCKS = 100;
 const CAPABILITIES: string[] = [PLAYER_CAPABILITIES.playbackControl];
 
 class BenchmarkPlayer implements Player {
-  #source: IIterableSource;
+  #source: IDeserializedIterableSource;
   #name: string;
   #listener?: (state: PlayerState) => Promise<void>;
   #subscriptions: SubscribePayload[] = [];
   #blockLoader?: BlockLoader;
   #alertManager = new PlayerAlertManager();
 
-  public constructor(name: string, source: IIterableSource) {
+  public constructor(name: string, source: IDeserializedIterableSource) {
     this.#name = name;
     this.#source = source;
   }

--- a/packages/suite-base/src/dataSources/McapLocalDataSourceFactory.test.ts
+++ b/packages/suite-base/src/dataSources/McapLocalDataSourceFactory.test.ts
@@ -3,10 +3,8 @@
 
 import { DataSourceFactoryInitializeArgs } from "@lichtblick/suite-base/context/PlayerSelectionContext";
 import { FILE_ACCEPT_TYPE } from "@lichtblick/suite-base/context/Workspace/constants";
-import {
-  WorkerIterableSource,
-  IterablePlayer,
-} from "@lichtblick/suite-base/players/IterablePlayer";
+import { IterablePlayer } from "@lichtblick/suite-base/players/IterablePlayer";
+import { WorkerSerializedIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource";
 import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
 
 import McapLocalDataSourceFactory from "./McapLocalDataSourceFactory";
@@ -20,8 +18,11 @@ global.Worker = jest.fn().mockImplementation(() => ({
 }));
 
 jest.mock("@lichtblick/suite-base/players/IterablePlayer", () => ({
-  WorkerIterableSource: jest.fn(),
   IterablePlayer: jest.fn(),
+}));
+
+jest.mock("@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource", () => ({
+  WorkerSerializedIterableSource: jest.fn(),
 }));
 
 describe("McapLocalDataSourceFactory", () => {
@@ -56,7 +57,7 @@ describe("McapLocalDataSourceFactory", () => {
 
     const player = factory.initialize(args);
 
-    expect(WorkerIterableSource).toHaveBeenCalledWith({
+    expect(WorkerSerializedIterableSource).toHaveBeenCalledWith({
       initWorker: expect.any(Function),
       initArgs: { files },
     });
@@ -65,6 +66,7 @@ describe("McapLocalDataSourceFactory", () => {
       source: expect.any(Object),
       name: files[0]!.name,
       sourceId: MCAP_LOCAL_FILE_ID,
+      readAheadDuration: { sec: 120, nsec: 0 },
     });
     expect(player).toBeInstanceOf(IterablePlayer);
   });
@@ -75,7 +77,7 @@ describe("McapLocalDataSourceFactory", () => {
 
     const player = factory.initialize(args);
 
-    expect(WorkerIterableSource).toHaveBeenCalledWith({
+    expect(WorkerSerializedIterableSource).toHaveBeenCalledWith({
       initWorker: expect.any(Function),
       initArgs: { files },
     });
@@ -84,6 +86,7 @@ describe("McapLocalDataSourceFactory", () => {
       source: expect.any(Object),
       name: `${files[0]!.name}, ${files[1]!.name}`,
       sourceId: MCAP_LOCAL_FILE_ID,
+      readAheadDuration: { sec: 120, nsec: 0 },
     });
     expect(player).toBeInstanceOf(IterablePlayer);
   });
@@ -94,7 +97,7 @@ describe("McapLocalDataSourceFactory", () => {
     const player = factory.initialize(args);
 
     expect(player).toBeUndefined();
-    expect(WorkerIterableSource).not.toHaveBeenCalled();
+    expect(WorkerSerializedIterableSource).not.toHaveBeenCalled();
     expect(IterablePlayer).not.toHaveBeenCalled();
   });
 
@@ -104,7 +107,7 @@ describe("McapLocalDataSourceFactory", () => {
 
     const player = factory.initialize(args);
 
-    expect(WorkerIterableSource).toHaveBeenCalledWith({
+    expect(WorkerSerializedIterableSource).toHaveBeenCalledWith({
       initWorker: expect.any(Function),
       initArgs: { files: [file] },
     });
@@ -113,6 +116,7 @@ describe("McapLocalDataSourceFactory", () => {
       source: expect.any(Object),
       name: file.name,
       sourceId: MCAP_LOCAL_FILE_ID,
+      readAheadDuration: { sec: 120, nsec: 0 },
     });
     expect(player).toBeInstanceOf(IterablePlayer);
   });
@@ -124,7 +128,7 @@ describe("McapLocalDataSourceFactory", () => {
 
     const player = factory.initialize(args);
 
-    expect(WorkerIterableSource).toHaveBeenCalledWith({
+    expect(WorkerSerializedIterableSource).toHaveBeenCalledWith({
       initWorker: expect.any(Function),
       initArgs: { files: [file, files[0]] },
     });
@@ -133,6 +137,7 @@ describe("McapLocalDataSourceFactory", () => {
       source: expect.any(Object),
       name: `${files[0]?.name}, ${file.name}`,
       sourceId: MCAP_LOCAL_FILE_ID,
+      readAheadDuration: { sec: 120, nsec: 0 },
     });
     expect(player).toBeInstanceOf(IterablePlayer);
   });

--- a/packages/suite-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/suite-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -10,10 +10,8 @@ import {
   IDataSourceFactory,
   DataSourceFactoryInitializeArgs,
 } from "@lichtblick/suite-base/context/PlayerSelectionContext";
-import {
-  IterablePlayer,
-  WorkerIterableSource,
-} from "@lichtblick/suite-base/players/IterablePlayer";
+import { IterablePlayer } from "@lichtblick/suite-base/players/IterablePlayer";
+import { WorkerSerializedIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource";
 import { Player } from "@lichtblick/suite-base/players/types";
 import { mergeMultipleFileNames } from "@lichtblick/suite-base/util/mergeMultipleFileName";
 
@@ -35,7 +33,7 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
       return;
     }
 
-    const source = new WorkerIterableSource({
+    const source = new WorkerSerializedIterableSource({
       initWorker: () => {
         return new Worker(
           // foxglove-depcheck-used: babel-plugin-transform-import-meta
@@ -53,6 +51,7 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
       source,
       name: mergeMultipleFileNames(files.map((file) => file.name)),
       sourceId: this.id,
+      readAheadDuration: { sec: 120, nsec: 0 },
     });
   }
 }

--- a/packages/suite-base/src/dataSources/RemoteDataSourceFactory.test.tsx
+++ b/packages/suite-base/src/dataSources/RemoteDataSourceFactory.test.tsx
@@ -4,17 +4,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { DataSourceFactoryInitializeArgs } from "@lichtblick/suite-base/context/PlayerSelectionContext";
-import {
-  IterablePlayer,
-  WorkerIterableSource,
-} from "@lichtblick/suite-base/players/IterablePlayer";
+import { IterablePlayer } from "@lichtblick/suite-base/players/IterablePlayer";
+import { WorkerSerializedIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource";
 import { PlayerMetricsCollectorInterface } from "@lichtblick/suite-base/players/types";
 
 import RemoteDataSourceFactory, { checkExtensionMatch } from "./RemoteDataSourceFactory";
 
 jest.mock("@lichtblick/suite-base/players/IterablePlayer", () => ({
-  WorkerIterableSource: jest.fn(),
   IterablePlayer: jest.fn(),
+}));
+
+jest.mock("@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource", () => ({
+  WorkerSerializedIterableSource: jest.fn(),
 }));
 
 function setupArgs(params?: Record<string, string | undefined>): DataSourceFactoryInitializeArgs {
@@ -59,7 +60,7 @@ describe("RemoteDataSourceFactory", () => {
   let factory: RemoteDataSourceFactory;
 
   const mockSource = { mock: "workerSource" };
-  (WorkerIterableSource as jest.Mock).mockImplementation(() => mockSource);
+  (WorkerSerializedIterableSource as jest.Mock).mockImplementation(() => mockSource);
 
   const mockPlayer = { mock: "playerInstance" };
   (IterablePlayer as jest.Mock).mockImplementation(() => mockPlayer);
@@ -75,7 +76,7 @@ describe("RemoteDataSourceFactory", () => {
 
     const result = factory.initialize(mockArgs);
 
-    expect(WorkerIterableSource).toHaveBeenCalledWith({
+    expect(WorkerSerializedIterableSource).toHaveBeenCalledWith({
       initWorker: expect.any(Function),
       initArgs: { urls: ["https://example.com/test.mcap"] },
     });
@@ -86,6 +87,7 @@ describe("RemoteDataSourceFactory", () => {
       metricsCollector: mockArgs.metricsCollector,
       urlParams: { urls: ["https://example.com/test.mcap"] },
       sourceId: "remote-file",
+      readAheadDuration: { sec: 10, nsec: 0 },
     });
 
     expect(result).toBe(mockPlayer);
@@ -104,6 +106,7 @@ describe("RemoteDataSourceFactory", () => {
       metricsCollector: mockArgs.metricsCollector,
       urlParams: { urls: ["https://example.com/test1.mcap", "https://example.com/test2.mcap"] },
       sourceId: "remote-file",
+      readAheadDuration: { sec: 10, nsec: 0 },
     });
 
     expect(result).toBe(mockPlayer);

--- a/packages/suite-base/src/dataSources/RemoteDataSourceFactory.tsx
+++ b/packages/suite-base/src/dataSources/RemoteDataSourceFactory.tsx
@@ -12,10 +12,8 @@ import {
   IDataSourceFactory,
   DataSourceFactoryInitializeArgs,
 } from "@lichtblick/suite-base/context/PlayerSelectionContext";
-import {
-  IterablePlayer,
-  WorkerIterableSource,
-} from "@lichtblick/suite-base/players/IterablePlayer";
+import { IterablePlayer } from "@lichtblick/suite-base/players/IterablePlayer";
+import { WorkerSerializedIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource";
 import { Player } from "@lichtblick/suite-base/players/types";
 
 const initWorkers: Record<string, () => Worker> = {
@@ -107,7 +105,7 @@ class RemoteDataSourceFactory implements IDataSourceFactory {
 
     const initWorker = initWorkers[extension]!;
 
-    const source = new WorkerIterableSource({ initWorker, initArgs: { urls } });
+    const source = new WorkerSerializedIterableSource({ initWorker, initArgs: { urls } });
 
     return new IterablePlayer({
       source,
@@ -115,6 +113,7 @@ class RemoteDataSourceFactory implements IDataSourceFactory {
       metricsCollector: args.metricsCollector,
       urlParams: { urls },
       sourceId: this.id,
+      readAheadDuration: { sec: 10, nsec: 0 },
     });
   }
 

--- a/packages/suite-base/src/dataSources/Ros1LocalBagDataSourceFactory.test.ts
+++ b/packages/suite-base/src/dataSources/Ros1LocalBagDataSourceFactory.test.ts
@@ -5,14 +5,14 @@ import { DataSourceFactoryInitializeArgs } from "@lichtblick/suite-base/context/
 import {
   IterablePlayer,
   IterablePlayerOptions,
-  WorkerIterableSource,
 } from "@lichtblick/suite-base/players/IterablePlayer";
+import { WorkerSerializedIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource";
 import NoopMetricsCollector from "@lichtblick/suite-base/players/NoopMetricsCollector";
 import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
 
 import Ros1LocalBagDataSourceFactory from "./Ros1LocalBagDataSourceFactory";
 
-jest.mock("@lichtblick/suite-base/players/IterablePlayer/WorkerIterableSource");
+jest.mock("@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource");
 jest.mock("@lichtblick/suite-base/players/IterablePlayer");
 
 describe("Ros1LocalBagDataSourceFactory", () => {
@@ -76,15 +76,16 @@ describe("Ros1LocalBagDataSourceFactory", () => {
     const player = factory.initialize(args);
 
     expect(player).toBeInstanceOf(IterablePlayer);
-    expect(WorkerIterableSource).toHaveBeenCalledWith({
+    expect(WorkerSerializedIterableSource).toHaveBeenCalledWith({
       initWorker: expect.any(Function),
       initArgs: expectedInitArgs,
     });
     expect(IterablePlayer).toHaveBeenCalledWith({
       metricsCollector: args.metricsCollector,
-      source: expect.any(WorkerIterableSource),
+      source: expect.any(WorkerSerializedIterableSource),
       name: expectedInitArgs.file?.name,
       sourceId: expect.any(String),
+      readAheadDuration: { sec: 120, nsec: 0 },
     } as IterablePlayerOptions);
   });
 });

--- a/packages/suite-base/src/dataSources/Ros1LocalBagDataSourceFactory.ts
+++ b/packages/suite-base/src/dataSources/Ros1LocalBagDataSourceFactory.ts
@@ -10,10 +10,8 @@ import {
   IDataSourceFactory,
   DataSourceFactoryInitializeArgs,
 } from "@lichtblick/suite-base/context/PlayerSelectionContext";
-import {
-  IterablePlayer,
-  WorkerIterableSource,
-} from "@lichtblick/suite-base/players/IterablePlayer";
+import { IterablePlayer } from "@lichtblick/suite-base/players/IterablePlayer";
+import { WorkerSerializedIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource";
 import { Player } from "@lichtblick/suite-base/players/types";
 
 class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
@@ -38,7 +36,7 @@ class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
       return;
     }
 
-    const source = new WorkerIterableSource({
+    const source = new WorkerSerializedIterableSource({
       initWorker: () => {
         return new Worker(
           // foxglove-depcheck-used: babel-plugin-transform-import-meta
@@ -56,6 +54,7 @@ class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
       source,
       name: file.name,
       sourceId: this.id,
+      readAheadDuration: { sec: 120, nsec: 0 },
     });
   }
 }

--- a/packages/suite-base/src/dataSources/Ros2LocalBagDataSourceFactory.ts
+++ b/packages/suite-base/src/dataSources/Ros2LocalBagDataSourceFactory.ts
@@ -10,10 +10,8 @@ import {
   IDataSourceFactory,
   DataSourceFactoryInitializeArgs,
 } from "@lichtblick/suite-base/context/PlayerSelectionContext";
-import {
-  IterablePlayer,
-  WorkerIterableSource,
-} from "@lichtblick/suite-base/players/IterablePlayer";
+import { IterablePlayer } from "@lichtblick/suite-base/players/IterablePlayer";
+import { WorkerSerializedIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource";
 import { Player } from "@lichtblick/suite-base/players/types";
 
 class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
@@ -32,7 +30,7 @@ class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
       return;
     }
 
-    const source = new WorkerIterableSource({
+    const source = new WorkerSerializedIterableSource({
       initWorker: () => {
         return new Worker(
           // foxglove-depcheck-used: babel-plugin-transform-import-meta
@@ -50,6 +48,7 @@ class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
       source,
       name,
       sourceId: this.id,
+      readAheadDuration: { sec: 120, nsec: 0 },
     });
   }
 }

--- a/packages/suite-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
+++ b/packages/suite-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
@@ -9,10 +9,8 @@ import {
   IDataSourceFactory,
   DataSourceFactoryInitializeArgs,
 } from "@lichtblick/suite-base/context/PlayerSelectionContext";
-import {
-  IterablePlayer,
-  WorkerIterableSource,
-} from "@lichtblick/suite-base/players/IterablePlayer";
+import { IterablePlayer } from "@lichtblick/suite-base/players/IterablePlayer";
+import { WorkerSerializedIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource";
 
 import SampleNuscenesLayout from "./SampleNuscenesLayout.json";
 
@@ -29,7 +27,7 @@ class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
   ): ReturnType<IDataSourceFactory["initialize"]> {
     const bagUrl = "https://assets.foxglove.dev/NuScenes-v1.0-mini-scene-0061-df24c12.mcap";
 
-    const source = new WorkerIterableSource({
+    const source = new WorkerSerializedIterableSource({
       initWorker: () => {
         return new Worker(
           // foxglove-depcheck-used: babel-plugin-transform-import-meta
@@ -50,6 +48,7 @@ class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
       // Use blank url params so the data source is set in the url
       urlParams: {},
       sourceId: this.id,
+      readAheadDuration: { sec: 10, nsec: 0 },
     });
   }
 }

--- a/packages/suite-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/suite-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -583,6 +583,13 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this.#parsedMessagesBytes = 0;
       }
 
+      // Override any previous start/end time when we set a clockTime for the first time which means
+      // we've received the first "time" event and know the server controlled time.
+      if (!this.#clockTime) {
+        this.#startTime = time;
+        this.#endTime = time;
+      }
+
       this.#clockTime = time;
       this.#emitState();
     });

--- a/packages/suite-base/src/players/IterablePlayer/BagIterableSourceWorker.worker.ts
+++ b/packages/suite-base/src/players/IterablePlayer/BagIterableSourceWorker.worker.ts
@@ -7,18 +7,20 @@
 
 import * as Comlink from "@lichtblick/comlink";
 import { IterableSourceInitializeArgs } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
-import { WorkerIterableSourceWorker } from "@lichtblick/suite-base/players/IterablePlayer/WorkerIterableSourceWorker";
+import { WorkerSerializedIterableSourceWorker } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSourceWorker";
 
 import { BagIterableSource } from "./BagIterableSource";
 
-export function initialize(args: IterableSourceInitializeArgs): WorkerIterableSourceWorker {
+export function initialize(
+  args: IterableSourceInitializeArgs,
+): WorkerSerializedIterableSourceWorker {
   if (args.file) {
     const source = new BagIterableSource({ type: "file", file: args.file });
-    const wrapped = new WorkerIterableSourceWorker(source);
+    const wrapped = new WorkerSerializedIterableSourceWorker(source);
     return Comlink.proxy(wrapped);
   } else if (args.url) {
     const source = new BagIterableSource({ type: "remote", url: args.url });
-    const wrapped = new WorkerIterableSourceWorker(source);
+    const wrapped = new WorkerSerializedIterableSourceWorker(source);
     return Comlink.proxy(wrapped);
   }
 

--- a/packages/suite-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -13,13 +13,14 @@ import { mockTopicSelection } from "@lichtblick/suite-base/test/mocks/mockTopicS
 import { BlockLoader, MEMORY_INFO_PRELOADED_MSGS } from "./BlockLoader";
 import {
   GetBackfillMessagesArgs,
-  IIterableSource,
+  IDeserializedIterableSource,
   Initialization,
   IteratorResult,
   MessageIteratorArgs,
 } from "./IIterableSource";
 
-class TestSource implements IIterableSource {
+class TestSource implements IDeserializedIterableSource {
+  public readonly sourceType = "deserialized";
   public async initialize(): Promise<Initialization> {
     return {
       start: { sec: 0, nsec: 0 },

--- a/packages/suite-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/suite-base/src/players/IterablePlayer/BlockLoader.ts
@@ -24,7 +24,7 @@ import { IteratorCursor } from "@lichtblick/suite-base/players/IterablePlayer/It
 import PlayerAlertManager from "@lichtblick/suite-base/players/PlayerAlertManager";
 import { MessageBlock, Progress, TopicSelection } from "@lichtblick/suite-base/players/types";
 
-import { IIterableSource, MessageIteratorArgs } from "./IIterableSource";
+import { IDeserializedIterableSource, MessageIteratorArgs } from "./IIterableSource";
 
 const log = Log.getLogger(__filename);
 
@@ -32,7 +32,7 @@ export const MEMORY_INFO_PRELOADED_MSGS = "Preloaded messages";
 
 type BlockLoaderArgs = {
   cacheSizeBytes: number;
-  source: IIterableSource;
+  source: IDeserializedIterableSource;
   start: Time;
   end: Time;
   maxBlocks: number;
@@ -54,7 +54,7 @@ type LoadArgs = {
  * BlockLoader manages loading blocks from a source. Blocks are fixed time span containers for messages.
  */
 export class BlockLoader {
-  #source: IIterableSource;
+  #source: IDeserializedIterableSource;
   #blocks: Blocks = [];
   #start: Time;
   #end: Time;

--- a/packages/suite-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -33,6 +33,8 @@ type Options = {
   readAheadDuration?: Time;
   // The minimum duration to buffer before playback resumes
   minReadAheadDuration?: Time;
+  // Max. cache size in bytes
+  maxCacheSizeBytes?: number;
 };
 
 interface EventTypes {
@@ -48,8 +50,11 @@ interface EventTypes {
  * is the consumer and reads messages from cache while the startProducer method produces messages by
  * reading from the underlying source and populating the cache.
  */
-class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterableSource {
-  #source: CachingIterableSource;
+class BufferedIterableSource<MessageType = unknown>
+  extends EventEmitter<EventTypes>
+  implements IIterableSource<MessageType>
+{
+  #source: CachingIterableSource<MessageType>;
 
   #readDone = false;
   #aborted = false;
@@ -61,8 +66,7 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
   #writeSignal = new Condvar();
 
   // The producer loads results into the cache and the consumer reads from the cache.
-  #cache = new VecQueue<IteratorResult>();
-
+  #cache = new VecQueue<IteratorResult<MessageType>>();
   // The location of the consumer read head
   #readHead: Time = { sec: 0, nsec: 0 };
 
@@ -78,12 +82,14 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
   // The minimum duration to buffer before playback resumes
   #minReadAheadDuration: Time;
 
-  public constructor(source: IIterableSource, opt?: Options) {
+  public constructor(source: IIterableSource<MessageType>, opt?: Options) {
     super();
 
     this.#readAheadDuration = opt?.readAheadDuration ?? DEFAULT_READ_AHEAD_DURATION;
     this.#minReadAheadDuration = opt?.minReadAheadDuration ?? DEFAULT_MIN_READ_AHEAD_DURATION;
-    this.#source = new CachingIterableSource(source);
+    this.#source = new CachingIterableSource<MessageType>(source, {
+      maxTotalSize: opt?.maxCacheSizeBytes,
+    });
 
     if (compare(this.#readAheadDuration, this.#minReadAheadDuration) < 0) {
       throw new Error("Invariant: readAheadDuration < minReadAheadDuration");
@@ -202,8 +208,9 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
 
     log.debug("producer done");
   }
-
+  /** Calls stopProducer, clears cache, and terminates sources */
   public async terminate(): Promise<void> {
+    await this.stopProducer();
     this.#cache.clear();
     this.#source.removeAllListeners("loadedRangesChange");
     await this.#source.terminate();
@@ -227,7 +234,7 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
 
   public messageIterator(
     args: MessageIteratorArgs,
-  ): AsyncIterableIterator<Readonly<IteratorResult>> {
+  ): AsyncIterableIterator<Readonly<IteratorResult<MessageType>>> {
     if (!this.#initResult) {
       throw new Error("Invariant: uninitialized");
     }
@@ -297,7 +304,9 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
     })();
   }
 
-  public async getBackfillMessages(args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
+  public async getBackfillMessages(
+    args: GetBackfillMessagesArgs,
+  ): Promise<MessageEvent<MessageType>[]> {
     return await this.#source.getBackfillMessages(args);
   }
 }

--- a/packages/suite-base/src/players/IterablePlayer/ComlinkTransferIteratorCursor.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/ComlinkTransferIteratorCursor.test.ts
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import * as Comlink from "@lichtblick/comlink";
+import { MessageEvent } from "@lichtblick/suite";
+import RosTimeBuilder from "@lichtblick/suite-base/testing/builders/RosTimeBuilder";
+
+import { ComlinkTransferIteratorCursor } from "./ComlinkTransferIteratorCursor";
+import type { IMessageCursor, IteratorResult } from "./IIterableSource";
+
+jest.mock("@lichtblick/comlink", () => ({
+  transfer: jest.fn((value, transferables) => ({ value, transferables })),
+}));
+
+describe("ComlinkTransferIteratorCursor", () => {
+  let mockCursor: jest.Mocked<IMessageCursor<Uint8Array>>;
+
+  beforeEach(() => {
+    mockCursor = {
+      next: jest.fn(),
+      nextBatch: jest.fn(),
+      readUntil: jest.fn(),
+      end: jest.fn(),
+    };
+    (Comlink.transfer as jest.Mock).mockClear();
+  });
+
+  it("transfers buffer in next() if type is 'message-event' and message is Uint8Array", async () => {
+    const buffer = new Uint8Array([1, 2, 3]).buffer;
+    const input: IteratorResult<Uint8Array> = {
+      type: "message-event",
+      msgEvent: { message: new Uint8Array(buffer) } as MessageEvent<Uint8Array>,
+    };
+
+    mockCursor.next.mockResolvedValueOnce(input);
+
+    const cursor = new ComlinkTransferIteratorCursor(mockCursor);
+    const result = await cursor.next();
+
+    expect(Comlink.transfer).toHaveBeenCalledWith(input, [buffer]);
+    expect(result).toEqual({
+      value: input,
+      transferables: [buffer],
+    });
+  });
+
+  it("does not transfer if next() is 'alert'", async () => {
+    const input: IteratorResult<Uint8Array> = {
+      type: "alert",
+      connectionId: 1,
+      alert: { message: "Warning", severity: "warn" },
+    };
+
+    mockCursor.next.mockResolvedValueOnce(input);
+
+    const cursor = new ComlinkTransferIteratorCursor(mockCursor);
+    const result = await cursor.next();
+
+    expect(Comlink.transfer).not.toHaveBeenCalled();
+    expect(result).toBe(input);
+  });
+
+  it("transfers multiple message-event buffers in nextBatch()", async () => {
+    const buf1 = new Uint8Array([10]).buffer;
+    const buf2 = new Uint8Array([20]).buffer;
+
+    const batch: IteratorResult<Uint8Array>[] = [
+      {
+        type: "message-event",
+        msgEvent: { message: new Uint8Array(buf1) } as MessageEvent<Uint8Array>,
+      },
+      {
+        type: "message-event",
+        msgEvent: { message: new Uint8Array(buf2) } as MessageEvent<Uint8Array>,
+      },
+      {
+        type: "alert",
+        connectionId: 2,
+        alert: { message: "Notice" } as any,
+      },
+    ];
+
+    mockCursor.nextBatch.mockResolvedValueOnce(batch);
+
+    const cursor = new ComlinkTransferIteratorCursor(mockCursor);
+    const result = await cursor.nextBatch(100);
+
+    expect(Comlink.transfer).toHaveBeenCalledWith(batch, [buf1, buf2]);
+    expect(result).toEqual({
+      value: batch,
+      transferables: [buf1, buf2],
+    });
+  });
+
+  it("delegates readUntil()", async () => {
+    const time = RosTimeBuilder.time();
+
+    const cursor = new ComlinkTransferIteratorCursor(mockCursor);
+    await cursor.readUntil(time);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockCursor.readUntil as jest.MockableFunction).toHaveBeenCalledWith(time);
+  });
+
+  it("delegates end()", async () => {
+    const cursor = new ComlinkTransferIteratorCursor(mockCursor);
+    await cursor.end();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockCursor.end).toHaveBeenCalled();
+  });
+});

--- a/packages/suite-base/src/players/IterablePlayer/ComlinkTransferIteratorCursor.ts
+++ b/packages/suite-base/src/players/IterablePlayer/ComlinkTransferIteratorCursor.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import * as Comlink from "@lichtblick/comlink";
+import { Time } from "@lichtblick/suite";
+
+import type { IMessageCursor, IteratorResult } from "./IIterableSource";
+
+/**
+ * Wraps a IMessageCursor<Uint8Array> and returns message-events with calls to Comlink.transfer.
+ * This allows ArrayBuffers to be transferred rather than being structureClone'd which is significantly faster.
+ * This class must only be used for worker communication because otherwise Comlink's interal transfer buffer
+ * will never be emptied leading to an OOM.
+ */
+class ComlinkTransferIteratorCursor implements IMessageCursor<Uint8Array> {
+  #cursor: IMessageCursor<Uint8Array>;
+
+  public constructor(cursor: IMessageCursor<Uint8Array>) {
+    this.#cursor = cursor;
+  }
+
+  public async next(): ReturnType<IMessageCursor<Uint8Array>["next"]> {
+    const next = await this.#cursor.next();
+    if (next == undefined) {
+      return next;
+    }
+
+    if (next.type === "message-event" && next.msgEvent.message instanceof Uint8Array) {
+      return Comlink.transfer(next, [next.msgEvent.message.buffer]);
+    }
+
+    return next;
+  }
+
+  public async nextBatch(durationMs: number): Promise<IteratorResult<Uint8Array>[] | undefined> {
+    const batch = await this.#cursor.nextBatch(durationMs);
+    if (batch == undefined) {
+      return batch;
+    }
+
+    const transferables: Transferable[] = [];
+    for (const iterResult of batch) {
+      if (
+        iterResult.type === "message-event" &&
+        iterResult.msgEvent.message instanceof Uint8Array
+      ) {
+        transferables.push(iterResult.msgEvent.message.buffer);
+      }
+    }
+    return Comlink.transfer(batch, transferables);
+  }
+
+  public async readUntil(end: Time): ReturnType<IMessageCursor<Uint8Array>["readUntil"]> {
+    return await this.#cursor.readUntil(end);
+  }
+
+  public async end(): ReturnType<IMessageCursor<Uint8Array>["end"]> {
+    await this.#cursor.end();
+  }
+}
+
+export { ComlinkTransferIteratorCursor };

--- a/packages/suite-base/src/players/IterablePlayer/DeserializedSourceWrapper.ts
+++ b/packages/suite-base/src/players/IterablePlayer/DeserializedSourceWrapper.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Immutable } from "immer";
+
+import { MessageEvent } from "@lichtblick/suite";
+
+import {
+  IDeserializedIterableSource,
+  Initialization,
+  MessageIteratorArgs,
+  GetBackfillMessagesArgs,
+  IteratorResult,
+  IIterableSource,
+} from "./IIterableSource";
+
+/**
+ * Wraps an iterable source to produce a deserialized iterable source.
+ */
+export class DeserializedSourceWrapper implements IDeserializedIterableSource {
+  #source: IIterableSource;
+
+  public readonly sourceType = "deserialized";
+
+  public constructor(source: IIterableSource) {
+    this.#source = source;
+  }
+
+  public async initialize(): Promise<Initialization> {
+    return await this.#source.initialize();
+  }
+  public messageIterator(
+    args: Immutable<MessageIteratorArgs>,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> {
+    return this.#source.messageIterator(args);
+  }
+
+  public async getBackfillMessages(
+    args: Immutable<GetBackfillMessagesArgs>,
+  ): Promise<MessageEvent[]> {
+    return await this.#source.getBackfillMessages(args);
+  }
+
+  public async terminate(): Promise<void> {
+    await this.#source.terminate?.();
+  }
+}

--- a/packages/suite-base/src/players/IterablePlayer/DeserializingIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/DeserializingIterableSource.test.ts
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MessageEvent } from "@lichtblick/suite";
+import {
+  GetBackfillMessagesArgs,
+  ISerializedIterableSource,
+  Initialization,
+  IteratorResult,
+  MessageIteratorArgs,
+} from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
+import { estimateObjectSize } from "@lichtblick/suite-base/players/messageMemoryEstimation";
+
+import { DeserializingIterableSource } from "./DeserializingIterableSource";
+
+const textEncoder = new TextEncoder();
+
+async function* defaultMessageIterator(
+  _args: MessageIteratorArgs,
+): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
+  for (let i = 0; i < 8; ++i) {
+    const message = textEncoder.encode(JSON.stringify({ foo: "bar", iteration: i }));
+    yield {
+      type: "message-event",
+      msgEvent: {
+        topic: "json_topic",
+        receiveTime: { sec: 0, nsec: i * 1e8 },
+        message,
+        sizeInBytes: message.byteLength,
+        schemaName: "some_type",
+      },
+    };
+  }
+}
+
+class TestSource implements ISerializedIterableSource {
+  public readonly sourceType = "serialized";
+
+  public async initialize(): Promise<Initialization> {
+    return {
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 10, nsec: 0 },
+      topics: [
+        {
+          name: "json_topic",
+          schemaName: "some_type",
+          messageEncoding: "json",
+        },
+      ],
+      topicStats: new Map(),
+      profile: undefined,
+      alerts: [],
+      datatypes: new Map(),
+      publishersByTopic: new Map(),
+    };
+  }
+
+  public async *messageIterator(
+    _args: MessageIteratorArgs,
+  ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {}
+
+  public async getBackfillMessages(
+    _args: GetBackfillMessagesArgs,
+  ): Promise<MessageEvent<Uint8Array>[]> {
+    return [];
+  }
+}
+
+describe("DeserializingIterableSources", () => {
+  it("should construct and initialize", async () => {
+    const source = new TestSource();
+    const deserSource = new DeserializingIterableSource(source);
+
+    const initResult = await deserSource.initialize();
+    expect(initResult.alerts).toStrictEqual([]);
+  });
+
+  it("deserializes messages from raw bytes", async () => {
+    const source = new TestSource();
+    const deserSource = new DeserializingIterableSource(source);
+    await deserSource.initialize();
+
+    source.messageIterator = defaultMessageIterator;
+    const messageIterator = deserSource.messageIterator({
+      topics: new Map([["json_topic", { topic: "json_topic" }]]),
+    });
+
+    for (let i = 0; i < 8; ++i) {
+      const iterResult = messageIterator.next();
+      await expect(iterResult).resolves.toEqual({
+        done: false,
+        value: {
+          type: "message-event",
+          msgEvent: {
+            receiveTime: { sec: 0, nsec: i * 1e8 },
+            message: { foo: "bar", iteration: i },
+            sizeInBytes: 36,
+            topic: "json_topic",
+            schemaName: "some_type",
+          },
+        },
+      });
+    }
+
+    // The message iterator should be done since we have no more data to read from the source
+    const iterResult = messageIterator.next();
+    await expect(iterResult).resolves.toEqual({
+      done: true,
+    });
+  });
+
+  it("performs message slicing", async () => {
+    const source = new TestSource();
+    const deserSource = new DeserializingIterableSource(source);
+    await deserSource.initialize();
+
+    source.messageIterator = defaultMessageIterator;
+    const messageIterator = deserSource.messageIterator({
+      topics: new Map([["json_topic", { topic: "json_topic", fields: ["iteration"] }]]),
+    });
+    const slicedMessageSizeEstimate = estimateObjectSize({ iteration: 1 });
+
+    for (let i = 0; i < 8; ++i) {
+      const iterResult = messageIterator.next();
+      await expect(iterResult).resolves.toEqual({
+        done: false,
+        value: {
+          type: "message-event",
+          msgEvent: {
+            receiveTime: { sec: 0, nsec: i * 1e8 },
+            message: { iteration: i },
+            sizeInBytes: slicedMessageSizeEstimate,
+            topic: "json_topic",
+            schemaName: "some_type",
+          },
+        },
+      });
+    }
+
+    // The message iterator should be done since we have no more data to read from the source
+    const iterResult = messageIterator.next();
+    await expect(iterResult).resolves.toEqual({
+      done: true,
+    });
+  });
+
+  it("correctly estimates message sizes for sliced and non-sliced messages", async () => {
+    const source = new TestSource();
+    const deserSource = new DeserializingIterableSource(source);
+    await deserSource.initialize();
+
+    source.messageIterator = defaultMessageIterator;
+
+    const nonslicedMessageIterator = deserSource.messageIterator({
+      topics: new Map([["json_topic", { topic: "json_topic" }]]),
+    });
+    const slicedMessageIterator = deserSource.messageIterator({
+      topics: new Map([["json_topic", { topic: "json_topic", fields: ["foo"] }]]),
+    });
+    const slicedMessageSizeEstimate = estimateObjectSize({ foo: "bar" });
+
+    for (let i = 0; i < 8; ++i) {
+      const iterResult = nonslicedMessageIterator.next();
+      await expect(iterResult).resolves.toMatchObject({
+        done: false,
+        value: {
+          type: "message-event",
+          msgEvent: {
+            message: { foo: "bar", iteration: i },
+            sizeInBytes: 36,
+          },
+        },
+      });
+    }
+
+    for (let i = 0; i < 8; ++i) {
+      const iterResult = slicedMessageIterator.next();
+      await expect(iterResult).resolves.toMatchObject({
+        done: false,
+        value: {
+          type: "message-event",
+          msgEvent: {
+            message: { foo: "bar" },
+            sizeInBytes: slicedMessageSizeEstimate,
+          },
+        },
+      });
+    }
+
+    // Both message iterators should be done since we have no more data to read from the source
+    await expect(nonslicedMessageIterator.next()).resolves.toEqual({
+      done: true,
+    });
+    await expect(slicedMessageIterator.next()).resolves.toEqual({
+      done: true,
+    });
+  });
+
+  it("handles deserialization errors in message iteration", async () => {
+    const source = new TestSource();
+    const deserSource = new DeserializingIterableSource(source);
+
+    const initResult = await deserSource.initialize();
+    expect(initResult.alerts).toStrictEqual([]);
+    await deserSource.initialize();
+
+    source.messageIterator = async function* messageIterator(
+      _args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
+      for (let i = 0; i < 8; ++i) {
+        yield {
+          type: "message-event",
+          msgEvent: {
+            topic: "json_topic",
+            receiveTime: { sec: 0, nsec: i * 1e8 },
+            // Every second message is invalid.
+            message:
+              i % 2 === 0
+                ? textEncoder.encode("non-valid json")
+                : textEncoder.encode(JSON.stringify({ foo: "bar", iteration: i })),
+            sizeInBytes: 0,
+            schemaName: "some_type",
+          },
+        };
+      }
+    };
+
+    const messageIterator = deserSource.messageIterator({
+      topics: new Map([["json_topic", { topic: "json_topic" }]]),
+    });
+
+    for (let i = 0; i < 8; ++i) {
+      const iterResult = messageIterator.next();
+      await expect(iterResult).resolves.toMatchObject({
+        done: false,
+        value: {
+          type: i % 2 === 0 ? "problem" : "message-event",
+        },
+      });
+    }
+  });
+
+  it("handles deserialization errors for backfill messages", async () => {
+    const source = new TestSource();
+    const deserSource = new DeserializingIterableSource(source);
+
+    const initResult = await deserSource.initialize();
+    expect(initResult.alerts).toStrictEqual([]);
+    await deserSource.initialize();
+
+    source.getBackfillMessages = async (_args: GetBackfillMessagesArgs) => {
+      return new Array(8).fill(1).map((_val, i) => {
+        return {
+          topic: "json_topic",
+          receiveTime: { sec: 0, nsec: i * 1e8 },
+          // Every second message is invalid.
+          message:
+            i % 2 === 0
+              ? textEncoder.encode("non-valid json")
+              : textEncoder.encode(JSON.stringify({ foo: "bar", iteration: i })),
+          sizeInBytes: 0,
+          schemaName: "some_type",
+        };
+      });
+    };
+
+    const messages = await deserSource.getBackfillMessages({
+      time: { sec: 0, nsec: 0 },
+      topics: new Map([["json_topic", { topic: "json_topic" }]]),
+    });
+    expect(messages.length).toBe(4);
+    expect(console.error).toHaveBeenCalledTimes(4);
+    (console.error as jest.Mock).mockClear();
+  });
+});

--- a/packages/suite-base/src/players/IterablePlayer/DeserializingIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/DeserializingIterableSource.test.ts
@@ -238,7 +238,7 @@ describe("DeserializingIterableSources", () => {
       await expect(iterResult).resolves.toMatchObject({
         done: false,
         value: {
-          type: i % 2 === 0 ? "problem" : "message-event",
+          type: i % 2 === 0 ? "alert" : "message-event",
         },
       });
     }

--- a/packages/suite-base/src/players/IterablePlayer/DeserializingIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/DeserializingIterableSource.ts
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { pickFields } from "@lichtblick/den/records";
+import Logger from "@lichtblick/log";
+import { parseChannel } from "@lichtblick/mcap-support";
+import { MessageEvent } from "@lichtblick/suite";
+import {
+  MessageIteratorArgs,
+  IteratorResult,
+  GetBackfillMessagesArgs,
+  IDeserializedIterableSource,
+  Initialization,
+  IIterableSource,
+} from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
+import { estimateObjectSize } from "@lichtblick/suite-base/players/messageMemoryEstimation";
+import { SubscribePayload } from "@lichtblick/suite-base/players/types";
+
+const log = Logger.getLogger(__filename);
+
+// Computes the subscription hash for a given topic & subscription payload pair.
+// In the simplest case, when there are no message slicing fields, the subscription hash is just
+// the topic name. If there are slicing fields, the hash is computed as the topic name appended
+// by "+" seperated message slicing fields.
+function computeSubscriptionHash(topic: string, subscribePayload: SubscribePayload): string {
+  return subscribePayload.fields ? topic + "+" + subscribePayload.fields.join("+") : topic;
+}
+
+/**
+ * Iterable source that deserializes messages from a raw iterable source (messages are Uint8Arrays).
+ */
+export class DeserializingIterableSource implements IDeserializedIterableSource {
+  #source: IIterableSource<Uint8Array>;
+  #deserializersByTopic: Record<string, (data: ArrayBufferView) => unknown> = {};
+  #messageSizeEstimateBySubHash: Record<string, number> = {};
+  #connectionIdByTopic: Record<string, number> = {};
+
+  public readonly sourceType = "deserialized";
+
+  public constructor(source: IIterableSource<Uint8Array>) {
+    this.#source = source;
+  }
+
+  public async initialize(): Promise<Initialization> {
+    return this.initializeDeserializers(await this.#source.initialize());
+  }
+
+  public initializeDeserializers(initResult: Initialization): Initialization {
+    const alerts: Initialization["alerts"] = [];
+
+    let nextConnectionId = 0;
+    for (const {
+      name: topic,
+      messageEncoding,
+      schemaName,
+      schemaData,
+      schemaEncoding,
+    } of initResult.topics) {
+      this.#connectionIdByTopic[topic] = nextConnectionId++;
+
+      if (this.#deserializersByTopic[topic] == undefined) {
+        try {
+          if (messageEncoding == undefined) {
+            throw new Error(`Unspecified message encoding for topic ${topic}`);
+          }
+
+          const schema =
+            schemaName != undefined && schemaData != undefined && schemaEncoding != undefined
+              ? {
+                  name: schemaName,
+                  encoding: schemaEncoding,
+                  data: schemaData,
+                }
+              : undefined;
+
+          const { deserialize } = parseChannel({
+            messageEncoding,
+            schema,
+          });
+          this.#deserializersByTopic[topic] = deserialize;
+        } catch (error) {
+          // This should in practice never happen as the underlying source filters out invalid topics
+          alerts.push({
+            severity: "error",
+            message: `Error in topic ${topic}: ${error.message}`,
+            error,
+          });
+        }
+      }
+    }
+
+    return { ...initResult, alerts: initResult.alerts.concat(alerts) };
+  }
+
+  public messageIterator(
+    args: MessageIteratorArgs,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> {
+    // Compute the unique subscription hash for every topic + subscription payload pair which will
+    // be used to lookup message size estimates. This is done here to avoid having to compute the
+    // the subscription hash for every new message event.
+    const subscribePayloadWithHashByTopic = new Map(
+      Array.from(args.topics, ([topic, subscribePayload]) => [
+        topic,
+        {
+          ...subscribePayload,
+          subscriptionHash: computeSubscriptionHash(topic, subscribePayload),
+        },
+      ]),
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+    const rawIterator = self.#source.messageIterator(args);
+    return (async function* deserializedIterableGenerator() {
+      try {
+        for await (const iterResult of rawIterator) {
+          if (iterResult.type !== "message-event") {
+            yield iterResult;
+            continue;
+          }
+
+          try {
+            const subscription = subscribePayloadWithHashByTopic.get(iterResult.msgEvent.topic);
+            if (!subscription) {
+              throw new Error(
+                `Received message on topic ${iterResult.msgEvent.topic} which was not subscribed to.`,
+              );
+            }
+
+            const deserializedMsgEvent = self.#deserializeMessage(
+              iterResult.msgEvent,
+              subscription,
+            );
+            yield {
+              type: iterResult.type,
+              msgEvent: deserializedMsgEvent,
+            };
+          } catch (err) {
+            const connectionId = self.#connectionIdByTopic[iterResult.msgEvent.topic] ?? 0;
+            yield {
+              type: "alert",
+              connectionId,
+              alert: {
+                severity: "error",
+                message: `Failed to deserialize message on topic ${
+                  iterResult.msgEvent.topic
+                }. ${err.toString()}`,
+                tip: `Check that your input file is not corrupted.`,
+              },
+            };
+          }
+        }
+      } finally {
+        await rawIterator.return?.();
+      }
+    })();
+  }
+
+  public async getBackfillMessages(args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
+    // Compute the unique subscription hash for every topic + subscription payload pair which will
+    // be used to lookup message size estimates. This is done here to avoid having to compute the
+    // the subscription hash for every new message event.
+    const subscribePayloadWithHashByTopic = new Map(
+      Array.from(args.topics, ([topic, subscribePayload]) => [
+        topic,
+        {
+          ...subscribePayload,
+          subscriptionHash: computeSubscriptionHash(topic, subscribePayload),
+        },
+      ]),
+    );
+
+    const rawMessages = await this.#source.getBackfillMessages(args);
+    const deserializedMsgs: MessageEvent[] = [];
+    for (const rawMsg of rawMessages) {
+      try {
+        const subscription = subscribePayloadWithHashByTopic.get(rawMsg.topic);
+        if (!subscription) {
+          throw new Error(`Received message on topic ${rawMsg.topic} which was not subscribed to.`);
+        }
+        deserializedMsgs.push(this.#deserializeMessage(rawMsg, subscription));
+      } catch (err) {
+        // We simply log errors here as there is no way to pass errors/problems to the caller.
+        // Besides this, the error has most likely been already surfaced to the user during normal iteration.
+        log.error(err);
+      }
+    }
+
+    return deserializedMsgs;
+  }
+
+  #deserializeMessage(
+    rawMessageEvent: MessageEvent<Uint8Array>,
+    subscription: SubscribePayload & { subscriptionHash: string },
+  ): MessageEvent {
+    const { topic, message } = rawMessageEvent;
+
+    const deserialize = this.#deserializersByTopic[topic];
+    if (!deserialize) {
+      throw new Error(`Failed to find deserializer for topic ${topic}`);
+    }
+
+    const deserializedMessage = deserialize(message) as Record<string, unknown>;
+    const msg = subscription.fields
+      ? pickFields(deserializedMessage, subscription.fields)
+      : deserializedMessage;
+
+    // Lookup the size estimate for this subscription hash or compute it if not found in the cache.
+    let msgSizeEstimate = this.#messageSizeEstimateBySubHash[subscription.subscriptionHash];
+    if (msgSizeEstimate == undefined) {
+      msgSizeEstimate = estimateObjectSize(msg);
+      this.#messageSizeEstimateBySubHash[subscription.subscriptionHash] = msgSizeEstimate;
+    }
+
+    // For sliced messages we use the estimated message size whereas for non-sliced messages
+    // take whatever size is bigger.
+    const sizeInBytes = subscription.fields
+      ? msgSizeEstimate
+      : Math.max(message.byteLength, msgSizeEstimate);
+
+    return {
+      ...rawMessageEvent,
+      message: msg,
+      sizeInBytes,
+    };
+  }
+}

--- a/packages/suite-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IIterableSource.ts
@@ -15,10 +15,16 @@ import {
 } from "@lichtblick/suite-base/players/types";
 import { RosDatatypes } from "@lichtblick/suite-base/types/RosDatatypes";
 
+export type TopicWithDecodingInfo = Topic & {
+  messageEncoding?: string;
+  schemaEncoding?: string;
+  schemaData?: Uint8Array;
+};
+
 export type Initialization = {
   start: Time;
   end: Time;
-  topics: Topic[];
+  topics: TopicWithDecodingInfo[];
   topicStats: Map<string, TopicStats>;
   datatypes: RosDatatypes;
   profile: string | undefined;
@@ -75,10 +81,10 @@ export type MessageIteratorArgs = {
  * The source may return stamp results to indicate to callers that it has read through some time
  * when there are no message events available to indicate the time is reached.
  */
-export type IteratorResult =
+export type IteratorResult<MessageType = unknown> =
   | {
       type: "message-event";
-      msgEvent: MessageEvent;
+      msgEvent: MessageEvent<MessageType>;
     }
   | {
       type: "alert";
@@ -112,11 +118,11 @@ export type GetBackfillMessagesArgs = {
 //
 // Providing an interface which allows callers to read a batch of messages significantly (4x speedup
 // on an 700k message dataset on M1 Pro) reduces the RPC call overhead.
-export interface IMessageCursor {
+export interface IMessageCursor<MessageType = unknown> {
   /**
    * Read the next message from the cursor. Return a result or undefined if the cursor is done
    */
-  next(): Promise<IteratorResult | undefined>;
+  next(): Promise<IteratorResult<MessageType> | undefined>;
 
   /**
    * Read the next batch of messages from the cursor. Return an array of results or undefined if the cursor is done.
@@ -125,14 +131,14 @@ export interface IMessageCursor {
    * more messages and return. This duration tracks the receive time from the first message in the
    * batch.
    */
-  nextBatch(durationMs: number): Promise<IteratorResult[] | undefined>;
+  nextBatch(durationMs: number): Promise<IteratorResult<MessageType>[] | undefined>;
 
   /**
    * Read a batch of messages through end time (inclusive) or end of cursor
    *
    * return undefined when no more message remain in the cursor
    */
-  readUntil(end: Time): Promise<IteratorResult[] | undefined>;
+  readUntil(end: Time): Promise<IteratorResult<MessageType>[] | undefined>;
 
   /**
    * End the cursor
@@ -150,7 +156,7 @@ export interface IMessageCursor {
  *
  * IIterableSources also provide a backfill method to obtain the last message available for topics.
  */
-export interface IIterableSource {
+export interface IIterableSource<MessageType = unknown> {
   /**
    * Initialize the source.
    */
@@ -172,13 +178,15 @@ export interface IIterableSource {
    */
   messageIterator(
     args: Immutable<MessageIteratorArgs>,
-  ): AsyncIterableIterator<Readonly<IteratorResult>>;
+  ): AsyncIterableIterator<Readonly<IteratorResult<MessageType>>>;
 
   /**
    * Load the most recent messages per topic that occurred before or at the target time, if
    * available.
    */
-  getBackfillMessages(args: Immutable<GetBackfillMessagesArgs>): Promise<MessageEvent[]>;
+  getBackfillMessages(
+    args: Immutable<GetBackfillMessagesArgs>,
+  ): Promise<MessageEvent<MessageType>[]>;
 
   /**
    * A source can optionally implement a cursor interface in addition to a messageIterator interface.
@@ -189,7 +197,7 @@ export interface IIterableSource {
    */
   getMessageCursor?: (
     args: Immutable<MessageIteratorArgs> & { abort?: AbortSignal },
-  ) => IMessageCursor;
+  ) => IMessageCursor<MessageType>;
 
   getStart?: () => Time | undefined;
 
@@ -211,4 +219,17 @@ export type IterableSourceInitializeArgs = {
     baseUrl: string;
     auth?: string;
   };
+};
+
+/**
+ * Interface for a raw iterable source where messages are in their serialized byte form (Uint8Arrays).
+ * A raw source is well suited for workers as array buffers can be efficientely transferred to the main thread.
+ */
+export type ISerializedIterableSource = IIterableSource<Uint8Array> & { sourceType: "serialized" };
+
+/**
+ * Interface for a deserialized iterable source where messages are in their deserialized form (unknown).
+ */
+export type IDeserializedIterableSource = IIterableSource & {
+  sourceType: "deserialized";
 };

--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -16,14 +16,16 @@ import { mockTopicSelection } from "@lichtblick/suite-base/test/mocks/mockTopicS
 
 import {
   GetBackfillMessagesArgs,
-  IIterableSource,
+  IDeserializedIterableSource,
   Initialization,
   IteratorResult,
   MessageIteratorArgs,
 } from "./IIterableSource";
 import { IterablePlayer } from "./IterablePlayer";
 
-class TestSource implements IIterableSource {
+class TestSource implements IDeserializedIterableSource {
+  public readonly sourceType = "deserialized";
+
   public async initialize(): Promise<Initialization> {
     return {
       start: { sec: 0, nsec: 0 },
@@ -546,7 +548,8 @@ describe("IterablePlayer", () => {
   });
 
   it("provides error message for inconsistent topic datatypes", async () => {
-    class DuplicateTopicsSource implements IIterableSource {
+    class DuplicateTopicsSource implements IDeserializedIterableSource {
+      public readonly sourceType = "deserialized";
       public async initialize(): Promise<Initialization> {
         return {
           start: { sec: 0, nsec: 0 },

--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -23,6 +23,8 @@ import {
   toString,
 } from "@lichtblick/rostime";
 import { Immutable, MessageEvent, Metadata, ParameterValue } from "@lichtblick/suite";
+import { DeserializedSourceWrapper } from "@lichtblick/suite-base/players/IterablePlayer/DeserializedSourceWrapper";
+import { DeserializingIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/DeserializingIterableSource";
 import { freezeMetadata } from "@lichtblick/suite-base/players/IterablePlayer/freezeMetadata";
 import NoopMetricsCollector from "@lichtblick/suite-base/players/NoopMetricsCollector";
 import PlayerAlertManager from "@lichtblick/suite-base/players/PlayerAlertManager";
@@ -46,7 +48,11 @@ import delay from "@lichtblick/suite-base/util/delay";
 
 import { BlockLoader } from "./BlockLoader";
 import { BufferedIterableSource } from "./BufferedIterableSource";
-import { IIterableSource, IteratorResult } from "./IIterableSource";
+import {
+  IDeserializedIterableSource,
+  ISerializedIterableSource,
+  IteratorResult,
+} from "./IIterableSource";
 
 const log = Log.getLogger(__filename);
 
@@ -79,7 +85,7 @@ const EMPTY_ARRAY = Object.freeze([]);
 export type IterablePlayerOptions = {
   metricsCollector?: PlayerMetricsCollectorInterface;
 
-  source: IIterableSource;
+  source: IDeserializedIterableSource | ISerializedIterableSource;
 
   // Optional player name
   name?: string;
@@ -94,6 +100,9 @@ export type IterablePlayerOptions = {
 
   // Set to _false_ to disable preloading. (default: true)
   enablePreload?: boolean;
+
+  // Max. time that messages will be buffered ahead for smoother playback. (default: 10sec)
+  readAheadDuration?: Time;
 };
 
 type IterablePlayerState =
@@ -162,8 +171,10 @@ export class IterablePlayer implements Player {
 
   #alertManager = new PlayerAlertManager();
 
-  #iterableSource: IIterableSource;
-  #bufferedSource: BufferedIterableSource;
+  #iterableSource: IDeserializedIterableSource | ISerializedIterableSource;
+  #bufferedSource: IDeserializedIterableSource;
+  // Buffering source implementation. We store a reference to it here so we can access buffer information such as loaded ranges & memory size.
+  #bufferImpl: BufferedIterableSource;
 
   // Some states register an abort controller to signal they should abort
   #abort?: AbortController;
@@ -187,10 +198,30 @@ export class IterablePlayer implements Player {
   #resolveIsClosed: () => void = () => {};
 
   public constructor(options: IterablePlayerOptions) {
-    const { metricsCollector, urlParams, source, name, enablePreload, sourceId } = options;
+    const {
+      metricsCollector,
+      urlParams,
+      source,
+      name,
+      enablePreload,
+      sourceId,
+      readAheadDuration = { sec: 10, nsec: 0 },
+    } = options;
 
     this.#iterableSource = source;
-    this.#bufferedSource = new BufferedIterableSource(source);
+    if (source.sourceType === "deserialized") {
+      this.#bufferImpl = new BufferedIterableSource(source);
+      this.#bufferedSource = new DeserializedSourceWrapper(this.#bufferImpl);
+    } else {
+      const MEGABYTE_IN_BYTES = 1024 * 1024;
+      const bufferInterface = new BufferedIterableSource(source, {
+        readAheadDuration,
+        maxCacheSizeBytes: 600 * MEGABYTE_IN_BYTES,
+      });
+      this.#bufferImpl = bufferInterface;
+      this.#bufferedSource = new DeserializingIterableSource(bufferInterface);
+    }
+
     this.#name = name;
     this.#urlParams = urlParams;
     this.#metricsCollector = metricsCollector ?? new NoopMetricsCollector();
@@ -469,6 +500,7 @@ export class IterablePlayer implements Player {
     this.#queueEmitState();
 
     try {
+      const initResult = await this.#bufferedSource.initialize();
       const {
         start,
         end,
@@ -476,11 +508,11 @@ export class IterablePlayer implements Player {
         profile,
         topicStats,
         alerts,
-        metadata,
         publishersByTopic,
         datatypes,
         name,
-      } = await this.#bufferedSource.initialize();
+        metadata,
+      } = initResult;
 
       // Prior to initialization, the seekTarget may have been set to an out-of-bounds value
       // This brings the value in bounds
@@ -532,9 +564,18 @@ export class IterablePlayer implements Player {
       if (this.#enablePreload) {
         // --- setup block loader which loads messages for _full_ subscriptions in the "background"
         try {
+          let blockLoaderSource;
+          if (this.#iterableSource.sourceType === "deserialized") {
+            blockLoaderSource = this.#iterableSource;
+          } else {
+            blockLoaderSource = new DeserializingIterableSource(this.#iterableSource);
+            // We must not call initialize() here, as the #iterableSource was already initialized above.
+            blockLoaderSource.initializeDeserializers(initResult);
+          }
+
           this.#blockLoader = new BlockLoader({
             cacheSizeBytes: DEFAULT_CACHE_SIZE_BYTES,
-            source: this.#iterableSource,
+            source: blockLoaderSource,
             start: this.#start,
             end: this.#end,
             maxBlocks: MAX_BLOCKS,
@@ -583,13 +624,22 @@ export class IterablePlayer implements Player {
       throw new Error("Invariant: Tried to reset playback iterator with no current time.");
     }
 
-    const next = add(this.#currentTime, { sec: 0, nsec: 1 });
+    if (!this.#start) {
+      throw new Error("Invariant: Tried to reset playback iterator with no start time.");
+    }
+
+    // When resetting the iterator to the start of the source, we must not add 1 ns otherwise we
+    // might skip messages whose timestamp is equal to the source start time.
+    const next =
+      compare(this.#currentTime, this.#start) === 0
+        ? this.#start
+        : add(this.#currentTime, { sec: 0, nsec: 1 });
 
     log.debug("Ending previous iterator");
     await this.#playbackIterator?.return?.();
 
     // set the playIterator to the seek time
-    await this.#bufferedSource.stopProducer();
+    await this.#bufferImpl.stopProducer();
 
     log.debug("Initializing forward iterator from", next);
     this.#playbackIterator = this.#bufferedSource.messageIterator({
@@ -993,7 +1043,7 @@ export class IterablePlayer implements Player {
     // set the latest value of the loaded ranges for the next emit state
     this.#progress = {
       ...this.#progress,
-      fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
+      fullyLoadedFractionRanges: this.#bufferImpl.loadedRanges(),
       messageCache: this.#progress.messageCache,
     };
 
@@ -1004,11 +1054,11 @@ export class IterablePlayer implements Player {
 
     const rangeChangeHandler = () => {
       this.#progress = {
-        fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
+        fullyLoadedFractionRanges: this.#bufferImpl.loadedRanges(),
         messageCache: this.#progress.messageCache,
         memoryInfo: {
           ...this.#progress.memoryInfo,
-          [MEMORY_INFO_BUFFERED_MSGS]: this.#bufferedSource.getCacheSize(),
+          [MEMORY_INFO_BUFFERED_MSGS]: this.#bufferImpl.getCacheSize(),
         },
       };
       this.#queueEmitState();
@@ -1016,11 +1066,11 @@ export class IterablePlayer implements Player {
 
     // While idle, the buffered source might still be loading and we still want to update downstream
     // with the new ranges we've buffered. This event will update progress and queue state emits
-    this.#bufferedSource.on("loadedRangesChange", rangeChangeHandler);
+    this.#bufferImpl.on("loadedRangesChange", rangeChangeHandler);
 
     this.#queueEmitState();
     await aborted;
-    this.#bufferedSource.off("loadedRangesChange", rangeChangeHandler);
+    this.#bufferImpl.off("loadedRangesChange", rangeChangeHandler);
   }
 
   async #statePlay() {
@@ -1059,11 +1109,11 @@ export class IterablePlayer implements Player {
         // Update with the latest loaded ranges from the buffered source
         // The messageCache is updated separately by block loader events
         this.#progress = {
-          fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
+          fullyLoadedFractionRanges: this.#bufferImpl.loadedRanges(),
           messageCache: this.#progress.messageCache,
           memoryInfo: {
             ...this.#progress.memoryInfo,
-            [MEMORY_INFO_BUFFERED_MSGS]: this.#bufferedSource.getCacheSize(),
+            [MEMORY_INFO_BUFFERED_MSGS]: this.#bufferImpl.getCacheSize(),
           },
         };
 
@@ -1096,8 +1146,7 @@ export class IterablePlayer implements Player {
     this.#isPlaying = false;
     await this.#blockLoader?.stopLoading();
     await this.#blockLoadingProcess;
-    await this.#bufferedSource.stopProducer();
-    await this.#bufferedSource.terminate();
+    await this.#bufferImpl.terminate();
     await this.#playbackIterator?.return?.();
     this.#playbackIterator = undefined;
     await this.#iterableSource.terminate?.();

--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -216,7 +216,7 @@ export class IterablePlayer implements Player {
       const MEGABYTE_IN_BYTES = 1024 * 1024;
       const bufferInterface = new BufferedIterableSource(source, {
         readAheadDuration,
-        maxCacheSizeBytes: 600 * MEGABYTE_IN_BYTES,
+        maxCacheSizeBytes: 300 * MEGABYTE_IN_BYTES, // 300mb
       });
       this.#bufferImpl = bufferInterface;
       this.#bufferedSource = new DeserializingIterableSource(bufferInterface);

--- a/packages/suite-base/src/players/IterablePlayer/IteratorCursor.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IteratorCursor.ts
@@ -13,24 +13,24 @@ import type { IMessageCursor, IteratorResult } from "./IIterableSource";
 const TIME_ZERO = Object.freeze({ sec: 0, nsec: 0 });
 
 /// IteratorCursor implements a IMessageCursor interface on top of an AsyncIterable
-class IteratorCursor implements IMessageCursor {
-  #iter: AsyncIterableIterator<Readonly<IteratorResult>>;
+class IteratorCursor<MessageType = unknown> implements IMessageCursor<MessageType> {
+  #iter: AsyncIterableIterator<Readonly<IteratorResult<MessageType>>>;
   // readUntil reads from the iterator inclusive of end time. To do this, it reads from the iterator
   // until it receives a receiveTime after end time to signal it has received all the messages
   // inclusive of end time. Since iterators are read once, this last result must be stored for the
   // next readUntil call otherwise it would be lost.
-  #lastIteratorResult?: IteratorResult;
+  #lastIteratorResult?: IteratorResult<MessageType>;
   #abort?: AbortSignal;
 
   public constructor(
-    iterator: AsyncIterableIterator<Readonly<IteratorResult>>,
+    iterator: AsyncIterableIterator<Readonly<IteratorResult<MessageType>>>,
     abort?: AbortSignal,
   ) {
     this.#iter = iterator;
     this.#abort = abort;
   }
 
-  public async next(): ReturnType<IMessageCursor["next"]> {
+  public async next(): ReturnType<IMessageCursor<MessageType>["next"]> {
     if (this.#abort?.aborted === true) {
       return undefined;
     }
@@ -39,7 +39,7 @@ class IteratorCursor implements IMessageCursor {
     return result.value;
   }
 
-  public async nextBatch(durationMs: number): Promise<IteratorResult[] | undefined> {
+  public async nextBatch(durationMs: number): Promise<IteratorResult<MessageType>[] | undefined> {
     const firstResult = await this.next();
     if (!firstResult) {
       return undefined;
@@ -49,7 +49,7 @@ class IteratorCursor implements IMessageCursor {
       return [firstResult];
     }
 
-    const results: IteratorResult[] = [firstResult];
+    const results: IteratorResult<MessageType>[] = [firstResult];
 
     let cutoffTime: Time = TIME_ZERO;
     switch (firstResult.type) {
@@ -82,7 +82,7 @@ class IteratorCursor implements IMessageCursor {
     return results;
   }
 
-  public async readUntil(end: Time): ReturnType<IMessageCursor["readUntil"]> {
+  public async readUntil(end: Time): ReturnType<IMessageCursor<MessageType>["readUntil"]> {
     // Assign to a variable to fool typescript control flow analysis which does not understand
     // that this value could change after the _await_
     const isAborted = this.#abort?.aborted;
@@ -90,7 +90,7 @@ class IteratorCursor implements IMessageCursor {
       return undefined;
     }
 
-    const results: IteratorResult[] = [];
+    const results: IteratorResult<MessageType>[] = [];
 
     // if the last result is still past end time, return empty results
     if (
@@ -137,7 +137,7 @@ class IteratorCursor implements IMessageCursor {
     return results;
   }
 
-  public async end(): ReturnType<IMessageCursor["end"]> {
+  public async end(): ReturnType<IMessageCursor<MessageType>["end"]> {
     await this.#iter.return?.();
   }
 }

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -7,30 +7,24 @@
 
 import { McapIndexedReader, McapTypes } from "@mcap/core";
 
-import { pickFields } from "@lichtblick/den/records";
 import Logger from "@lichtblick/log";
 import { ParsedChannel, parseChannel } from "@lichtblick/mcap-support";
 import { Time, fromNanoSec, toNanoSec, compare } from "@lichtblick/rostime";
 import { MessageEvent, Metadata } from "@lichtblick/suite";
 import {
   GetBackfillMessagesArgs,
-  IIterableSource,
   Initialization,
+  ISerializedIterableSource,
   IteratorResult,
   MessageIteratorArgs,
+  TopicWithDecodingInfo,
 } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
-import { estimateObjectSize } from "@lichtblick/suite-base/players/messageMemoryEstimation";
-import {
-  PlayerAlert,
-  SubscribePayload,
-  Topic,
-  TopicStats,
-} from "@lichtblick/suite-base/players/types";
+import { PlayerAlert, TopicStats } from "@lichtblick/suite-base/players/types";
 import { RosDatatypes } from "@lichtblick/suite-base/types/RosDatatypes";
 
 const log = Logger.getLogger(__filename);
 
-export class McapIndexedIterableSource implements IIterableSource {
+export class McapIndexedIterableSource implements ISerializedIterableSource {
   #reader: McapIndexedReader;
   #channelInfoById = new Map<
     number,
@@ -42,7 +36,8 @@ export class McapIndexedIterableSource implements IIterableSource {
   >();
   #start?: Time;
   #end?: Time;
-  #messageSizeEstimateByHash: Record<string /* subscription hash */, number> = {};
+
+  public readonly sourceType = "serialized";
 
   public constructor(reader: McapIndexedReader) {
     this.#reader = reader;
@@ -61,7 +56,7 @@ export class McapIndexedIterableSource implements IIterableSource {
     }
 
     const topicStats = new Map<string, TopicStats>();
-    const topicsByName = new Map<string, Topic>();
+    const topicsByName = new Map<string, TopicWithDecodingInfo>();
     const datatypes: RosDatatypes = new Map();
     const alerts: PlayerAlert[] = [];
     const metadata: Metadata[] = [];
@@ -97,7 +92,13 @@ export class McapIndexedIterableSource implements IIterableSource {
 
       let topic = topicsByName.get(channel.topic);
       if (!topic) {
-        topic = { name: channel.topic, schemaName: schema?.name };
+        topic = {
+          name: channel.topic,
+          schemaName: schema?.name,
+          messageEncoding: channel.messageEncoding,
+          schemaData: schema?.data,
+          schemaEncoding: schema?.encoding,
+        };
         topicsByName.set(channel.topic, topic);
 
         const numMessages = this.#reader.statistics?.channelMessageCounts.get(channel.id);
@@ -151,7 +152,7 @@ export class McapIndexedIterableSource implements IIterableSource {
 
   public async *messageIterator(
     args: MessageIteratorArgs,
-  ): AsyncIterableIterator<Readonly<IteratorResult>> {
+  ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
     const topics = args.topics;
     const start = args.start ?? this.#start;
     const end = args.end ?? this.#end;
@@ -159,18 +160,6 @@ export class McapIndexedIterableSource implements IIterableSource {
     if (topics.size === 0 || !start || !end) {
       return;
     }
-
-    // Determine the subscription hash which is used to lookup message size estimates.
-    // This is done here to avoid doing this repeatedly when iterating over messages.
-    const topicsWithSubscriptionHash = new Map(
-      Array.from(topics, ([topic, subscribePayload]) => [
-        topic,
-        {
-          ...subscribePayload,
-          subscriptionHash: computeSubscriptionHash(topic, subscribePayload),
-        },
-      ]),
-    );
 
     const topicNames = Array.from(topics.keys());
 
@@ -193,26 +182,14 @@ export class McapIndexedIterableSource implements IIterableSource {
         continue;
       }
       try {
-        const msg = channelInfo.parsedChannel.deserialize(message.data) as Record<string, unknown>;
-        const spec = topicsWithSubscriptionHash.get(channelInfo.channel.topic);
-        const payload = spec?.fields != undefined ? pickFields(msg, spec.fields) : msg;
-        const estimatedMemorySize = this.#estimateMessageSize(
-          spec?.subscriptionHash ?? channelInfo.channel.topic,
-          payload,
-        );
-        const sizeInBytes =
-          spec?.fields == undefined
-            ? Math.max(message.data.byteLength, estimatedMemorySize)
-            : estimatedMemorySize;
-
         yield {
           type: "message-event",
           msgEvent: {
             topic: channelInfo.channel.topic,
             receiveTime: fromNanoSec(message.logTime),
             publishTime: fromNanoSec(message.publishTime),
-            message: payload,
-            sizeInBytes,
+            message: message.data,
+            sizeInBytes: message.data.byteLength,
             schemaName: channelInfo.schemaName ?? "",
           },
         };
@@ -230,10 +207,12 @@ export class McapIndexedIterableSource implements IIterableSource {
     }
   }
 
-  public async getBackfillMessages(args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
+  public async getBackfillMessages(
+    args: GetBackfillMessagesArgs,
+  ): Promise<MessageEvent<Uint8Array>[]> {
     const { topics, time } = args;
 
-    const messages: MessageEvent[] = [];
+    const messages: MessageEvent<Uint8Array>[] = [];
     for (const topic of topics.keys()) {
       // NOTE: An iterator is made for each topic to get the latest message on that topic.
       // An single iterator for all the topics could result in iterating through many
@@ -250,23 +229,14 @@ export class McapIndexedIterableSource implements IIterableSource {
           continue;
         }
 
-        try {
-          const deserializedMessage = channelInfo.parsedChannel.deserialize(message.data);
-          const sizeInBytes = Math.max(
-            message.data.byteLength,
-            this.#estimateMessageSize(channelInfo.channel.topic, deserializedMessage),
-          );
-          messages.push({
-            topic: channelInfo.channel.topic,
-            receiveTime: fromNanoSec(message.logTime),
-            publishTime: fromNanoSec(message.publishTime),
-            message: deserializedMessage,
-            sizeInBytes,
-            schemaName: channelInfo.schemaName ?? "",
-          });
-        } catch (err: unknown) {
-          log.error(err);
-        }
+        messages.push({
+          topic: channelInfo.channel.topic,
+          receiveTime: fromNanoSec(message.logTime),
+          publishTime: fromNanoSec(message.publishTime),
+          message: message.data,
+          sizeInBytes: message.data.byteLength,
+          schemaName: channelInfo.schemaName ?? "",
+        });
 
         break;
       }
@@ -275,33 +245,7 @@ export class McapIndexedIterableSource implements IIterableSource {
     return messages;
   }
 
-  /**
-   * Returns the cached size estimate for the given {@link subscriptionHash}. Estimates the size
-   * of the given {@link msg} object and updates the cache if no such cache entry exists.
-   * @param subscriptionHash Subscription hash
-   * @param msg Deserialized message object
-   * @returns Size estimate in bytes
-   */
-  #estimateMessageSize(subscriptionHash: string, msg: unknown): number {
-    const cachedSize = this.#messageSizeEstimateByHash[subscriptionHash];
-    if (cachedSize != undefined) {
-      return cachedSize;
-    }
-
-    const sizeEstimate = estimateObjectSize(msg);
-    this.#messageSizeEstimateByHash[subscriptionHash] = sizeEstimate;
-    return sizeEstimate;
-  }
-
   public getStart(): Time | undefined {
     return this.#start;
   }
-}
-
-// Computes the subscription hash for a given topic & subscription payload pair.
-// In the simplest case, when there are no message slicing fields, the subscription hash is just
-// the topic name. If there are slicing fields, the hash is computed as the topic name appended
-// by "+" seperated message slicing fields.
-function computeSubscriptionHash(topic: string, subscribePayload: SubscribePayload): string {
-  return subscribePayload.fields ? topic + "+" + subscribePayload.fields.join("+") : topic;
 }

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 import * as Comlink from "@lichtblick/comlink";
-import { WorkerIterableSourceWorker } from "@lichtblick/suite-base/players/IterablePlayer/WorkerIterableSourceWorker";
+import { WorkerSerializedIterableSourceWorker } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSourceWorker";
 import { MultiIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/shared/MultiIterableSource";
 import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
 
@@ -17,7 +17,7 @@ jest.mock("@lichtblick/comlink", () => ({
 }));
 
 jest.mock("./McapIterableSource");
-jest.mock("@lichtblick/suite-base/players/IterablePlayer/WorkerIterableSourceWorker");
+jest.mock("@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSourceWorker");
 jest.mock("@lichtblick/suite-base/players/IterablePlayer/shared/MultiIterableSource");
 
 describe("initialize", () => {
@@ -32,9 +32,9 @@ describe("initialize", () => {
     const result = initialize({ file });
 
     expect(McapIterableSource).toHaveBeenCalledWith({ type: "file", file });
-    expect(WorkerIterableSourceWorker).toHaveBeenCalled();
+    expect(WorkerSerializedIterableSourceWorker).toHaveBeenCalled();
     expect(Comlink.proxy).toHaveBeenCalled();
-    expect(result).toBeInstanceOf(WorkerIterableSourceWorker);
+    expect(result).toBeInstanceOf(WorkerSerializedIterableSourceWorker);
   });
 
   it("should initialize with multiple files", () => {
@@ -45,9 +45,9 @@ describe("initialize", () => {
     const result = initialize({ files });
 
     expect(MultiIterableSource).toHaveBeenCalledWith({ type: "files", files }, McapIterableSource);
-    expect(WorkerIterableSourceWorker).toHaveBeenCalled();
+    expect(WorkerSerializedIterableSourceWorker).toHaveBeenCalled();
     expect(Comlink.proxy).toHaveBeenCalled();
-    expect(result).toBeInstanceOf(WorkerIterableSourceWorker);
+    expect(result).toBeInstanceOf(WorkerSerializedIterableSourceWorker);
   });
 
   it("should initialize with a single URL", () => {
@@ -56,9 +56,9 @@ describe("initialize", () => {
     const result = initialize({ url });
 
     expect(McapIterableSource).toHaveBeenCalledWith({ type: "url", url });
-    expect(WorkerIterableSourceWorker).toHaveBeenCalled();
+    expect(WorkerSerializedIterableSourceWorker).toHaveBeenCalled();
     expect(Comlink.proxy).toHaveBeenCalled();
-    expect(result).toBeInstanceOf(WorkerIterableSourceWorker);
+    expect(result).toBeInstanceOf(WorkerSerializedIterableSourceWorker);
   });
 
   it("should initialize with multiple URLs", () => {
@@ -70,9 +70,9 @@ describe("initialize", () => {
     const result = initialize({ urls });
 
     expect(MultiIterableSource).toHaveBeenCalledWith({ type: "urls", urls }, McapIterableSource);
-    expect(WorkerIterableSourceWorker).toHaveBeenCalled();
+    expect(WorkerSerializedIterableSourceWorker).toHaveBeenCalled();
     expect(Comlink.proxy).toHaveBeenCalled();
-    expect(result).toBeInstanceOf(WorkerIterableSourceWorker);
+    expect(result).toBeInstanceOf(WorkerSerializedIterableSourceWorker);
   });
 
   it("should throw an error if no valid input is provided", () => {

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.ts
@@ -7,30 +7,32 @@
 
 import * as Comlink from "@lichtblick/comlink";
 import { IterableSourceInitializeArgs } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
-import { WorkerIterableSourceWorker } from "@lichtblick/suite-base/players/IterablePlayer/WorkerIterableSourceWorker";
+import { WorkerSerializedIterableSourceWorker } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSourceWorker";
 import { MultiIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/shared/MultiIterableSource";
 
 import { McapIterableSource } from "./McapIterableSource";
 
-export function initialize(args: IterableSourceInitializeArgs): WorkerIterableSourceWorker {
+export function initialize(
+  args: IterableSourceInitializeArgs,
+): WorkerSerializedIterableSourceWorker {
   if (args.file) {
     const source = new McapIterableSource({ type: "file", file: args.file });
-    const wrapped = new WorkerIterableSourceWorker(source);
+    const wrapped = new WorkerSerializedIterableSourceWorker(source);
     return Comlink.proxy(wrapped);
   } else if (args.files) {
     const source = new MultiIterableSource(
       { type: "files", files: args.files },
       McapIterableSource,
     );
-    const wrapped = new WorkerIterableSourceWorker(source);
+    const wrapped = new WorkerSerializedIterableSourceWorker(source);
     return Comlink.proxy(wrapped);
   } else if (args.url) {
     const source = new McapIterableSource({ type: "url", url: args.url });
-    const wrapped = new WorkerIterableSourceWorker(source);
+    const wrapped = new WorkerSerializedIterableSourceWorker(source);
     return Comlink.proxy(wrapped);
   } else if (args.urls) {
     const source = new MultiIterableSource({ type: "urls", urls: args.urls }, McapIterableSource);
-    const wrapped = new WorkerIterableSourceWorker(source);
+    const wrapped = new WorkerSerializedIterableSourceWorker(source);
     return Comlink.proxy(wrapped);
   }
 

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
@@ -20,7 +20,7 @@ import {
   toRFC3339String,
   compare,
 } from "@lichtblick/rostime";
-import { MessageEvent } from "@lichtblick/suite";
+import { MessageEvent, Metadata } from "@lichtblick/suite";
 import {
   GetBackfillMessagesArgs,
   Initialization,
@@ -60,6 +60,7 @@ export class McapUnindexedIterableSource implements ISerializedIterableSource {
     const streamReader = this.#options.stream.getReader();
 
     const alerts: PlayerAlert[] = [];
+    const metadata: Metadata[] = [];
     const channelIdsWithErrors = new Set<number>();
 
     let messageCount = 0;
@@ -85,6 +86,14 @@ export class McapUnindexedIterableSource implements ISerializedIterableSource {
 
         case "Header": {
           profile = record.profile;
+          break;
+        }
+
+        case "Metadata": {
+          metadata.push({
+            name: record.name,
+            metadata: Object.fromEntries(record.metadata),
+          });
           break;
         }
 
@@ -257,6 +266,7 @@ export class McapUnindexedIterableSource implements ISerializedIterableSource {
       alerts,
       publishersByTopic,
       topicStats,
+      metadata,
     };
   }
 

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
@@ -20,16 +20,16 @@ import {
   toRFC3339String,
   compare,
 } from "@lichtblick/rostime";
-import { MessageEvent, Metadata } from "@lichtblick/suite";
+import { MessageEvent } from "@lichtblick/suite";
 import {
   GetBackfillMessagesArgs,
-  IIterableSource,
   Initialization,
+  ISerializedIterableSource,
   IteratorResult,
   MessageIteratorArgs,
+  TopicWithDecodingInfo,
 } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
-import { estimateObjectSize } from "@lichtblick/suite-base/players/messageMemoryEstimation";
-import { PlayerAlert, Topic, TopicStats } from "@lichtblick/suite-base/players/types";
+import { PlayerAlert, TopicStats } from "@lichtblick/suite-base/players/types";
 import { RosDatatypes } from "@lichtblick/suite-base/types/RosDatatypes";
 
 const DURATION_YEAR_SEC = 365 * 24 * 60 * 60;
@@ -37,11 +37,13 @@ const DURATION_YEAR_SEC = 365 * 24 * 60 * 60;
 type Options = { size: number; stream: ReadableStream<Uint8Array> };
 
 /** Only efficient for small files */
-export class McapUnindexedIterableSource implements IIterableSource {
+export class McapUnindexedIterableSource implements ISerializedIterableSource {
   #options: Options;
-  #msgEventsByChannel?: Map<number, MessageEvent[]>;
+  #msgEventsByChannel?: Map<number, MessageEvent<Uint8Array>[]>;
   #start?: Time;
   #end?: Time;
+
+  public readonly sourceType = "serialized";
 
   public constructor(options: Options) {
     this.#options = options;
@@ -58,11 +60,10 @@ export class McapUnindexedIterableSource implements IIterableSource {
     const streamReader = this.#options.stream.getReader();
 
     const alerts: PlayerAlert[] = [];
-    const metadata: Metadata[] = [];
     const channelIdsWithErrors = new Set<number>();
 
     let messageCount = 0;
-    const messagesByChannel = new Map<number, MessageEvent[]>();
+    const messagesByChannel = new Map<number, MessageEvent<Uint8Array>[]>();
     const schemasById = new Map<number, McapTypes.TypedMcapRecords["Schema"]>();
     const channelInfoById = new Map<
       number,
@@ -70,20 +71,10 @@ export class McapUnindexedIterableSource implements IIterableSource {
         channel: McapTypes.Channel;
         parsedChannel: ParsedChannel;
         schemaName: string | undefined;
+        schemaEncoding: string | undefined;
+        schemaData: Uint8Array | undefined;
       }
     >();
-    const messageSizeEstimateByTopic: Record<string, number> = {};
-    const estimateMessageSize = (topic: string, msg: unknown): number => {
-      const cachedSize = messageSizeEstimateByTopic[topic];
-      if (cachedSize != undefined) {
-        return cachedSize;
-      }
-
-      const sizeEstimate = estimateObjectSize(msg);
-      messageSizeEstimateByTopic[topic] = sizeEstimate;
-      return sizeEstimate;
-    };
-
     let startTime: Time | undefined;
     let endTime: Time | undefined;
     let profile: string | undefined;
@@ -94,14 +85,6 @@ export class McapUnindexedIterableSource implements IIterableSource {
 
         case "Header": {
           profile = record.profile;
-          break;
-        }
-
-        case "Metadata": {
-          metadata.push({
-            name: record.name,
-            metadata: Object.fromEntries(record.metadata),
-          });
           break;
         }
 
@@ -140,6 +123,8 @@ export class McapUnindexedIterableSource implements IIterableSource {
               channel: record,
               parsedChannel,
               schemaName: schema?.name,
+              schemaEncoding: schema?.encoding,
+              schemaData: schema?.data,
             });
             messagesByChannel.set(record.id, []);
           } catch (error) {
@@ -171,17 +156,12 @@ export class McapUnindexedIterableSource implements IIterableSource {
           if (!endTime || isGreaterThan(receiveTime, endTime)) {
             endTime = receiveTime;
           }
-          const deserializedMessage = channelInfo.parsedChannel.deserialize(record.data);
-          const estimatedMemorySize = estimateMessageSize(
-            channelInfo.channel.topic,
-            deserializedMessage,
-          );
           messages.push({
             topic: channelInfo.channel.topic,
             receiveTime,
             publishTime: fromNanoSec(record.publishTime),
-            message: deserializedMessage,
-            sizeInBytes: Math.max(record.data.byteLength, estimatedMemorySize),
+            message: record.data,
+            sizeInBytes: record.data.byteLength,
             schemaName: channelInfo.schemaName ?? "",
           });
           break;
@@ -199,13 +179,25 @@ export class McapUnindexedIterableSource implements IIterableSource {
 
     this.#msgEventsByChannel = messagesByChannel;
 
-    const topics: Topic[] = [];
+    const topics: TopicWithDecodingInfo[] = [];
     const topicStats = new Map<string, TopicStats>();
     const datatypes: RosDatatypes = new Map();
     const publishersByTopic = new Map<string, Set<string>>();
 
-    for (const { channel, parsedChannel, schemaName } of channelInfoById.values()) {
-      topics.push({ name: channel.topic, schemaName });
+    for (const {
+      channel,
+      parsedChannel,
+      schemaName,
+      schemaData,
+      schemaEncoding,
+    } of channelInfoById.values()) {
+      topics.push({
+        name: channel.topic,
+        messageEncoding: channel.messageEncoding,
+        schemaName,
+        schemaData,
+        schemaEncoding,
+      });
       const numMessages = messagesByChannel.get(channel.id)?.length;
       if (numMessages != undefined) {
         topicStats.set(channel.topic, { numMessages });
@@ -265,13 +257,12 @@ export class McapUnindexedIterableSource implements IIterableSource {
       alerts,
       publishersByTopic,
       topicStats,
-      metadata,
     };
   }
 
   public async *messageIterator(
     args: MessageIteratorArgs,
-  ): AsyncIterableIterator<Readonly<IteratorResult>> {
+  ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
     if (!this.#msgEventsByChannel) {
       throw new Error("initialization not completed");
     }
@@ -296,7 +287,9 @@ export class McapUnindexedIterableSource implements IIterableSource {
           resultMessages.push({
             type: "message-event" as const,
             connectionId: channelId,
-            msgEvent,
+            // We copy the message event here as we are transferring the underlying array buffer
+            // to the main thread which invalidates it.
+            msgEvent: structuredClone(msgEvent),
           });
         }
       }
@@ -308,17 +301,21 @@ export class McapUnindexedIterableSource implements IIterableSource {
     yield* resultMessages;
   }
 
-  public async getBackfillMessages(args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
+  public async getBackfillMessages(
+    args: GetBackfillMessagesArgs,
+  ): Promise<MessageEvent<Uint8Array>[]> {
     if (!this.#msgEventsByChannel) {
       throw new Error("initialization not completed");
     }
 
     const needTopics = args.topics;
-    const msgEventsByTopic = new Map<string, MessageEvent>();
+    const msgEventsByTopic = new Map<string, MessageEvent<Uint8Array>>();
     for (const [, msgEvents] of this.#msgEventsByChannel) {
       for (const msgEvent of msgEvents) {
         if (compare(msgEvent.receiveTime, args.time) <= 0 && needTopics.has(msgEvent.topic)) {
-          msgEventsByTopic.set(msgEvent.topic, msgEvent);
+          // We copy the message event here as we are transferring the underlying array buffer
+          // to the main thread which invalidates it.
+          msgEventsByTopic.set(msgEvent.topic, structuredClone(msgEvent));
         }
       }
     }

--- a/packages/suite-base/src/players/IterablePlayer/WorkerSerializedIterableSourceWorker.ts
+++ b/packages/suite-base/src/players/IterablePlayer/WorkerSerializedIterableSourceWorker.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as Comlink from "@lichtblick/comlink";
+import { abortSignalTransferHandler } from "@lichtblick/comlink-transfer-handlers";
+import { Immutable, MessageEvent } from "@lichtblick/suite";
+
+import { ComlinkTransferIteratorCursor } from "./ComlinkTransferIteratorCursor";
+import type {
+  GetBackfillMessagesArgs,
+  IMessageCursor,
+  IteratorResult,
+  MessageIteratorArgs,
+  ISerializedIterableSource,
+  Initialization,
+} from "./IIterableSource";
+import { IteratorCursor } from "./IteratorCursor";
+
+const pickTransferableBuffer = (msg: MessageEvent<Uint8Array>) => msg.message.buffer;
+
+export class WorkerSerializedIterableSourceWorker implements ISerializedIterableSource {
+  #source: ISerializedIterableSource;
+
+  public constructor(source: ISerializedIterableSource) {
+    this.#source = source;
+  }
+
+  public readonly sourceType = "serialized";
+
+  public async initialize(): Promise<Initialization> {
+    return await this.#source.initialize();
+  }
+
+  public messageIterator(
+    args: MessageIteratorArgs,
+  ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> & Comlink.ProxyMarked {
+    return Comlink.proxy(this.#source.messageIterator(args));
+  }
+
+  public async getBackfillMessages(
+    args: Omit<GetBackfillMessagesArgs, "abortSignal">,
+    // abortSignal is a separate argument so it can be proxied by comlink since AbortSignal is not
+    // clonable (and needs to signal across the worker boundary)
+    abortSignal?: AbortSignal,
+  ): Promise<MessageEvent<Uint8Array>[]> {
+    const messages = await this.#source.getBackfillMessages({
+      ...args,
+      abortSignal,
+    });
+    return Comlink.transfer(messages, messages.map(pickTransferableBuffer));
+  }
+
+  public getMessageCursor(
+    args: Omit<Immutable<MessageIteratorArgs>, "abort">,
+    abort?: AbortSignal,
+  ): IMessageCursor<Uint8Array> & Comlink.ProxyMarked {
+    const iter = this.#source.messageIterator(args);
+    const cursor = new ComlinkTransferIteratorCursor(new IteratorCursor<Uint8Array>(iter, abort));
+    return Comlink.proxy(cursor);
+  }
+}
+
+Comlink.transferHandlers.set("abortsignal", abortSignalTransferHandler);

--- a/packages/suite-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
@@ -5,35 +5,40 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { MessageDefinition } from "@lichtblick/message-definition";
 import { ROS2_TO_DEFINITIONS, Rosbag2, SqliteSqljs } from "@lichtblick/rosbag2-web";
 import { stringify } from "@lichtblick/rosmsg";
 import { Time, add as addTime } from "@lichtblick/rostime";
 import { MessageEvent } from "@lichtblick/suite";
-import { estimateObjectSize } from "@lichtblick/suite-base/players/messageMemoryEstimation";
-import {
-  MessageDefinitionsByTopic,
-  ParsedMessageDefinitionsByTopic,
-  PlayerAlert,
-  Topic,
-  TopicStats,
-} from "@lichtblick/suite-base/players/types";
+import { PlayerAlert, TopicStats } from "@lichtblick/suite-base/players/types";
 import { RosDatatypes } from "@lichtblick/suite-base/types/RosDatatypes";
 import { basicDatatypes } from "@lichtblick/suite-base/util/basicDatatypes";
 
 import {
   GetBackfillMessagesArgs,
-  IIterableSource,
+  ISerializedIterableSource,
   Initialization,
   IteratorResult,
   MessageIteratorArgs,
+  TopicWithDecodingInfo,
 } from "../IIterableSource";
 
-export class RosDb3IterableSource implements IIterableSource {
+function dataTypeToFullName(dataType: string): string {
+  const parts = dataType.split("/");
+  if (parts.length === 2) {
+    return `${parts[0]!}/msg/${parts[1]!}`;
+  }
+  return dataType;
+}
+
+export class RosDb3IterableSource implements ISerializedIterableSource {
   #files: File[];
   #bag?: Rosbag2;
   #start: Time = { sec: 0, nsec: 0 };
   #end: Time = { sec: 0, nsec: 0 };
-  #messageSizeEstimateByTopic: Record<string, number> = {};
+  #textEncoder = new TextEncoder();
+
+  public readonly sourceType = "serialized";
 
   public constructor(files: File[]) {
     this.#files = files;
@@ -67,36 +72,60 @@ export class RosDb3IterableSource implements IIterableSource {
     }
 
     const alerts: PlayerAlert[] = [];
-    const topics: Topic[] = [];
+    const topics: TopicWithDecodingInfo[] = [];
     const topicStats = new Map<string, TopicStats>();
     // ROS 2 .db3 files do not contain message definitions, so we can only support well-known ROS types.
     const datatypes: RosDatatypes = new Map([...ROS2_TO_DEFINITIONS, ...basicDatatypes]);
-    const messageDefinitionsByTopic: MessageDefinitionsByTopic = {};
-    const parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
 
     for (const topicDef of topicDefs) {
       const numMessages = messageCounts.get(topicDef.name);
 
-      topics.push({ name: topicDef.name, schemaName: topicDef.type });
+      const topic: TopicWithDecodingInfo = {
+        name: topicDef.name,
+        schemaName: topicDef.type,
+        messageEncoding: topicDef.serializationFormat,
+      };
+
       if (numMessages != undefined) {
         topicStats.set(topicDef.name, { numMessages });
       }
 
-      const parsedMsgdef = datatypes.get(topicDef.type);
+      const parsedMsgdef = ROS2_TO_DEFINITIONS.get(topicDef.type);
       if (parsedMsgdef == undefined) {
         alerts.push({
           severity: "warn",
           message: `Topic "${topicDef.name}" has unsupported datatype "${topicDef.type}"`,
-          tip: "ROS 2 .db3 files do not contain message definitions, so only well-known ROS types are supported in Lichtblick. As a workaround, you can convert the db3 file to mcap using the mcap CLI. For more information, see: https://docs.foxglove.dev/docs/connecting-to-data/frameworks/ros2",
+          tip: "ROS 2 .db3 files do not contain message definitions, so only well-known ROS types are supported in Foxglove Studio. As a workaround, you can convert the db3 file to mcap using the mcap CLI. For more information, see: https://docs.foxglove.dev/docs/connecting-to-data/frameworks/ros2",
         });
-        continue;
-      }
+      } else {
+        // Create the full gendeps-like message definition so that parseChannel() can parse it.
+        const typesToProcess = [parsedMsgdef];
+        const typesForMessage: MessageDefinition[] = [];
+        const seenTypes = new Set<string>();
+        while (typesToProcess.length > 0) {
+          const rosType = typesToProcess.shift()!;
+          typesForMessage.push(rosType);
+          for (const { type, isComplex } of rosType.definitions) {
+            const fullTypeName = dataTypeToFullName(type);
+            if (isComplex === true && !seenTypes.has(fullTypeName)) {
+              const newComplexType = ROS2_TO_DEFINITIONS.get(fullTypeName);
+              if (!newComplexType) {
+                // Should in theory never happen as these are all well-known types
+                throw new Error(
+                  `invariant: Subtype ${fullTypeName} of type ${rosType.name} not found.`,
+                );
+              }
+              typesToProcess.push(newComplexType);
+              seenTypes.add(fullTypeName);
+            }
+          }
+        }
 
-      const fullParsedMessageDefinitions = [parsedMsgdef];
-      const messageDefinition = stringify(fullParsedMessageDefinitions);
-      datatypes.set(topicDef.type, { name: topicDef.type, definitions: parsedMsgdef.definitions });
-      messageDefinitionsByTopic[topicDef.name] = messageDefinition;
-      parsedMessageDefinitionsByTopic[topicDef.name] = fullParsedMessageDefinitions;
+        const messageDefinition = stringify(typesForMessage);
+        topic.schemaData = this.#textEncoder.encode(messageDefinition);
+        topic.schemaEncoding = "ros2msg";
+        topics.push(topic);
+      }
     }
 
     this.#start = start;
@@ -116,7 +145,7 @@ export class RosDb3IterableSource implements IIterableSource {
 
   public async *messageIterator(
     opt: MessageIteratorArgs,
-  ): AsyncIterableIterator<Readonly<IteratorResult>> {
+  ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
     if (this.#bag == undefined) {
       throw new Error(`Rosbag2DataProvider is not initialized`);
     }
@@ -136,29 +165,25 @@ export class RosDb3IterableSource implements IIterableSource {
       startTime: start,
       endTime: inclusiveEndTime,
       topics: Array.from(topics.keys()),
+      rawMessages: true,
     });
     for await (const msg of msgIterator) {
-      // Lookup the size estimate for this topic or compute it if not found in the cache.
-      let msgSizeEstimate = this.#messageSizeEstimateByTopic[msg.topic.name];
-      if (msgSizeEstimate == undefined) {
-        msgSizeEstimate = estimateObjectSize(msg.value);
-        this.#messageSizeEstimateByTopic[msg.topic.name] = msgSizeEstimate;
-      }
-
       yield {
         type: "message-event",
         msgEvent: {
           topic: msg.topic.name,
           receiveTime: msg.timestamp,
-          message: msg.value,
-          sizeInBytes: Math.max(msg.data.byteLength, msgSizeEstimate),
+          message: msg.data,
+          sizeInBytes: msg.data.byteLength,
           schemaName: msg.topic.type,
         },
       };
     }
   }
 
-  public async getBackfillMessages(_args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
+  public async getBackfillMessages(
+    _args: GetBackfillMessagesArgs,
+  ): Promise<MessageEvent<Uint8Array>[]> {
     return [];
   }
 }

--- a/packages/suite-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSourceWorker.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSourceWorker.test.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import * as Comlink from "@lichtblick/comlink";
+import { WorkerSerializedIterableSourceWorker } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSourceWorker";
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+
+import { RosDb3IterableSource } from "./RosDb3IterableSource";
+import { initialize } from "./RosDb3IterableSourceWorker.worker";
+
+jest.mock("@lichtblick/comlink", () => ({
+  expose: jest.fn((val) => val),
+  proxy: jest.fn((val) => val),
+  transferHandlers: {
+    set: jest.fn(),
+  },
+}));
+
+jest.mock("./RosDb3IterableSource");
+jest.mock("@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSourceWorker");
+
+describe("initialize", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should initialize with multiple files", () => {
+    const filename1 = `${BasicBuilder.string()}.bag`;
+    const filename2 = `${BasicBuilder.string()}.bag`;
+    const files = [new File(["data"], filename1), new File(["data"], filename2)];
+
+    const result = initialize({ files });
+
+    expect(RosDb3IterableSource).toHaveBeenCalledWith(files);
+    expect(WorkerSerializedIterableSourceWorker).toHaveBeenCalled();
+    expect(Comlink.proxy).toHaveBeenCalled();
+    expect(result).toBeInstanceOf(WorkerSerializedIterableSourceWorker);
+  });
+
+  it("should initialize with a single file", () => {
+    const filename = `${BasicBuilder.string()}.bag`;
+    const file = new File(["data"], filename);
+
+    const result = initialize({ file });
+
+    expect(RosDb3IterableSource).toHaveBeenCalledWith([file]);
+    expect(WorkerSerializedIterableSourceWorker).toHaveBeenCalled();
+    expect(Comlink.proxy).toHaveBeenCalled();
+    expect(result).toBeInstanceOf(WorkerSerializedIterableSourceWorker);
+  });
+
+  it("should throw with initialized with a url", () => {
+    const url = `http://${BasicBuilder.string()}.com/${BasicBuilder.string()}.bag`;
+
+    expect(() => {
+      initialize({ url });
+    }).toThrow("files required");
+  });
+});

--- a/packages/suite-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSourceWorker.worker.ts
+++ b/packages/suite-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSourceWorker.worker.ts
@@ -7,17 +7,19 @@
 
 import * as Comlink from "@lichtblick/comlink";
 import { IterableSourceInitializeArgs } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
-import { WorkerIterableSourceWorker } from "@lichtblick/suite-base/players/IterablePlayer/WorkerIterableSourceWorker";
+import { WorkerSerializedIterableSourceWorker } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSourceWorker";
 
 import { RosDb3IterableSource } from "./RosDb3IterableSource";
 
-export function initialize(args: IterableSourceInitializeArgs): WorkerIterableSourceWorker {
+export function initialize(
+  args: IterableSourceInitializeArgs,
+): WorkerSerializedIterableSourceWorker {
   const files = args.file ? [args.file] : args.files;
   if (!files) {
     throw new Error("files required");
   }
   const source = new RosDb3IterableSource(files);
-  const wrapped = new WorkerIterableSourceWorker(source);
+  const wrapped = new WorkerSerializedIterableSourceWorker(source);
   return Comlink.proxy(wrapped);
 }
 

--- a/packages/suite-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/suite-base/src/providers/WorkspaceContextProvider.tsx
@@ -79,6 +79,11 @@ function createWorkspaceContextStore(
         // include and restore when persisting to and from localStorage.
         return _.pick(state, ["featureTours", "playbackControls", "sidebars"]);
       },
+      merge(persistedState, currentState) {
+        // Use a deep merge to ensure that defaults are filled in for nested values if the values
+        // were not present in localStorage.
+        return _.merge(currentState, persistedState);
+      },
     }),
   );
 }


### PR DESCRIPTION
## User-Facing Changes
Users will notice buffering happening so much faster and less OOM problems

## Description
The discussion #581, created by [@shub14](https://github.com/shub14), brought to our attention about a feature implemented in Foxglove v1.87.0, about buffering messages as UInt8Array. After some testing, it was concluded that it is really powerful and makes the buffering so much robust.

### Mainly changes
- Add messages as UInt8Array instead of deserialized messages. It saves so much space and the serialization is done only when needed.
- All `IterableSources` have to been adapted to IDeserializedIterableSource (bag, mcap and remote) or to ISerializedIterableSource (ulog)
- Added  dynamic `readAheadDuration`, 10 seconds for remote sources and 120 seconds for local sources.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
