### PR TITLE
Fix displayTemporaryError

### DIFF
--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -6,7 +6,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import * as _ from "lodash-es";
-import { useSnackbar } from "notistack";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import { useLatest } from "react-use";
@@ -57,7 +56,7 @@ const log = Logger.getLogger(__filename);
  * A panel that renders a 3D scene. This is a thin wrapper around a `Renderer` instance.
  */
 export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.Element {
-  const { context, interfaceMode, testOptions, customSceneExtensions, customCameraModels } = props;
+  const { context, interfaceMode, testOptions, customSceneExtensions, customCameraModels, enqueueSnackbarFromParent } = props;
   const {
     initialState,
     saveState,
@@ -104,13 +103,13 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
   const [renderer, setRenderer] = useState<IRenderer | undefined>(undefined);
   const rendererRef = useRef<IRenderer | undefined>(undefined);
 
-  const { enqueueSnackbar } = useSnackbar();
-
   const displayTemporaryError = useCallback(
     (errorString: string) => {
-      enqueueSnackbar(errorString, { variant: "error" });
+      if (enqueueSnackbarFromParent) {
+        enqueueSnackbarFromParent(errorString, "error");
+      }
     },
-    [enqueueSnackbar],
+    [enqueueSnackbarFromParent],
   );
 
   useEffect(() => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/index.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/index.tsx
@@ -5,6 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { useSnackbar } from "notistack";
 import { useMemo } from "react";
 import { DeepPartial } from "ts-essentials";
 
@@ -38,6 +39,7 @@ type InitPanelArgs = {
   testOptions: TestOptions;
   customSceneExtensions?: DeepPartial<SceneExtensionConfig>;
   customCameraModels: CameraModelsMap;
+  enqueueSnackbarFromParent?: (message: string, variant?: "default" | "error" | "success" | "warning" | "info") => void;
 };
 
 function initPanel(args: InitPanelArgs, context: BuiltinPanelExtensionContext) {
@@ -48,6 +50,7 @@ function initPanel(args: InitPanelArgs, context: BuiltinPanelExtensionContext) {
     testOptions,
     customSceneExtensions,
     customCameraModels,
+    enqueueSnackbarFromParent,
   } = args;
   return createSyncRoot(
     <CaptureErrorBoundary onError={crash}>
@@ -58,6 +61,7 @@ function initPanel(args: InitPanelArgs, context: BuiltinPanelExtensionContext) {
           testOptions={testOptions}
           customSceneExtensions={customSceneExtensions}
           customCameraModels={customCameraModels}
+          enqueueSnackbarFromParent={enqueueSnackbarFromParent}
         />
       </ForwardAnalyticsContextProvider>
     </CaptureErrorBoundary>,
@@ -74,6 +78,7 @@ type Props = {
 
 function ThreeDeeRenderAdapter(interfaceMode: InterfaceMode, props: Props) {
   const crash = useCrash();
+  const { enqueueSnackbar } = useSnackbar();
 
   const customCameraModels = useExtensionCatalog(
     (state) => state.installedCameraModels,
@@ -97,9 +102,15 @@ function ThreeDeeRenderAdapter(interfaceMode: InterfaceMode, props: Props) {
         crash,
         forwardedAnalytics,
         interfaceMode,
-        testOptions: { onDownloadImage: props.onDownloadImage, debugPicking: props.debugPicking },
+        testOptions: {
+          onDownloadImage: props.onDownloadImage,
+          debugPicking: props.debugPicking,
+        },
         customSceneExtensions,
         customCameraModels,
+        enqueueSnackbarFromParent: (message: string, variant?: "default" | "error" | "success" | "warning" | "info") => {
+          enqueueSnackbar(message, { variant: variant ?? "default" });
+        },
       }),
     [
       crash,
@@ -109,6 +120,7 @@ function ThreeDeeRenderAdapter(interfaceMode: InterfaceMode, props: Props) {
       props.debugPicking,
       customSceneExtensions,
       customCameraModels,
+      enqueueSnackbar,
     ],
   );
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/types.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/types.ts
@@ -28,4 +28,6 @@ export type ThreeDeeRenderProps = {
   /** Allow for injection or overriding of default extensions by custom extensions */
   customSceneExtensions?: DeepPartial<SceneExtensionConfig>;
   customCameraModels: CameraModelsMap;
+  /** Allow for accessing the parent toast snackbar from the new sync root */
+  enqueueSnackbarFromParent?: (message: string, variant?: "default" | "error" | "success" | "warning" | "info") => void;
 };


### PR DESCRIPTION
## User-Facing Changes

When SceneExtensions try and use the Renderer's displayTemporaryError() function, it now properly displays it on the main window's snackbar/toast.

## Description

Previously, `displayTemporaryError()` as defined in `ThreeDeeRender.tsx` tried to use:
```ts
const { enqueueSnackbar } = useSnackbar();
```

Calling this `enqueueSnackbar()` did nothing because the ThreeDeeRender.tsx sits inside an isolated new sync root that doesn't have access to the `StudioToastProvider`.

This PR passes `enqueueSnackbarFromParent` in through the ThreeDeeRender's props so that the isolated context can share the same toast through `displayTemporaryError()`.

## Slight caveats

The owner toast does not seem to be temporary; it doesn't auto dismiss after some time.
I think this should be fine since you won't run into this often at all.
At this point in time, `displayTemporaryError()` is called only in `ImageMode.ts` for when downloading the camera image fails.
I also call it in another feature I'm developing but decided to split the fix out to this separate PR.

## Video
https://github.com/user-attachments/assets/d25d224c-10cd-4635-92ba-99aad66bb33e

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] ~This change is covered by unit tests~
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
