### PR TITLE
Remove sync instances feature from experimental features

### DIFF
--- a/e2e/tests/web/sync-instances.web.spec.ts
+++ b/e2e/tests/web/sync-instances.web.spec.ts
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { test, expect } from "@playwright/test";
+
+import { loadFile } from "../../fixtures/load-file";
+
+/**
+ * GIVEN two Lichtblick web instances are running in different tabs
+ * WHEN the same file is loaded in both instances
+ * AND sync is turned on and play is clicked
+ * THEN both instances should have the same timestamp
+ */
+test("Should sync playback between multiple web instances", async ({ browser }) => {
+  // Create a browser context - this enables BroadcastChannel communication between tabs
+  const context = await browser.newContext();
+
+  // Create two pages (tabs) in the same context
+  const page1 = await context.newPage();
+  const page2 = await context.newPage();
+
+  try {
+    // Navigate both pages to the Lichtblick web app
+    await page1.goto("/");
+    await page2.goto("localhost:8080");
+
+    // Wait for both pages to load
+    await page1.waitForLoadState("networkidle");
+    await page2.waitForLoadState("networkidle");
+
+    // Load the same file in both instances
+    const filename = "example.mcap";
+
+    // Load file in first tab
+    await loadFile({ mainWindow: page1, filename });
+    await page1.waitForSelector('input[value*="2025-02-26"]', { timeout: 15000 });
+
+    // Load file in second tab
+    await loadFile({ mainWindow: page2, filename });
+    await page2.waitForSelector('input[value*="2025-02-26"]', { timeout: 15000 });
+
+    // Verify sync button is available and initially off in both tabs
+    await expect(page1.getByText("Sync")).toBeVisible();
+    await expect(page2.getByText("Sync")).toBeVisible();
+    await expect(page1.getByText("off")).toBeVisible();
+    await expect(page2.getByText("off")).toBeVisible();
+
+    // Enable sync in both instances by clicking the Sync button
+    await page1.getByText("Sync").click();
+    await page2.getByText("Sync").click();
+
+    // Verify sync is enabled (button should show "on")
+    await expect(page1.getByText("on")).toBeVisible();
+    await expect(page2.getByText("on")).toBeVisible();
+
+    // Get initial timestamps to ensure they're the same before playing
+    const initialTimeInput1 = page1.locator('input[value*="2025-02-26"]').first();
+    const initialTimeInput2 = page2.locator('input[value*="2025-02-26"]').first();
+
+    const initialTime1 = await initialTimeInput1.inputValue();
+    const initialTime2 = await initialTimeInput2.inputValue();
+
+    // Both instances should start with the same timestamp
+    expect(initialTime1).toBe(initialTime2);
+
+    // Click play on the first instance
+    await page1.getByTitle("Play", { exact: true }).click();
+    await page1.waitForTimeout(100);
+
+    // Verify both instances are playing (pause button visible)
+    await expect(page1.getByTitle("Pause")).toBeVisible();
+    await expect(page2.getByTitle("Pause")).toBeVisible();
+
+    // Wait a bit for sync to propagate and playback to advance
+    await page1.waitForTimeout(2000);
+
+    // Pause to get stable timestamps
+    await page1.getByTitle("Pause").click();
+    await page1.waitForTimeout(100);
+
+    // Verify both instances are paused (play button visible)
+    await expect(page1.getByTitle("Play", { exact: true })).toBeVisible();
+    await expect(page2.getByTitle("Play", { exact: true })).toBeVisible();
+
+    // Get current time from both instances after playing
+    const timeInput1 = page1.locator('input[value*="2025-02-26"]').first();
+    const timeInput2 = page2.locator('input[value*="2025-02-26"]').first();
+
+    const time1 = await timeInput1.inputValue();
+    const time2 = await timeInput2.inputValue();
+
+    // Both instances should have the same timestamp after sync
+    expect(time1).toBe(time2);
+
+    // The timestamp should have advanced from the initial time
+    expect(time1).not.toBe(initialTime1);
+
+    // Test seek synchronization
+    // Seek forward on instance 1
+    await page1.getByTitle("Seek forward").click();
+    await page1.waitForTimeout(100);
+
+    const newTime1 = await timeInput1.inputValue();
+    const newTime2 = await timeInput2.inputValue();
+
+    // Timestamps should have changed and still be synchronized
+    expect(newTime1).not.toBe(time1);
+    expect(newTime1).toBe(newTime2);
+  } finally {
+    // Clean up
+    await page1.close();
+    await page2.close();
+    await context.close();
+  }
+});

