### PR TITLE
Add more segments to image distortion

### DIFF
--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -546,8 +546,8 @@ function createGeometry(
   cameraModel: ICameraModel,
   settings: ImageRenderableSettings,
 ): THREE.PlaneGeometry {
-  const WIDTH_SEGMENTS = 10;
-  const HEIGHT_SEGMENTS = 10;
+  const WIDTH_SEGMENTS = 100;
+  const HEIGHT_SEGMENTS = 100;
 
   const width = cameraModel.width;
   const height = cameraModel.height;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -546,8 +546,8 @@ function createGeometry(
   cameraModel: ICameraModel,
   settings: ImageRenderableSettings,
 ): THREE.PlaneGeometry {
-  const WIDTH_SEGMENTS = 50;
-  const HEIGHT_SEGMENTS = 50;
+  const WIDTH_SEGMENTS = 100;
+  const HEIGHT_SEGMENTS = 100;
 
   const width = cameraModel.width;
   const height = cameraModel.height;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -546,8 +546,8 @@ function createGeometry(
   cameraModel: ICameraModel,
   settings: ImageRenderableSettings,
 ): THREE.PlaneGeometry {
-  const WIDTH_SEGMENTS = 100;
-  const HEIGHT_SEGMENTS = 100;
+  const WIDTH_SEGMENTS = 50;
+  const HEIGHT_SEGMENTS = 50;
 
   const width = cameraModel.width;
   const height = cameraModel.height;


### PR DESCRIPTION
## User-Facing Changes
Improved rendering for camera models with distortion at the image edges.

## Description
Some camera models produced noticeable distortion near the edges, leading to a visually incorrect rendering.
To address this, the plane geometry resolution was increased from 10 to 100 segments. While this increases the loop size, the computation only happens when the image is created or when a new camera model is selected, so runtime performance is not affected.

Before:
<img width="364" height="490" alt="image" src="https://github.com/user-attachments/assets/795c37f6-808d-46e0-ab2f-e9ba429b5b36" />

After:
<img width="364" height="490" alt="image" src="https://github.com/user-attachments/assets/7186e7e6-6e6c-489e-a5b7-9c04f7adfb2d" />


## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
