### PR TITLE
Improve layout section - Bulk actions

### DIFF
--- a/packages/suite-base/src/components/LayoutBrowser/LayoutRow.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutRow.tsx
@@ -120,19 +120,14 @@ export default React.memo(function LayoutRow({
     setEditingName(true);
   }, [layout]);
 
-  const onClick = useCallback(
-    (event: MouseEvent) => {
-      onSelect(layout, { selectedViaClick: true, event });
-    },
-    [layout, onSelect],
-  );
-
   const duplicateAction = useCallback(() => {
     onDuplicate(layout);
   }, [layout, onDuplicate]);
+
   const shareAction = useCallback(() => {
     onShare(layout);
   }, [layout, onShare]);
+
   const exportAction = useCallback(() => {
     onExport(layout);
   }, [layout, onExport]);
@@ -268,7 +263,9 @@ export default React.memo(function LayoutRow({
         type: "item",
         key: "revert",
         text: "Revert",
-        onClick: confirmRevert,
+        onClick: () => {
+          void confirmRevert();
+        },
         disabled: deletedOnServer,
       },
     ];
@@ -301,19 +298,21 @@ export default React.memo(function LayoutRow({
     (item): item is LayoutActionMenuItem => typeof item === "object",
   );
 
-  const actionIcon = useMemo(
-    () =>
-      deletedOnServer ? (
-        <ErrorIcon fontSize="small" color="error" />
-      ) : hasModifications ? (
+  const actionIcon = useMemo(() => {
+    let icon;
+    if (deletedOnServer) {
+      icon = <ErrorIcon fontSize="small" color="error" />;
+    } else if (hasModifications) {
+      icon = (
         <SvgIcon fontSize="small" color="primary">
           <circle cx={12} cy={12} r={4} />
         </SvgIcon>
-      ) : (
-        <MoreVertIcon fontSize="small" />
-      ),
-    [deletedOnServer, hasModifications],
-  );
+      );
+    } else {
+      icon = <MoreVertIcon fontSize="small" />;
+    }
+    return icon;
+  }, [deletedOnServer, hasModifications]);
 
   useEffect(() => {
     if (editingName) {

--- a/packages/suite-base/src/components/LayoutBrowser/LayoutRow.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutRow.tsx
@@ -346,7 +346,10 @@ export default React.memo(function LayoutRow({
         data-testid="layout-list-item"
         selected={selected || multiSelectedIds.includes(layout.id)}
         onSubmit={onSubmit}
-        onClick={editingName ? undefined : onClick}
+        onClick={(event) => {
+          // Toggle selection for multi-select support
+          onSelect(layout, { selectedViaClick: true, event });
+        }}
         onContextMenu={editingName ? undefined : handleContextMenu}
         component="form"
       >

--- a/packages/suite-base/src/components/LayoutBrowser/LayoutSection.test.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutSection.test.tsx
@@ -1,0 +1,163 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom"; // Add this import for DOM testing matchers
+
+import { LayoutID } from "@lichtblick/suite-base/context/CurrentLayoutContext";
+import { Layout } from "@lichtblick/suite-base/services/ILayoutStorage";
+import LayoutBuilder from "@lichtblick/suite-base/testing/builders/LayoutBuilder";
+
+import LayoutSection from "./LayoutSection";
+
+// Mock the LayoutRow component
+jest.mock("./LayoutRow", () => ({
+  __esModule: true,
+  default: ({ layout, onDuplicate }: { layout: Layout; onDuplicate: () => void }) => (
+    <div data-testid={`layout-row-${layout.id}`}>
+      <button data-testid={`duplicate-button-${layout.id}`} onClick={onDuplicate}>
+        Duplicate
+      </button>
+    </div>
+  ),
+}));
+
+describe("LayoutSection", () => {
+  // Sample layouts for testing
+  const layout1 = LayoutBuilder.layout({
+    id: "1" as LayoutID,
+    name: "Layout 1",
+  });
+  const layout2 = LayoutBuilder.layout({
+    id: "2" as LayoutID,
+    name: "Layout 2",
+  });
+  const layout3 = LayoutBuilder.layout({
+    id: "3" as LayoutID,
+    name: "Layout 3",
+  });
+
+  const sampleLayouts: Layout[] = [layout1, layout2, layout3];
+
+  // Default props
+  const defaultProps = {
+    title: "Test Section",
+    emptyText: "No layouts found",
+    items: sampleLayouts,
+    anySelectedModifiedLayouts: false,
+    multiSelectedIds: [] as string[],
+    selectedId: undefined,
+    onSelect: jest.fn(),
+    onRename: jest.fn(),
+    onDuplicate: jest.fn(),
+    onDelete: jest.fn(),
+    onShare: jest.fn(),
+    onExport: jest.fn(),
+    onOverwrite: jest.fn(),
+    onRevert: jest.fn(),
+    onMakePersonalCopy: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders with title", () => {
+    // GIVEN
+    const title = "Test Section";
+
+    // WHEN
+    render(<LayoutSection {...defaultProps} title={title} />);
+
+    // THEN
+    expect(screen.getByText(title)).toBeInTheDocument();
+  });
+
+  it("renders empty text when items array is empty", () => {
+    // GIVEN
+    const emptyText = "No layouts found";
+
+    // WHEN
+    render(<LayoutSection {...defaultProps} items={[]} emptyText={emptyText} />);
+
+    // THEN
+    expect(screen.getByText(emptyText)).toBeInTheDocument();
+  });
+
+  it("calls onDuplicate for a single selected layout", () => {
+    // GIVEN
+    const multiSelectedIds = ["1"];
+
+    // WHEN
+    render(<LayoutSection {...defaultProps} multiSelectedIds={multiSelectedIds} />);
+    fireEvent.click(screen.getByTestId("duplicate-button-1"));
+
+    // THEN
+    expect(defaultProps.onDuplicate).toHaveBeenCalledTimes(1);
+    // Check that onDuplicate was called with the first layout (regardless of additional params)
+    expect(defaultProps.onDuplicate.mock.calls[0][0]).toEqual(sampleLayouts[0]);
+  });
+
+  it("calls onDuplicate for all selected layouts", () => {
+    // GIVEN
+    const multiSelectedIds = ["1", "3"];
+
+    // WHEN
+    render(<LayoutSection {...defaultProps} multiSelectedIds={multiSelectedIds} />);
+    fireEvent.click(screen.getByTestId("duplicate-button-2")); // Click on any layout's duplicate button
+
+    // THEN
+    expect(defaultProps.onDuplicate).toHaveBeenCalledTimes(2);
+    // Check that the first call was with layout 1
+    expect(defaultProps.onDuplicate.mock.calls[0][0]).toEqual(sampleLayouts[0]);
+    // Check that the second call was with layout 3
+    expect(defaultProps.onDuplicate.mock.calls[1][0]).toEqual(sampleLayouts[2]);
+  });
+
+  it("doesn't call onDuplicate when no layouts are selected", () => {
+    // GIVEN
+    const multiSelectedIds: string[] = [];
+
+    // WHEN
+    render(<LayoutSection {...defaultProps} multiSelectedIds={multiSelectedIds} />);
+    fireEvent.click(screen.getByTestId("duplicate-button-1"));
+
+    // THEN
+    expect(defaultProps.onDuplicate).not.toHaveBeenCalled();
+  });
+
+  it("handles undefined items gracefully", () => {
+    // GIVEN
+
+    // WHEN
+    render(<LayoutSection {...defaultProps} items={undefined} />);
+
+    // THEN
+    expect(screen.queryByTestId(/layout-row-/)).not.toBeInTheDocument();
+  });
+
+  it("only duplicates selected layouts", () => {
+    // GIVEN
+    const multiSelectedIds = ["1", "3"];
+
+    // WHEN
+    render(<LayoutSection {...defaultProps} multiSelectedIds={multiSelectedIds} />);
+    fireEvent.click(screen.getByTestId("duplicate-button-1"));
+
+    // THEN
+    expect(defaultProps.onDuplicate).toHaveBeenCalledTimes(2);
+
+    // Check the arguments for each call separately
+    const firstCallArgs = defaultProps.onDuplicate.mock.calls[0];
+    const secondCallArgs = defaultProps.onDuplicate.mock.calls[1];
+
+    expect(firstCallArgs[0]).toEqual(sampleLayouts[0]); // Layout 1
+    expect(secondCallArgs[0]).toEqual(sampleLayouts[2]); // Layout 3
+
+    // Check Layout 2 was not duplicated
+    const allLayouts = defaultProps.onDuplicate.mock.calls.map((call) => call[0]);
+    expect(allLayouts).not.toContainEqual(sampleLayouts[1]);
+  });
+});

--- a/packages/suite-base/src/components/LayoutBrowser/LayoutSection.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutSection.tsx
@@ -30,7 +30,7 @@ export default function LayoutSection({
   onOverwrite,
   onRevert,
   onMakePersonalCopy,
-}: {
+}: Readonly<{
   title: string | undefined;
   disablePadding?: boolean;
   emptyText: string | undefined;
@@ -47,7 +47,26 @@ export default function LayoutSection({
   onOverwrite: (item: Layout) => void;
   onRevert: (item: Layout) => void;
   onMakePersonalCopy: (item: Layout) => void;
-}): React.JSX.Element {
+}>): React.JSX.Element {
+  // Get selected layouts
+  const selectedLayouts = items?.filter((layout) => multiSelectedIds.includes(layout.id)) ?? [];
+
+  const handleDuplicateSelected = () => {
+    selectedLayouts.forEach(onDuplicate);
+  };
+
+  const handleDeleteSelected = () => {
+    selectedLayouts.forEach(onDelete);
+  };
+
+  const handleExportSelected = () => {
+    selectedLayouts.forEach(onExport);
+  };
+
+  const handleOverwriteSelected = () => {
+    selectedLayouts.forEach(onOverwrite);
+  };
+
   return (
     <Stack>
       {title != undefined && (
@@ -74,11 +93,11 @@ export default function LayoutSection({
             layout={layout}
             onSelect={onSelect}
             onRename={onRename}
-            onDuplicate={onDuplicate}
-            onDelete={onDelete}
+            onDuplicate={handleDuplicateSelected}
+            onDelete={handleDeleteSelected}
             onShare={onShare}
-            onExport={onExport}
-            onOverwrite={onOverwrite}
+            onExport={handleExportSelected}
+            onOverwrite={handleOverwriteSelected}
             onRevert={onRevert}
             onMakePersonalCopy={onMakePersonalCopy}
           />

--- a/packages/suite-base/src/components/LayoutBrowser/LayoutSection.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutSection.tsx
@@ -59,10 +59,6 @@ export default function LayoutSection({
     selectedLayouts.forEach(onDelete);
   };
 
-  const handleExportSelected = () => {
-    selectedLayouts.forEach(onExport);
-  };
-
   const handleOverwriteSelected = () => {
     selectedLayouts.forEach(onOverwrite);
   };
@@ -96,7 +92,7 @@ export default function LayoutSection({
             onDuplicate={handleDuplicateSelected}
             onDelete={handleDeleteSelected}
             onShare={onShare}
-            onExport={handleExportSelected}
+            onExport={onExport}
             onOverwrite={handleOverwriteSelected}
             onRevert={onRevert}
             onMakePersonalCopy={onMakePersonalCopy}

--- a/packages/suite-base/src/components/LayoutBrowser/SignInPrompt.style.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/SignInPrompt.style.tsx
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+/* eslint-disable tss-unused-classes/unused-classes */
+
+import { makeStyles } from "tss-react/mui";
+
+export const useStyles = makeStyles()((theme) => ({
+  root: {
+    display: "flex",
+    padding: theme.spacing(1.5, 1, 1.5, 2),
+    gap: theme.spacing(1),
+    backgroundColor: theme.palette.action.hover,
+    position: "sticky",
+    alignItems: "center",
+    bottom: 0,
+
+    "&:hover": {
+      backgroundColor: theme.palette.action.focus,
+    },
+  },
+  title: {
+    maxWidth: 280,
+  },
+}));

--- a/packages/suite-base/src/components/LayoutBrowser/SignInPrompt.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/SignInPrompt.tsx
@@ -7,37 +7,16 @@
 
 import CloseIcon from "@mui/icons-material/Close";
 import { ButtonBase, IconButton, Link, Typography } from "@mui/material";
-import { makeStyles } from "tss-react/mui";
 
 import { AppSetting } from "@lichtblick/suite-base/AppSetting";
+import { SignInPromptProps } from "@lichtblick/suite-base/components/LayoutBrowser/types";
 import { useCurrentUser } from "@lichtblick/suite-base/context/CurrentUserContext";
 import { useWorkspaceActions } from "@lichtblick/suite-base/context/Workspace/useWorkspaceActions";
 import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks";
 
-type SignInPromptProps = {
-  onDismiss?: () => void;
-};
+import { useStyles } from "./SignInPrompt.style";
 
-const useStyles = makeStyles()((theme) => ({
-  root: {
-    display: "flex",
-    padding: theme.spacing(1.5, 1, 1.5, 2),
-    gap: theme.spacing(1),
-    backgroundColor: theme.palette.action.hover,
-    position: "sticky",
-    alignItems: "center",
-    bottom: 0,
-
-    "&:hover": {
-      backgroundColor: theme.palette.action.focus,
-    },
-  },
-  title: {
-    maxWidth: 280,
-  },
-}));
-
-export default function SignInPrompt(props: SignInPromptProps): React.JSX.Element {
+export default function SignInPrompt(props: Readonly<SignInPromptProps>): React.JSX.Element {
   const { onDismiss } = props;
   const { signIn } = useCurrentUser();
   const { classes } = useStyles();

--- a/packages/suite-base/src/components/LayoutBrowser/UnsavedChangesPrompt.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/UnsavedChangesPrompt.tsx
@@ -20,15 +20,10 @@ import {
 import { ChangeEvent, useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useLatest, useUnmount } from "react-use";
 
+import { UnsavedChangesResolution } from "@lichtblick/suite-base/components/LayoutBrowser/types";
 import Stack from "@lichtblick/suite-base/components/Stack";
 import { useLayoutManager } from "@lichtblick/suite-base/context/LayoutManagerContext";
 import { Layout } from "@lichtblick/suite-base/services/ILayoutStorage";
-
-type UnsavedChangesResolution =
-  | { type: "cancel" }
-  | { type: "discard" }
-  | { type: "makePersonal"; name: string }
-  | { type: "overwrite" };
 
 export function UnsavedChangesPrompt({
   layout,
@@ -36,13 +31,13 @@ export function UnsavedChangesPrompt({
   onComplete,
   defaultSelectedKey = "discard",
   defaultPersonalCopyName,
-}: {
+}: Readonly<{
   layout: Layout;
   isOnline: boolean;
   onComplete: (_: UnsavedChangesResolution) => void;
   defaultSelectedKey?: Exclude<UnsavedChangesResolution["type"], "cancel">;
   defaultPersonalCopyName?: string;
-}): React.JSX.Element {
+}>): React.JSX.Element {
   const [selectedKey, setSelectedKey] = useState<string>(defaultSelectedKey);
 
   const handleChoiceGroupChange = React.useCallback(

--- a/packages/suite-base/src/components/LayoutBrowser/index.style.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/index.style.tsx
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+/* eslint-disable tss-unused-classes/unused-classes */
+
+import { makeStyles } from "tss-react/mui";
+
+export const useStyles = makeStyles()((theme) => ({
+  actionList: {
+    paddingTop: theme.spacing(1),
+  },
+}));

--- a/packages/suite-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/index.tsx
@@ -22,7 +22,6 @@ import moment from "moment";
 import { useSnackbar } from "notistack";
 import { useEffect, useLayoutEffect, useMemo } from "react";
 import useAsyncFn from "react-use/lib/useAsyncFn";
-import { makeStyles } from "tss-react/mui";
 
 import Logger from "@lichtblick/log";
 import { AppSetting } from "@lichtblick/suite-base/AppSetting";
@@ -49,16 +48,11 @@ import { AppEvent } from "@lichtblick/suite-base/services/IAnalytics";
 import { Layout, layoutIsShared } from "@lichtblick/suite-base/services/ILayoutStorage";
 
 import LayoutSection from "./LayoutSection";
+import { useStyles } from "./index.style";
 
 const log = Logger.getLogger(__filename);
 
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
-
-const useStyles = makeStyles()((theme) => ({
-  actionList: {
-    paddingTop: theme.spacing(1),
-  },
-}));
 
 export default function LayoutBrowser({
   currentDateForStorybook,

--- a/packages/suite-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/index.tsx
@@ -131,7 +131,6 @@ export default function LayoutBrowser({
           switch (state.multiAction.action) {
             case "delete":
               await layoutManager.deleteLayout({ id: id as LayoutID });
-              dispatch({ type: "shift-multi-action" });
               break;
             case "duplicate": {
               const layout = await layoutManager.getLayout(id as LayoutID);
@@ -142,16 +141,13 @@ export default function LayoutBrowser({
                   permission: "CREATOR_WRITE",
                 });
               }
-              dispatch({ type: "shift-multi-action" });
               break;
             }
             case "revert":
               await layoutManager.revertLayout({ id: id as LayoutID });
-              dispatch({ type: "shift-multi-action" });
               break;
             case "save":
               await layoutManager.overwriteLayout({ id: id as LayoutID });
-              dispatch({ type: "shift-multi-action" });
               break;
           }
         } catch (err: unknown) {

--- a/packages/suite-base/src/components/LayoutBrowser/reducer.test.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/reducer.test.tsx
@@ -1,0 +1,318 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { renderHook, act } from "@testing-library/react";
+import * as _ from "lodash-es";
+
+import BasicBuilder from "@lichtblick/suite-base/testing/builders/BasicBuilder";
+
+import { useLayoutBrowserReducer } from "./reducer";
+
+// Mock lodash-es functions
+jest.mock("lodash-es", () => ({
+  ...jest.requireActual("lodash-es"),
+  xor: jest.fn((arr1, arr2) =>
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    arr1.filter((x: any) => !arr2.includes(x)).concat(arr2.filter((x: any) => !arr1.includes(x))),
+  ),
+  compact: jest.fn((arr) => arr.filter(Boolean)),
+}));
+
+describe("LayoutBrowser reducer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /**
+   * GIVEN a state with multiAction set
+   * WHEN the clear-multi-action is dispatched
+   * THEN the multiAction should be cleared
+   */
+  it("clear-multi-action clears multiAction", () => {
+    // Given
+    const { result } = renderHook(() =>
+      useLayoutBrowserReducer({
+        busy: false,
+        error: undefined,
+        online: true,
+        lastSelectedId: undefined,
+      }),
+    );
+
+    // Set up multiAction first
+    const testId = BasicBuilder.string();
+    act(() => {
+      result.current[1]({ type: "select-id", id: testId });
+      result.current[1]({ type: "queue-multi-action", action: "save" });
+    });
+
+    expect(result.current[0].multiAction).toBeDefined();
+
+    // When
+    act(() => {
+      result.current[1]({ type: "clear-multi-action" });
+    });
+
+    // Then
+    expect(result.current[0].multiAction).toBeUndefined();
+  });
+
+  /**
+   * GIVEN a state with selected IDs
+   * WHEN the queue-multi-action is dispatched
+   * THEN the multiAction should be set with the provided action and selectedIds
+   */
+  it("queue-multi-action sets multiAction", () => {
+    // Given
+    const action = "save";
+    const { result } = renderHook(() =>
+      useLayoutBrowserReducer({
+        busy: false,
+        error: undefined,
+        online: true,
+        lastSelectedId: undefined,
+      }),
+    );
+
+    // First select some IDs
+    const testId = BasicBuilder.string();
+    act(() => {
+      result.current[1]({ type: "select-id", id: testId });
+    });
+
+    expect(result.current[0].selectedIds).toEqual([testId]);
+
+    // When
+    act(() => {
+      result.current[1]({ type: "queue-multi-action", action });
+    });
+
+    // Then
+    expect(result.current[0].multiAction).toEqual({
+      action,
+      ids: [testId],
+    });
+  });
+
+  /**
+   * GIVEN a state with some selected IDs
+   * WHEN select-id is dispatched with modKey=true
+   * THEN the selection should be toggled
+   */
+  it("select-id with modKey toggles selection", () => {
+    // Given
+    const { result } = renderHook(() =>
+      useLayoutBrowserReducer({
+        busy: false,
+        error: undefined,
+        online: true,
+        lastSelectedId: undefined,
+      }),
+    );
+
+    // First select an ID
+    const testId1 = BasicBuilder.string();
+    const testId2 = BasicBuilder.string();
+    act(() => {
+      result.current[1]({ type: "select-id", id: testId1 });
+    });
+
+    expect(result.current[0].selectedIds).toEqual([testId1]);
+
+    // When selecting another ID with modKey
+    act(() => {
+      result.current[1]({ type: "select-id", id: testId2, modKey: true });
+    });
+
+    // Then - should have both ids selected
+    expect(result.current[0].selectedIds).toEqual([testId1, testId2]);
+    expect(result.current[0].lastSelectedId).toBe(testId2);
+
+    // When toggling existing ID with modKey
+    act(() => {
+      result.current[1]({ type: "select-id", id: testId1, modKey: true });
+    });
+
+    // Then - id1 should be removed
+    expect(result.current[0].selectedIds).toEqual([testId2]);
+  });
+
+  /**
+   * GIVEN a state with multiAction
+   * WHEN select-id is dispatched with shiftKey=true
+   * THEN multiAction should be cleared
+   */
+  it("select-id with shiftKey clears multiAction", () => {
+    // Given
+    const { result } = renderHook(() =>
+      useLayoutBrowserReducer({
+        busy: false,
+        error: undefined,
+        online: true,
+        lastSelectedId: undefined,
+      }),
+    );
+
+    // Setup multiAction
+    const testId1 = BasicBuilder.string();
+    const testId2 = BasicBuilder.string();
+    act(() => {
+      result.current[1]({ type: "select-id", id: testId1 });
+      result.current[1]({ type: "queue-multi-action", action: "save" });
+    });
+
+    expect(result.current[0].multiAction).toBeDefined();
+
+    // When
+    act(() => {
+      result.current[1]({ type: "select-id", id: testId2, shiftKey: true });
+    });
+
+    // Then
+    expect(result.current[0].multiAction).toBeUndefined();
+    expect(result.current[0].lastSelectedId).toBe(testId2);
+    // Note: selectedIds remains unchanged with shift key in this implementation
+    expect(result.current[0].selectedIds).toEqual([testId1]);
+  });
+
+  /**
+   * GIVEN any state
+   * WHEN select-id is dispatched with normal click
+   * THEN it should perform single selection
+   */
+  it("select-id with normal click performs single selection", () => {
+    // Given
+    const { result } = renderHook(() =>
+      useLayoutBrowserReducer({
+        busy: false,
+        error: undefined,
+        online: true,
+        lastSelectedId: undefined,
+      }),
+    );
+
+    // Select multiple IDs first
+    const testId1 = BasicBuilder.string();
+    const testId2 = BasicBuilder.string();
+    const testId3 = BasicBuilder.string();
+    act(() => {
+      result.current[1]({ type: "select-id", id: testId1 });
+      result.current[1]({ type: "select-id", id: testId2, modKey: true });
+    });
+
+    expect(result.current[0].selectedIds.length).toBeGreaterThan(1);
+
+    // When - normal click on a new ID
+    act(() => {
+      result.current[1]({ type: "select-id", id: testId3 });
+    });
+
+    // Then
+    expect(result.current[0].selectedIds).toEqual([testId3]);
+    expect(result.current[0].multiAction).toBeUndefined();
+    expect(result.current[0].lastSelectedId).toBe(testId3);
+  });
+
+  /**
+   * GIVEN any state
+   * WHEN set-busy is dispatched
+   * THEN busy state should be updated
+   */
+  it("set-busy updates busy state", () => {
+    // Given
+    const { result } = renderHook(() =>
+      useLayoutBrowserReducer({
+        busy: false,
+        error: undefined,
+        online: true,
+        lastSelectedId: undefined,
+      }),
+    );
+
+    // When
+    act(() => {
+      result.current[1]({ type: "set-busy", value: true });
+    });
+
+    // Then
+    expect(result.current[0].busy).toBe(true);
+  });
+
+  /**
+   * GIVEN any state
+   * WHEN set-error is dispatched
+   * THEN error state should be updated
+   */
+  it("set-error updates error state", () => {
+    // Given
+    const error = new Error("Test error");
+    const { result } = renderHook(() =>
+      useLayoutBrowserReducer({
+        busy: false,
+        error: undefined,
+        online: true,
+        lastSelectedId: undefined,
+      }),
+    );
+
+    // When
+    act(() => {
+      result.current[1]({ type: "set-error", value: error });
+    });
+
+    // Then
+    expect(result.current[0].error).toBe(error);
+  });
+
+  /**
+   * GIVEN any state
+   * WHEN set-online is dispatched
+   * THEN online state should be updated
+   */
+  it("set-online updates online state", () => {
+    // Given
+    const { result } = renderHook(() =>
+      useLayoutBrowserReducer({
+        busy: false,
+        error: undefined,
+        online: true,
+        lastSelectedId: undefined,
+      }),
+    );
+
+    // When
+    act(() => {
+      result.current[1]({ type: "set-online", value: false });
+    });
+
+    // Then
+    expect(result.current[0].online).toBe(false);
+  });
+
+  /**
+   * GIVEN props for the hook
+   * WHEN the hook is initialized
+   * THEN it should return the initial state with default values
+   */
+  it("useLayoutBrowserReducer initializes with correct defaults", () => {
+    // Given
+    const props = {
+      busy: true,
+      error: new Error("Test"),
+      online: false,
+      lastSelectedId: BasicBuilder.string(),
+    };
+
+    // When
+    const { result } = renderHook(() => useLayoutBrowserReducer(props));
+
+    // Then
+    expect(result.current[0]).toEqual({
+      ...props,
+      selectedIds: [],
+      multiAction: undefined,
+    });
+  });
+});

--- a/packages/suite-base/src/components/LayoutBrowser/reducer.ts
+++ b/packages/suite-base/src/components/LayoutBrowser/reducer.ts
@@ -19,47 +19,41 @@ function reducer(draft: LayoutSelectionState, action: LayoutSelectionAction) {
     case "clear-multi-action":
       draft.multiAction = undefined;
       break;
+
     case "queue-multi-action":
       draft.multiAction = { action: action.action, ids: draft.selectedIds };
       break;
-    case "select-id":
-      if (action.modKey === true) {
-        draft.selectedIds = _.xor(draft.selectedIds, _.compact([action.id]));
-      } else if (action.shiftKey === true) {
-        for (const layouts of Object.values(action.layouts ?? {})) {
-          const lastId = layouts.findIndex((layout) => layout.id === draft.lastSelectedId);
-          const thisId = layouts.findIndex((layout) => layout.id === action.id);
-          if (lastId !== -1 && thisId !== -1) {
-            const start = Math.min(lastId, thisId);
-            const end = Math.max(lastId, thisId);
-            for (let i = start; i <= end; i++) {
-              draft.selectedIds = _.union(draft.selectedIds, [layouts[i]!.id]);
-            }
-          }
-        }
-      } else {
+
+    case "select-id": {
+      const { id, modKey, shiftKey } = action;
+
+      if (modKey === true) {
+        // Toggle selection (Ctrl / Cmd)
+        draft.selectedIds = _.xor(draft.selectedIds, _.compact([id]));
+      } else if (shiftKey === true) {
+        // explicitly disable multi selection with shift key
         draft.multiAction = undefined;
-        draft.selectedIds = _.compact([action.id]);
+      } else {
+        // Normal click → single select
+        draft.multiAction = undefined;
+        draft.selectedIds = _.compact([id]);
       }
-      draft.lastSelectedId = action.id;
+
+      draft.lastSelectedId = id;
       break;
+    }
+
     case "set-busy":
       draft.busy = action.value;
       break;
+
     case "set-error":
       draft.error = action.value;
       break;
+
     case "set-online":
       draft.online = action.value;
       break;
-    case "shift-multi-action": {
-      const id = draft.multiAction?.ids.shift();
-      if (draft.multiAction?.ids.length === 0) {
-        draft.multiAction = undefined;
-      }
-      _.pull(draft.selectedIds, id);
-      break;
-    }
   }
 }
 

--- a/packages/suite-base/src/components/LayoutBrowser/types.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/types.tsx
@@ -51,3 +51,13 @@ export type LayoutActionMenuItem =
       text: string;
       debug?: boolean;
     };
+
+export type SignInPromptProps = {
+  onDismiss?: () => void;
+};
+
+export type UnsavedChangesResolution =
+  | { type: "cancel" }
+  | { type: "discard" }
+  | { type: "makePersonal"; name: string }
+  | { type: "overwrite" };

--- a/packages/suite-base/src/hooks/types.ts
+++ b/packages/suite-base/src/hooks/types.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { Layout } from "@lichtblick/suite-base/services/ILayoutStorage";
+
+export type UseLayoutActions = {
+  onRenameLayout: (item: Layout, newName: string) => Promise<void>;
+  onDuplicateLayout: (item: Layout) => Promise<void>;
+  onDeleteLayout: (item: Layout) => Promise<void>;
+  onRevertLayout: (item: Layout) => Promise<void>;
+  onOverwriteLayout: (item: Layout) => Promise<void>;
+  confirmModal: React.JSX.Element | undefined;
+};


### PR DESCRIPTION
## User-Facing Changes

Users can now select multiple layouts at once. Previously, the UI suggested that bulk actions (Delete, Revert, Duplicate, Save) would apply to all selected layouts, but these actions were either broken or misleading.

This PR fixes the bulk actions so that they correctly apply to multiple selections.

## Description

Enables bulk actions (Delete, Revert, Duplicate, Save) to work as expected when multiple layouts are selected.

Multiple selection is supported via `modKey + mouse click`.
Multiple selection with `shift + mouse click` is intentionally disabled.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