--- a/packages/suite-base/src/AppSetting.ts
+++ b/packages/suite-base/src/AppSetting.ts
@@ -25,7 +25,6 @@ export enum AppSetting {
 
   // Experimental features
   SHOW_DEBUG_PANELS = "showDebugPanels",
-  SHOW_SYNC_LB_INSTANCES = "showSyncLBInstances",
 
   // Miscellaneous
   HIDE_SIGN_IN_PROMPT = "hideSignInPrompt",

--- a/packages/suite-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/suite-base/src/components/ExperimentalFeatureSettings.tsx
@@ -48,11 +48,6 @@ function useFeatures(): Feature[] {
       name: t("memoryUseIndicator"),
       description: <>{t("memoryUseIndicatorDescription")}</>,
     },
-    {
-      key: AppSetting.SHOW_SYNC_LB_INSTANCES,
-      name: t("syncLichtblickInstances"),
-      description: <>{t("syncLichtblickInstancesDescription")}</>,
-    },
   ];
 
   if (process.env.NODE_ENV === "development") {

--- a/packages/suite-base/src/components/PlaybackControls/SwitchSyncInstances/SyncInstanceToggle.test.tsx
+++ b/packages/suite-base/src/components/PlaybackControls/SwitchSyncInstances/SyncInstanceToggle.test.tsx
@@ -9,13 +9,8 @@ import "@testing-library/jest-dom";
 
 import { useWorkspaceStore } from "@lichtblick/suite-base/context/Workspace/WorkspaceContext";
 import { useWorkspaceActions } from "@lichtblick/suite-base/context/Workspace/useWorkspaceActions";
-import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks";
 
 import SyncInstanceToggle from "./SyncInstanceToggle";
-
-jest.mock("@lichtblick/suite-base/hooks", () => ({
-  useAppConfigurationValue: jest.fn(),
-}));
 
 jest.mock("@lichtblick/suite-base/context/Workspace/WorkspaceContext", () => ({
   useWorkspaceStore: jest.fn(),
@@ -38,7 +33,6 @@ jest.mock("./SyncInstanceToggle.style", () => ({
 
 describe("SyncInstanceToggle", () => {
   const useWorkspaceActionsMock = useWorkspaceActions as jest.Mock;
-  const useAppConfigurationValueMock = useAppConfigurationValue as jest.Mock;
   const useWorkspaceStoreMock = useWorkspaceStore as jest.Mock;
 
   const setSyncInstancesMock = jest.fn();
@@ -53,25 +47,8 @@ describe("SyncInstanceToggle", () => {
     jest.clearAllMocks();
   });
 
-  it("returns null and disables sync if config is false", () => {
-    // GIVEN
-    useAppConfigurationValueMock.mockReturnValue([false]);
-    useWorkspaceStoreMock.mockImplementation((selector: any) =>
-      selector({ playbackControls: { syncInstances: true } }),
-    );
-
-    // WHEN
-    const { container } = render(<SyncInstanceToggle />);
-
-    // THEN
-    expect(setSyncInstancesMock).toHaveBeenCalledTimes(1);
-    expect(setSyncInstancesMock).toHaveBeenCalledWith(false);
-    expect(container.firstChild).toBeNull();
-  });
-
   it("renders button with correct text when sync is on", () => {
     // GIVEN
-    useAppConfigurationValueMock.mockReturnValue([true]);
     useWorkspaceStoreMock.mockImplementation((selector: any) =>
       selector({ playbackControls: { syncInstances: true } }),
     );
@@ -86,7 +63,6 @@ describe("SyncInstanceToggle", () => {
 
   it("renders button with correct text when sync is off", () => {
     // GIVEN
-    useAppConfigurationValueMock.mockReturnValue([true]);
     useWorkspaceStoreMock.mockImplementation((selector: any) =>
       selector({ playbackControls: { syncInstances: false } }),
     );
@@ -101,7 +77,6 @@ describe("SyncInstanceToggle", () => {
 
   it("toggles sync state on button click (turn on)", () => {
     // GIVEN sync is initially off
-    useAppConfigurationValueMock.mockReturnValue([true]);
     useWorkspaceStoreMock.mockImplementationOnce((selector: any) =>
       selector({ playbackControls: { syncInstances: false } }),
     );
@@ -117,7 +92,6 @@ describe("SyncInstanceToggle", () => {
 
   it("toggles sync state on button click (turn off)", () => {
     // GIVEN sync is initially on
-    useAppConfigurationValueMock.mockReturnValue([true]);
     useWorkspaceStoreMock.mockImplementationOnce((selector: any) =>
       selector({ playbackControls: { syncInstances: true } }),
     );
@@ -129,38 +103,5 @@ describe("SyncInstanceToggle", () => {
     // THEN sync is turned off
     expect(setSyncInstancesMock).toHaveBeenCalledTimes(1);
     expect(setSyncInstancesMock).toHaveBeenCalledWith(false);
-  });
-
-  it("should turn synchronization off when experimental feature is disabled", () => {
-    // GIVEN feature is initially enabled
-    useAppConfigurationValueMock.mockReturnValue([true]);
-    useWorkspaceStoreMock.mockImplementation((selector: any) =>
-      selector({ playbackControls: { syncInstances: true } }),
-    );
-
-    const { rerender } = render(<SyncInstanceToggle />);
-    expect(setSyncInstancesMock).not.toHaveBeenCalled();
-
-    // WHEN feature is disabled and component re-renders
-    useAppConfigurationValueMock.mockReturnValue([false]);
-    rerender(<SyncInstanceToggle />);
-
-    // THEN syncInstances is explicitly turned off
-    expect(setSyncInstancesMock).toHaveBeenCalledTimes(1);
-    expect(setSyncInstancesMock).toHaveBeenCalledWith(false);
-  });
-
-  it("should not deactivate synchronization when experimental feature is disabled", () => {
-    // GIVEN feature is initially disabled
-    useAppConfigurationValueMock.mockReturnValue([false]);
-
-    // WHEN sync is off
-    useWorkspaceStoreMock.mockImplementation((selector: any) =>
-      selector({ playbackControls: { syncInstances: false } }),
-    );
-    render(<SyncInstanceToggle />);
-
-    // THEN syncInstances is not explicitly turned off
-    expect(setSyncInstancesMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/suite-base/src/components/PlaybackControls/SwitchSyncInstances/SyncInstanceToggle.tsx
+++ b/packages/suite-base/src/components/PlaybackControls/SwitchSyncInstances/SyncInstanceToggle.tsx
@@ -3,18 +3,12 @@
 
 import { Stack, Button, Typography } from "@mui/material";
 
-import { AppSetting } from "@lichtblick/suite-base/AppSetting";
 import { useWorkspaceStore } from "@lichtblick/suite-base/context/Workspace/WorkspaceContext";
 import { useWorkspaceActions } from "@lichtblick/suite-base/context/Workspace/useWorkspaceActions";
-import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks";
 
 import { useStyles } from "./SyncInstanceToggle.style";
 
 const SyncInstanceToggle = (): React.JSX.Element => {
-  const [enableSyncLBInstances = false] = useAppConfigurationValue<boolean>(
-    AppSetting.SHOW_SYNC_LB_INSTANCES,
-  );
-
   const syncInstances = useWorkspaceStore((store) => store.playbackControls.syncInstances);
 
   const {
@@ -22,14 +16,6 @@ const SyncInstanceToggle = (): React.JSX.Element => {
   } = useWorkspaceActions();
 
   const { classes } = useStyles({ syncInstances });
-
-  if (!enableSyncLBInstances) {
-    // Turn off sync if experimental feature is turned off
-    if (syncInstances) {
-      setSyncInstances(false);
-    }
-    return <></>;
-  }
 
   const handleToogle = () => {
     setSyncInstances(!syncInstances);


### PR DESCRIPTION
## User-Facing Changes
Users don't need to enable the `Sync Instances` features anymore, It will be always visible.

## Description
Remove `Sync Instances` feature from experimental features.

<img width="179" height="72" alt="image" src="https://github.com/user-attachments/assets/8c71c6dd-cb21-4c72-ab96-41e3a625a28f" />

Documentation update: https://github.com/lichtblick-suite/docs/pull/48

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
