### PR TITLE
Fix layout selection logic and add unit tests

### DIFF
--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -163,6 +163,18 @@ describe("CurrentLayoutProvider", () => {
     };
     const condvar = new Condvar();
     const layoutStorageGetCalledWait = condvar.wait();
+
+    mockLayoutManager.getLayouts.mockImplementation(async () => {
+      return [
+        {
+          id: "example",
+          name: "Example layout",
+          data: { data: expectedState },
+          permission: "CREATOR_WRITE",
+        },
+      ];
+    });
+
     mockLayoutManager.getLayout.mockImplementation(async () => {
       condvar.notifyAll();
       return {
@@ -179,7 +191,7 @@ describe("CurrentLayoutProvider", () => {
       await layoutStorageGetCalledWait;
     });
 
-    expect(mockLayoutManager.getLayout.mock.calls).toEqual([["example"], ["example"]]);
+    expect(mockLayoutManager.getLayouts).toHaveBeenCalled();
     expect(all.map((item) => (item instanceof Error ? undefined : item.layoutState))).toEqual([
       { selectedLayout: undefined },
       {
@@ -205,6 +217,18 @@ describe("CurrentLayoutProvider", () => {
 
     const condvar = new Condvar();
     const layoutStorageGetCalledWait = condvar.wait();
+
+    mockLayoutManager.getLayouts.mockImplementation(async () => {
+      return [
+        {
+          id: "example",
+          name: "Example layout",
+          data: { data: expectedState },
+          permission: "CREATOR_WRITE",
+        },
+      ];
+    });
+
     mockLayoutManager.getLayout.mockImplementation(async () => {
       condvar.notifyAll();
       return {
@@ -221,7 +245,7 @@ describe("CurrentLayoutProvider", () => {
       await layoutStorageGetCalledWait;
     });
 
-    expect(mockLayoutManager.getLayout.mock.calls).toEqual([["example"], ["example"]]);
+    expect(mockLayoutManager.getLayouts).toHaveBeenCalled();
     expect(all.map((item) => (item instanceof Error ? undefined : item.layoutState))).toEqual([
       { selectedLayout: undefined },
       { selectedLayout: undefined },
@@ -229,17 +253,20 @@ describe("CurrentLayoutProvider", () => {
   });
 
   it("keeps identity of action functions when modifying layout", async () => {
-    mockLayoutManager.getLayout.mockImplementation(async () => {
-      return {
-        id: "TEST_ID",
-        name: "Test layout",
-        baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
-      };
+    mockLayoutManager.getLayouts.mockImplementation(async () => {
+      return [
+        {
+          id: "example",
+          name: "Test layout",
+          data: { data: TEST_LAYOUT },
+          permission: "CREATOR_WRITE",
+        },
+      ];
     });
 
     mockLayoutManager.updateLayout.mockImplementation(async () => {
       return {
-        id: "TEST_ID",
+        id: "example",
         name: "Test layout",
         baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
       };

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -330,7 +330,7 @@ export default function CurrentLayoutProvider({
       });
     }
 
-    // Retreive the selected layout id from the user's profile. If there's no layout specified
+    // Retrieve the selected layout id from the user's profile. If there's no layout specified
     // or we can't load it then save and select a default layout
     const layout = currentLayoutId
       ? layouts.find((element) => element.id === currentLayoutId)


### PR DESCRIPTION
## User-Facing Changes

Improves layout selection behavior when the current layout ID exists.

## Description

Fixes the default layout not setting when a current layout ID exists. Adds unit tests to ensure the correct layout is selected under various conditions.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated