### PR TITLE
Add Experimental Message Range Subscription API

### DIFF
--- a/benchmark/src/players/BenchmarkPlayer.ts
+++ b/benchmark/src/players/BenchmarkPlayer.ts
@@ -11,7 +11,10 @@ import { toRFC3339String } from "@lichtblick/rostime";
 import { MessageEvent } from "@lichtblick/suite";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
 import { BlockLoader } from "@lichtblick/suite-base/players/IterablePlayer/BlockLoader";
-import { IDeserializedIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
+import {
+  IDeserializedIterableSource,
+  IteratorResult,
+} from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import PlayerAlertManager from "@lichtblick/suite-base/players/PlayerAlertManager";
 import { PLAYER_CAPABILITIES } from "@lichtblick/suite-base/players/constants";
 import {
@@ -43,6 +46,12 @@ class BenchmarkPlayer implements Player {
   public constructor(name: string, source: IDeserializedIterableSource) {
     this.#name = name;
     this.#source = source;
+  }
+
+  public getBatchIterator(
+    _topic: string,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> | undefined {
+    return undefined;
   }
 
   public setListener(listener: (state: PlayerState) => Promise<void>): void {

--- a/benchmark/src/players/PointcloudPlayer.ts
+++ b/benchmark/src/players/PointcloudPlayer.ts
@@ -10,6 +10,7 @@ import * as rostime from "@lichtblick/rostime";
 import { Time } from "@lichtblick/rostime";
 import { MessageEvent } from "@lichtblick/suite";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
+import { IteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import {
   AdvertiseOptions,
   Player,
@@ -150,6 +151,12 @@ class PointcloudPlayer implements Player {
         },
       ],
     });
+  }
+
+  public getBatchIterator(
+    _topic: string,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> | undefined {
+    return undefined;
   }
 
   public setListener(listener: (state: PlayerState) => Promise<void>): void {

--- a/benchmark/src/players/SinewavePlayer.ts
+++ b/benchmark/src/players/SinewavePlayer.ts
@@ -10,6 +10,7 @@ import * as rostime from "@lichtblick/rostime";
 import { Time } from "@lichtblick/rostime";
 import { MessageEvent } from "@lichtblick/suite";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
+import { IteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import {
   AdvertiseOptions,
   Player,
@@ -44,6 +45,12 @@ class SinewavePlayer implements Player {
         },
       ],
     });
+  }
+
+  public getBatchIterator(
+    _topic: string,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> | undefined {
+    return undefined;
   }
 
   public setListener(listener: (state: PlayerState) => Promise<void>): void {

--- a/benchmark/src/players/TransformPlayer.ts
+++ b/benchmark/src/players/TransformPlayer.ts
@@ -12,6 +12,7 @@ import * as rostime from "@lichtblick/rostime";
 import { Time } from "@lichtblick/rostime";
 import { MessageEvent } from "@lichtblick/suite";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
+import { IteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import {
   AdvertiseOptions,
   Player,
@@ -56,6 +57,12 @@ class TransformPlayer implements Player {
         { name: "rotation", type: "Quaternion", isComplex: true },
       ],
     });
+  }
+
+  public getBatchIterator(
+    _topic: string,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> | undefined {
+    return undefined;
   }
 
   public setListener(listener: (state: PlayerState) => Promise<void>): void {

--- a/benchmark/src/players/TransformPreloadingPlayer.ts
+++ b/benchmark/src/players/TransformPreloadingPlayer.ts
@@ -97,7 +97,7 @@ class TransformPreloadingPlayer implements Player {
   public getBatchIterator(
     _topic: string,
   ): AsyncIterableIterator<Readonly<IteratorResult>> | undefined {
-    return undefined;
+    throw new Error("Method not implemented.");
   }
 
   public setListener(listener: (state: PlayerState) => Promise<void>): void {

--- a/benchmark/src/players/TransformPreloadingPlayer.ts
+++ b/benchmark/src/players/TransformPreloadingPlayer.ts
@@ -12,6 +12,7 @@ import { Time, compare } from "@lichtblick/rostime";
 import { MessageEvent } from "@lichtblick/suite";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
 import { normalizeFrameTransform } from "@lichtblick/suite-base/panels/ThreeDeeRender/normalizeMessages";
+import { IteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import { PLAYER_CAPABILITIES } from "@lichtblick/suite-base/players/constants";
 import {
   AdvertiseOptions,
@@ -91,6 +92,12 @@ class TransformPreloadingPlayer implements Player {
         schemaName: "foxglove.FrameTransform",
       },
     ];
+  }
+
+  public getBatchIterator(
+    _topic: string,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> | undefined {
+    return undefined;
   }
 
   public setListener(listener: (state: PlayerState) => Promise<void>): void {

--- a/packages/suite-base/src/components/MessagePipeline/FakePlayer.ts
+++ b/packages/suite-base/src/components/MessagePipeline/FakePlayer.ts
@@ -15,6 +15,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Metadata, ParameterValue } from "@lichtblick/suite";
+import { IteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import { freezeMetadata } from "@lichtblick/suite-base/players/IterablePlayer/freezeMetadata";
 import { PLAYER_CAPABILITIES } from "@lichtblick/suite-base/players/constants";
 import {
@@ -61,6 +62,12 @@ export default class FakePlayer implements Player {
       progress: progress ?? {},
       activeData,
     });
+  }
+
+  public getBatchIterator(
+    _topic: string,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> | undefined {
+    return undefined;
   }
 
   public close = (): void => {

--- a/packages/suite-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
+++ b/packages/suite-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
@@ -205,6 +205,9 @@ function getPublicState(
           condvar.notifyAll();
         };
       },
+    getBatchIterator: () => {
+      return undefined;
+    },
   };
 }
 

--- a/packages/suite-base/src/components/MessagePipeline/index.test.tsx
+++ b/packages/suite-base/src/components/MessagePipeline/index.test.tsx
@@ -98,6 +98,7 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
         seekPlayback: undefined,
         setParameter: expect.any(Function),
         pauseFrame: expect.any(Function),
+        getBatchIterator: expect.any(Function),
       },
       {
         playerState: {
@@ -126,6 +127,7 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
         seekPlayback: undefined,
         setParameter: expect.any(Function),
         pauseFrame: expect.any(Function),
+        getBatchIterator: expect.any(Function),
       },
     ]);
   });

--- a/packages/suite-base/src/components/MessagePipeline/selectors.test.ts
+++ b/packages/suite-base/src/components/MessagePipeline/selectors.test.ts
@@ -35,6 +35,7 @@ it("map schema names by topic name", () => {
     setSubscriptions: jest.fn(),
     subscriptions: [],
     getMetadata: jest.fn(),
+    getBatchIterator: () => undefined,
   };
   const result = getTopicToSchemaNameMap(state);
   expect(result).toEqual({

--- a/packages/suite-base/src/components/MessagePipeline/store.ts
+++ b/packages/suite-base/src/components/MessagePipeline/store.ts
@@ -215,6 +215,10 @@ export function createMessagePipelineStore({
         const player = get().player;
         return player?.getMetadata?.() ?? Object.freeze([]);
       },
+      getBatchIterator(topic: string) {
+        const player = get().player;
+        return player?.getBatchIterator?.(topic);
+      },
       startPlayback: undefined,
       playUntil: undefined,
       pausePlayback: undefined,

--- a/packages/suite-base/src/components/MessagePipeline/store.ts
+++ b/packages/suite-base/src/components/MessagePipeline/store.ts
@@ -217,7 +217,7 @@ export function createMessagePipelineStore({
       },
       getBatchIterator(topic: string) {
         const player = get().player;
-        return player?.getBatchIterator?.(topic);
+        return player?.getBatchIterator(topic);
       },
       startPlayback: undefined,
       playUntil: undefined,

--- a/packages/suite-base/src/components/MessagePipeline/types.ts
+++ b/packages/suite-base/src/components/MessagePipeline/types.ts
@@ -8,6 +8,7 @@
 import { Time } from "@lichtblick/rostime";
 import { Immutable, MessageEvent, Metadata, ParameterValue } from "@lichtblick/suite";
 import { BuiltinPanelExtensionContext } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
+import { IteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import {
   AdvertiseOptions,
   PlayerState,
@@ -39,4 +40,5 @@ export type MessagePipelineContext = Immutable<{
   seekPlayback?: (time: Time) => void;
   // Don't render the next frame until the returned function has been called.
   pauseFrame: (name: string) => ResumeFrame;
+  getBatchIterator: (topic: string) => AsyncIterableIterator<Readonly<IteratorResult>> | undefined;
 }>;

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
@@ -810,11 +810,11 @@ describe("PanelExtensionAdapter", () => {
     let cleanupCalled = false;
     const initPanel = (context: PanelExtensionContext) => {
       const cleanup = context.unstable_subscribeMessageRange({
-        topic: "/test/topic", 
+        topic: "/test/topic",
         onNewRangeIterator: async () => {},
       });
       expect(typeof cleanup).toBe("function");
-      
+
       // Test that cleanup function works
       cleanup();
       cleanupCalled = true;

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
@@ -775,4 +775,68 @@ describe("PanelExtensionAdapter", () => {
     handle.rerender(<Wrapper />);
     await sig;
   });
+
+  it("should handle unstable_subscribeMessageRange when getBatchIterator returns undefined", async () => {
+    const initPanel = (context: PanelExtensionContext) => {
+      const cleanup = context.unstable_subscribeMessageRange({
+        topic: "/test/topic",
+        onNewRangeIterator: async () => {
+          // This callback should not be called when no batch iterator is available
+          throw new Error("onNewRangeIterator should not be called");
+        },
+      });
+      expect(typeof cleanup).toBe("function");
+    };
+
+    const sig = signal();
+
+    render(
+      <ThemeProvider isDark>
+        <MockPanelContextProvider>
+          <PanelSetup>
+            <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+          </PanelSetup>
+        </MockPanelContextProvider>
+      </ThemeProvider>,
+    );
+
+    await act(async () => {
+      sig.resolve();
+    });
+    await sig;
+  });
+
+  it("should return cleanup function from unstable_subscribeMessageRange", async () => {
+    let cleanupCalled = false;
+    const initPanel = (context: PanelExtensionContext) => {
+      const cleanup = context.unstable_subscribeMessageRange({
+        topic: "/test/topic", 
+        onNewRangeIterator: async () => {},
+      });
+      expect(typeof cleanup).toBe("function");
+      
+      // Test that cleanup function works
+      cleanup();
+      cleanupCalled = true;
+    };
+
+    const sig = signal();
+
+    render(
+      <ThemeProvider isDark>
+        <MockPanelContextProvider>
+          <PanelSetup>
+            <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+          </PanelSetup>
+        </MockPanelContextProvider>
+      </ThemeProvider>,
+    );
+
+    await act(async () => {
+      sig.resolve();
+    });
+    await sig;
+
+    expect(cleanupCalled).toBe(true);
+  });
 });

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -575,7 +575,7 @@ function PanelExtensionAdapter(
         });
 
         // Call the callback with the processed iterable
-        void onNewRangeIterator(messageEventIterable).catch((err: unknown) => {
+        onNewRangeIterator(messageEventIterable).catch((err: unknown) => {
           log.error("Error in onNewRangeIterator callback:", err);
         });
 

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -555,6 +555,20 @@ function PanelExtensionAdapter(
         setDefaultPanelTitle(title);
       },
 
+      /**
+       * EXPERIMENTAL: Subscribe to message ranges for efficient batch processing.
+       *
+       * This API is marked as "unstable" because it's still experimental and not fully functional.
+       * We're gradually testing and refining this feature to see how it performs in real-world scenarios.
+       *
+       * The API may change without notice as we gather feedback and improve the implementation.
+       * Use with caution in production environments.
+       *
+       * Current limitations:
+       * - Performance characteristics may vary
+       * - Error handling is still being refined
+       * - API surface may change based on testing feedback
+       */
       unstable_subscribeMessageRange({ topic, convertTo, onNewRangeIterator }) {
         if (!isMounted()) {
           return () => {};

--- a/packages/suite-base/src/components/PanelExtensionAdapter/contants.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/contants.ts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This is the target interval for batching messages. It is set to 16ms to align with a 60Hz update rate.
+export const BATCH_INTERVAL_MS = 16;

--- a/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.test.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.test.ts
@@ -1,0 +1,239 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MessageEvent } from "@lichtblick/suite";
+
+import { createMessageRangeIterator } from "./messageRangeIterator";
+import { IteratorResult } from "../../players/IterablePlayer/IIterableSource";
+
+// Mock the message processing module
+jest.mock("./messageProcessing", () => ({
+  convertMessage: jest.fn(),
+  collateTopicSchemaConversions: jest.fn().mockReturnValue({
+    topicSchemaConverters: new Map(),
+    unconvertedSubscriptionTopics: new Set(),
+  }),
+}));
+
+describe("createMessageRangeIterator", () => {
+  const mockTopic = "/test_topic";
+  const mockSortedTopics = [{ name: mockTopic, schemaName: "test_schema" }];
+  const mockMessageConverters: never[] = [];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  async function* createMockRawBatchIterator(
+    results: IteratorResult[],
+  ): AsyncIterableIterator<Readonly<IteratorResult>> {
+    for (const result of results) {
+      yield result;
+    }
+  }
+
+  it("should create an iterable and cancel function", () => {
+    const rawBatchIterator = createMockRawBatchIterator([]);
+
+    const result = createMessageRangeIterator({
+      topic: mockTopic,
+      rawBatchIterator,
+      sortedTopics: mockSortedTopics,
+      messageConverters: mockMessageConverters,
+    });
+
+    expect(result).toHaveProperty("iterable");
+    expect(result).toHaveProperty("cancel");
+    expect(typeof result.cancel).toBe("function");
+  });
+
+  it("should filter messages by topic", async () => {
+    const mockMessage: MessageEvent = {
+      topic: mockTopic,
+      schemaName: "test_schema",
+      receiveTime: { sec: 1, nsec: 0 },
+      message: { data: "test" },
+      sizeInBytes: 100,
+    };
+
+    const otherTopicMessage: MessageEvent = {
+      topic: "/other_topic",
+      schemaName: "test_schema",
+      receiveTime: { sec: 1, nsec: 0 },
+      message: { data: "other" },
+      sizeInBytes: 100,
+    };
+
+    const results: IteratorResult[] = [
+      {
+        type: "message-event",
+        msgEvent: mockMessage,
+      },
+      {
+        type: "message-event",
+        msgEvent: otherTopicMessage,
+      },
+    ];
+
+    const rawBatchIterator = createMockRawBatchIterator(results);
+    const { iterable } = createMessageRangeIterator({
+      topic: mockTopic,
+      rawBatchIterator,
+      sortedTopics: mockSortedTopics,
+      messageConverters: mockMessageConverters,
+    });
+
+    const batches: MessageEvent[][] = [];
+    for await (const batch of iterable) {
+      batches.push(batch);
+    }
+
+    // Should only include the message for the requested topic
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toContain(mockMessage);
+    expect(batches[0]).not.toContain(otherTopicMessage);
+  });
+
+  it("should handle cancellation", async () => {
+    const mockMessage: MessageEvent = {
+      topic: mockTopic,
+      schemaName: "test_schema",
+      receiveTime: { sec: 1, nsec: 0 },
+      message: { data: "test" },
+      sizeInBytes: 100,
+    };
+
+    // Create a slow iterator to test cancellation
+    async function* slowIterator(): AsyncIterableIterator<Readonly<IteratorResult>> {
+      yield {
+        type: "message-event",
+        msgEvent: mockMessage,
+      };
+      // Add a delay to allow cancellation
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      yield {
+        type: "message-event",
+        msgEvent: mockMessage,
+      };
+    }
+
+    const { iterable, cancel } = createMessageRangeIterator({
+      topic: mockTopic,
+      rawBatchIterator: slowIterator(),
+      sortedTopics: mockSortedTopics,
+      messageConverters: mockMessageConverters,
+    });
+
+    const batches: MessageEvent[][] = [];
+    const iterator = iterable[Symbol.asyncIterator]();
+
+    // Get first batch
+    const firstResult = await iterator.next();
+    expect(firstResult.done).toBe(false);
+    if (firstResult.done !== true) {
+      batches.push(firstResult.value);
+    }
+
+    // Cancel before getting second batch
+    cancel();
+
+    // Try to get next batch - should be cancelled
+    const secondResult = await iterator.next();
+    expect(secondResult.done).toBe(true);
+
+    // Should only have received the first batch
+    expect(batches).toHaveLength(1);
+  });
+
+  it("should handle convertTo parameter", () => {
+    const rawBatchIterator = createMockRawBatchIterator([]);
+    const convertTo = "converted_schema";
+
+    const result = createMessageRangeIterator({
+      topic: mockTopic,
+      convertTo,
+      rawBatchIterator,
+      sortedTopics: mockSortedTopics,
+      messageConverters: mockMessageConverters,
+    });
+
+    expect(result).toHaveProperty("iterable");
+    expect(result).toHaveProperty("cancel");
+  });
+
+  it("should batch messages based on time", async () => {
+    const mockMessages: MessageEvent[] = [
+      {
+        topic: mockTopic,
+        schemaName: "test_schema",
+        receiveTime: { sec: 1, nsec: 0 },
+        message: { data: "test1" },
+        sizeInBytes: 100,
+      },
+      {
+        topic: mockTopic,
+        schemaName: "test_schema",
+        receiveTime: { sec: 1, nsec: 1000000 }, // 1ms later
+        message: { data: "test2" },
+        sizeInBytes: 100,
+      },
+    ];
+
+    const results: IteratorResult[] = mockMessages.map((msg) => ({
+      type: "message-event" as const,
+      msgEvent: msg,
+    }));
+
+    const rawBatchIterator = createMockRawBatchIterator(results);
+    const { iterable } = createMessageRangeIterator({
+      topic: mockTopic,
+      rawBatchIterator,
+      sortedTopics: mockSortedTopics,
+      messageConverters: mockMessageConverters,
+    });
+
+    const batches: MessageEvent[][] = [];
+    for await (const batch of iterable) {
+      batches.push(batch);
+    }
+
+    // Should receive at least one batch with both messages
+    expect(batches.length).toBeGreaterThanOrEqual(1);
+    const allMessages = batches.flat();
+    expect(allMessages).toHaveLength(2);
+  });
+
+  it("should handle non-message-event results", async () => {
+    const results: IteratorResult[] = [
+      {
+        type: "alert",
+        connectionId: 1,
+        alert: { severity: "info", message: "test alert" },
+      },
+      {
+        type: "stamp",
+        stamp: { sec: 1, nsec: 0 },
+      },
+    ];
+
+    const rawBatchIterator = createMockRawBatchIterator(results);
+    const { iterable } = createMessageRangeIterator({
+      topic: mockTopic,
+      rawBatchIterator,
+      sortedTopics: mockSortedTopics,
+      messageConverters: mockMessageConverters,
+    });
+
+    const batches: MessageEvent[][] = [];
+    for await (const batch of iterable) {
+      batches.push(batch);
+    }
+
+    // Should not yield any batches since there are no message events
+    expect(batches).toHaveLength(0);
+  });
+});

--- a/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.test.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.test.ts
@@ -185,13 +185,13 @@ describe("createMessageRangeIterator", () => {
   });
 
   it("should properly cancel during iteration", async () => {
-    const mockMessages: MessageEvent[] = Array.from({ length: 10 }, (_, i) => ({
-      topic: mockTopic,
-      schemaName: "test_schema",
-      receiveTime: { sec: 1, nsec: i * 1000000 },
-      message: { data: `test${i}` },
-      sizeInBytes: 100,
-    }));
+    const mockMessages: MessageEvent[] = Array.from({ length: 10 }, (_, i) =>
+      MessageEventBuilder.messageEvent({
+        topic: mockTopic,
+        receiveTime: { sec: 1, nsec: i * 1000000 },
+        message: { data: `test${i}` },
+      }),
+    );
 
     // Create an iterator that yields slowly to allow cancellation
     async function* slowIterator(): AsyncIterableIterator<Readonly<IteratorResult>> {
@@ -232,17 +232,19 @@ describe("createMessageRangeIterator", () => {
     // Should have received limited results due to cancellation
     expect(batches.length).toBeGreaterThan(0);
     const totalMessages = batches.flat().length;
-    expect(totalMessages).toBeLessThan(10); // Should not have processed all messages
+    expect(totalMessages).toBeLessThan(mockMessages.length); // Should not have processed all messages
   });
 
   it("should yield batches after 16ms timeout", async () => {
-    const mockMessages: MessageEvent[] = Array.from({ length: 5 }, (_, i) => ({
-      topic: mockTopic,
-      schemaName: "test_schema",
-      receiveTime: { sec: 1, nsec: i * 1000000 },
-      message: { data: `test${i}` },
-      sizeInBytes: 100,
-    }));
+    const mockMessages: MessageEvent[] = Array.from({ length: 5 }, (_, i) =>
+      MessageEventBuilder.messageEvent({
+        topic: mockTopic,
+        schemaName: "test_schema",
+        receiveTime: { sec: 1, nsec: i * 1000000 },
+        message: { data: `test${i}` },
+        sizeInBytes: 100,
+      }),
+    );
 
     // Create an iterator with artificial delays to trigger time-based batching
     async function* timedIterator(): AsyncIterableIterator<Readonly<IteratorResult>> {

--- a/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.test.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.test.ts
@@ -194,4 +194,271 @@ describe("createMessageRangeIterator", () => {
     // Should not yield any batches since there are no message events
     expect(batches).toHaveLength(0);
   });
+
+  it("should properly cancel during iteration", async () => {
+    const mockMessages: MessageEvent[] = Array.from({ length: 10 }, (_, i) => ({
+      topic: mockTopic,
+      schemaName: "test_schema",
+      receiveTime: { sec: 1, nsec: i * 1000000 },
+      message: { data: `test${i}` },
+      sizeInBytes: 100,
+    }));
+
+    // Create an iterator that yields slowly to allow cancellation
+    async function* slowIterator(): AsyncIterableIterator<Readonly<IteratorResult>> {
+      for (const msg of mockMessages) {
+        yield {
+          type: "message-event",
+          msgEvent: msg,
+        };
+        // Delay to allow cancellation between yields
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+    }
+
+    const { iterable, cancel } = createMessageRangeIterator({
+      topic: mockTopic,
+      rawBatchIterator: slowIterator(),
+      sortedTopics: mockSortedTopics,
+      messageConverters: mockMessageConverters,
+    });
+
+    const batches: MessageEvent[][] = [];
+    const iterator = iterable[Symbol.asyncIterator]();
+
+    // Get first result
+    const firstResult = await iterator.next();
+    expect(firstResult.done).toBe(false);
+    if (firstResult.done !== true) {
+      batches.push(firstResult.value);
+    }
+
+    // Cancel immediately
+    cancel();
+
+    // Try to get next batch - should be cancelled
+    const secondResult = await iterator.next();
+    expect(secondResult.done).toBe(true);
+
+    // Should have received limited results due to cancellation
+    expect(batches.length).toBeGreaterThan(0);
+    const totalMessages = batches.flat().length;
+    expect(totalMessages).toBeLessThan(10); // Should not have processed all messages
+  });
+
+  it("should yield batches after 16ms timeout", async () => {
+    const mockMessages: MessageEvent[] = Array.from({ length: 5 }, (_, i) => ({
+      topic: mockTopic,
+      schemaName: "test_schema",
+      receiveTime: { sec: 1, nsec: i * 1000000 },
+      message: { data: `test${i}` },
+      sizeInBytes: 100,
+    }));
+
+    // Create an iterator with artificial delays to trigger time-based batching
+    async function* timedIterator(): AsyncIterableIterator<Readonly<IteratorResult>> {
+      for (let i = 0; i < mockMessages.length; i++) {
+        yield {
+          type: "message-event",
+          msgEvent: mockMessages[i]!,
+        };
+
+        // Add a delay after the second message to trigger 16ms batching
+        if (i === 1) {
+          await new Promise((resolve) => setTimeout(resolve, 16)); // 16ms delay
+        }
+      }
+    }
+
+    const { iterable } = createMessageRangeIterator({
+      topic: mockTopic,
+      rawBatchIterator: timedIterator(),
+      sortedTopics: mockSortedTopics,
+      messageConverters: mockMessageConverters,
+    });
+
+    const batches: MessageEvent[][] = [];
+    for await (const batch of iterable) {
+      batches.push([...batch]);
+    }
+
+    // Should have multiple batches due to time-based splitting
+    expect(batches.length).toBeGreaterThan(1);
+
+    // All messages should be received
+    const allMessages = batches.flat();
+    expect(allMessages).toHaveLength(5);
+  });
+
+  it("should handle message conversion when converters are available", async () => {
+    const mockMessage: MessageEvent = {
+      topic: mockTopic,
+      schemaName: "test_schema",
+      receiveTime: { sec: 1, nsec: 0 },
+      message: { data: "test" },
+      sizeInBytes: 100,
+    };
+
+    const { convertMessage, collateTopicSchemaConversions } =
+      jest.requireMock("./messageProcessing");
+
+    // Mock to include topic schema converters
+    collateTopicSchemaConversions.mockReturnValue({
+      topicSchemaConverters: new Map([["test_key", jest.fn()]]),
+      unconvertedSubscriptionTopics: new Set(),
+    });
+
+    const rawBatchIterator = createMockRawBatchIterator([
+      {
+        type: "message-event",
+        msgEvent: mockMessage,
+      },
+    ]);
+
+    const { iterable } = createMessageRangeIterator({
+      topic: mockTopic,
+      rawBatchIterator,
+      sortedTopics: mockSortedTopics,
+      messageConverters: mockMessageConverters,
+    });
+
+    const batches: MessageEvent[][] = [];
+    for await (const batch of iterable) {
+      batches.push(batch);
+    }
+
+    // Should have called convertMessage since topicSchemaConverters is not empty
+    expect(convertMessage).toHaveBeenCalledWith(mockMessage, expect.any(Map), expect.any(Array));
+  });
+
+  it("should yield final batch of remaining messages", async () => {
+    const mockMessages: MessageEvent[] = [
+      {
+        topic: mockTopic,
+        schemaName: "test_schema",
+        receiveTime: { sec: 1, nsec: 0 },
+        message: { data: "test1" },
+        sizeInBytes: 100,
+      },
+      {
+        topic: mockTopic,
+        schemaName: "test_schema",
+        receiveTime: { sec: 1, nsec: 1000000 },
+        message: { data: "test2" },
+        sizeInBytes: 100,
+      },
+    ];
+
+    // Create an iterator that finishes quickly to test final batch handling
+    async function* quickIterator(): AsyncIterableIterator<Readonly<IteratorResult>> {
+      for (const msg of mockMessages) {
+        yield {
+          type: "message-event",
+          msgEvent: msg,
+        };
+      }
+    }
+
+    const { iterable } = createMessageRangeIterator({
+      topic: mockTopic,
+      rawBatchIterator: quickIterator(),
+      sortedTopics: mockSortedTopics,
+      messageConverters: mockMessageConverters,
+    });
+
+    const batches: MessageEvent[][] = [];
+    for await (const batch of iterable) {
+      batches.push(batch);
+    }
+
+    // Should receive at least one batch with all messages
+    expect(batches.length).toBeGreaterThanOrEqual(1);
+    const allMessages = batches.flat();
+    expect(allMessages).toHaveLength(2);
+    expect(allMessages[0]?.message).toEqual({ data: "test1" });
+    expect(allMessages[1]?.message).toEqual({ data: "test2" });
+  });
+
+  it("should handle errors gracefully", async () => {
+    (console.error as jest.Mock).mockImplementation(() => {});
+
+    // Create an iterator that throws an error
+    async function* errorIterator(): AsyncIterableIterator<Readonly<IteratorResult>> {
+      //Simulate delay to send a batch
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      yield {
+        type: "message-event",
+        msgEvent: {
+          topic: mockTopic,
+          schemaName: "test_schema",
+          receiveTime: { sec: 1, nsec: 0 },
+          message: { data: "test" },
+          sizeInBytes: 100,
+        },
+      };
+      throw new Error("Test error");
+    }
+
+    const { iterable } = createMessageRangeIterator({
+      topic: mockTopic,
+      rawBatchIterator: errorIterator(),
+      sortedTopics: mockSortedTopics,
+      messageConverters: mockMessageConverters,
+    });
+
+    const batches: MessageEvent[][] = [];
+
+    // Should not throw, but handle error gracefully
+    for await (const batch of iterable) {
+      batches.push(batch);
+    }
+
+    // Should have received one batch before the error
+    expect(batches).toHaveLength(1);
+
+    expect(console.error).toHaveBeenCalledWith(
+      "Error in createMessageRangeIterator:",
+      expect.any(Error),
+    );
+
+    (console.error as jest.Mock).mockReset();
+  });
+
+  it("should not yield remaining messages when cancelled", async () => {
+    const mockMessages: MessageEvent[] = Array.from({ length: 3 }, (_, i) => ({
+      topic: mockTopic,
+      schemaName: "test_schema",
+      receiveTime: { sec: 1, nsec: i * 1000000 },
+      message: { data: `test${i}` },
+      sizeInBytes: 100,
+    }));
+
+    async function* interruptibleIterator(): AsyncIterableIterator<Readonly<IteratorResult>> {
+      for (const msg of mockMessages) {
+        yield {
+          type: "message-event",
+          msgEvent: msg,
+        };
+      }
+    }
+
+    const { iterable, cancel } = createMessageRangeIterator({
+      topic: mockTopic,
+      rawBatchIterator: interruptibleIterator(),
+      sortedTopics: mockSortedTopics,
+      messageConverters: mockMessageConverters,
+    });
+
+    // Cancel before starting iteration
+    cancel();
+
+    const batches: MessageEvent[][] = [];
+    for await (const batch of iterable) {
+      batches.push(batch);
+    }
+
+    // Should not yield any batches since it was cancelled before starting
+    expect(batches).toHaveLength(0);
+  });
 });

--- a/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.ts
@@ -8,6 +8,7 @@
 import Logger from "@lichtblick/log";
 import { MessageEvent, Subscription } from "@lichtblick/suite";
 import { CreateMessageRangeIteratorParams } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
+import { BATCH_INTERVAL_MS } from "@lichtblick/suite-base/components/PanelExtensionAdapter/contants";
 
 const log = Logger.getLogger(__filename);
 
@@ -72,7 +73,7 @@ export function createMessageRangeIterator(params: CreateMessageRangeIteratorPar
             convertMessage(msgEvent, topicSchemaConverters, batchMessages);
           }
 
-          if (performance.now() - lastBatchTime > 16) {
+          if (performance.now() - lastBatchTime > BATCH_INTERVAL_MS) {
             // Yield the batch if it has been more than 16ms since the last yield
             if (batchMessages.length > 0) {
               yield batchMessages; // No copy needed - we clear it immediately after

--- a/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.ts
@@ -7,7 +7,7 @@
 
 import Logger from "@lichtblick/log";
 import { MessageEvent, Subscription } from "@lichtblick/suite";
-import { CreateMessageRangeIteratorParams } from "@lichtblick/suite-base/components/PanelExtensionAdapter/types";
+import { CreateMessageRangeIteratorParams } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
 
 const log = Logger.getLogger(__filename);
 

--- a/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.ts
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Logger from "@lichtblick/log";
+import { MessageEvent, Subscription } from "@lichtblick/suite";
+import type { RegisterMessageConverterArgs } from "@lichtblick/suite";
+import { Topic } from "@lichtblick/suite-base/players/types";
+
+import { IteratorResult } from "../../players/IterablePlayer/IIterableSource";
+
+const log = Logger.getLogger(__filename);
+
+type MessageConverter = RegisterMessageConverterArgs<unknown>;
+
+export type CreateMessageRangeIteratorParams = {
+  topic: string;
+  convertTo?: string;
+  rawBatchIterator: AsyncIterableIterator<Readonly<IteratorResult>>;
+  sortedTopics: readonly Topic[];
+  messageConverters: readonly MessageConverter[];
+};
+
+/**
+ * Creates an async iterable that processes messages from a raw batch iterator,
+ * applying conversions and batching as needed.
+ */
+export function createMessageRangeIterator(params: CreateMessageRangeIteratorParams): {
+  iterable: AsyncIterable<MessageEvent[]>;
+  cancel: () => void;
+} {
+  const { topic, convertTo, rawBatchIterator, sortedTopics, messageConverters } = params;
+
+  // Create a cancellation token
+  let cancelled = false;
+
+  // Create a wrapper async iterable that converts IteratorResult to MessageEvent
+  const messageEventIterable = {
+    async *[Symbol.asyncIterator]() {
+      try {
+        // Create a fake subscription to get message converters for this topic
+        // Include convertTo if specified to get proper conversion setup
+        const subscription: Subscription = convertTo
+          ? { topic, preload: true, convertTo }
+          : { topic, preload: true };
+
+        // Import necessary functions for message processing
+        const { convertMessage, collateTopicSchemaConversions } = await import(
+          "./messageProcessing"
+        );
+
+        const collatedConversions = collateTopicSchemaConversions(
+          [subscription],
+          sortedTopics,
+          messageConverters,
+        );
+
+        const { topicSchemaConverters, unconvertedSubscriptionTopics } = collatedConversions;
+
+        const batchMessages: MessageEvent[] = [];
+        let lastBatchTime = performance.now();
+
+        for await (const iterResult of rawBatchIterator) {
+          // Check if cancelled before processing each iteration
+          if (cancelled) {
+            break;
+          }
+
+          // Only process message-event type results
+          if (iterResult.type === "message-event") {
+            const msgEvent = iterResult.msgEvent;
+
+            // Filter by topic (the iterator might return other topics)
+            if (msgEvent.topic === topic) {
+              if (unconvertedSubscriptionTopics.has(msgEvent.topic)) {
+                batchMessages.push(msgEvent);
+              }
+              // Apply message conversion if converters exist
+              if (topicSchemaConverters.size > 0) {
+                convertMessage(msgEvent, topicSchemaConverters, batchMessages);
+              }
+
+              if (performance.now() - lastBatchTime > 16) {
+                // Yield the batch if it has been more than 16ms since the last yield
+                if (batchMessages.length > 0) {
+                  yield batchMessages; // No copy needed - we clear it immediately after
+                  batchMessages.length = 0; // Clear the batch
+                  lastBatchTime = performance.now();
+                }
+              }
+            }
+          }
+        }
+
+        // Yield any remaining messages if not cancelled
+        if (!cancelled && batchMessages.length > 0) {
+          yield batchMessages; // No copy needed - array will be garbage collected
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          log.error("Error in createMessageRangeIterator:", err);
+        }
+      }
+    },
+  };
+
+  // Return the iterable and a cancel function
+  return {
+    iterable: messageEventIterable,
+    cancel: () => {
+      cancelled = true;
+    },
+  };
+}

--- a/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.ts
@@ -7,22 +7,9 @@
 
 import Logger from "@lichtblick/log";
 import { MessageEvent, Subscription } from "@lichtblick/suite";
-import type { RegisterMessageConverterArgs } from "@lichtblick/suite";
-import { Topic } from "@lichtblick/suite-base/players/types";
-
-import { IteratorResult } from "../../players/IterablePlayer/IIterableSource";
+import { CreateMessageRangeIteratorParams } from "@lichtblick/suite-base/components/PanelExtensionAdapter/types";
 
 const log = Logger.getLogger(__filename);
-
-type MessageConverter = RegisterMessageConverterArgs<unknown>;
-
-export type CreateMessageRangeIteratorParams = {
-  topic: string;
-  convertTo?: string;
-  rawBatchIterator: AsyncIterableIterator<Readonly<IteratorResult>>;
-  sortedTopics: readonly Topic[];
-  messageConverters: readonly MessageConverter[];
-};
 
 /**
  * Creates an async iterable that processes messages from a raw batch iterator,

--- a/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/messageRangeIterator.ts
@@ -56,28 +56,28 @@ export function createMessageRangeIterator(params: CreateMessageRangeIteratorPar
             break;
           }
 
-          // Only process message-event type results
-          if (iterResult.type === "message-event") {
-            const msgEvent = iterResult.msgEvent;
+          // Only process "message-event" type results
+          if (iterResult.type !== "message-event") {
+            continue;
+          }
 
-            // Filter by topic (the iterator might return other topics)
-            if (msgEvent.topic === topic) {
-              if (unconvertedSubscriptionTopics.has(msgEvent.topic)) {
-                batchMessages.push(msgEvent);
-              }
-              // Apply message conversion if converters exist
-              if (topicSchemaConverters.size > 0) {
-                convertMessage(msgEvent, topicSchemaConverters, batchMessages);
-              }
+          const msgEvent = iterResult.msgEvent;
 
-              if (performance.now() - lastBatchTime > 16) {
-                // Yield the batch if it has been more than 16ms since the last yield
-                if (batchMessages.length > 0) {
-                  yield batchMessages; // No copy needed - we clear it immediately after
-                  batchMessages.length = 0; // Clear the batch
-                  lastBatchTime = performance.now();
-                }
-              }
+          // If the topic is not in unconvertedSubscriptionTopics, skip conversion
+          if (unconvertedSubscriptionTopics.has(msgEvent.topic)) {
+            batchMessages.push(msgEvent);
+          }
+          // Apply message conversion if converters exist
+          if (topicSchemaConverters.size > 0) {
+            convertMessage(msgEvent, topicSchemaConverters, batchMessages);
+          }
+
+          if (performance.now() - lastBatchTime > 16) {
+            // Yield the batch if it has been more than 16ms since the last yield
+            if (batchMessages.length > 0) {
+              yield batchMessages; // No copy needed - we clear it immediately after
+              batchMessages.length = 0; // Clear the batch
+              lastBatchTime = performance.now();
             }
           }
         }

--- a/packages/suite-base/src/components/PanelExtensionAdapter/types.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/types.ts
@@ -5,7 +5,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { PanelExtensionContext } from "@lichtblick/suite";
+import { PanelExtensionContext, RegisterMessageConverterArgs, Topic } from "@lichtblick/suite";
+import { IteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 
 /**
  * An asset loaded from Studio's asset manager.
@@ -85,3 +86,13 @@ export type BuiltinPanelExtensionContext = {
    */
   unstable_setMessagePathDropConfig: (config: MessagePathDropConfig | undefined) => void;
 } & PanelExtensionContext;
+
+type MessageConverter = RegisterMessageConverterArgs<unknown>;
+
+export type CreateMessageRangeIteratorParams = {
+  topic: string;
+  convertTo?: string;
+  rawBatchIterator: AsyncIterableIterator<Readonly<IteratorResult>>;
+  sortedTopics: readonly Topic[];
+  messageConverters: readonly MessageConverter[];
+};

--- a/packages/suite-base/src/components/PanelExtensionAdapter/types.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/types.ts
@@ -5,8 +5,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { PanelExtensionContext, RegisterMessageConverterArgs, Topic } from "@lichtblick/suite";
+import { PanelExtensionContext, RegisterMessageConverterArgs } from "@lichtblick/suite";
 import { IteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
+import { Topic } from "@lichtblick/suite-base/players/types";
 
 /**
  * An asset loaded from Studio's asset manager.

--- a/packages/suite-base/src/panels/Indicator/Indicator.test.tsx
+++ b/packages/suite-base/src/panels/Indicator/Indicator.test.tsx
@@ -65,6 +65,7 @@ describe("Indicator Component", () => {
         unsubscribeAll: jest.fn(),
         updatePanelSettingsEditor: jest.fn(),
         watch: jest.fn(),
+        unstable_subscribeMessageRange: jest.fn(),
         ...contextOverride,
       },
     };

--- a/packages/suite-base/src/panels/Map/FilteredPointLayer.ts
+++ b/packages/suite-base/src/panels/Map/FilteredPointLayer.ts
@@ -4,26 +4,14 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import { Map, LatLngBounds, FeatureGroup, CircleMarker, PathOptions, Ellipse } from "leaflet";
+import { FeatureGroup, CircleMarker, PathOptions, Ellipse } from "leaflet";
 
+import { POINT_MARKER_RADIUS } from "@lichtblick/suite-base/panels/Map/constants";
 import { MessageEvent } from "@lichtblick/suite-base/players/types";
 
 import "leaflet-ellipse";
 import { getAccuracy } from "./getAccuracy";
-import { NavSatFixMsg } from "./types";
-
-export const POINT_MARKER_RADIUS = 3;
-
-type Args = {
-  map: Map;
-  bounds: LatLngBounds;
-  color: string;
-  hoverColor: string;
-  showAccuracy?: boolean;
-  navSatMessageEvents: readonly MessageEvent<NavSatFixMsg>[];
-  onHover?: (event: MessageEvent<NavSatFixMsg> | undefined) => void;
-  onClick?: (event: MessageEvent<NavSatFixMsg>) => void;
-};
+import { FilteredPointLayerArgs, NavSatFixMsg } from "./types";
 
 class PointMarker extends CircleMarker {
   public messageEvent?: MessageEvent<NavSatFixMsg>;
@@ -32,7 +20,7 @@ class PointMarker extends CircleMarker {
 /**
  * Create a leaflet LayerGroup with filtered points
  */
-function FilteredPointLayer(args: Args): FeatureGroup {
+function FilteredPointLayer(args: FilteredPointLayerArgs): FeatureGroup {
   const { navSatMessageEvents: points, bounds, map } = args;
   const defaultStyle: PathOptions = {
     stroke: false,

--- a/packages/suite-base/src/panels/Map/MapPanel.tsx
+++ b/packages/suite-base/src/panels/Map/MapPanel.tsx
@@ -33,9 +33,8 @@ import {
 } from "@lichtblick/suite";
 import EmptyState from "@lichtblick/suite-base/components/EmptyState";
 import Stack from "@lichtblick/suite-base/components/Stack";
-import FilteredPointLayer, {
-  POINT_MARKER_RADIUS,
-} from "@lichtblick/suite-base/panels/Map/FilteredPointLayer";
+import FilteredPointLayer from "@lichtblick/suite-base/panels/Map/FilteredPointLayer";
+import { POINT_MARKER_RADIUS } from "@lichtblick/suite-base/panels/Map/constants";
 import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
 import { darkColor, lightColor, lineColors } from "@lichtblick/suite-base/util/plotColors";
 

--- a/packages/suite-base/src/panels/Map/MapPanel.tsx
+++ b/packages/suite-base/src/panels/Map/MapPanel.tsx
@@ -318,11 +318,9 @@ function MapPanel(props: MapPanelProps): React.JSX.Element {
         topic: topic.name,
         convertTo: topic.schemaName,
         onNewRangeIterator: async (batchIterator) => {
-          const bufferMessages: MessageEvent[] = [];
           for await (const messages of batchIterator) {
-            bufferMessages.push(...messages);
+            setAllMapMessages((prev) => memoizedFilterMessages([...prev, ...messages]));
           }
-          setAllMapMessages((prev) => memoizedFilterMessages([...prev, ...bufferMessages]));
         },
       });
       unsubscriptions.push(unsubscribe);

--- a/packages/suite-base/src/panels/Map/constants.ts
+++ b/packages/suite-base/src/panels/Map/constants.ts
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+export const POINT_MARKER_RADIUS = 3;

--- a/packages/suite-base/src/panels/Map/types.ts
+++ b/packages/suite-base/src/panels/Map/types.ts
@@ -5,7 +5,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { MessageEvent } from "@lichtblick/suite";
+import { Map, LatLngBounds } from "leaflet";
+
+import { MessageEvent } from "@lichtblick/suite-base/players/types";
 import { FoxgloveMessages } from "@lichtblick/suite-base/types/FoxgloveMessages";
 
 export type Point = {
@@ -52,3 +54,14 @@ export type NavSatFixMsg = {
 export type MapPanelMessage =
   | MessageEvent<FoxgloveMessages["foxglove.GeoJSON"]>
   | MessageEvent<NavSatFixMsg>;
+
+export type FilteredPointLayerArgs = {
+  map: Map;
+  bounds: LatLngBounds;
+  color: string;
+  hoverColor: string;
+  showAccuracy?: boolean;
+  navSatMessageEvents: readonly MessageEvent<NavSatFixMsg>[];
+  onHover?: (event: MessageEvent<NavSatFixMsg> | undefined) => void;
+  onClick?: (event: MessageEvent<NavSatFixMsg>) => void;
+};

--- a/packages/suite-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/suite-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -1184,6 +1184,11 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
   public setGlobalVariables(): void {}
 
+  public getBatchIterator(): undefined {
+    // FoxgloveWebSocketPlayer does not support batch iteration
+    return undefined;
+  }
+
   // Return the current time
   //
   // For servers which publish a clock, we return that time. If the server disconnects we continue

--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -391,8 +391,7 @@ export class IterablePlayer implements Player {
 
     return this.#messageRangeSource?.messageIterator({
       topics: topicSelection,
-      start: this.#start,
-      consumptionType: "partial",
+      consumptionType: "full",
     });
   }
 

--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -185,6 +185,8 @@ export class IterablePlayer implements Player {
   #blockLoader?: BlockLoader;
   #blockLoadingProcess?: Promise<void>;
 
+  #messageRangeSource?: IDeserializedIterableSource;
+
   #queueEmitState: ReturnType<typeof debouncePromise>;
 
   readonly #sourceId: string;
@@ -382,6 +384,18 @@ export class IterablePlayer implements Player {
     // no-op
   }
 
+  public getBatchIterator(
+    topic: string,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> | undefined {
+    const topicSelection = new Map([[topic, { topic }]]);
+
+    return this.#messageRangeSource?.messageIterator({
+      topics: topicSelection,
+      start: this.#start,
+      consumptionType: "partial",
+    });
+  }
+
   public setParameter(_key: string, _value: ParameterValue): void {
     throw new Error("Parameter editing is not supported by this data source");
   }
@@ -559,6 +573,15 @@ export class IterablePlayer implements Player {
       for (const alert of alerts) {
         this.#alertManager.addAlert(`init-alert-${idx}`, alert);
         idx += 1;
+      }
+
+      if (this.#iterableSource.sourceType === "deserialized") {
+        this.#messageRangeSource = this.#iterableSource;
+      } else {
+        this.#messageRangeSource = new DeserializingIterableSource(this.#iterableSource);
+        (this.#messageRangeSource as DeserializingIterableSource).initializeDeserializers(
+          initResult,
+        );
       }
 
       if (this.#enablePreload) {

--- a/packages/suite-base/src/players/Ros1Player.ts
+++ b/packages/suite-base/src/players/Ros1Player.ts
@@ -591,6 +591,11 @@ export default class Ros1Player implements Player {
     // no-op
   }
 
+  public getBatchIterator(): undefined {
+    // Ros1Player does not support batch iteration
+    return undefined;
+  }
+
   #getRosDatatypes = (datatype: string, messageDefinition: MessageDefinition[]): RosDatatypes => {
     const typesByName: RosDatatypes = new Map();
     for (const def of messageDefinition) {

--- a/packages/suite-base/src/players/RosbridgePlayer.ts
+++ b/packages/suite-base/src/players/RosbridgePlayer.ts
@@ -647,6 +647,11 @@ export default class RosbridgePlayer implements Player {
     // no-op
   }
 
+  public getBatchIterator(): undefined {
+    // RosbridgePlayer does not support batch iteration
+    return undefined;
+  }
+
   #setupPublishers(): void {
     // This function will be called again once a connection is established
     if (!this.#rosClient) {

--- a/packages/suite-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.ts
+++ b/packages/suite-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.ts
@@ -27,6 +27,7 @@ import {
   StateProcessorFactory,
   TopicAliasFunctions,
 } from "./StateProcessorFactory";
+import { IteratorResult } from "../IterablePlayer/IIterableSource";
 
 export type { TopicAliasFunctions };
 
@@ -71,6 +72,12 @@ export class TopicAliasingPlayer implements Player {
 
   public getMetadata(): ReadonlyArray<Readonly<Metadata>> {
     return this.#player.getMetadata?.() ?? Object.freeze([]);
+  }
+
+  public getBatchIterator(
+    topic: string,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> | undefined {
+    return this.#player.getBatchIterator(topic);
   }
 
   public setListener(listener: (playerState: PlayerState) => Promise<void>): void {

--- a/packages/suite-base/src/players/UserScriptPlayer/index.ts
+++ b/packages/suite-base/src/players/UserScriptPlayer/index.ts
@@ -31,6 +31,7 @@ import {
   PerformanceMetricID,
 } from "@lichtblick/suite-base/context/PerformanceContext";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
+import { IteratorResult as IIterableSourceIteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import { MemoizedLibGenerator } from "@lichtblick/suite-base/players/UserScriptPlayer/MemoizedLibGenerator";
 import { generateTypesLib } from "@lichtblick/suite-base/players/UserScriptPlayer/transformerWorker/generateTypesLib";
 import { TransformArgs } from "@lichtblick/suite-base/players/UserScriptPlayer/transformerWorker/types";
@@ -1066,6 +1067,11 @@ export default class UserScriptPlayer implements Player {
 
   public getMetadata(): ReadonlyArray<Readonly<Metadata>> {
     return this.#player.getMetadata?.() ?? Object.freeze([]);
+  }
+  public getBatchIterator(
+    topic: string,
+  ): AsyncIterableIterator<Readonly<IIterableSourceIteratorResult>> | undefined {
+    return this.#player.getBatchIterator(topic);
   }
 
   public setPublishers(publishers: AdvertiseOptions[]): void {

--- a/packages/suite-base/src/players/VelodynePlayer.ts
+++ b/packages/suite-base/src/players/VelodynePlayer.ts
@@ -319,6 +319,11 @@ export default class VelodynePlayer implements Player {
   public setGlobalVariables(_globalVariables: GlobalVariables): void {
     // no-op
   }
+
+  public getBatchIterator(): undefined {
+    // VelodynePlayer does not support batch iteration
+    return undefined;
+  }
 }
 
 function rawPacketToRos(packet: RawPacket, topOfHour: Time): { stamp: Time; data: Uint8Array } {

--- a/packages/suite-base/src/players/types.ts
+++ b/packages/suite-base/src/players/types.ts
@@ -20,6 +20,7 @@ import type { MessageEvent, Metadata, ParameterValue } from "@lichtblick/suite";
 import { Immutable } from "@lichtblick/suite";
 import { Asset } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
+import { IteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import { PLAYER_CAPABILITIES } from "@lichtblick/suite-base/players/constants";
 import { RosDatatypes } from "@lichtblick/suite-base/types/RosDatatypes";
 import { Range } from "@lichtblick/suite-base/util/ranges";
@@ -76,6 +77,8 @@ export interface Player {
   setPlaybackSpeed?(speedFraction: number): void;
   setGlobalVariables(globalVariables: GlobalVariables): void;
   getMetadata?: () => ReadonlyArray<Readonly<Metadata>>;
+  // Create a batch iterator for streaming messages. Available for data source players that support message iteration.
+  getBatchIterator: (topic: string) => AsyncIterableIterator<Readonly<IteratorResult>> | undefined;
 }
 
 export enum PlayerPresence {

--- a/packages/suite/src/index.ts
+++ b/packages/suite/src/index.ts
@@ -294,13 +294,13 @@ export type SubscribeMessageRangeArgs = {
   convertTo?: string;
 
   /**
-   * `onNewRangeIterator` is a function that receives an async iterable when there is message data available on
-   * the subscription.
+   * The `onNewRangeIterator` callback function is invoked whenever message data becomes available for
+   * the subscribed topic.
    *
-   * To read messages, your function should iterate through the provided async iterable. Each item
-   * of the iterable is a batch of message events for the subscription's topic. These batches and
-   * messages are in _log time_ order. When there are no more messages to read the iterator will
-   * finish.
+   * Your function should process messages by iterating through the supplied async iterable. Each element
+   * in the iterable represents a batch containing message events for the subscription's topic. Both the batches and
+   * individual messages are ordered by _log time_. The iterator completes when no additional messages remain
+   * to be read.
    *
    * ```typescript
    * async function onNewRangeIterator(batchIterator) {
@@ -310,14 +310,14 @@ export type SubscribeMessageRangeArgs = {
    * }
    * ```
    *
-   * `onNewRangeIterator` is called again when the upstream topic data changes. I.E subscribing to a
-   * user-script output topic and the user script changes, or subscribing to an aliased topic and
-   * the alias changes. When topic data changes, the previous iterator will end, and its data is no
-   * longer valid. When `onNewRangeIterator` is called, you should discard previously received data.
+   * The `onNewRangeIterator` callback is triggered again whenever upstream topic data undergoes changes. For instance, this occurs when
+   * subscribing to a user-script output topic and the script is modified, or when subscribing to an aliased topic where
+   * the alias configuration changes. Following topic data changes, the existing iterator terminates, rendering its data
+   * obsolete. Upon receiving a new `onNewRangeIterator` call, you should discard any previously received data.
    *
-   * If your `onNewRangeIterator` function throws an error, the iterator will end and you will not receive any
-   * more messages until `onNewRangeIterator` is called again. Your error will appear in the problems sidebar
-   * for user visibility.
+   * Should your `onNewRangeIterator` function encounter an error, the iterator will terminate and no additional
+   * messages will be delivered until `onNewRangeIterator` is invoked again. Any errors will be displayed in the problems sidebar
+   * to ensure user visibility.
    */
   onNewRangeIterator: (batchIterator: AsyncIterable<Immutable<MessageEvent[]>>) => Promise<void>;
 };
@@ -486,18 +486,18 @@ export type PanelExtensionContext = {
   setDefaultPanelTitle(defaultTitle: string | undefined): void;
 
   /**
-   * Subscribe to receive the entire time range of messages for a given topic for the current data source.
+   * Enables subscription to retrieve complete message history for a specified topic from the active data source.
    *
    * See {@link SubscribeMessageRangeArgs} for more information on behavior.
    *
-   * Note: This will not read messages for live sources, like foxglove_bridge, rosbridge, or ROS 1
-   * native connections. For those messages you will still need to use `context.subscribe()` and
+   * Note: This functionality is unavailable for real-time data sources, including foxglove_bridge, rosbridge, or ROS 1
+   * native connections. For such sources, you must utilize `context.subscribe()` and
    * `watch("currentFrame")`.
    *
-   * @returns A function that will unsubscribe from the topic, cancel the active async iterator,
-   * and prevent {@link SubscribeMessageRangeArgs.onNewRangeIterator | onNewRangeIterator} from being called again.
+   * @returns A cleanup function that terminates the topic subscription, cancels the running async iterator,
+   * and blocks future invocations of {@link SubscribeMessageRangeArgs.onNewRangeIterator | onNewRangeIterator}.
    */
-  subscribeMessageRange?: (args: SubscribeMessageRangeArgs) => () => void;
+  unstable_subscribeMessageRange: (args: SubscribeMessageRangeArgs) => () => void;
 };
 
 export type ExtensionPanelRegistration = {


### PR DESCRIPTION
## User-Facing Changes
This PR introduces an experimental message range subscription API to enable efficient batch processing of historical messages in panels. The implementation includes integration with the Map panel to demonstrate real-world usage and performance benefits.

## Description

#### New Experimental API
- Added `context.unstable_subscribeMessageRange()` for efficient batch message processing
- API is marked as "unstable" because it's experimental and may change based on feedback
- Includes comprehensive documentation explaining limitations and experimental status

#### Map Panel Improvements
- Integrated new message range API for better performance with large GPS datasets
- Fixed bug where messages would disappear during hover interactions
- Improved hover behavior to highlight only one marker at a time during fast mouse movements

#### Technical Details
- Created `messageRangeIterator.ts` utility for message processing with 16ms batching
- Enhanced `FilteredPointLayer.ts` with better hover state management
- Added proper cleanup and cancellation support for range subscriptions

#### Current Limitations:
- Performance may vary across different data sources
- Error handling is still being refined
- API surface may change without notice

### Next steps
- Migrate Core Panels: Update `3D Panel`, `Plot Panel`, and `State Transitions Panel` to use the new `unstable_subscribeMessageRange` API
- Block Loader Deprecation: Once core panels are migrated and stable, deprecate the block loader system completely
- API Stabilization: Based on feedback from core panel migrations, stabilize the API and remove "unstable" prefix
- Documentation: Create comprehensive migration guide for other panels and external developers

**Obs.:** PR with less then 80%, but Map Panel is already on roadmap to be tested.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
