### PR TITLE
Improve management of second instances

### DIFF
--- a/packages/suite-desktop/src/main/secondInstanceHandler.test.ts
+++ b/packages/suite-desktop/src/main/secondInstanceHandler.test.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { app, BrowserWindow } from "electron";
+
+import { createNewWindow } from "./createNewWindow";
+import { isFileToOpen } from "./fileUtils";
+import { handleSecondInstance } from "./secondInstanceHandler";
+
+jest.mock("@lichtblick/log", () => ({
+  __esModule: true,
+  default: {
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("./fileUtils", () => ({
+  isFileToOpen: jest.fn(),
+}));
+
+jest.mock("./createNewWindow", () => ({
+  createNewWindow: jest.fn(),
+}));
+
+jest.mock("electron", () => {
+  const emit = jest.fn();
+  const restore = jest.fn();
+  const focus = jest.fn();
+  const getAllWindows = jest.fn(() => [{ restore, focus }]);
+
+  return {
+    app: {
+      emit,
+    },
+    BrowserWindow: {
+      getAllWindows,
+    },
+  };
+});
+
+const mockIsFileToOpen = isFileToOpen as jest.MockedFunction<typeof isFileToOpen>;
+const mockCreateNewWindow = createNewWindow as jest.MockedFunction<typeof createNewWindow>;
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const mockEmit = app.emit as jest.MockedFunction<typeof app.emit>;
+const mockGetAllWindows = BrowserWindow.getAllWindows as jest.Mock;
+
+describe("handleSecondInstance", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should call createNewWindow when --force-multiple-windows is passed", () => {
+    const argv = ["app", "--force-multiple-windows"];
+    handleSecondInstance({}, argv, "");
+    expect(mockCreateNewWindow).toHaveBeenCalledWith(argv);
+  });
+
+  it("should emit open-url and open-file events for deeplinks and files", () => {
+    const argv = ["app", "lichtblick://something", "file.bag"];
+    mockIsFileToOpen.mockImplementation((file) => file.endsWith(".bag"));
+
+    handleSecondInstance({}, argv, "");
+
+    expect(mockEmit).toHaveBeenCalledWith("open-url", expect.anything(), "lichtblick://something");
+    expect(mockEmit).toHaveBeenCalledWith("open-file", expect.anything(), "file.bag");
+  });
+
+  it("should bring app to front if no files or deeplinks", () => {
+    const argv = ["app"];
+
+    const restoreMock = jest.fn();
+    const focusMock = jest.fn();
+    mockGetAllWindows.mockReturnValue([{ restore: restoreMock, focus: focusMock }]);
+
+    handleSecondInstance({}, argv, "");
+
+    expect(restoreMock).toHaveBeenCalled();
+    expect(focusMock).toHaveBeenCalled();
+  });
+
+  it("should not emit open-file for non-file args", () => {
+    const argv = ["app", "--not-a-file"];
+    mockIsFileToOpen.mockReturnValue(false);
+
+    handleSecondInstance({}, argv, "");
+
+    expect(mockEmit).not.toHaveBeenCalledWith("open-file", expect.anything(), expect.anything());
+  });
+
+  it("should skip deepLinks or files if none present and no windows open", () => {
+    mockGetAllWindows.mockReturnValueOnce([]);
+
+    const argv = ["app"];
+    expect(() => {
+      handleSecondInstance({}, argv, "");
+    }).not.toThrow();
+  });
+});

--- a/packages/suite-desktop/src/main/secondInstanceHandler.ts
+++ b/packages/suite-desktop/src/main/secondInstanceHandler.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { BrowserWindow, app } from "electron";
+
+import log from "@lichtblick/log";
+
+import { createNewWindow } from "./createNewWindow";
+import { isFileToOpen } from "./fileUtils";
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function handleSecondInstance(_ev: unknown, argv: string[], _workingDirectory: string) {
+  log.debug("Received arguments from second app instance:", argv);
+  const multipleWindows = argv.includes("--force-multiple-windows");
+
+  const deepLinks = argv.slice(1).filter((arg) => arg.startsWith("lichtblick://"));
+  const files = argv
+    .slice(1)
+    .filter((arg) => !arg.startsWith("--"))
+    .filter((arg) => isFileToOpen(arg));
+
+  if (multipleWindows) {
+    log.debug("second-instance: Forcing a new window to run in this instance.");
+    createNewWindow(argv);
+    return;
+  }
+
+  if (files.length > 0 || deepLinks.length > 0) {
+    log.debug("second-instance: Opening new window due to file or deeplink.");
+
+    for (const link of deepLinks) {
+      app.emit("open-url", { preventDefault() {} }, link);
+    }
+
+    for (const file of files) {
+      app.emit("open-file", { preventDefault() {} }, file);
+    }
+    return;
+  } else {
+    // Bring the app to the front
+    const someWindow = BrowserWindow.getAllWindows()[0];
+    someWindow?.restore();
+    someWindow?.focus();
+  }
+}


### PR DESCRIPTION
## User-Facing Changes
The application now properly prevents multiple instances from being opened simultaneously. The new behavior is as follows:
1. If you open a Lichtblick instance and then try to open a new one, the app will not open, and focus will be returned to the current app.
2. If you open a Lichtblick instance and double-click on a log, a new instance will open, allowing you to keep the information in the first instance and view the log in the second instance.
3. If you open a Lichtblick instance and open a new one with the `--force-multiple-windows `flag, a new instance will open.

## Description
After adding the `--force-multiple-windows` flag the second instances were not handled correctly and more instances are opened when they should not be.
I've improved and moved the logic into a new file and also added unit tests for it

Fixes #651 

## Checklist

- [X] The web version was tested and it is running ok
- [X] The desktop version was tested and it is running ok
- [X] This change is covered by unit tests
- [X] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
