### PR TITLE
Fix: Topic aliasing callbacks not re-running on global variable changes

### DIFF
--- a/packages/suite-base/src/players/UserScriptPlayer/index.test.ts
+++ b/packages/suite-base/src/players/UserScriptPlayer/index.test.ts
@@ -16,7 +16,6 @@
 //   You may not use this file except in compliance with the License.
 
 import { signal } from "@lichtblick/den/async";
-import { Basic } from "@lichtblick/suite-base/Workspace.stories";
 import FakePlayer from "@lichtblick/suite-base/components/MessagePipeline/FakePlayer";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
 import MockUserScriptPlayerWorker from "@lichtblick/suite-base/players/UserScriptPlayer/MockUserScriptPlayerWorker";
@@ -36,7 +35,7 @@ import delay from "@lichtblick/suite-base/util/delay";
 import { DEFAULT_STUDIO_SCRIPT_PREFIX } from "@lichtblick/suite-base/util/globalConstants";
 
 import UserScriptPlayer from ".";
-import { DIAGNOSTIC_SEVERITY, SOURCES, ERROR_CODES } from "./constants";
+import { DIAGNOSTIC_SEVERITY, ERROR_CODES, SOURCES } from "./constants";
 import exampleDatatypes from "./transformerWorker/fixtures/example-datatypes";
 
 const nodeId = "nodeId";

--- a/packages/suite-base/src/players/UserScriptPlayer/index.ts
+++ b/packages/suite-base/src/players/UserScriptPlayer/index.ts
@@ -355,6 +355,7 @@ export default class UserScriptPlayer implements Player {
 
   public setGlobalVariables(globalVariables: GlobalVariables): void {
     this.#globalVariables = globalVariables;
+    this.#player.setGlobalVariables(globalVariables);
   }
 
   // Called when userScript state is updated (i.e. scripts are saved)


### PR DESCRIPTION
## User-Facing Changes

Fixed an issue where topic aliased callbacks in panel extensions were not re-running when global variables were added, updated, or removed in the UI, and the `globalVariables` parameter was always empty.

## Description

This PR fixes a bug in the UserScriptPlayer where global variables were not being properly forwarded to wrapped players in the player hierarchy (MessagePipelineProvider > UserScriptPlayer > Base Player).

Extension callbacks registered via `registerTopicAliases` now re-run when global variables change.

Related issue: #690 

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
