### PR TITLE
org layouts take preference if no layout selected

### DIFF
--- a/packages/suite-base/src/providers/CurrentLayoutProvider/constants.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/constants.ts
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: MPL-2.0
 
 export const MAX_SUPPORTED_LAYOUT_VERSION = 1;
+export const ORG_PERMISSION_PREFIX = "ORG_";

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -267,11 +267,13 @@ describe("CurrentLayoutProvider", () => {
           id: "layout1",
           name: "LAYOUT 1",
           data: { data: TEST_LAYOUT },
+          permission: "CREATOR_WRITE",
         },
         {
           id: "layout2",
           name: "ABC Layout 2",
           data: { data: TEST_LAYOUT },
+          permission: "CREATOR_WRITE",
         },
       ];
     });
@@ -292,7 +294,47 @@ describe("CurrentLayoutProvider", () => {
     expect(selectedLayout).toBe("layout2");
   });
 
-  it("should select a layout though app parameters", async () => {
+  it("selects the first org layout, if any, in alphabetic order, when there is no selected layout", async () => {
+    mockLayoutManager.getLayouts.mockImplementation(async () => {
+      return [
+        {
+          id: "layout1",
+          name: "ABC Layout 1",
+          data: { data: TEST_LAYOUT },
+          permission: "CREATOR_WRITE",
+        },
+        {
+          id: "layout2",
+          name: "DEF Layout 2",
+          data: { data: TEST_LAYOUT },
+          permission: "ORG_READ",
+        },
+        {
+          id: "layout3",
+          name: "ABC Layout 3",
+          data: { data: TEST_LAYOUT },
+          permission: "ORG_READ",
+        },
+      ];
+    });
+
+    const { result, all } = renderTest({
+      mockLayoutManager,
+      mockUserProfile,
+    });
+
+    await act(async () => {
+      await result.current.childMounted;
+    });
+
+    const selectedLayout = all.find((item) => item.layoutState.selectedLayout?.id)?.layoutState
+      .selectedLayout?.id;
+
+    expect(selectedLayout).toBeDefined();
+    expect(selectedLayout).toBe("layout3");
+  });
+
+  it("select a layout through app parameters", async () => {
     const mockAppParameters = { defaultLayout: "LAYOUT 2" };
     mockLayoutManager.getLayouts.mockImplementation(async () => {
       return [
@@ -300,11 +342,19 @@ describe("CurrentLayoutProvider", () => {
           id: "layout1",
           name: "LAYOUT 1",
           data: { data: TEST_LAYOUT },
+          permission: "CREATOR_WRITE",
         },
         {
           id: "layout2",
           name: "LAYOUT 2",
           data: { data: TEST_LAYOUT },
+          permission: "CREATOR_WRITE",
+        },
+        {
+          id: "layout3",
+          name: "ABC Layout 3",
+          data: { data: TEST_LAYOUT },
+          permission: "ORG_READ",
         },
       ];
     });

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -40,7 +40,10 @@ import {
 } from "@lichtblick/suite-base/context/CurrentLayoutContext/actions";
 import { useLayoutManager } from "@lichtblick/suite-base/context/LayoutManagerContext";
 import { useUserProfileStorage } from "@lichtblick/suite-base/context/UserProfileStorageContext";
-import { MAX_SUPPORTED_LAYOUT_VERSION } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/constants";
+import {
+  MAX_SUPPORTED_LAYOUT_VERSION,
+  ORG_PERMISSION_PREFIX,
+} from "@lichtblick/suite-base/providers/CurrentLayoutProvider/constants";
 import { defaultLayout } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/defaultLayout";
 import useUpdateSharedPanelState from "@lichtblick/suite-base/providers/CurrentLayoutProvider/hooks/useUpdateSharedPanelState";
 import { loadDefaultLayouts } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/loadDefaultLayouts";
@@ -275,10 +278,6 @@ export default function CurrentLayoutProvider({
 
   // Load initial state by re-selecting the last selected layout from the UserProfile.
   useAsync(async () => {
-    if (layoutManager.supportsSharing) {
-      return;
-    }
-
     // Don't restore the layout if there's one specified in the app state url.
     if (windowAppURLState()?.layoutId) {
       return;
@@ -316,7 +315,9 @@ export default function CurrentLayoutProvider({
     }
 
     if (layouts.length > 0) {
-      const sortedLayouts = [...layouts].sort((a, b) => a.name.localeCompare(b.name));
+      const orgLayouts = layouts.filter((l) => l.permission.startsWith(ORG_PERMISSION_PREFIX));
+      const layoutsToSort = orgLayouts.length > 0 ? orgLayouts : layouts;
+      const sortedLayouts = [...layoutsToSort].sort((a, b) => a.name.localeCompare(b.name));
       await setSelectedLayoutId(sortedLayouts[0]!.id);
       return;
     }


### PR DESCRIPTION
## User-Facing Changes

Organizational layouts now take precedence when no specific layout is selected, ensuring a more intuitive user experience.

## Description

This update allows the application to automatically select the first organizational layout in alphabetical order if no layout is specified. This change enhances layout selection logic and improves usability.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

