### PR TITLE
[E2E] Open layout via drag and drop

### DIFF
--- a/e2e/fixtures/assets/layout-e2e.json
+++ b/e2e/fixtures/assets/layout-e2e.json
@@ -1,0 +1,52 @@
+{
+  "configById": {
+    "3D!2vt2drh": {
+      "cameraState": {
+        "distance": 20,
+        "perspective": true,
+        "phi": 60,
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "targetOffset": [
+          0,
+          0,
+          0
+        ],
+        "targetOrientation": [
+          0,
+          0,
+          0,
+          1
+        ],
+        "thetaOffset": 45,
+        "fovy": 45,
+        "near": 0.5,
+        "far": 5000
+      },
+      "followMode": "follow-pose",
+      "scene": {},
+      "transforms": {},
+      "topics": {},
+      "layers": {},
+      "publish": {
+        "type": "point",
+        "poseTopic": "/move_base_simple/goal",
+        "pointTopic": "/clicked_point",
+        "poseEstimateTopic": "/initialpose",
+        "poseEstimateXDeviation": 0.5,
+        "poseEstimateYDeviation": 0.5,
+        "poseEstimateThetaDeviation": 0.26179939
+      },
+      "imageMode": {}
+    }
+  },
+  "globalVariables": {},
+  "userNodes": {},
+  "playbackConfig": {
+    "speed": 1
+  },
+  "layout": "3D!2vt2drh"
+}

--- a/e2e/tests/desktop/layout/open-layout.spec.ts
+++ b/e2e/tests/desktop/layout/open-layout.spec.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+import { test, expect } from "../../../fixtures/electron";
+import { loadFiles } from "../../../fixtures/load-files";
+
+const LAYOUT_FILENAME = "layout-e2e.json";
+/**
+ * GIVEN the "layout-e2e" layout file is loaded
+ * WHEN the user clicks on the Layouts sidebar button
+ * THEN the "layout-e2e" layout should be displayed in the layout list
+ */
+test("open layout via drag and drop", async ({ mainWindow }) => {
+  // Given
+  await loadFiles({
+    mainWindow,
+    filenames: LAYOUT_FILENAME,
+  });
+
+  // When
+  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+  await mainWindow.getByTestId("layouts-left").click();
+
+  // Then
+  await expect(mainWindow.getByText("layout-e2e", { exact: true }).count()).resolves.toBe(1);
+});


### PR DESCRIPTION
## User-Facing Changes

<!-- will be used as a changelog entry -->

## Description
E2E to test opening a layout via file picker

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [ ] The web version was tested and it is running NA
- [ ] The desktop version was tested and it is running NA
- [ ] This change is covered by unit tests NA
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated NA
