### PR TITLE
Reduce panel settings save throttle time

### DIFF
--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -323,10 +323,13 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
     (newConfig: Immutable<RendererConfig>) => {
       saveState(newConfig);
     },
-    1000,
+    100,
     { leading: false, trailing: true, maxWait: 1000 },
   );
-  useEffect(() => throttledSave(config), [config, throttledSave]);
+
+  useEffect(() => {
+    throttledSave(config);
+  }, [config, throttledSave]);
 
   // Keep default panel title up to date with selected image topic in image mode
   useEffect(() => {


### PR DESCRIPTION
## User-Facing Changes
Settings API more responsive

## Description
It was reduced the debounce time, because the settings API is updated after the settings are saved. This seems more like a workaround, but until we have other solution it solve the issues. 

This change increases the frequency of I/O operations, as settings are now saved more often. However, this is necessary because the Settings API reflects changes only after they are persisted. Since the UI updates immediately on user interaction, but the actual state and layout updates were previously throttled by 1 second, users experienced a noticeable delay. By reducing the debounce time, we ensure that changes propagate more quickly through the system, allowing the Settings API to respond in near real-time. While this is not an ideal long-term solution, it restores expected behavior and improves user experience for now.

We should revisit this in the future and consider decoupling UI feedback from layout persistence.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
