### PR TITLE
fix: avoid dropping frames before H.264 decoding

### DIFF
--- a/packages/den/video/h264/SPS.ts
+++ b/packages/den/video/h264/SPS.ts
@@ -336,7 +336,7 @@ export class SPS {
         this.num_units_in_tick = bitstream.u(32);
         this.time_scale = bitstream.u(32);
         this.fixed_frame_rate_flag = bitstream.u_1();
-        if (this.num_units_in_tick !== 0 && this.time_scale !== 0 && this.num_units_in_tick !== 0) {
+        if (this.num_units_in_tick !== 0 && this.time_scale !== 0) {
           this.framesPerSecond = this.time_scale / (2 * this.num_units_in_tick);
         }
       }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -277,7 +277,6 @@ export class ImageMode
         subscription: {
           handler: this.messageHandler.handleCompressedVideo,
           shouldSubscribe: this.imageShouldSubscribe,
-          filterQueue: this.#filterMessageQueue.bind(this),
         },
       },
     ];

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -146,7 +146,6 @@ export class Images extends SceneExtension<ImageRenderable> {
         schemaNames: COMPRESSED_VIDEO_DATATYPES,
         subscription: {
           handler: this.#handleCompressedVideo,
-          filterQueue: onlyLastByTopicMessage,
         },
       },
     ];


### PR DESCRIPTION
## User-Facing Changes

Fixes incorrect video output when playing H.264 streams at high speed or with long GOP intervals by ensuring frames are not filtered out before decoding.

---
## Description

Currently, some frames are filtered out before being passed to the WebCodecs decoder.  
This breaks H.264 decoding because inter frames depend on previous reference frames, which can lead to visual corruption, especially when:

- Playing at high playback speed  
- The key frame (IDR) interval is large  

This PR removes the pre-decode frame filtering logic and always feeds a complete frame sequence into the decoder, ensuring correct reference frame handling and stable playback for compressed video streams.

You can reproduce the issue using the file below by playing it at 5× speed.

https://drive.google.com/file/d/1z6PnopbkXyMWdln4h-u5rIw_p1pB6v15/view?usp=drive_link

Additionally, this PR removes a duplicated condition check inside an `if` statement to simplify the logic and improve code clarity.

---

I also wanted to ask: is there any plan to support H.265 (HEVC) decoding in this project?  
If so, I would be happy to help contribute support for it.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
