### PR TITLE
Add support for "foxglove.sdk.v1" WebSocket subprotocols

### DIFF
--- a/packages/suite-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/suite-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -180,11 +180,13 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this.#client?.close();
     }, 10000);
 
+    const subprotocols = [FoxgloveClient.SUPPORTED_SUBPROTOCOL, "foxglove.sdk.v1"];
+
     this.#client = new FoxgloveClient({
       ws:
         typeof Worker !== "undefined"
-          ? new WorkerSocketAdapter(this.#url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL])
-          : new WebSocket(this.#url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
+          ? new WorkerSocketAdapter(this.#url, subprotocols)
+          : new WebSocket(this.#url, subprotocols),
     });
 
     this.#client.on("open", () => {
@@ -229,7 +231,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           message: "Insecure WebSocket connection",
           tip: `Check that the WebSocket server at ${
             this.#url
-          } is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
+          } is reachable and supports protocol version one of: ${subprotocols.join(", ")}.`,
         });
         this.#emitState();
       }
@@ -261,7 +263,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         message: "Connection failed",
         tip: `Check that the WebSocket server at ${
           this.#url
-        } is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
+        } is reachable and supports protocol version one of: ${subprotocols.join(", ")}.`,
       });
 
       this.#emitState();


### PR DESCRIPTION
## User-Facing Changes

<!-- will be used as a changelog entry -->

## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

Talking about #547 , #604 and #750 , why is the solution for Foxglove bridge incompatibility always 'downgrade to 0.8.5'? `foxglove.sdk.v1` is, at least for now, completely identical protocol to `foxglove.websocket.v1` except for the name (which is not guaranteed for the long term though; [this](https://github.com/orgs/foxglove/discussions/1131) is their official stance), so supporting the new bridge 3.2.1 is just as easy as adding a string into the array. Even Flora did that. 

AFAIR, one of the many reasons why ws-protocol is deprecated in the Foxglove side is that the old bridge depends on websocketpp, a C++ websocket implementation which has been, de facto stopped maintaining since about 5 years ago. If the team is really working on drop-in replacement of ws-protocol, I would expect that would involve implementing websocket from scratch as well.

## Checklist

- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
