### PR TITLE
Add Lichtblick to GH pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,52 @@
+name: Deploy Lichtblick Web to GH Pages
+
+on:
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+      - run: corepack enable
+      - name: Install dependencies
+        run: yarn install
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build web static files
+        run: yarn web:build:prod
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./web/.webpack
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Lichtblick is an integrated visualization and diagnosis tool for robotics, avail
   </p>
 </div>
 
+## :rocket: Try Lichtblick
+
+**[Try Lichtblick now in your browser!](https://lichtblick-suite.github.io/lichtblick/)**
+
+No installation required - experience the full power of Lichtblick directly in your web browser!
+
 ## :book: Documentation
 
 Looking for guidance on using Lichtblick? Check out our [official documentation here!](https://lichtblick-suite.github.io/docs/)


### PR DESCRIPTION
## User-Facing Changes
Users can access Lichtblick web version by only clicking the link. For now it will be the default URL of GH pages (https://lichtblick-suite.github.io/lichtblick/), but it can be configured and changed to a custom one, if desired in the future.

## Description
Add pipeline to add Lichtblick web to gh-pages, the main version. It can be triggered manually too, just in case something goes wrong, it does not need a new release.

## Checklist

- [x] The web version was tested and it is running ok
