### PR TITLE
xacro-parser version bump

### DIFF
--- a/packages/den/package.json
+++ b/packages/den/package.json
@@ -16,7 +16,7 @@
     "@lichtblick/comlink": "1.0.3",
     "async-mutex": "0.5.0",
     "eventemitter3": "5.0.1",
-    "xacro-parser": "0.3.9"
+    "xacro-parser": "0.3.11"
   },
   "devDependencies": {
     "@lichtblick/log": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2847,7 +2847,7 @@ __metadata:
     "@types/dom-webcodecs": 0.1.14
     async-mutex: 0.5.0
     eventemitter3: 5.0.1
-    xacro-parser: 0.3.9
+    xacro-parser: 0.3.11
   languageName: unknown
   linkType: soft
 
@@ -10880,10 +10880,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expr-eval@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "expr-eval@npm:2.0.2"
-  checksum: 01862f09b50b17b45a6268b1153280afede99e1b51752a323661f7f4010eaed34cd6c682bf439b7f8a92df6aa82f326f0ce0aa20964d175feee97377fe53921d
+"expr-eval-fork@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "expr-eval-fork@npm:3.0.0"
+  checksum: 56579f29bc9d05b0107bf6ea0a0e9552c145e67d222cb60741b74bc1f66acef3f2fd2387dc48ee64e20b740dc5d3d0317832174638d87d32efbbc3139ee7be1c
   languageName: node
   linkType: hard
 
@@ -21274,14 +21274,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xacro-parser@npm:0.3.9":
-  version: 0.3.9
-  resolution: "xacro-parser@npm:0.3.9"
+"xacro-parser@npm:0.3.11":
+  version: 0.3.11
+  resolution: "xacro-parser@npm:0.3.11"
   dependencies:
-    expr-eval: ^2.0.2
+    expr-eval-fork: ^3.0.0
     yaml: ^2.1.3
     yargs: ^17.6.2
-  checksum: 065eb5d13118ffd65bcdf5b98c4232c6b81a4e8b3bd8b37e380ce9b4198f898aef32dec07b70dbc9f49549a2c1bb3b082ce2bb606cfd4075acd0524b1f0079ab
+  checksum: 6cbb2ade4b308d913ebb447fce9cfeba046427de473b04b865a602fe75c77e5a8e9aa83184f3902cee63e8302cad775e03edb7fc7c9a0e457a9551b7374e187a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## User-Facing Changes
N/A

## Description

Updating xacro-parser package to fix https://nvd.nist.gov/vuln/detail/CVE-2025-12735 

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
