### PR TITLE
Added validations to step size configuration

### DIFF
--- a/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
@@ -26,7 +26,7 @@ import {
   ToggleButtonGroupProps,
 } from "@mui/material";
 import moment from "moment-timezone";
-import { MouseEvent, useCallback, useMemo } from "react";
+import { MouseEvent, useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
 
@@ -305,10 +305,29 @@ export function MessageFramerate(): React.ReactElement {
 
 export function StepSize(): React.ReactElement {
   const { t } = useTranslation("appSettings");
+  const defaultStepValue = 100;
+  const minValueAllowed = 1;
 
-  const [stepSize = 100, setStepSize] = useAppConfigurationValue<number>(
+  const [stepSize = defaultStepValue, setStepSize] = useAppConfigurationValue<number>(
     AppSetting.DEFAULT_STEP_SIZE,
   );
+
+  const valueValidation = (value: number) => {
+    return isNaN(value) || value < minValueAllowed;
+  };
+
+  const latestStepSizeRef = useRef(stepSize);
+  latestStepSizeRef.current = stepSize;
+
+  useEffect(() => {
+    return () => {
+      const latest = latestStepSizeRef.current;
+      if (valueValidation(latest)) {
+        void setStepSize(defaultStepValue);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Stack>
@@ -332,6 +351,7 @@ export function StepSize(): React.ReactElement {
             },
           },
         }}
+        error={valueValidation(stepSize)}
       ></TextField>
     </Stack>
   );

--- a/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
@@ -312,9 +312,8 @@ export function StepSize(): React.ReactElement {
     AppSetting.DEFAULT_STEP_SIZE,
   );
 
-  const valueValidation = (value: number) => {
-    return isNaN(value) || value < minValueAllowed;
-  };
+  const valueValidation = (value: number) => isNaN(value) || value < minValueAllowed;
+  const isStepSizeInvalid = valueValidation(stepSize);
 
   const latestStepSizeRef = useRef(stepSize);
   latestStepSizeRef.current = stepSize;
@@ -351,7 +350,8 @@ export function StepSize(): React.ReactElement {
             },
           },
         }}
-        error={valueValidation(stepSize)}
+        error={isStepSizeInvalid}
+        helperText={isStepSizeInvalid ? "Step size will default to 100ms" : " "}
       ></TextField>
     </Stack>
   );

--- a/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
@@ -305,14 +305,14 @@ export function MessageFramerate(): React.ReactElement {
 
 export function StepSize(): React.ReactElement {
   const { t } = useTranslation("appSettings");
-  const defaultStepValue = 100;
-  const minValueAllowed = 1;
+  const defaultStepSize = 100;
+  const minStepSize = 1;
 
-  const [stepSize = defaultStepValue, setStepSize] = useAppConfigurationValue<number>(
+  const [stepSize = defaultStepSize, setStepSize] = useAppConfigurationValue<number>(
     AppSetting.DEFAULT_STEP_SIZE,
   );
 
-  const valueValidation = (value: number) => isNaN(value) || value < minValueAllowed;
+  const valueValidation = (value: number) => isNaN(value) || value < minStepSize;
   const isStepSizeInvalid = valueValidation(stepSize);
 
   const latestStepSizeRef = useRef(stepSize);
@@ -322,7 +322,7 @@ export function StepSize(): React.ReactElement {
     return () => {
       const latest = latestStepSizeRef.current;
       if (valueValidation(latest)) {
-        void setStepSize(defaultStepValue);
+        void setStepSize(defaultStepSize);
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/suite-base/src/components/PlaybackControls/sharedHelpers.ts
+++ b/packages/suite-base/src/components/PlaybackControls/sharedHelpers.ts
@@ -31,11 +31,18 @@ export const jumpSeek = (
   defaultStepSize?: number,
 ): Time => {
   const timeMs = toMillis(currentTime);
-  const deltaMs =
-    modifierKeys?.altKey === true
-      ? ARROW_SEEK_BIG_MS
-      : modifierKeys?.shiftKey === true
-        ? ARROW_SEEK_SMALL_MS
-        : defaultStepSize ?? ARROW_SEEK_DEFAULT_MS;
+
+  const correctSeekValue =
+    typeof defaultStepSize === "number" && !isNaN(defaultStepSize) && defaultStepSize > 0;
+
+  let deltaMs: number;
+  if (modifierKeys?.altKey === true) {
+    deltaMs = ARROW_SEEK_BIG_MS;
+  } else if (modifierKeys?.shiftKey === true) {
+    deltaMs = ARROW_SEEK_SMALL_MS;
+  } else {
+    deltaMs = correctSeekValue ? defaultStepSize : ARROW_SEEK_DEFAULT_MS;
+  }
+
   return fromMillis(timeMs + deltaMs * directionSign);
 };


### PR DESCRIPTION
## User-Facing Changes

The input bar will now change to red whenever it doesn't have value or it's value is 0. On both of those situations Lichtblick will apply the default value of 100ms to the step size

## Description
Added validation and warning to the users when the input is left empty or in 0 as value 

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [X] The web version was tested and it is running ok
- [X] The desktop version was tested and it is running ok
- [X] This change is covered by unit tests
- [X] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
