### PR TITLE
E2e test to playback time format switch

### DIFF
--- a/e2e/tests/desktop/player/timestamp-type-switch.desktop.spec.ts
+++ b/e2e/tests/desktop/player/timestamp-type-switch.desktop.spec.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { test, expect } from "../../../fixtures/electron";
+import { loadFile } from "../../../fixtures/load-file";
+
+/**
+ * GIVEN a .mcap file is loaded
+ * WHEN playback time displayed is hovered
+ * And playback time dropown button is clicked
+ * And playback time epoch format is selected
+ * THEN the player time displayed should change to 1740566235.547000000 (epoch format)
+ */
+test("should switch playback time to epoch format next to the player", async ({ mainWindow }) => {
+  // Given
+  const initialTimeInUTC = "2025-02-26 10:37:15.547 AM WET";
+  const intialTimeInEpoch = "1740566235.547000000";
+
+  const filename = "example.mcap";
+  await loadFile({
+    mainWindow,
+    filename,
+  });
+
+  // When
+  const playerStartingTime = mainWindow.locator(`input[value="${initialTimeInUTC}"]`);
+  // Playback time display needs to be hovered first so clicking on it is possible
+  await playerStartingTime.hover();
+
+  const timestampDropdown = mainWindow.getByTestId("playback-time-display-toggle-button");
+  await timestampDropdown.click();
+
+  const newTimestampOption = mainWindow.getByTestId("playback-time-display-option-SEC");
+  await newTimestampOption.click();
+
+  // Then
+  const playerStartingTimeInEpoch = mainWindow.locator(`input[value="${intialTimeInEpoch}"]`);
+  await expect(playerStartingTimeInEpoch).toBeVisible();
+});

--- a/packages/suite-base/src/components/PlaybackControls/UnconnectedPlaybackTimeDisplay.tsx
+++ b/packages/suite-base/src/components/PlaybackControls/UnconnectedPlaybackTimeDisplay.tsx
@@ -118,6 +118,7 @@ function PlaybackTimeMethodMenu({
     <>
       <IconButton
         id="playback-time-display-toggle-button"
+        data-testid="playback-time-display-toggle-button"
         aria-controls={open ? "playback-time-display-toggle-menu" : undefined}
         aria-haspopup="true"
         aria-expanded={open ? "true" : undefined}
@@ -150,6 +151,7 @@ function PlaybackTimeMethodMenu({
         ].map((option) => (
           <MenuItem
             key={option.key}
+            data-testid={`playback-time-display-option-${option.key}`}
             selected={timeFormat === option.key}
             onClick={async () => {
               await setTimeFormat(option.key as TimeDisplayMethod);


### PR DESCRIPTION
## User-Facing Changes

N/A

## Description
E2e test for playback time format switch
*Note:* Had to add a hover over the playback time display before being able to click it

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok

