### PR TITLE
increasing values range for vec2 unit test, to avoid test failures

### DIFF
--- a/packages/suite-base/src/components/SettingsTreeEditor/FieldEditor.test.tsx
+++ b/packages/suite-base/src/components/SettingsTreeEditor/FieldEditor.test.tsx
@@ -342,8 +342,8 @@ describe("FieldEditor", () => {
         field: { input, label, value },
       });
 
-      const newValue0 = BasicBuilder.number();
-      const newValue1 = BasicBuilder.number();
+      const newValue0 = BasicBuilder.number({ max: 2000 });
+      const newValue1 = BasicBuilder.number({ max: 2000 });
 
       const vec2Input0 = screen.getByTestId("Vec2Input-0").querySelector("input")!;
       fireEvent.change(vec2Input0, { target: { value: newValue0 } });


### PR DESCRIPTION
## User-Facing Changes

N/A

## Description

Increasing max range on BasicBuilder so vec2 unit test avoid failures because of input values

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
