### PR TITLE
Feature/only-allow-release-triggering-from-release-and-hotfix-branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
       github.event.pull_request.merged == true &&
       (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/'))
     runs-on: macos-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description

Restrict release job to only trigger from release and hotfix branches

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
