### PR TITLE
Panel toolbar visual bug fixes

### DIFF
--- a/packages/suite-base/src/components/Autocomplete/Autocomplete.style.ts
+++ b/packages/suite-base/src/components/Autocomplete/Autocomplete.style.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { makeStyles } from "tss-react/mui";
+
+export const useStyles = makeStyles()((theme) => ({
+  inputError: {
+    input: {
+      color: theme.palette.error.main,
+    },
+  },
+  root: {
+    "& .MuiAutocomplete-endAdornment": {
+      top: "50%",
+    },
+    "& .MuiAutocomplete-clearIndicator": {
+      top: "50% !important",
+    },
+  },
+}));

--- a/packages/suite-base/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/suite-base/src/components/Autocomplete/Autocomplete.tsx
@@ -14,69 +14,23 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import {
-  Autocomplete as MuiAutocomplete,
-  Popper,
-  PopperProps,
-  TextField,
-  TextFieldProps,
-} from "@mui/material";
+import { Autocomplete as MuiAutocomplete, Popper, PopperProps, TextField } from "@mui/material";
 import { Fzf, FzfResultItem } from "fzf";
 import * as React from "react";
+import { SyntheticEvent, useCallback, useImperativeHandle, useMemo, useRef, useState } from "react";
+
+import { useStyles } from "@lichtblick/suite-base/components/Autocomplete/Autocomplete.style";
 import {
-  CSSProperties,
-  SyntheticEvent,
-  useCallback,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { makeStyles } from "tss-react/mui";
+  EMPTY_SET,
+  FAST_FIND_ITEM_CUTOFF,
+  MAX_FZF_MATCHES,
+} from "@lichtblick/suite-base/components/Autocomplete/constants";
+import {
+  AutocompleteProps,
+  IAutocomplete,
+} from "@lichtblick/suite-base/components/Autocomplete/types";
 
 import { ListboxAdapterChild, ReactWindowListboxAdapter } from "./ReactWindowListboxAdapter";
