### PR TITLE
Add flag to force multiple instances

### DIFF
--- a/packages/suite-desktop/src/main/createNewWindow.test.ts
+++ b/packages/suite-desktop/src/main/createNewWindow.test.ts
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// Mock all dependencies before any imports
+jest.mock("@lichtblick/log", () => ({
+  getLogger: () => ({
+    debug: jest.fn(),
+  }),
+}));
+
+jest.mock("./fileUtils", () => ({
+  isFileToOpen: jest.fn(),
+}));
+
+jest.mock("./injectFilesToOpen", () => jest.fn());
+
+// Mock StudioWindow completely to avoid React dependencies
+const mockLoad = jest.fn();
+const mockGetBrowserWindow = jest.fn();
+
+jest.mock("./StudioWindow", () => {
+  return jest.fn().mockImplementation(() => ({
+    load: mockLoad,
+    getBrowserWindow: mockGetBrowserWindow,
+  }));
+});
+
+// Import after mocks
+// eslint-disable-next-line import/first
+import StudioWindow from "./StudioWindow";
+// eslint-disable-next-line import/first
+import { createNewWindow } from "./createNewWindow";
+// eslint-disable-next-line import/first
+import { isFileToOpen } from "./fileUtils";
+// eslint-disable-next-line import/first
+import injectFilesToOpen from "./injectFilesToOpen";
+
+const mockIsFileToOpen = isFileToOpen as jest.MockedFunction<typeof isFileToOpen>;
+const mockInjectFilesToOpen = injectFilesToOpen as jest.MockedFunction<typeof injectFilesToOpen>;
+const MockStudioWindow = StudioWindow as jest.MockedClass<typeof StudioWindow>;
+
+describe("createNewWindow", () => {
+  const mockWebContents = {
+    once: jest.fn(),
+    debugger: { mock: "debugger" },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetBrowserWindow.mockReturnValue({ webContents: mockWebContents });
+  });
+
+  it("should create a new window with deep links", () => {
+    const argv = ["app", "lichtblick://test-link"];
+
+    createNewWindow(argv);
+
+    expect(MockStudioWindow).toHaveBeenCalledWith(["lichtblick://test-link"]);
+    expect(mockLoad).toHaveBeenCalled();
+  });
+
+  it("should filter out flags and process files", () => {
+    const argv = ["app", "--flag=value", "test.bag"];
+    mockIsFileToOpen.mockReturnValue(true);
+
+    createNewWindow(argv);
+
+    expect(mockIsFileToOpen).toHaveBeenCalledWith("test.bag");
+    expect(mockIsFileToOpen).not.toHaveBeenCalledWith("--flag=value");
+    expect(MockStudioWindow).toHaveBeenCalledWith([]);
+  });
+
+  it("should setup file injection callback", async () => {
+    const argv = ["app", "test.bag"];
+    mockIsFileToOpen.mockReturnValue(true);
+
+    let callback: (() => Promise<void>) | undefined;
+    mockWebContents.once.mockImplementation((event: string, cb: () => Promise<void>) => {
+      if (event === "did-finish-load") {
+        callback = cb;
+      }
+    });
+
+    createNewWindow(argv);
+
+    expect(mockWebContents.once).toHaveBeenCalledWith("did-finish-load", expect.any(Function));
+
+    // Simulate the callback execution
+    await callback!();
+
+    expect(mockInjectFilesToOpen).toHaveBeenCalledWith(mockWebContents.debugger, ["test.bag"]);
+  });
+
+  it("should not inject files when no files are present", async () => {
+    const argv = ["app", "lichtblick://link"];
+    mockIsFileToOpen.mockReturnValue(false);
+
+    let callback: (() => Promise<void>) | undefined;
+    mockWebContents.once.mockImplementation((event: string, cb: () => Promise<void>) => {
+      if (event === "did-finish-load") {
+        callback = cb;
+      }
+    });
+
+    createNewWindow(argv);
+
+    // Simulate the callback execution
+    await callback!();
+
+    expect(mockInjectFilesToOpen).not.toHaveBeenCalled();
+  });
+});

--- a/packages/suite-desktop/src/main/createNewWindow.ts
+++ b/packages/suite-desktop/src/main/createNewWindow.ts
@@ -3,8 +3,8 @@
 
 import Logger from "@lichtblick/log";
 
-import { isFileToOpen } from ".";
 import StudioWindow from "./StudioWindow";
+import { isFileToOpen } from "./fileUtils";
 import injectFilesToOpen from "./injectFilesToOpen";
 
 const log = Logger.getLogger(__filename);

--- a/packages/suite-desktop/src/main/fileUtils.test.ts
+++ b/packages/suite-desktop/src/main/fileUtils.test.ts
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import fs from "fs";
+
+import { isFileToOpen } from "./fileUtils";
+
+// Mock the fs module
+jest.mock("fs");
+const mockFs = fs as jest.Mocked<typeof fs>;
+
+// Mock the logger to avoid actual logging during tests
+jest.mock("@lichtblick/log", () => ({
+  getLogger: () => ({
+    error: jest.fn(),
+  }),
+}));
+
+describe("isFileToOpen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return true when argument is a valid file", () => {
+    // Mock fs.statSync to return a file stat object
+    const mockStat = {
+      isFile: jest.fn().mockReturnValue(true),
+      isDirectory: jest.fn().mockReturnValue(false),
+    } as unknown as fs.Stats;
+
+    mockFs.statSync.mockReturnValue(mockStat);
+
+    const result = isFileToOpen("/path/to/valid/file.txt");
+
+    expect(result).toBe(true);
+    expect(mockFs.statSync).toHaveBeenCalledWith("/path/to/valid/file.txt");
+  });
+
+  it("should return false when argument is a directory", () => {
+    // Mock fs.statSync to return a directory stat object
+    const mockStat = {
+      isFile: jest.fn().mockReturnValue(false),
+      isDirectory: jest.fn().mockReturnValue(true),
+    } as unknown as fs.Stats;
+
+    mockFs.statSync.mockReturnValue(mockStat);
+
+    const result = isFileToOpen("/path/to/directory");
+
+    expect(result).toBe(false);
+    expect(mockFs.statSync).toHaveBeenCalledWith("/path/to/directory");
+  });
+
+  it("should return false when fs.statSync throws an error (file does not exist)", () => {
+    // Mock fs.statSync to throw an error
+    const error = new Error("ENOENT: no such file or directory");
+    mockFs.statSync.mockImplementation(() => {
+      throw error;
+    });
+
+    const result = isFileToOpen("/path/to/nonexistent/file.txt");
+
+    expect(result).toBe(false);
+    expect(mockFs.statSync).toHaveBeenCalledWith("/path/to/nonexistent/file.txt");
+  });
+
+  it("should return false when fs.statSync throws a permission error", () => {
+    // Mock fs.statSync to throw a permission error
+    const error = new Error("EACCES: permission denied");
+    mockFs.statSync.mockImplementation(() => {
+      throw error;
+    });
+
+    const result = isFileToOpen("/path/to/restricted/file.txt");
+
+    expect(result).toBe(false);
+    expect(mockFs.statSync).toHaveBeenCalledWith("/path/to/restricted/file.txt");
+  });
+
+  it("should handle empty string argument", () => {
+    // Mock fs.statSync to throw an error for empty path
+    const error = new Error("ENOENT: no such file or directory");
+    mockFs.statSync.mockImplementation(() => {
+      throw error;
+    });
+
+    const result = isFileToOpen("");
+
+    expect(result).toBe(false);
+    expect(mockFs.statSync).toHaveBeenCalledWith("");
+  });
+
+  it("should handle special characters in file path", () => {
+    // Mock fs.statSync to return a file stat object
+    const mockStat = {
+      isFile: jest.fn().mockReturnValue(true),
+      isDirectory: jest.fn().mockReturnValue(false),
+    } as unknown as fs.Stats;
+
+    mockFs.statSync.mockReturnValue(mockStat);
+
+    const specialPath = "/path/with spaces/file-with_special.chars.txt";
+    const result = isFileToOpen(specialPath);
+
+    expect(result).toBe(true);
+    expect(mockFs.statSync).toHaveBeenCalledWith(specialPath);
+  });
+
+  it("should handle relative file paths", () => {
+    // Mock fs.statSync to return a file stat object
+    const mockStat = {
+      isFile: jest.fn().mockReturnValue(true),
+      isDirectory: jest.fn().mockReturnValue(false),
+    } as unknown as fs.Stats;
+
+    mockFs.statSync.mockReturnValue(mockStat);
+
+    const relativePath = "./relative/path/file.txt";
+    const result = isFileToOpen(relativePath);
+
+    expect(result).toBe(true);
+    expect(mockFs.statSync).toHaveBeenCalledWith(relativePath);
+  });
+
+  it("should handle file paths with different extensions", () => {
+    // Mock fs.statSync to return a file stat object
+    const mockStat = {
+      isFile: jest.fn().mockReturnValue(true),
+      isDirectory: jest.fn().mockReturnValue(false),
+    } as unknown as fs.Stats;
+
+    mockFs.statSync.mockReturnValue(mockStat);
+
+    const testCases = [
+      "/path/to/file.bag",
+      "/path/to/file.mcap",
+      "/path/to/file.json",
+      "/path/to/file.csv",
+      "/path/to/file", // file without extension
+    ];
+
+    testCases.forEach((filePath) => {
+      const result = isFileToOpen(filePath);
+      expect(result).toBe(true);
+      expect(mockFs.statSync).toHaveBeenCalledWith(filePath);
+    });
+  });
+});

