### PR TITLE
Increasing number range for vec3 unit test

### DIFF
--- a/packages/suite-base/src/components/SettingsTreeEditor/FieldEditor.test.tsx
+++ b/packages/suite-base/src/components/SettingsTreeEditor/FieldEditor.test.tsx
@@ -290,9 +290,9 @@ describe("FieldEditor", () => {
       const { props } = await renderComponent({
         field: { input, label, value },
       });
-      const newValue0 = BasicBuilder.number();
-      const newValue1 = BasicBuilder.number();
-      const newValue2 = BasicBuilder.number();
+      const newValue0 = BasicBuilder.number({ max: 2000 });
+      const newValue1 = BasicBuilder.number({ max: 2000 });
+      const newValue2 = BasicBuilder.number({ max: 2000 });
 
       const vec3Input0 = screen.getByTestId("Vec3Input-0").querySelector("input")!;
       fireEvent.change(vec3Input0, { target: { value: newValue0 } });


### PR DESCRIPTION
## User-Facing Changes

N/A

## Description
Increasing the range of random numbers used on Vec3 component unit test to avoid a small range and consequently a higher chance of the test failing.

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