-
-const MAX_FZF_MATCHES = 200;
-
-// Above this number of items we fall back to the faster fuzzy find algorithm.
-const FAST_FIND_ITEM_CUTOFF = 1_000;
-
-type AutocompleteProps = {
-  className?: string;
-  disableAutoSelect?: boolean;
-  disabled?: boolean;
-  filterText?: string;
-  hasError?: boolean;
-  inputStyle?: CSSProperties;
-  items: readonly string[];
-  menuStyle?: CSSProperties;
-  minWidth?: number;
-  onBlur?: () => void;
-  onChange?: (event: React.SyntheticEvent, text: string) => void;
-  onSelect: (value: string, autocomplete: IAutocomplete) => void;
-  placeholder?: string;
-  readOnly?: boolean;
-  selectOnFocus?: boolean;
-  sortWhenFiltering?: boolean;
-  value?: string;
-  variant?: TextFieldProps["variant"];
-};
-
-export interface IAutocomplete {
-  setSelectionRange(selectionStart: number, selectionEnd: number): void;
-  focus(): void;
-  blur(): void;
-}
-
-const useStyles = makeStyles()((theme) => ({
-  inputError: {
-    input: {
-      color: theme.palette.error.main,
-    },
-  },
-}));
-
-const EMPTY_SET = new Set<number>();
 
 function itemToFzfResult<T>(item: T): FzfResultItem<T> {
   return {
@@ -204,7 +158,7 @@ export const Autocomplete = React.forwardRef(function Autocomplete(
 
   return (
     <MuiAutocomplete
-      className={className}
+      className={cx(className, classes.root)}
       getOptionLabel={getOptionLabel}
       disableCloseOnSelect
       disabled={disabled}

--- a/packages/suite-base/src/components/Autocomplete/constants.ts
+++ b/packages/suite-base/src/components/Autocomplete/constants.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+export const MAX_FZF_MATCHES = 200;
+
+// Above this number of items we fall back to the faster fuzzy find algorithm.
+export const FAST_FIND_ITEM_CUTOFF = 1_000;
+
+export const EMPTY_SET = new Set<number>();

--- a/packages/suite-base/src/components/Autocomplete/types.ts
+++ b/packages/suite-base/src/components/Autocomplete/types.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { TextFieldProps } from "@mui/material";
+import { CSSProperties } from "react";
+
+export type AutocompleteProps = {
+  className?: string;
+  disableAutoSelect?: boolean;
+  disabled?: boolean;
+  filterText?: string;
+  hasError?: boolean;
+  inputStyle?: CSSProperties;
+  items: readonly string[];
+  menuStyle?: CSSProperties;
+  minWidth?: number;
+  onBlur?: () => void;
+  onChange?: (event: React.SyntheticEvent, text: string) => void;
+  onSelect: (value: string, autocomplete: IAutocomplete) => void;
+  placeholder?: string;
+  readOnly?: boolean;
+  selectOnFocus?: boolean;
+  sortWhenFiltering?: boolean;
+  value?: string;
+  variant?: TextFieldProps["variant"];
+};
+
+export interface IAutocomplete {
+  setSelectionRange(selectionStart: number, selectionEnd: number): void;
+  focus(): void;
+  blur(): void;
+}

--- a/packages/suite-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/suite-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -27,7 +27,8 @@ import {
   PrimitiveType,
 } from "@lichtblick/message-path";
 import * as PanelAPI from "@lichtblick/suite-base/PanelAPI";
-import { Autocomplete, IAutocomplete } from "@lichtblick/suite-base/components/Autocomplete";
+import { Autocomplete } from "@lichtblick/suite-base/components/Autocomplete";
+import { IAutocomplete } from "@lichtblick/suite-base/components/Autocomplete/types";
 import { useStructuredItemsByPath } from "@lichtblick/suite-base/components/MessagePathSyntax/useStructureItemsByPath";
 import useGlobalVariables, {
   GlobalVariables,

--- a/packages/suite-base/src/components/PanelToolbar/PanelToolbar.style.ts
+++ b/packages/suite-base/src/components/PanelToolbar/PanelToolbar.style.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { makeStyles } from "tss-react/mui";
+
+import { PANEL_TOOLBAR_MIN_HEIGHT } from "@lichtblick/suite-base/components/PanelToolbar/constants";
+
+export const useStyles = makeStyles()((theme) => ({
+  root: {
+    transition: "transform 80ms ease-in-out, opacity 80ms ease-in-out",
+    cursor: "auto",
+    flex: "0 0 auto",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    padding: theme.spacing(0.25, 0.75),
+    display: "flex",
+    minHeight: PANEL_TOOLBAR_MIN_HEIGHT,
+    backgroundColor: theme.palette.background.paper,
+    width: "100%",
+    left: 0,
+    zIndex: theme.zIndex.appBar,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    position: "relative !important" as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    top: "auto !important" as any,
+  },
+}));

--- a/packages/suite-base/src/components/PanelToolbar/index.tsx
+++ b/packages/suite-base/src/components/PanelToolbar/index.tsx
@@ -17,52 +17,27 @@
 import FullscreenIcon from "@mui/icons-material/Fullscreen";
 import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
 import { Typography } from "@mui/material";
-import { useContext, useMemo, CSSProperties } from "react";
-import { makeStyles } from "tss-react/mui";
+import { useContext, useMemo } from "react";
 
 import PanelContext from "@lichtblick/suite-base/components/PanelContext";
+import { useStyles } from "@lichtblick/suite-base/components/PanelToolbar/PanelToolbar.style";
 import ToolbarIconButton from "@lichtblick/suite-base/components/PanelToolbar/ToolbarIconButton";
-import { PANEL_TOOLBAR_MIN_HEIGHT } from "@lichtblick/suite-base/components/PanelToolbar/constants";
+import { PanelToolbarProps } from "@lichtblick/suite-base/components/PanelToolbar/types";
 import { useDefaultPanelTitle } from "@lichtblick/suite-base/providers/PanelStateContextProvider";
 import { PANEL_TITLE_CONFIG_KEY } from "@lichtblick/suite-base/util/layout";
 
 import { PanelToolbarControls } from "./PanelToolbarControls";
 
-type Props = {
-  additionalIcons?: React.ReactNode;
-  backgroundColor?: CSSProperties["backgroundColor"];
-  children?: React.ReactNode;
-  className?: string;
-  isUnknownPanel?: boolean;
-};
-
-const useStyles = makeStyles()((theme) => ({
-  root: {
-    transition: "transform 80ms ease-in-out, opacity 80ms ease-in-out",
-    cursor: "auto",
-    flex: "0 0 auto",
-    alignItems: "center",
-    justifyContent: "flex-end",
-    padding: theme.spacing(0.25, 0.75),
-    display: "flex",
-    minHeight: PANEL_TOOLBAR_MIN_HEIGHT,
-    backgroundColor: theme.palette.background.paper,
-    width: "100%",
-    left: 0,
-    zIndex: theme.zIndex.appBar,
-  },
-}));
-
 // Panel toolbar should be added to any panel that's part of the
 // react-mosaic layout.  It adds a drag handle, remove/replace controls
 // and has a place to add custom controls via it's children property
-export default React.memo<Props>(function PanelToolbar({
+export default React.memo<PanelToolbarProps>(function PanelToolbar({
   additionalIcons,
   backgroundColor,
   children,
   className,
   isUnknownPanel = false,
-}: Props) {
+}: PanelToolbarProps) {
   const { classes, cx } = useStyles();
   const {
     isFullscreen,

--- a/packages/suite-base/src/components/PanelToolbar/types.ts
+++ b/packages/suite-base/src/components/PanelToolbar/types.ts
@@ -1,7 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
+import { CSSProperties } from "react";
+
 export type PanelToolbarControlsProps = {
   additionalIcons?: React.ReactNode;
   isUnknownPanel: boolean;
+};
+
+export type PanelToolbarProps = {
+  additionalIcons?: React.ReactNode;
+  backgroundColor?: CSSProperties["backgroundColor"];
+  children?: React.ReactNode;
+  className?: string;
+  isUnknownPanel?: boolean;
 };


### PR DESCRIPTION
## User-Facing Changes

Fixed two visual bugs related to the panel Toolbar:

- The Plot panel toolbar could occasionally overlap the panel content;
- The clear icon in the Raw Messages autocomplete was misaligned and appeared too high relative to the input.

## Description

Had to enforce certain CSS properties in order o fix both issues. The plot overlap bug was of unknown origin while the clear icon on Raw Messages was probably related to MUI version update.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
