### PR TITLE
Force converter to be called when changing settings

### DIFF
--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -144,6 +144,7 @@ function PanelExtensionAdapter(
   const [panelId] = useState(() => uuid());
   const isMounted = useSynchronousMountedState();
   const [error, setError] = useState<Error | undefined>();
+  const [forceConversion, setForceConversion] = useState(new Set<string>);
   const [watchedFields, setWatchedFields] = useState(new Set<keyof RenderState>());
   const messageConverters = useExtensionCatalog(selectInstalledMessageConverters);
 
@@ -256,6 +257,7 @@ function PanelExtensionAdapter(
       sortedServices,
       subscriptions: localSubscriptions,
       watchedFields,
+      forceConversion,
       config: initialState.current,
     });
 
@@ -267,6 +269,9 @@ function PanelExtensionAdapter(
       setSlowRender(true);
       return;
     }
+
+    // Clear any conversions that were forced.
+    forceConversion.clear();
 
     setSlowRender(false);
     const resumeFrame = pauseFrame(panelId);
@@ -308,6 +313,7 @@ function PanelExtensionAdapter(
     sortedServices,
     watchedFields,
     initialState,
+    forceConversion,
   ]);
 
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
@@ -357,6 +363,9 @@ function PanelExtensionAdapter(
             }
 
             extensionsSettings[panelName]?.[schemaName]?.handler(action, draft.topics[topicName]);
+            setForceConversion((_old) => {
+              return new Set([ topicName ]);
+            })
           }
         }),
       );


### PR DESCRIPTION
I'm not sure if it was documented anywhere, but it seems like the `handler` parameter for message converters was not getting called. I found a fix to that and decided to see about fixing the re-calling of the converter itself as well.

_Small disclaimer_: I am not a web developer, I mostly do C++. If something is wrong please let me know!

## User-Facing Changes

- `registerMessageConverter` `handler` callback will now be called.
- Message converters should now be re-run when the associated settings change.

## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

Should close #503.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
