### PR TITLE
dotenv configured via webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ storybook-screenshots/
 storybook-static/
 # for jest --coverage
 coverage/
+.env
 
 # E2E tests
 e2e/reports

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@lichtblick/ros2idl-parser": "1.0.0",
     "@lichtblick/suite": "workspace:*",
     "@mui/material": "5.13.5",
+    "dotenv": "17.2.1",
     "react-use": "17.6.0",
     "rehype-raw": "7.0.0",
     "vm-browserify": "1.1.2"

--- a/packages/suite-base/src/typings/env.d.ts
+++ b/packages/suite-base/src/typings/env.d.ts
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    readonly DEV_WORKSPACE?: string;
+  }
+}

--- a/packages/suite-base/src/typings/index.d.ts
+++ b/packages/suite-base/src/typings/index.d.ts
@@ -13,3 +13,4 @@ import "./overrides";
 import "./webpack-defines";
 import "./i18next";
 import "./leaflet-ellipse";
+import "./env";

--- a/packages/suite-base/webpack.ts
+++ b/packages/suite-base/webpack.ts
@@ -5,6 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import dotenv from "dotenv";
 import { ESBuildMinifyPlugin } from "esbuild-loader";
 import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import MonacoWebpackPlugin from "monaco-editor-webpack-plugin";
@@ -17,6 +18,9 @@ import { createTssReactNameTransformer } from "@lichtblick/typescript-transforme
 
 import { WebpackArgv } from "./WebpackArgv";
 
+// Load environment variables from .env.local
+dotenv.config({ path: path.resolve(__dirname, "../../.env") });
+
 type Options = {
   // During hot reloading and development it is useful to comment out code while iterating.
   // We ignore errors from unused locals to avoid having to also comment
@@ -27,6 +31,12 @@ type Options = {
   /** Specify the path to the tsconfig.json file for ForkTsCheckerWebpackPlugin. If unset, the plugin defaults to finding the config file in the webpack `context` directory. */
   tsconfigPath?: string;
 };
+
+function buildEnvVars(): Record<string, string | undefined> {
+  return {
+    "process.env.DEV_WORKSPACE": JSON.stringify(process.env.DEV_WORKSPACE),
+  };
+}
 
 // Create a partial webpack configuration required to build app using webpack.
 // Returns a webpack configuration containing resolve, module, plugins, and node fields.
@@ -231,6 +241,7 @@ export function makeConfig(
         // Should match webpack-defines.d.ts
         ReactNull: null, // eslint-disable-line no-restricted-syntax
         LICHTBLICK_SUITE_VERSION: JSON.stringify(version),
+        ...buildEnvVars(),
       }),
       // https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales
       new webpack.IgnorePlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -9936,6 +9936,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:17.2.1":
+  version: 17.2.1
+  resolution: "dotenv@npm:17.2.1"
+  checksum: 2a3842a5451eb64f41cd11bd30d4d9d83941058f952f5e3adc3ca470d381e46ed8acbb0c0e3059da9725df91b42796987fa1deb032fafac992c37b94870ef085
+  languageName: node
+  linkType: hard
+
 "dotenv@npm:^16.4.5":
   version: 16.4.7
   resolution: "dotenv@npm:16.4.7"
@@ -14468,6 +14475,7 @@ __metadata:
     babel-plugin-transform-import-meta: 2.2.1
     cross-env: 7.0.3
     depcheck: 1.4.7
+    dotenv: 17.2.1
     electron: 37.2.5
     electron-builder: 26.0.12
     eslint: 8.57


### PR DESCRIPTION
## User-Facing Changes
N/A
<!-- will be used as a changelog entry -->

## Description
Dotenv and webpack is configured to start up application with .env values

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