--- a/packages/suite-desktop/src/main/fileUtils.ts
+++ b/packages/suite-desktop/src/main/fileUtils.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import fs from "fs";
+
+import Logger from "@lichtblick/log";
+
+const log = Logger.getLogger(__filename);
+
+/**
+ * Check if the argument is a file that can be opened.
+ *
+ * Note: in dev we launch electron with `electron .webpack` so we need to filter out things that are not files
+ */
+export const isFileToOpen = (arg: string): boolean => {
+  // Anything that isn't a file or directory will throw, we filter those out too
+  try {
+    return fs.statSync(arg).isFile();
+  } catch (err: unknown) {
+    log.error(err);
+    // ignore
+  }
+  return false;
+};

--- a/packages/suite-desktop/src/main/index.ts
+++ b/packages/suite-desktop/src/main/index.ts
@@ -6,7 +6,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { app, BrowserWindow, ipcMain, Menu, nativeTheme, session } from "electron";
-import fs from "fs";
 import path from "path";
 
 import Logger from "@lichtblick/log";
@@ -16,6 +15,7 @@ import { initI18n, sharedI18nObject as i18n } from "@lichtblick/suite-base/src/i
 import StudioAppUpdater from "./StudioAppUpdater";
 import StudioWindow from "./StudioWindow";
 import { createNewWindow } from "./createNewWindow";
+import { isFileToOpen } from "./fileUtils";
 import getDevModeIcon from "./getDevModeIcon";
 import injectFilesToOpen from "./injectFilesToOpen";
 import installChromeExtensions from "./installChromeExtensions";
@@ -39,22 +39,6 @@ const homeOverride = process.argv.find((arg) => arg.startsWith("--home-dir="));
 if (homeOverride != undefined) {
   app.setPath("home", homeOverride.split("=")[1]!);
 }
-
-/**
- * Determine whether an item in argv is a file that we should try opening as a data source.
- *
- * Note: in dev we launch electron with `electron .webpack` so we need to filter out things that are not files
- */
-export const isFileToOpen = (arg: string): boolean => {
-  // Anything that isn't a file or directory will throw, we filter those out too
-  try {
-    return fs.statSync(arg).isFile();
-  } catch (err: unknown) {
-    log.error(err);
-    // ignore
-  }
-  return false;
-};
 
 function updateNativeColorScheme() {
   const colorScheme = getAppSetting<string>(AppSetting.COLOR_SCHEME) ?? "system";


### PR DESCRIPTION
## User-Facing Changes
Users can open multiple Lichtblick instances using `--force-multiple-windows` flag.

## Description
- Added a functionality to force Electron to open multiple windows within the same instance, when using the flag.
- It will not have conflicts when accessing extensions and IndexDB, because we are creating a new window within the same Electron instance.
- Not using the flag, the behavior is the same of before.

## Checklist
- [x] The desktop version was tested and it is running ok
- [x] Unit tests