### PR TITLE
E2E installing extensions via root folder

### DIFF
--- a/e2e/fixtures/assets/lichtblick.suite-extension-turtlesim-0.0.1/CHANGELOG.md
+++ b/e2e/fixtures/assets/lichtblick.suite-extension-turtlesim-0.0.1/CHANGELOG.md
@@ -1,0 +1,5 @@
+# studio-extension-turtlesim version history
+
+## 0.0.0
+
+- Alpha testing

--- a/e2e/fixtures/assets/lichtblick.suite-extension-turtlesim-0.0.1/README.md
+++ b/e2e/fixtures/assets/lichtblick.suite-extension-turtlesim-0.0.1/README.md
@@ -1,0 +1,3 @@
+# studio-extension-turtlesim
+
+## _A Foxglove Studio Extension_

--- a/e2e/fixtures/assets/lichtblick.suite-extension-turtlesim-0.0.1/package.json
+++ b/e2e/fixtures/assets/lichtblick.suite-extension-turtlesim-0.0.1/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "studio-extension-turtlesim",
+  "version": "0.0.1",
+  "displayName": "turtlesim",
+  "description": "",
+  "publisher": "Foxglove Inc.",
+  "license": "MPL-2.0",
+  "main": "./dist/extension.js",
+  "scripts": {
+    "foxglove:prepublish": "fox build --mode production",
+    "build": "fox build",
+    "package": "fox build --mode production && fox package",
+    "local-install": "fox build && fox install",
+    "pretest": "fox pretest"
+  },
+  "devDependencies": {
+    "@foxglove/fox": "file:../fox",
+    "@foxglove/studio": "0.11.0",
+    "typescript": "4.3.2"
+  }
+}

--- a/e2e/tests/desktop/extension/install-extension-on-source-folder.spec.ts
+++ b/e2e/tests/desktop/extension/install-extension-on-source-folder.spec.ts
@@ -3,17 +3,22 @@
 
 import { test, expect } from "../../../fixtures/electron";
 
+const extensionSourceFolder = "lichtblick.suite-extension-turtlesim-0.0.1";
+
 /**
- * GIVEN
+ * GIVEN turtlesim extension in already on root level folder
+ * WHEN the extensions menu is opened
+ * AND searched for turtlesim
+ * THEN the turtlesim extension should appear on the extensions list
  */
 test.use({
-  preInstalledExtensions: ["lichtblick.suite-extension-turtlesim-0.0.1.foxe"],
+  preInstalledExtensions: [extensionSourceFolder],
 });
 
 test("should install an extension (user folder)", async ({ mainWindow }) => {
+  // When
   await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
 
-  // When
   await mainWindow.getByTestId("user-button").click();
   await mainWindow.getByRole("menuitem", { name: "Extensions" }).click();
   const searchBar = mainWindow.getByPlaceholder("Search Extensions...");
@@ -22,5 +27,7 @@ test("should install an extension (user folder)", async ({ mainWindow }) => {
     .locator('[data-testid="extension-list-entry"]')
     .filter({ hasText: "turtlesim" })
     .filter({ hasText: "0.0.1" });
+
+  // Then
   await expect(turtlesimExtension).toBeVisible();
 });


### PR DESCRIPTION
## User-Facing Changes
N/A

## Description

E2E test to verify that opening adding files to `./lichtblick-suite/extensions` will make Lichtblick open it said extensions already loaded.

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
