### PR TITLE
Disable auto update by default

### DIFF
--- a/packages/suite-base/src/components/AppSettingsDialog/settings.test.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.test.tsx
@@ -6,16 +6,19 @@
 import "@testing-library/jest-dom";
 import { render, screen, fireEvent } from "@testing-library/react";
 
-import { StepSize } from "./settings";
+import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks/useAppConfigurationValue";
 
-const mockSetStepSize = jest.fn();
+import { AutoUpdate, StepSize } from "./settings";
 
-jest.mock("../../hooks/useAppConfigurationValue", () => ({
-  useAppConfigurationValue: () => [100, mockSetStepSize],
+jest.mock("@lichtblick/suite-base/hooks/useAppConfigurationValue", () => ({
+  useAppConfigurationValue: jest.fn(),
 }));
 
 describe("StepSize component", () => {
+  const mockSetStepSize = jest.fn();
+
   beforeEach(() => {
+    (useAppConfigurationValue as jest.Mock).mockReturnValue([100, mockSetStepSize]);
     mockSetStepSize.mockClear();
   });
 
@@ -33,5 +36,23 @@ describe("StepSize component", () => {
     fireEvent.change(input, { target: { value: "250" } });
 
     expect(mockSetStepSize).toHaveBeenCalledWith(250);
+  });
+});
+
+describe("AutoUpdate component", () => {
+  it("should render update.enable as false by default", () => {
+    (useAppConfigurationValue as jest.Mock).mockReturnValue([undefined, jest.fn()]);
+
+    render(<AutoUpdate />);
+    const input: HTMLInputElement = screen.getByRole("checkbox");
+    expect(input.checked).toBe(false);
+  });
+
+  it("should render a checked checkbox when update.enable is true", () => {
+    (useAppConfigurationValue as jest.Mock).mockReturnValue([true, jest.fn()]);
+
+    render(<AutoUpdate />);
+    const input: HTMLInputElement = screen.getByRole("checkbox");
+    expect(input.checked).toBe(true);
   });
 });

--- a/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
@@ -338,7 +338,7 @@ export function StepSize(): React.ReactElement {
 }
 
 export function AutoUpdate(): React.ReactElement {
-  const [updatesEnabled = true, setUpdatedEnabled] = useAppConfigurationValue<boolean>(
+  const [updatesEnabled = false, setUpdatedEnabled] = useAppConfigurationValue<boolean>(
     AppSetting.UPDATES_ENABLED,
   );
 

--- a/packages/suite-desktop/src/main/StudioAppUpdater.test.ts
+++ b/packages/suite-desktop/src/main/StudioAppUpdater.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+import { autoUpdater } from "electron-updater";
+
+import StudioAppUpdater from "./StudioAppUpdater"; // ajuste o caminho se necessário
+import { getAppSetting } from "./settings";
+
+jest.mock("electron-updater", () => ({
+  autoUpdater: {
+    checkForUpdatesAndNotify: jest.fn(),
+    isUpdaterActive: jest.fn().mockReturnValue(true),
+  },
+}));
+
+jest.mock("./settings", () => ({
+  getAppSetting: jest.fn(),
+}));
+
+// In order to advance timers in tests, we need to use fake timers
+jest.useFakeTimers();
+
+describe("StudioAppUpdater.#maybeCheckForUpdates", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  const getInstance = async (): Promise<StudioAppUpdater> => {
+    const instance = StudioAppUpdater.Instance();
+    instance.start();
+    // Advance 600 seconds to trigger the update check
+    jest.advanceTimersByTime(600_000);
+    return instance;
+  };
+
+  it("should call checkForUpdatesAndNotify if updates are enabled", async () => {
+    (getAppSetting as jest.Mock).mockReturnValue(true);
+
+    await getInstance();
+
+    expect(autoUpdater.checkForUpdatesAndNotify).toHaveBeenCalled();
+  });
+
+  it("should not call checkForUpdatesAndNotify if updates are disabled", async () => {
+    (getAppSetting as jest.Mock).mockReturnValue(false);
+
+    await getInstance();
+
+    expect(autoUpdater.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+  });
+
+  it("should not call checkForUpdatesAndNotify if updates setting is undefined", async () => {
+    (getAppSetting as jest.Mock).mockReturnValue(undefined);
+
+    await getInstance();
+
+    expect(autoUpdater.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+  });
+});

--- a/packages/suite-desktop/src/main/StudioAppUpdater.ts
+++ b/packages/suite-desktop/src/main/StudioAppUpdater.ts
@@ -102,9 +102,9 @@ class StudioAppUpdater extends EventEmitter<EventTypes> {
   async #maybeCheckForUpdates(): Promise<void> {
     try {
       // The user may have changed the app update setting so we load it again
-      const appUpdatesEnabled = getAppSetting<boolean>(AppSetting.UPDATES_ENABLED);
+      const appUpdatesEnabled = getAppSetting<boolean>(AppSetting.UPDATES_ENABLED) ?? false;
 
-      if (appUpdatesEnabled ?? true) {
+      if (appUpdatesEnabled) {
         log.info("Checking for updates");
         await autoUpdater.checkForUpdatesAndNotify();
       }


### PR DESCRIPTION
## User-Facing Changes
Auto update will be disabled by default. User has to enable it manually.

## Description
- Changed default auto update to false.

## Checklist
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
