### PR TITLE
Add missing dependencies note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,38 @@ $ docker run -p 8080:8080 lichtblick
 $ yarn run clean
 ```
 
+## :warning: Note on Linux dependencies (.tar.gz only)
+
+When installing the **`.tar.gz` package**, unlike the `.deb`, **system dependencies are not installed automatically**.
+In many cases, if you already have **Google Chrome** or another Chromium-based application installed, Lichtblick will run fine since these applications bring most of the required libraries.
+
+However, if you see errors about missing libraries when launching Lichtblick, you will need to install them manually.
+The most common missing dependencies are:
+
+- `libgtk-3-0`
+- `libatk1.0-0`
+- `libatk-bridge2.0-0`
+- `libatspi2.0-0`
+- `libnss3`
+- `libnspr4`
+- `libasound2`
+- `libcups2`
+- `libnotify4`
+- `libxtst6`
+- `xdg-utils`
+- `libdrm2`
+- `libgbm1`
+- `libxcb-dri3-0`
+
+Example (Debian/Ubuntu):
+
+```bash
+sudo apt-get update && sudo apt-get install -y libgtk-3-0 libatk1.0-0 libatk-bridge2.0-0 libatspi2.0-0 libnss3 libnspr4 libasound2 libcups2 libnotify4 libxtst6 xdg-utils libdrm2 libgbm1 libxcb-dri3-0
+```
+
+👉 **Recommendation**: if using the `.tar.gz`, always check the error messages in the terminal. They will indicate which library is missing so you can install it manually.
+
+
 - The desktop builds are located in the `dist` directory, and the web builds are found in the `web/.webpack` directory.
 
 ## :pencil: License (Open Source)


### PR DESCRIPTION
## Description

This PR adds a new section to the README clarifying that when installing Lichtblick from the `.tar.gz` package, system dependencies are not installed automatically.