### PR TITLE
Fix broken comparison for triangle primitive vertex update optimization

### DIFF
--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
@@ -74,9 +74,9 @@ export class RenderableTriangles extends RenderablePrimitive {
       if (!singleColor && !geometry.attributes.color) {
         geometry.createAttribute("color", Uint8Array, 4, true);
       }
+
       const colors = geometry.attributes.color;
-      const vertices_arr = vertices.array;
-      const vertices_stride = vertices.itemSize;
+      const verticesStride = vertices.itemSize;
 
       for (let i = 0; i < primitive.points.length; i++) {
         const point = primitive.points[i]!;
@@ -88,11 +88,11 @@ export class RenderableTriangles extends RenderablePrimitive {
           continue;
         }
 
-        const offset = i * vertices_stride;
+        const offset = i * verticesStride;
         const thisVertChanged =
-          Math.fround(vertices_arr[offset]!) !== Math.fround(point.x) ||
-          Math.fround(vertices_arr[offset + 1]!) !== Math.fround(point.y) ||
-          Math.fround(vertices_arr[offset + 2]!) !== Math.fround(point.z);
+          Math.fround(vertices.array[offset]!) !== Math.fround(point.x) ||
+          Math.fround(vertices.array[offset + 1]!) !== Math.fround(point.y) ||
+          Math.fround(vertices.array[offset + 2]!) !== Math.fround(point.z);
 
         if (thisVertChanged) {
           vertices.setXYZ(i, point.x, point.y, point.z);
@@ -114,16 +114,15 @@ export class RenderableTriangles extends RenderablePrimitive {
           const b = SRGBToLinear(color.b);
           const a = color.a;
 
-          const color_arr = colors.array as Uint8Array;
-          const color_stride = colors.itemSize; // 4
-          const cOffset = i * color_stride;
+          const colorStride = colors.itemSize;
+          const colorOffset = i * colorStride;
 
           const EPS = 2 / 255;
           const diff =
-            Math.abs(color_arr[cOffset]! / 255 - r) > EPS ||
-            Math.abs(color_arr[cOffset + 1]! / 255 - g) > EPS ||
-            Math.abs(color_arr[cOffset + 2]! / 255 - b) > EPS ||
-            Math.abs(color_arr[cOffset + 3]! / 255 - a) > EPS;
+            Math.abs(colors.array[colorOffset]! / 255 - r) > EPS ||
+            Math.abs(colors.array[colorOffset + 1]! / 255 - g) > EPS ||
+            Math.abs(colors.array[colorOffset + 2]! / 255 - b) > EPS ||
+            Math.abs(colors.array[colorOffset + 3]! / 255 - a) > EPS;
 
           if (diff) {
             colors.setXYZW(i, r, g, b, a);


### PR DESCRIPTION
For triangle primitives there is code that checks if a new vertex/color changed as compared to the previous state of the TriangleMesh object. This was supposed to prevent unnecessary updates/computation.

But we noticed that the vertex comparison does not work due to internal three.js vertex data being of type `Float32Array` whereas the primitive vertex data is of type `Point3` with underlying `number`-values (64-bit floating-point values). So the `vertChanged`/`colorChanged` comparisons - even if incoming values don't change as compared to the previous step - never evaluate to true, hence the optimization never actually works.

This PR fixes the existing optimization by rounding to the nearest 32-bit single precision float representation of both numbers before the comparison. I added a small tolerance to the comparison for it to work reliably. This PR uses this comparison as basis to prevent re-setting identical vertex/color data if it hasn't changed.