### PR TITLE
Use conservative read ahead buffer for remote connections

### DIFF
--- a/packages/suite-base/src/util/getNewConnection.ts
+++ b/packages/suite-base/src/util/getNewConnection.ts
@@ -136,7 +136,6 @@ function getNewConnectionWithoutExistingConnection({
     // Use a conservative read-ahead of 50 MB to avoid downloading too much data that may not be needed
     readAheadRange = {
       start: lastResolvedCallbackEnd,
-      // end: Math.min(lastResolvedCallbackEnd + maxRequestSize, fileSize),
       end: Math.min(lastResolvedCallbackEnd + READ_AHEAD_BUFFER_SIZE, fileSize),
     };
   }


### PR DESCRIPTION
## User-Facing Changes

N/A

## Description

Use a conservative read-ahead buffer size of 50 MB for connection management

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
