### PR TITLE
Making default step size customizable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
 
     name: e2e (ubuntu-latest)
 
+    env:
+      TZ: Europe/Lisbon
+
     steps:
       - uses: actions/checkout@v4.1.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
 
     name: e2e (ubuntu-latest)
 
+    # Set a fixed timezone to ensure consistent test results.
+    # Lichtblick uses the system's local timezone, which can cause test assertions
+    # to fail due to time discrepancies across different environments.
     env:
       TZ: Europe/Lisbon
 

--- a/e2e/tests/desktop/settings/customize-step-size.desktop.spec.ts
+++ b/e2e/tests/desktop/settings/customize-step-size.desktop.spec.ts
@@ -15,10 +15,13 @@ import { loadFile } from "../../../fixtures/load-file";
  * WHEN the user clicks on the seek backward button
  * THEN the player time should go back to 2025-02-26 10:37:15.547 AM WET
  */
-test("Display the open a new connection dialog when clicking File > Open... > Open connection", async ({
+test("Should update the step size value via settings and verify that change being applied on the player by moving forward and backward", async ({
   mainWindow,
 }) => {
   // Given
+  const initialTime = "2025-02-26 10:37:15.547 AM WET";
+  const forwardedTime = "2025-02-26 10:37:15.947 AM WET";
+
   const filename = "example.mcap";
   await loadFile({
     mainWindow,
@@ -26,8 +29,8 @@ test("Display the open a new connection dialog when clicking File > Open... > Op
   });
 
   // Then
-  const playerStartingTime = mainWindow.locator('input[value="2025-02-26 10:37:15.547 AM WET"]');
-  expect(await playerStartingTime.inputValue()).toBe("2025-02-26 10:37:15.547 AM WET");
+  const playerStartingTime = mainWindow.locator(`input[value="${initialTime}"]`);
+  expect(await playerStartingTime.inputValue()).toBe(initialTime);
 
   //When
   await mainWindow.getByTestId("user-button").click();
@@ -38,12 +41,12 @@ test("Display the open a new connection dialog when clicking File > Open... > Op
   await mainWindow.getByTitle("Seek forward").click();
 
   // Then
-  const playerForwardedTime = mainWindow.locator('input[value="2025-02-26 10:37:15.947 AM WET"]');
-  expect(await playerForwardedTime.inputValue()).toBe("2025-02-26 10:37:15.947 AM WET");
+  const playerForwardedTime = mainWindow.locator(`input[value="${forwardedTime}"]`);
+  expect(await playerForwardedTime.inputValue()).toBe(forwardedTime);
 
-  //When
+  // When
   await mainWindow.getByTitle("Seek backward").click();
 
   // Then
-  expect(await playerStartingTime.inputValue()).toBe("2025-02-26 10:37:15.547 AM WET");
+  expect(await playerStartingTime.inputValue()).toBe(initialTime);
 });

--- a/e2e/tests/desktop/settings/customize-step-size.desktop.spec.ts
+++ b/e2e/tests/desktop/settings/customize-step-size.desktop.spec.ts
@@ -27,8 +27,6 @@ test("Display the open a new connection dialog when clicking File > Open... > Op
 
   // Then
   const playerStartingTime = mainWindow.locator('input[value="2025-02-26 10:37:15.547 AM WET"]');
-
-  await mainWindow.waitForTimeout(10000);
   expect(await playerStartingTime.inputValue()).toBe("2025-02-26 10:37:15.547 AM WET");
 
   //When

--- a/e2e/tests/desktop/settings/customize-step-size.desktop.spec.ts
+++ b/e2e/tests/desktop/settings/customize-step-size.desktop.spec.ts
@@ -33,7 +33,7 @@ test("Display the open a new connection dialog when clicking File > Open... > Op
   await mainWindow.getByTestId("user-button").click();
   await mainWindow.getByText("Visualization settings").click();
 
-  await mainWindow.locator('#stepSizeInput').fill('400');
+  await mainWindow.locator("#stepSizeInput").fill("400");
   await mainWindow.getByText("Done").click();
   await mainWindow.getByTitle("Seek forward").click();
 

--- a/e2e/tests/desktop/settings/customize-step-size.desktop.spec.ts
+++ b/e2e/tests/desktop/settings/customize-step-size.desktop.spec.ts
@@ -27,6 +27,8 @@ test("Display the open a new connection dialog when clicking File > Open... > Op
 
   // Then
   const playerStartingTime = mainWindow.locator('input[value="2025-02-26 10:37:15.547 AM WET"]');
+
+  await mainWindow.waitForTimeout(10000);
   expect(await playerStartingTime.inputValue()).toBe("2025-02-26 10:37:15.547 AM WET");
 
   //When

--- a/e2e/tests/desktop/settings/customize-step-size.desktop.spec.ts
+++ b/e2e/tests/desktop/settings/customize-step-size.desktop.spec.ts
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { test, expect } from "../../../fixtures/electron";
+import { loadFile } from "../../../fixtures/load-file";
+
+/**
+ * GIVEN example.mcap file is loaded
+ * THEN the player time should be 2025-02-26 10:37:15.547 AM WET
+ * WHEN the user opens settings
+ * And changes the step size to 400ms
+ * And clicks on the seek forward button
+ * THEN the player time should move 400ms forward
+ * And be 2025-02-26 10:37:15.947 AM WET
+ * WHEN the user clicks on the seek backward button
+ * THEN the player time should go back to 2025-02-26 10:37:15.547 AM WET
+ */
+test("Display the open a new connection dialog when clicking File > Open... > Open connection", async ({
+  mainWindow,
+}) => {
+  // Given
+  const filename = "example.mcap";
+  await loadFile({
+    mainWindow,
+    filename,
+  });
+
+  // Then
+  const playerStartingTime = mainWindow.locator('input[value="2025-02-26 10:37:15.547 AM WET"]');
+  expect(await playerStartingTime.inputValue()).toBe("2025-02-26 10:37:15.547 AM WET");
+
+  //When
+  await mainWindow.getByTestId("user-button").click();
+  await mainWindow.getByText("Visualization settings").click();
+
+  await mainWindow.locator('#stepSizeInput').fill('400');
+  await mainWindow.getByText("Done").click();
+  await mainWindow.getByTitle("Seek forward").click();
+
+  // Then
+  const playerForwardedTime = mainWindow.locator('input[value="2025-02-26 10:37:15.947 AM WET"]');
+  expect(await playerForwardedTime.inputValue()).toBe("2025-02-26 10:37:15.947 AM WET");
+
+  //When
+  await mainWindow.getByTitle("Seek backward").click();
+
+  // Then
+  expect(await playerStartingTime.inputValue()).toBe("2025-02-26 10:37:15.547 AM WET");
+});

--- a/packages/suite-base/src/AppSetting.ts
+++ b/packages/suite-base/src/AppSetting.ts
@@ -13,6 +13,7 @@ export enum AppSetting {
   MESSAGE_RATE = "messageRate",
   UPDATES_ENABLED = "updates.enabled",
   LANGUAGE = "language",
+  DEFAULT_STEP_SIZE = "stepSize",
 
   // ROS
   ROS_PACKAGE_PATH = "ros.ros_package_path",

--- a/packages/suite-base/src/components/AppSettingsDialog/AppSettingsDialog.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/AppSettingsDialog.tsx
@@ -50,6 +50,7 @@ import {
   LanguageSettings,
   LaunchDefault,
   MessageFramerate,
+  StepSize,
   RosPackagePath,
   TimeFormat,
   TimezoneSettings,
@@ -125,6 +126,7 @@ export function AppSettingsDialog(
               <TimezoneSettings />
               <TimeFormat orientation={smUp ? "horizontal" : "vertical"} />
               <MessageFramerate />
+              <StepSize />
               <LanguageSettings />
               {supportsAppUpdates && <AutoUpdate />}
               {!isDesktopApp() && <LaunchDefault />}

--- a/packages/suite-base/src/components/AppSettingsDialog/settings.test.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.test.tsx
@@ -1,0 +1,38 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { StepSize } from "./settings";
+
+const mockSetStepSize = jest.fn();
+
+jest.mock("../../hooks/useAppConfigurationValue", () => ({
+  useAppConfigurationValue: () => [100, mockSetStepSize],
+}));
+
+describe("StepSize component", () => {
+  beforeEach(() => {
+    mockSetStepSize.mockClear();
+  });
+
+  it("renders the step size input field with default value", () => {
+    render(<StepSize />);
+    const input = screen.getByRole("spinbutton");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue(100);
+  });
+
+  it("calls setStepSize when user types a new number", () => {
+    render(<StepSize />);
+    const input = screen.getByRole("spinbutton");
+
+    fireEvent.change(input, { target: { value: "250" } });
+
+    expect(mockSetStepSize).toHaveBeenCalledWith(250);
+  });
+
+});

--- a/packages/suite-base/src/components/AppSettingsDialog/settings.test.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.test.tsx
@@ -34,5 +34,4 @@ describe("StepSize component", () => {
 
     expect(mockSetStepSize).toHaveBeenCalledWith(250);
   });
-
 });

--- a/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
@@ -313,7 +313,7 @@ export function StepSize(): React.ReactElement {
   // console.log("GOLD STEP", stepSize)
   return (
     <Stack>
-      <FormLabel>{t("stepSize")} (ms)</FormLabel>
+      <FormLabel>{t("stepSize")} (ms):</FormLabel>
       <TextField
         fullWidth
         type="number"

--- a/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
@@ -303,6 +303,40 @@ export function MessageFramerate(): React.ReactElement {
   );
 }
 
+export function StepSize(): React.ReactElement {
+  const { t } = useTranslation("appSettings");
+
+  const [stepSize = 100, setStepSize] = useAppConfigurationValue<number>(
+    AppSetting.DEFAULT_STEP_SIZE,
+  );
+
+  // console.log("GOLD STEP", stepSize)
+  return (
+    <Stack>
+      <FormLabel>{t("stepSize")}</FormLabel>
+      <TextField
+        fullWidth
+        type="number"
+        value={stepSize}
+        onChange={(event) => {
+          void setStepSize(parseInt(event.target.value));
+        }}
+        InputProps={{
+          type: "number",
+          sx: {
+            "& input::-webkit-outer-spin-button, & input::-webkit-inner-spin-button": {
+              display: "none",
+            },
+            "& input[type=number]": {
+              MozAppearance: "textfield",
+            },
+          },
+        }}
+      ></TextField>
+    </Stack>
+  );
+}
+
 export function AutoUpdate(): React.ReactElement {
   const [updatesEnabled = true, setUpdatedEnabled] = useAppConfigurationValue<boolean>(
     AppSetting.UPDATES_ENABLED,

--- a/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
@@ -310,11 +310,11 @@ export function StepSize(): React.ReactElement {
     AppSetting.DEFAULT_STEP_SIZE,
   );
 
-  // console.log("GOLD STEP", stepSize)
   return (
     <Stack>
       <FormLabel>{t("stepSize")} (ms):</FormLabel>
       <TextField
+        id="stepSizeInput"
         fullWidth
         type="number"
         value={stepSize}

--- a/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
@@ -313,7 +313,7 @@ export function StepSize(): React.ReactElement {
   // console.log("GOLD STEP", stepSize)
   return (
     <Stack>
-      <FormLabel>{t("stepSize")}</FormLabel>
+      <FormLabel>{t("stepSize")} (ms)</FormLabel>
       <TextField
         fullWidth
         type="number"

--- a/packages/suite-base/src/components/PlaybackControls/index.style.ts
+++ b/packages/suite-base/src/components/PlaybackControls/index.style.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { makeStyles } from "tss-react/mui";
+
+export const useStyles = makeStyles()((theme) => ({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    padding: theme.spacing(0.5, 1, 1, 1),
+    position: "relative",
+    backgroundColor: theme.palette.background.paper,
+    borderTop: `1px solid ${theme.palette.divider}`,
+    zIndex: 100000,
+    overflowX: "auto",
+  },
+  scrubberWrapper: {
+    position: "sticky",
+    top: 0,
+    right: 0,
+    left: 0,
+  },
+  disabled: {
+    opacity: theme.palette.action.disabledOpacity,
+  },
+  popper: {
+    "&[data-popper-placement*=top] .MuiTooltip-tooltip": {
+      margin: theme.spacing(0.5, 0.5, 0.75),
+    },
+  },
+  dataSourceInfoButton: {
+    cursor: "default",
+  },
+}));

--- a/packages/suite-base/src/components/PlaybackControls/sharedHelpers.ts
+++ b/packages/suite-base/src/components/PlaybackControls/sharedHelpers.ts
@@ -28,7 +28,7 @@ export const jumpSeek = (
   directionSign: (typeof DIRECTION)[keyof typeof DIRECTION],
   currentTime: Time,
   modifierKeys?: { altKey: boolean; shiftKey: boolean },
-  defaultStepSize?: number
+  defaultStepSize?: number,
 ): Time => {
   const timeMs = toMillis(currentTime);
   const deltaMs =

--- a/packages/suite-base/src/components/PlaybackControls/sharedHelpers.ts
+++ b/packages/suite-base/src/components/PlaybackControls/sharedHelpers.ts
@@ -28,6 +28,7 @@ export const jumpSeek = (
   directionSign: (typeof DIRECTION)[keyof typeof DIRECTION],
   currentTime: Time,
   modifierKeys?: { altKey: boolean; shiftKey: boolean },
+  defaultStepSize?: number
 ): Time => {
   const timeMs = toMillis(currentTime);
   const deltaMs =
@@ -35,6 +36,6 @@ export const jumpSeek = (
       ? ARROW_SEEK_BIG_MS
       : modifierKeys?.shiftKey === true
         ? ARROW_SEEK_SMALL_MS
-        : ARROW_SEEK_DEFAULT_MS;
+        : defaultStepSize ?? ARROW_SEEK_DEFAULT_MS;
   return fromMillis(timeMs + deltaMs * directionSign);
 };

--- a/packages/suite-base/src/components/PlaybackControls/useDirectionalSeek.test.ts
+++ b/packages/suite-base/src/components/PlaybackControls/useDirectionalSeek.test.ts
@@ -47,6 +47,9 @@ describe("useDirectionalSeek", () => {
 
   beforeEach(() => {
     (useAppConfigurationValue as jest.Mock).mockReturnValue([true, jest.fn()]);
+  });
+
+  afterEach(() => {
     jest.clearAllMocks();
   });
 

--- a/packages/suite-base/src/components/PlaybackControls/useDirectionalSeek.test.ts
+++ b/packages/suite-base/src/components/PlaybackControls/useDirectionalSeek.test.ts
@@ -1,0 +1,121 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { renderHook } from "@testing-library/react";
+
+import { Time } from "@lichtblick/rostime";
+import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks";
+import RosTimeBuilder from "@lichtblick/suite-base/testing/builders/RosTimeBuilder";
+import MockBroadcastChannel from "@lichtblick/suite-base/util/broadcast/MockBroadcastChannel";
+
+import { useDirectionalSeek } from "./useDirectionalSeek";
+
+type Setup = {
+  seek: jest.Mock;
+  playUntil: jest.Mock | undefined;
+  currentTime: Time | undefined;
+};
+
+(global as any).BroadcastChannel = MockBroadcastChannel;
+
+jest.mock("@lichtblick/suite-base/hooks", () => ({
+  useAppConfigurationValue: jest.fn(),
+}));
+
+describe("useDirectionalSeek", () => {
+  const mockSeek = jest.fn();
+  const mockPlayUntil: jest.Mock | undefined = jest.fn();
+
+  const mockStartTime = RosTimeBuilder.time();
+  const mockEndTime = RosTimeBuilder.time();
+
+  function setup({ seek, playUntil, currentTime }: Setup) {
+    const getTimeInfo = () => ({
+      startTime: mockStartTime,
+      endTime: mockEndTime,
+      currentTime,
+    });
+
+    const { result } = renderHook(() => useDirectionalSeek({ seek, getTimeInfo, playUntil }));
+    return {
+      seekForward: result.current.seekForwardAction,
+      seekBackward: result.current.seekBackwardAction,
+    };
+  }
+
+  beforeEach(() => {
+    (useAppConfigurationValue as jest.Mock).mockReturnValue([true, jest.fn()]);
+    jest.clearAllMocks();
+  });
+
+  describe("seekForwardAction", () => {
+    it("should do nothing if there's no current time", () => {
+      const { seekForward } = setup({
+        seek: mockSeek,
+        playUntil: mockPlayUntil,
+        currentTime: undefined,
+      });
+
+      seekForward();
+
+      expect(mockPlayUntil).not.toHaveBeenCalled();
+      expect(mockSeek).not.toHaveBeenCalled();
+    });
+
+    it("should call playUnitl with the target time", () => {
+      const { seekForward } = setup({
+        seek: mockSeek,
+        playUntil: mockPlayUntil,
+        currentTime: RosTimeBuilder.time(),
+      });
+
+      seekForward();
+
+      expect(mockPlayUntil).toHaveBeenCalled();
+      expect(mockSeek).not.toHaveBeenCalled();
+    });
+
+    it("should call seek with the target time", () => {
+      const { seekForward } = setup({
+        seek: mockSeek,
+        playUntil: undefined,
+        currentTime: RosTimeBuilder.time(),
+      });
+
+      seekForward();
+
+      expect(mockPlayUntil).not.toHaveBeenCalled();
+      expect(mockSeek).toHaveBeenCalled();
+    });
+  });
+
+  describe("seekBackwardAction", () => {
+    it("should do nothing if there's no current time", () => {
+      const { seekBackward } = setup({
+        seek: mockSeek,
+        playUntil: mockPlayUntil,
+        currentTime: undefined,
+      });
+
+      seekBackward();
+
+      expect(mockPlayUntil).not.toHaveBeenCalled();
+      expect(mockSeek).not.toHaveBeenCalled();
+    });
+
+    it("should call seek with the target time", () => {
+      const { seekBackward } = setup({
+        seek: mockSeek,
+        playUntil: undefined,
+        currentTime: RosTimeBuilder.time(),
+      });
+
+      seekBackward();
+
+      expect(mockPlayUntil).not.toHaveBeenCalled();
+      expect(mockSeek).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/suite-base/src/components/PlaybackControls/useDirectionalSeek.ts
+++ b/packages/suite-base/src/components/PlaybackControls/useDirectionalSeek.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { useCallback } from "react";
+
+import { Time } from "@lichtblick/rostime";
+import { AppSetting } from "@lichtblick/suite-base/AppSetting";
+import {
+  DIRECTION,
+  jumpSeek,
+} from "@lichtblick/suite-base/components/PlaybackControls/sharedHelpers";
+import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks";
+import { Player } from "@lichtblick/suite-base/players/types";
+import BroadcastManager from "@lichtblick/suite-base/util/broadcast/BroadcastManager";
+
+type UseDirectionalSeek = {
+  seekForwardAction: (ev?: KeyboardEvent) => void;
+  seekBackwardAction: (ev?: KeyboardEvent) => void;
+};
+
+type UseDirectionalSeekProps = {
+  seek: NonNullable<Player["seekPlayback"]>;
+  playUntil?: Player["playUntil"];
+  getTimeInfo: () => { startTime?: Time; endTime?: Time; currentTime?: Time };
+};
+
+export function useDirectionalSeek({
+  seek,
+  getTimeInfo,
+  playUntil,
+}: UseDirectionalSeekProps): UseDirectionalSeek {
+  const [defaultStepSize] = useAppConfigurationValue<number>(AppSetting.DEFAULT_STEP_SIZE);
+
+  const seekForwardAction = useCallback(
+    (ev?: KeyboardEvent) => {
+      const { currentTime } = getTimeInfo();
+      if (!currentTime) {
+        return;
+      }
+
+      // If playUntil is available, we prefer to use that rather than seek, which performs a jump
+      // seek.
+      //
+      // Playing forward up to the desired seek time will play all messages to the panels which
+      // mirrors the behavior panels would expect when playing without stepping. This behavior is
+      // important for some message types which convey state information.
+      //
+      // i.e. Skipping coordinate frame messages may result in incorrectly rendered markers or
+      // missing markers altogther.
+
+      const targetTime = jumpSeek(DIRECTION.FORWARD, currentTime, ev, defaultStepSize);
+      if (playUntil) {
+        playUntil(targetTime);
+
+        BroadcastManager.getInstance().postMessage({
+          type: "playUntil",
+          time: targetTime,
+        });
+      } else {
+        seek(targetTime);
+
+        BroadcastManager.getInstance().postMessage({
+          type: "seek",
+          time: targetTime,
+        });
+      }
+    },
+    [getTimeInfo, playUntil, seek, defaultStepSize],
+  );
+
+  const seekBackwardAction = useCallback(
+    (ev?: KeyboardEvent) => {
+      const { currentTime } = getTimeInfo();
+      if (!currentTime) {
+        return;
+      }
+      const targetTime = jumpSeek(DIRECTION.BACKWARD, currentTime, ev, defaultStepSize);
+      seek(targetTime);
+
+      BroadcastManager.getInstance().postMessage({
+        type: "seek",
+        time: targetTime,
+      });
+    },
+    [defaultStepSize, getTimeInfo, seek],
+  );
+
+  return { seekForwardAction, seekBackwardAction };
+}

--- a/packages/suite-base/src/i18n/en/appSettings.ts
+++ b/packages/suite-base/src/i18n/en/appSettings.ts
@@ -24,6 +24,7 @@ export const appSettings = {
   layoutDebuggingDescription: "Show extra controls for developing and debugging layout storage.",
   light: "Light",
   messageRate: "Message rate",
+  stepSize: "Step size",
   memoryUseIndicator: "Memory use indicator",
   memoryUseIndicatorDescription: "Show the app memory use in the sidebar.",
   syncLichtblickInstances: "Sync Lichtblick instances",


### PR DESCRIPTION
**User-Facing Changes**
Users can now customize the size of the default step (only using the arrows) by going to general settings and updating the value that by default is 100 milliseconds.

<img width="1201" height="798" alt="image" src="https://github.com/user-attachments/assets/9864771b-b5dd-414f-87ac-1c709ee3b7af" />


**Description**
Added a new configuration option and new `Textfield` component on Settings. I also removed the logic that is triggered when the the user wants to go forward or backward to a custom hook so it could be easier to unit test.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [X] The web version was tested and it is running ok
- [X] The desktop version was tested and it is running ok
- [X] This change is covered by unit tests
- [X] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
