### PR TITLE
Making release branch names more strict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,18 @@ jobs:
         run: |
           branch_name="${GITHUB_HEAD_REF}"
           if [[ "$branch_name" == hotfix/* ]]; then
-            echo "type=patch" >> $GITHUB_ENV
-          elif [[ "$branch_name" =~ ^release/major ]]; then
-            echo "type=major" >> $GITHUB_ENV
-          elif [[ "$branch_name" =~ ^release/minor ]]; then
-            echo "type=minor" >> $GITHUB_ENV
-          elif [[ "$branch_name" == release/* ]]; then
-            echo "type=minor" >> $GITHUB_ENV
+            echo "type=patch" >> "$GITHUB_ENV"
+          elif [[ "$branch_name" =~ ^release/major(/.*)?$ ]]; then
+            echo "type=major" >> "$GITHUB_ENV"
+          elif [[ "$branch_name" =~ ^release/minor(/.*)?$ ]]; then
+            echo "type=minor" >> "$GITHUB_ENV"
           else
-            echo "type=patch" >> $GITHUB_ENV
+            echo "ERROR: Invalid branch name: $branch_name
+            Expected one of:
+              - hotfix/<name>
+              - release/major/<anything>
+              - release/minor/<anything>" >&2
+            exit 1
           fi
 
       - name: Bump root version


### PR DESCRIPTION
## User-Facing Changes

N/A

## Description

Removing dead code on release workflow and making release branch names more strict.
With this change to make a new release maintainers will need to name their branch like:

For a **patch release:** `hotfix/*`
For a **minor release:** `release/minor/*` (the `/` after minor is optional) 
For a **major release:** `release/major/*` (the `/` after major is optional) 

Anything else will throw an error and break the workflow with exit code 1



## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
