### PR TITLE
feat: Tooltip in 3D view to show metadata

### DIFF
--- a/packages/suite-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -57,6 +57,11 @@ export type RendererEvents = {
     renderer: IRenderer,
   ) => void;
   selectedRenderable: (selection: PickedRenderable | undefined, renderer: IRenderer) => void;
+  renderableHovered: (
+    selections: PickedRenderable[],
+    cursorCoords: { x: number; y: number },
+    renderer: IRenderer,
+  ) => void;
   parametersChange: (
     parameters: ReadonlyMap<string, ParameterValue> | undefined,
     renderer: IRenderer,

--- a/packages/suite-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -62,6 +62,7 @@ export type RendererEvents = {
     cursorCoords: { x: number; y: number },
     renderer: IRenderer,
   ) => void;
+  hoverMoved: (cursorCoords: { x: number; y: number }, renderer: IRenderer) => void;
   parametersChange: (
     parameters: ReadonlyMap<string, ParameterValue> | undefined,
     renderer: IRenderer,

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.style.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.style.ts
@@ -80,4 +80,12 @@ export const useStyles = makeStyles()((theme) => ({
     paddingTop: 1,
     paddingBottom: 1,
   },
+  pinHint: {
+    fontSize: "0.65rem",
+    color: theme.palette.text.disabled,
+    textAlign: "center",
+    marginTop: theme.spacing(0.75),
+    fontStyle: "italic",
+    display: "block",
+  },
 }));

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.style.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.style.ts
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { makeStyles } from "tss-react/mui";
+
+import { customTypography } from "@lichtblick/theme";
+
+export const useStyles = makeStyles()((theme) => ({
+  root: {
+    position: "fixed",
+    zIndex: theme.zIndex.tooltip,
+    maxWidth: 620,
+    maxHeight: 480,
+    overflow: "auto",
+    padding: theme.spacing(1, 1.5),
+    transition: "opacity 0.15s ease",
+    scrollbarColor: `${theme.palette.action.disabled} ${theme.palette.action.hover}`,
+    "&::-webkit-scrollbar": {
+      width: 16,
+      height: 16,
+    },
+    "&::-webkit-scrollbar-track": {
+      background: theme.palette.action.hover,
+      borderRadius: theme.shape.borderRadius,
+    },
+    "&::-webkit-scrollbar-thumb": {
+      background: theme.palette.action.disabled,
+      borderRadius: theme.shape.borderRadius,
+      border: `2px solid ${theme.palette.background.paper}`,
+      "&:hover": {
+        background: theme.palette.action.active,
+      },
+    },
+  },
+  entitySection: {
+    marginBottom: theme.spacing(0.75),
+    "&:last-child": {
+      marginBottom: 0,
+    },
+  },
+  entityId: {
+    fontWeight: theme.typography.fontWeightMedium,
+    color: theme.palette.info.main,
+    fontSize: "0.75rem",
+    display: "block",
+  },
+  topicLine: {
+    color: theme.palette.text.secondary,
+    fontSize: "0.7rem",
+    marginBottom: theme.spacing(0.25),
+    display: "block",
+  },
+  divider: {
+    margin: theme.spacing(0.75, 0),
+  },
+  table: {
+    width: "100%",
+    borderCollapse: "collapse",
+    marginTop: theme.spacing(0.25),
+  },
+  tableRow: {
+    "&:nth-of-type(odd)": {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+  keyCell: {
+    color: theme.palette.text.secondary,
+    fontSize: "0.75rem",
+    whiteSpace: "nowrap",
+    paddingRight: theme.spacing(2),
+    paddingTop: 1,
+    paddingBottom: 1,
+    verticalAlign: "top",
+  },
+  valueCell: {
+    fontSize: "0.75rem",
+    fontFamily: customTypography.fontMonospace,
+    textAlign: "right",
+    wordBreak: "break-all",
+    paddingTop: 1,
+    paddingBottom: 1,
+  },
+}));

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.test.tsx
@@ -126,7 +126,11 @@ describe("<HoverTooltip />", () => {
 
   it("keeps tooltip visible briefly when entities clear, then hides after grace period", async () => {
     const entities: HoverEntityInfo[] = [
-      { topic: "/t", entityId: "e", metadata: [{ key: "k", value: "v" }] },
+      {
+        topic: "/sensors/lidar",
+        entityId: "obstacle-1",
+        metadata: [{ key: "distance", value: "12.5m" }],
+      },
     ];
 
     const view = renderHoverTooltip({
@@ -167,7 +171,11 @@ describe("<HoverTooltip />", () => {
   it("pins on hover during grace and hides after leave delay", async () => {
     const canvas = makeCanvas();
     const entities: HoverEntityInfo[] = [
-      { topic: "/t", entityId: "e", metadata: [{ key: "k", value: "v" }] },
+      {
+        topic: "/sensors/lidar",
+        entityId: "obstacle-1",
+        metadata: [{ key: "distance", value: "12.5m" }],
+      },
     ];
 
     const view = renderHoverTooltip({
@@ -210,14 +218,22 @@ describe("<HoverTooltip />", () => {
     });
   });
 
-  it("click-pins the tooltip with frozen content, and dismisses on outside click / Escape", async () => {
+  it("freezes content when click-pinned", async () => {
     const canvas = makeCanvas();
 
     const entitiesA: HoverEntityInfo[] = [
-      { topic: "/t", entityId: "eA", metadata: [{ key: "k", value: "vA" }] },
+      {
+        topic: "/sensors/lidar",
+        entityId: "obstacle-front",
+        metadata: [{ key: "distance", value: "5.2m" }],
+      },
     ];
     const entitiesB: HoverEntityInfo[] = [
-      { topic: "/t", entityId: "eB", metadata: [{ key: "k", value: "vB" }] },
+      {
+        topic: "/sensors/camera",
+        entityId: "pedestrian-1",
+        metadata: [{ key: "confidence", value: "0.95" }],
+      },
     ];
 
     const view = renderHoverTooltip({
@@ -247,11 +263,37 @@ describe("<HoverTooltip />", () => {
       </ThemeProvider>,
     );
 
-    // Still shows eA data; eB must not appear.
+    // Still shows original data; new entity must not appear.
     await waitFor(() => {
-      expect(view.getByText("eA")).toBeInTheDocument();
-      expect(view.queryByText("eB")).toBeNull();
+      expect(view.getByText("obstacle-front")).toBeInTheDocument();
+      expect(view.queryByText("pedestrian-1")).toBeNull();
     });
+  });
+
+  it("ignores mouse leave when click-pinned", async () => {
+    const canvas = makeCanvas();
+    const entities: HoverEntityInfo[] = [
+      {
+        topic: "/sensors/lidar",
+        entityId: "obstacle-front",
+        metadata: [{ key: "distance", value: "5.2m" }],
+      },
+    ];
+
+    const view = renderHoverTooltip({
+      entities,
+      position: { clientX: 100, clientY: 100 },
+      canvas,
+    });
+
+    // Enter grace then click-pin.
+    view.rerender(
+      <ThemeProvider isDark={false}>
+        <HoverTooltip entities={[]} position={{ clientX: 100, clientY: 100 }} canvas={canvas} />
+      </ThemeProvider>,
+    );
+    const paper = view.container.querySelector(".MuiPaper-root")!;
+    fireEvent.click(paper);
 
     // Leaving should not hide when click-pinned.
     fireEvent.mouseLeave(paper);
@@ -259,40 +301,88 @@ describe("<HoverTooltip />", () => {
       jest.advanceTimersByTime(2000);
     });
     expect(view.container.querySelector(".MuiPaper-root")).not.toBeNull();
+  });
+
+  it("dismisses click-pinned tooltip on outside click", async () => {
+    const canvas = makeCanvas();
+    const entities: HoverEntityInfo[] = [
+      {
+        topic: "/sensors/lidar",
+        entityId: "obstacle-front",
+        metadata: [{ key: "distance", value: "5.2m" }],
+      },
+    ];
+
+    const view = renderHoverTooltip({
+      entities,
+      position: { clientX: 100, clientY: 100 },
+      canvas,
+    });
+
+    // Enter grace then click-pin.
+    view.rerender(
+      <ThemeProvider isDark={false}>
+        <HoverTooltip entities={[]} position={{ clientX: 100, clientY: 100 }} canvas={canvas} />
+      </ThemeProvider>,
+    );
+    const paper = view.container.querySelector(".MuiPaper-root")!;
+    fireEvent.click(paper);
+    expect(view.container.querySelector(".MuiPaper-root")).not.toBeNull();
 
     // Outside click dismisses.
     fireEvent.mouseDown(document.body);
     await waitFor(() => {
       expect(view.container.querySelector(".MuiPaper-root")).toBeNull();
     });
+  });
 
-    // Re-open and ensure Escape dismisses.
-    const view2 = renderHoverTooltip({
-      entities: entitiesA,
+  it("dismisses click-pinned tooltip on Escape key", async () => {
+    const canvas = makeCanvas();
+    const entities: HoverEntityInfo[] = [
+      {
+        topic: "/sensors/lidar",
+        entityId: "obstacle-front",
+        metadata: [{ key: "distance", value: "5.2m" }],
+      },
+    ];
+
+    const view = renderHoverTooltip({
+      entities,
       position: { clientX: 100, clientY: 100 },
       canvas,
     });
-    view2.rerender(
+
+    // Enter grace then click-pin.
+    view.rerender(
       <ThemeProvider isDark={false}>
         <HoverTooltip entities={[]} position={{ clientX: 100, clientY: 100 }} canvas={canvas} />
       </ThemeProvider>,
     );
-    const paper2 = view2.container.querySelector(".MuiPaper-root")!;
-    fireEvent.click(paper2);
+    const paper = view.container.querySelector(".MuiPaper-root")!;
+    fireEvent.click(paper);
+    expect(view.container.querySelector(".MuiPaper-root")).not.toBeNull();
 
     fireEvent.keyDown(document, { key: "Escape" });
     await waitFor(() => {
-      expect(view2.container.querySelector(".MuiPaper-root")).toBeNull();
+      expect(view.container.querySelector(".MuiPaper-root")).toBeNull();
     });
   });
 
   it("enters settled mode after dwell and delays update to new item with grace period", async () => {
     const canvas = makeCanvas();
     const entitiesA: HoverEntityInfo[] = [
-      { topic: "/t", entityId: "eA", metadata: [{ key: "k", value: "vA" }] },
+      {
+        topic: "/sensors/lidar",
+        entityId: "obstacle-front",
+        metadata: [{ key: "distance", value: "5.2m" }],
+      },
     ];
     const entitiesB: HoverEntityInfo[] = [
-      { topic: "/t", entityId: "eB", metadata: [{ key: "k", value: "vB" }] },
+      {
+        topic: "/sensors/camera",
+        entityId: "pedestrian-1",
+        metadata: [{ key: "confidence", value: "0.95" }],
+      },
     ];
 
     const view = renderHoverTooltip({
@@ -306,7 +396,7 @@ describe("<HoverTooltip />", () => {
       jest.advanceTimersByTime(700);
     });
 
-    // Now switch to eB while settled – grace period (350 ms) should delay the update.
+    // Now switch to pedestrian-1 while settled – grace period (350 ms) should delay the update.
     view.rerender(
       <ThemeProvider isDark={false}>
         <HoverTooltip
@@ -317,35 +407,43 @@ describe("<HoverTooltip />", () => {
       </ThemeProvider>,
     );
 
-    // During grace, still showing eA.
-    expect(view.getByText("eA")).toBeInTheDocument();
-    expect(view.queryByText("eB")).toBeNull();
+    // During grace, still showing obstacle-front.
+    expect(view.getByText("obstacle-front")).toBeInTheDocument();
+    expect(view.queryByText("pedestrian-1")).toBeNull();
 
     // 349 ms in – still in grace.
     act(() => {
       jest.advanceTimersByTime(349);
     });
-    expect(view.getByText("eA")).toBeInTheDocument();
-    expect(view.queryByText("eB")).toBeNull();
+    expect(view.getByText("obstacle-front")).toBeInTheDocument();
+    expect(view.queryByText("pedestrian-1")).toBeNull();
 
-    // 1 ms more – grace ends, eB content appears.
+    // 1 ms more – grace ends, pedestrian-1 content appears.
     act(() => {
       jest.advanceTimersByTime(1);
     });
 
     await waitFor(() => {
-      expect(view.getByText("eB")).toBeInTheDocument();
-      expect(view.queryByText("eA")).toBeNull();
+      expect(view.getByText("pedestrian-1")).toBeInTheDocument();
+      expect(view.queryByText("obstacle-front")).toBeNull();
     });
   });
 
   it("hover-pinned mode freezes content and ignores entity changes", async () => {
     const canvas = makeCanvas();
     const entitiesA: HoverEntityInfo[] = [
-      { topic: "/t", entityId: "eA", metadata: [{ key: "k", value: "vA" }] },
+      {
+        topic: "/sensors/lidar",
+        entityId: "obstacle-front",
+        metadata: [{ key: "distance", value: "5.2m" }],
+      },
     ];
     const entitiesB: HoverEntityInfo[] = [
-      { topic: "/t", entityId: "eB", metadata: [{ key: "k", value: "vB" }] },
+      {
+        topic: "/sensors/camera",
+        entityId: "pedestrian-1",
+        metadata: [{ key: "confidence", value: "0.95" }],
+      },
     ];
 
     const view = renderHoverTooltip({
@@ -374,8 +472,8 @@ describe("<HoverTooltip />", () => {
       </ThemeProvider>,
     );
 
-    expect(view.getByText("eA")).toBeInTheDocument();
-    expect(view.queryByText("eB")).toBeNull();
+    expect(view.getByText("obstacle-front")).toBeInTheDocument();
+    expect(view.queryByText("pedestrian-1")).toBeNull();
   });
 
   it("omits topic line when topic is undefined", () => {
@@ -405,7 +503,11 @@ describe("<HoverTooltip />", () => {
   it("shows 'Click to pin' hint in hover-pinned mode and hides it in click-pinned mode", async () => {
     const canvas = makeCanvas();
     const entities: HoverEntityInfo[] = [
-      { topic: "/t", entityId: "e", metadata: [{ key: "k", value: "v" }] },
+      {
+        topic: "/sensors/lidar",
+        entityId: "obstacle-1",
+        metadata: [{ key: "distance", value: "12.5m" }],
+      },
     ];
 
     const view = renderHoverTooltip({
@@ -436,9 +538,21 @@ describe("<HoverTooltip />", () => {
   });
 
   it("positions the tooltip inside canvas bounds by flipping left/up when near the edge", async () => {
-    const canvas = makeCanvas({ left: 0, top: 0, right: 300, bottom: 300 });
+    // offsetWidth/offsetHeight are mocked to 200 in beforeEach.
+    const canvas = makeCanvas({
+      left: 0,
+      top: 0,
+      right: 300,
+      bottom: 300,
+      width: 300,
+      height: 300,
+    });
     const entities: HoverEntityInfo[] = [
-      { topic: "/t", entityId: "e", metadata: [{ key: "k", value: "v" }] },
+      {
+        topic: "/sensors/lidar",
+        entityId: "obstacle-1",
+        metadata: [{ key: "distance", value: "12.5m" }],
+      },
     ];
 
     const view = renderHoverTooltip({
@@ -447,9 +561,22 @@ describe("<HoverTooltip />", () => {
       canvas,
     });
 
+    // Trigger a second render so paperRef.current is populated and the
+    // measured element size (200×200) is used instead of the max constants.
+    view.rerender(
+      <ThemeProvider isDark={false}>
+        <HoverTooltip
+          entities={entities}
+          position={{ clientX: 290, clientY: 290 }}
+          canvas={canvas}
+        />
+      </ThemeProvider>,
+    );
+
     const paper = await waitFor(() => view.container.querySelector<HTMLElement>(".MuiPaper-root")!);
 
-    // With tooltip 200x200 and offset 6, at (290, 290) in 300x300 bounds it must flip left/up:
+    // Measured tooltip size is 200×200, offset is 6.
+    // At (290, 290) in 300×300 bounds there isn't space right/below so it flips:
     // left = 290 - 200 - 6 = 84, top = 290 - 200 - 6 = 84
     expect(paper.style.left).toBe("84px");
     expect(paper.style.top).toBe("84px");

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.test.tsx
@@ -9,8 +9,8 @@ import { act, fireEvent, render, waitFor } from "@testing-library/react";
 
 import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
 
-import type { HoverEntityInfo } from "./types";
 import { HoverTooltip } from "./HoverTooltip";
+import type { HoverEntityInfo } from "./types";
 
 function makeCanvas(bounds?: Partial<DOMRect>): HTMLCanvasElement {
   const canvas = document.createElement("canvas");

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.test.tsx
@@ -151,7 +151,7 @@ describe("<HoverTooltip />", () => {
     expect(view.container.querySelector(".MuiPaper-root")).not.toBeNull();
 
     act(() => {
-      jest.advanceTimersByTime(399);
+      jest.advanceTimersByTime(349);
     });
     expect(view.container.querySelector(".MuiPaper-root")).not.toBeNull();
 
@@ -210,7 +210,7 @@ describe("<HoverTooltip />", () => {
     });
   });
 
-  it("click-pins the tooltip, continues updating content while pinned, and dismisses on outside click / Escape", async () => {
+  it("click-pins the tooltip with frozen content, and dismisses on outside click / Escape", async () => {
     const canvas = makeCanvas();
 
     const entitiesA: HoverEntityInfo[] = [
@@ -236,7 +236,7 @@ describe("<HoverTooltip />", () => {
     const paper = view.container.querySelector(".MuiPaper-root")!;
     fireEvent.click(paper);
 
-    // Now provide new entities; content should update even while click-pinned.
+    // Providing new entities while click-pinned must NOT update the displayed content.
     view.rerender(
       <ThemeProvider isDark={false}>
         <HoverTooltip
@@ -247,9 +247,10 @@ describe("<HoverTooltip />", () => {
       </ThemeProvider>,
     );
 
+    // Still shows eA data; eB must not appear.
     await waitFor(() => {
-      expect(view.getByText("eB")).toBeInTheDocument();
-      expect(view.getByText("vB")).toBeInTheDocument();
+      expect(view.getByText("eA")).toBeInTheDocument();
+      expect(view.queryByText("eB")).toBeNull();
     });
 
     // Leaving should not hide when click-pinned.
@@ -282,6 +283,155 @@ describe("<HoverTooltip />", () => {
     fireEvent.keyDown(document, { key: "Escape" });
     await waitFor(() => {
       expect(view2.container.querySelector(".MuiPaper-root")).toBeNull();
+    });
+  });
+
+  it("enters settled mode after dwell and delays update to new item with grace period", async () => {
+    const canvas = makeCanvas();
+    const entitiesA: HoverEntityInfo[] = [
+      { topic: "/t", entityId: "eA", metadata: [{ key: "k", value: "vA" }] },
+    ];
+    const entitiesB: HoverEntityInfo[] = [
+      { topic: "/t", entityId: "eB", metadata: [{ key: "k", value: "vB" }] },
+    ];
+
+    const view = renderHoverTooltip({
+      entities: entitiesA,
+      position: { clientX: 100, clientY: 100 },
+      canvas,
+    });
+
+    // Dwell 700 ms → settled mode.
+    act(() => {
+      jest.advanceTimersByTime(700);
+    });
+
+    // Now switch to eB while settled – grace period (350 ms) should delay the update.
+    view.rerender(
+      <ThemeProvider isDark={false}>
+        <HoverTooltip
+          entities={entitiesB}
+          position={{ clientX: 110, clientY: 110 }}
+          canvas={canvas}
+        />
+      </ThemeProvider>,
+    );
+
+    // During grace, still showing eA.
+    expect(view.getByText("eA")).toBeInTheDocument();
+    expect(view.queryByText("eB")).toBeNull();
+
+    // 349 ms in – still in grace.
+    act(() => {
+      jest.advanceTimersByTime(349);
+    });
+    expect(view.getByText("eA")).toBeInTheDocument();
+    expect(view.queryByText("eB")).toBeNull();
+
+    // 1 ms more – grace ends, eB content appears.
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    await waitFor(() => {
+      expect(view.getByText("eB")).toBeInTheDocument();
+      expect(view.queryByText("eA")).toBeNull();
+    });
+  });
+
+  it("hover-pinned mode freezes content and ignores entity changes", async () => {
+    const canvas = makeCanvas();
+    const entitiesA: HoverEntityInfo[] = [
+      { topic: "/t", entityId: "eA", metadata: [{ key: "k", value: "vA" }] },
+    ];
+    const entitiesB: HoverEntityInfo[] = [
+      { topic: "/t", entityId: "eB", metadata: [{ key: "k", value: "vB" }] },
+    ];
+
+    const view = renderHoverTooltip({
+      entities: entitiesA,
+      position: { clientX: 100, clientY: 100 },
+      canvas,
+    });
+
+    // Enter grace then hover-pin.
+    view.rerender(
+      <ThemeProvider isDark={false}>
+        <HoverTooltip entities={[]} position={{ clientX: 100, clientY: 100 }} canvas={canvas} />
+      </ThemeProvider>,
+    );
+    const paper = view.container.querySelector(".MuiPaper-root")!;
+    fireEvent.mouseEnter(paper);
+
+    // Provide different entities while hover-pinned – content must stay frozen.
+    view.rerender(
+      <ThemeProvider isDark={false}>
+        <HoverTooltip
+          entities={entitiesB}
+          position={{ clientX: 999, clientY: 999 }}
+          canvas={canvas}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(view.getByText("eA")).toBeInTheDocument();
+    expect(view.queryByText("eB")).toBeNull();
+  });
+
+  it("omits topic line when topic is undefined", () => {
+    const entities: HoverEntityInfo[] = [
+      {
+        topic: undefined,
+        entityId: "frame::child",
+        metadata: [
+          { key: "child_frame_id", value: "base_link" },
+          { key: "parent_frame_id", value: "map" },
+        ],
+      },
+    ];
+
+    const { getByText, queryByText } = renderHoverTooltip({
+      entities,
+      position: { clientX: 10, clientY: 20 },
+      canvas: makeCanvas(),
+    });
+
+    expect(getByText("frame::child")).toBeInTheDocument();
+    expect(getByText("base_link")).toBeInTheDocument();
+    // No topic line should appear.
+    expect(queryByText("unknown")).toBeNull();
+  });
+
+  it("shows 'Click to pin' hint in hover-pinned mode and hides it in click-pinned mode", async () => {
+    const canvas = makeCanvas();
+    const entities: HoverEntityInfo[] = [
+      { topic: "/t", entityId: "e", metadata: [{ key: "k", value: "v" }] },
+    ];
+
+    const view = renderHoverTooltip({
+      entities,
+      position: { clientX: 100, clientY: 100 },
+      canvas,
+    });
+
+    // Enter grace so tooltip is interactive.
+    view.rerender(
+      <ThemeProvider isDark={false}>
+        <HoverTooltip entities={[]} position={{ clientX: 100, clientY: 100 }} canvas={canvas} />
+      </ThemeProvider>,
+    );
+
+    const paper = view.container.querySelector(".MuiPaper-root")!;
+    fireEvent.mouseEnter(paper);
+
+    // In hover-pinned mode, hint should be visible.
+    expect(view.getByText("Click to pin")).toBeInTheDocument();
+
+    // Click to pin — hint should disappear.
+    fireEvent.click(paper);
+
+    await waitFor(() => {
+      expect(view.queryByText("Click to pin")).toBeNull();
     });
   });
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.test.tsx
@@ -1,0 +1,297 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import "@testing-library/jest-dom";
+
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
+
+import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
+
+import { HoverTooltip, HoverEntityInfo } from "./HoverTooltip";
+
+function makeCanvas(bounds?: Partial<DOMRect>): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.getBoundingClientRect = jest.fn(() =>
+    ({
+      left: 0,
+      top: 0,
+      right: 300,
+      bottom: 300,
+      width: 300,
+      height: 300,
+      x: 0,
+      y: 0,
+      toJSON: () => "",
+      ...bounds,
+    }) as DOMRect,
+  );
+  return canvas;
+}
+
+function renderHoverTooltip(props: {
+  entities: HoverEntityInfo[];
+  position: { clientX: number; clientY: number };
+  canvas: HTMLCanvasElement | ReactNull;
+}) {
+  return render(
+    <ThemeProvider isDark={false}>
+      <HoverTooltip {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe("<HoverTooltip />", () => {
+  const originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth");
+  const originalOffsetHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "offsetHeight",
+  );
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      get() {
+        return 200;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      get() {
+        return 200;
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+
+    if (originalOffsetWidth) {
+      Object.defineProperty(HTMLElement.prototype, "offsetWidth", originalOffsetWidth);
+    }
+    if (originalOffsetHeight) {
+      Object.defineProperty(HTMLElement.prototype, "offsetHeight", originalOffsetHeight);
+    }
+  });
+
+  it("renders nothing when there are no entities", () => {
+    const { container } = renderHoverTooltip({
+      entities: [],
+      position: { clientX: 10, clientY: 20 },
+      canvas: makeCanvas(),
+    });
+
+    expect(container.querySelector(".MuiPaper-root")).toBeNull();
+  });
+
+  it("renders topic, entityId, and metadata rows", () => {
+    const entities: HoverEntityInfo[] = [
+      {
+        topic: "/topic",
+        entityId: "entity-1",
+        metadata: [
+          { key: "k1", value: "v1" },
+          { key: "k2", value: "v2" },
+        ],
+      },
+      {
+        topic: "/topic",
+        entityId: "entity-2",
+        metadata: [{ key: "k3", value: "v3" }],
+      },
+    ];
+
+    const { getAllByText, getByText } = renderHoverTooltip({
+      entities,
+      position: { clientX: 10, clientY: 20 },
+      canvas: makeCanvas(),
+    });
+
+    // Topic is shown per entry on its own line.
+    expect(getAllByText("/topic")).toHaveLength(2);
+
+    expect(getByText("entity-1")).toBeInTheDocument();
+    expect(getByText("k1")).toBeInTheDocument();
+    expect(getByText("v1")).toBeInTheDocument();
+
+    expect(getByText("entity-2")).toBeInTheDocument();
+    expect(getByText("k3")).toBeInTheDocument();
+    expect(getByText("v3")).toBeInTheDocument();
+  });
+
+  it("keeps tooltip visible briefly when entities clear, then hides after grace period", async () => {
+    const entities: HoverEntityInfo[] = [
+      { topic: "/t", entityId: "e", metadata: [{ key: "k", value: "v" }] },
+    ];
+
+    const view = renderHoverTooltip({
+      entities,
+      position: { clientX: 100, clientY: 100 },
+      canvas: makeCanvas(),
+    });
+
+    expect(view.container.querySelector(".MuiPaper-root")).not.toBeNull();
+
+    view.rerender(
+      <ThemeProvider isDark={false}>
+        <HoverTooltip entities={[]} position={{ clientX: 100, clientY: 100 }} canvas={makeCanvas()} />
+      </ThemeProvider>,
+    );
+
+    // Still visible during grace.
+    expect(view.container.querySelector(".MuiPaper-root")).not.toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(399);
+    });
+    expect(view.container.querySelector(".MuiPaper-root")).not.toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    await waitFor(() => {
+      expect(view.container.querySelector(".MuiPaper-root")).toBeNull();
+    });
+  });
+
+  it("pins on hover during grace and hides after leave delay", async () => {
+    const canvas = makeCanvas();
+    const entities: HoverEntityInfo[] = [
+      { topic: "/t", entityId: "e", metadata: [{ key: "k", value: "v" }] },
+    ];
+
+    const view = renderHoverTooltip({
+      entities,
+      position: { clientX: 100, clientY: 100 },
+      canvas,
+    });
+
+    // Enter grace.
+    view.rerender(
+      <ThemeProvider isDark={false}>
+        <HoverTooltip entities={[]} position={{ clientX: 100, clientY: 100 }} canvas={canvas} />
+      </ThemeProvider>,
+    );
+
+    const paper = view.container.querySelector(".MuiPaper-root")!;
+    expect(paper).toBeTruthy();
+
+    fireEvent.mouseEnter(paper);
+
+    // Grace timer should no longer hide it.
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(view.container.querySelector(".MuiPaper-root")).not.toBeNull();
+
+    fireEvent.mouseLeave(paper);
+
+    act(() => {
+      jest.advanceTimersByTime(299);
+    });
+    expect(view.container.querySelector(".MuiPaper-root")).not.toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    await waitFor(() => {
+      expect(view.container.querySelector(".MuiPaper-root")).toBeNull();
+    });
+  });
+
+  it("click-pins the tooltip, continues updating content while pinned, and dismisses on outside click / Escape", async () => {
+    const canvas = makeCanvas();
+
+    const entitiesA: HoverEntityInfo[] = [
+      { topic: "/t", entityId: "eA", metadata: [{ key: "k", value: "vA" }] },
+    ];
+    const entitiesB: HoverEntityInfo[] = [
+      { topic: "/t", entityId: "eB", metadata: [{ key: "k", value: "vB" }] },
+    ];
+
+    const view = renderHoverTooltip({
+      entities: entitiesA,
+      position: { clientX: 100, clientY: 100 },
+      canvas,
+    });
+
+    // Enter grace (interactive) so click is realistic.
+    view.rerender(
+      <ThemeProvider isDark={false}>
+        <HoverTooltip entities={[]} position={{ clientX: 100, clientY: 100 }} canvas={canvas} />
+      </ThemeProvider>,
+    );
+
+    const paper = view.container.querySelector(".MuiPaper-root")!;
+    fireEvent.click(paper);
+
+    // Now provide new entities; content should update even while click-pinned.
+    view.rerender(
+      <ThemeProvider isDark={false}>
+        <HoverTooltip entities={entitiesB} position={{ clientX: 999, clientY: 999 }} canvas={canvas} />
+      </ThemeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(view.getByText("eB")).toBeInTheDocument();
+      expect(view.getByText("vB")).toBeInTheDocument();
+    });
+
+    // Leaving should not hide when click-pinned.
+    fireEvent.mouseLeave(paper);
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(view.container.querySelector(".MuiPaper-root")).not.toBeNull();
+
+    // Outside click dismisses.
+    fireEvent.mouseDown(document.body);
+    await waitFor(() => {
+      expect(view.container.querySelector(".MuiPaper-root")).toBeNull();
+    });
+
+    // Re-open and ensure Escape dismisses.
+    const view2 = renderHoverTooltip({
+      entities: entitiesA,
+      position: { clientX: 100, clientY: 100 },
+      canvas,
+    });
+    view2.rerender(
+      <ThemeProvider isDark={false}>
+        <HoverTooltip entities={[]} position={{ clientX: 100, clientY: 100 }} canvas={canvas} />
+      </ThemeProvider>,
+    );
+    const paper2 = view2.container.querySelector(".MuiPaper-root")!;
+    fireEvent.click(paper2);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(view2.container.querySelector(".MuiPaper-root")).toBeNull();
+    });
+  });
+
+  it("positions the tooltip inside canvas bounds by flipping left/up when near the edge", async () => {
+    const canvas = makeCanvas({ left: 0, top: 0, right: 300, bottom: 300 });
+    const entities: HoverEntityInfo[] = [
+      { topic: "/t", entityId: "e", metadata: [{ key: "k", value: "v" }] },
+    ];
+
+    const view = renderHoverTooltip({
+      entities,
+      position: { clientX: 290, clientY: 290 },
+      canvas,
+    });
+
+    const paper = await waitFor(() => view.container.querySelector<HTMLElement>(".MuiPaper-root")!);
+
+    // With tooltip 200x200 and offset 6, at (290, 290) in 300x300 bounds it must flip left/up:
+    // left = 290 - 200 - 6 = 84, top = 290 - 200 - 6 = 84
+    expect(paper.style.left).toBe("84px");
+    expect(paper.style.top).toBe("84px");
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.test.tsx
@@ -9,23 +9,25 @@ import { act, fireEvent, render, waitFor } from "@testing-library/react";
 
 import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
 
-import { HoverTooltip, HoverEntityInfo } from "./HoverTooltip";
+import type { HoverEntityInfo } from "./types";
+import { HoverTooltip } from "./HoverTooltip";
 
 function makeCanvas(bounds?: Partial<DOMRect>): HTMLCanvasElement {
   const canvas = document.createElement("canvas");
-  canvas.getBoundingClientRect = jest.fn(() =>
-    ({
-      left: 0,
-      top: 0,
-      right: 300,
-      bottom: 300,
-      width: 300,
-      height: 300,
-      x: 0,
-      y: 0,
-      toJSON: () => "",
-      ...bounds,
-    }) as DOMRect,
+  canvas.getBoundingClientRect = jest.fn(
+    () =>
+      ({
+        left: 0,
+        top: 0,
+        right: 300,
+        bottom: 300,
+        width: 300,
+        height: 300,
+        x: 0,
+        y: 0,
+        toJSON: () => "",
+        ...bounds,
+      }) as DOMRect,
   );
   return canvas;
 }
@@ -137,7 +139,11 @@ describe("<HoverTooltip />", () => {
 
     view.rerender(
       <ThemeProvider isDark={false}>
-        <HoverTooltip entities={[]} position={{ clientX: 100, clientY: 100 }} canvas={makeCanvas()} />
+        <HoverTooltip
+          entities={[]}
+          position={{ clientX: 100, clientY: 100 }}
+          canvas={makeCanvas()}
+        />
       </ThemeProvider>,
     );
 
@@ -233,7 +239,11 @@ describe("<HoverTooltip />", () => {
     // Now provide new entities; content should update even while click-pinned.
     view.rerender(
       <ThemeProvider isDark={false}>
-        <HoverTooltip entities={entitiesB} position={{ clientX: 999, clientY: 999 }} canvas={canvas} />
+        <HoverTooltip
+          entities={entitiesB}
+          position={{ clientX: 999, clientY: 999 }}
+          canvas={canvas}
+        />
       </ThemeProvider>,
     );
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
@@ -12,8 +12,8 @@ import {
   HOVER_TOOLTIP_MAX_H,
   HOVER_TOOLTIP_MAX_W,
   HOVER_TOOLTIP_OFFSET_PX,
-  clampTooltipAxis,
 } from "./constants";
+import { clampTooltipAxis } from "./helpers";
 import type { HoverEntityInfo, HoverTooltipProperties, TooltipMode } from "./types";
 
 /**

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
@@ -2,35 +2,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { Divider, Paper, Typography } from "@mui/material";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useStyles } from "./HoverTooltip.style";
 import {
   HOVER_TOOLTIP_DWELL_MS,
   HOVER_TOOLTIP_GRACE_PERIOD_MS,
   HOVER_TOOLTIP_LEAVE_DELAY_MS,
+  HOVER_TOOLTIP_MAX_H,
+  HOVER_TOOLTIP_MAX_W,
   HOVER_TOOLTIP_OFFSET_PX,
+  clampTooltipAxis,
 } from "./constants";
-import type { HoverEntityInfo } from "./types";
-
-/**
- * Tooltip display modes:
- * - `following`  – tooltip follows cursor and updates immediately (fast browsing).
- * - `settled`    – user dwelled 700 ms on one object; tooltip still follows cursor
- *                  but any change to hovered objects triggers a grace delay.
- * - `grace`      – position frozen; waiting for the user to reach the tooltip or
- *                  for the grace timer to expire and apply the pending update.
- * - `hover-pinned` – mouse is on the tooltip; content is frozen.
- * - `click-pinned` – user clicked to pin; fully static until explicit dismiss.
- */
-type TooltipMode = "hidden" | "following" | "settled" | "grace" | "hover-pinned" | "click-pinned";
-
-type Props = {
-  entities: HoverEntityInfo[];
-  position: { clientX: number; clientY: number };
-  /** Canvas element used to constrain tooltip within the 3D panel bounds. */
-  canvas: HTMLCanvasElement | ReactNull;
-};
+import type { HoverEntityInfo, HoverTooltipProperties, TooltipMode } from "./types";
 
 /**
  * Tooltip that follows the mouse cursor and shows metadata for hovered 3D
@@ -39,7 +23,11 @@ type Props = {
  * until the mouse leaves it. Clicking on the tooltip pins it in place until
  * an outside click or the Escape key dismisses it.
  */
-export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.Element | ReactNull {
+export function HoverTooltip({
+  entities,
+  position,
+  canvas,
+}: HoverTooltipProperties): React.JSX.Element | ReactNull {
   const { classes } = useStyles();
   const paperRef = useRef<HTMLDivElement>(ReactNull);
   const graceTimer = useRef<ReturnType<typeof setTimeout>>();
@@ -67,15 +55,17 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
   useEffect(() => {
     const currentMode = modeRef.current;
 
+    // Always keep the entity key up to date, even while pinned. This avoids
+    // stale comparisons after the tooltip is dismissed.
+    const newKey = entities.map((e) => `${e.topic ?? ""}::${e.entityId}`).join("|");
+    const keyChanged = newKey !== lastEntityKey.current;
+    lastEntityKey.current = newKey;
+
     // These modes are fully frozen – the user is actively interacting with the
     // tooltip, so we must not disturb its content or position.
     if (currentMode === "click-pinned" || currentMode === "hover-pinned") {
       return;
     }
-
-    const newKey = entities.map((e) => `${e.topic ?? ""}::${e.entityId}`).join("|");
-    const keyChanged = newKey !== lastEntityKey.current;
-    lastEntityKey.current = newKey;
 
     if (entities.length > 0) {
       if (currentMode === "hidden" || currentMode === "following") {
@@ -85,9 +75,9 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
         if (currentMode === "hidden") {
           setMode("following");
         }
-        // Start (or reset) the dwell timer only when the hovered object changes.
-        // Staying on the same object keeps the timer counting toward "settled".
-        if (keyChanged) {
+        // Start (or reset) the dwell timer when the hovered object changes or
+        // when entering from hidden (to ensure dwell always starts fresh).
+        if (keyChanged || currentMode === "hidden") {
           clearTimeout(dwellTimer.current);
           dwellTimer.current = setTimeout(() => {
             if (modeRef.current === "following") {
@@ -234,46 +224,32 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
   // ---------------------------------------------------------------------------
   // Smart positioning: keep tooltip inside the 3D panel (or viewport)
   // ---------------------------------------------------------------------------
-  useLayoutEffect(() => {
-    const el = paperRef.current;
-    if (!el) {
-      return;
-    }
-    const displayPos = mode === "following" || mode === "settled" ? position : frozenPosition;
-    const tooltipW = el.offsetWidth;
-    const tooltipH = el.offsetHeight;
-
-    // Use canvas bounds when available; fall back to viewport.
-    const bounds = canvas
+  const displayPos = mode === "following" || mode === "settled" ? position : frozenPosition;
+  const bounds =
+    canvas != undefined
       ? canvas.getBoundingClientRect()
       : { left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight };
 
-    const spaceRight = bounds.right - displayPos.clientX;
-    const spaceLeft = displayPos.clientX - bounds.left;
-    const spaceBelow = bounds.bottom - displayPos.clientY;
-    const spaceAbove = displayPos.clientY - bounds.top;
+  // Use measured element size when available so the tooltip stays close to the
+  // cursor. Fall back to the CSS max dimensions only on the very first render.
+  const el = paperRef.current;
+  const tooltipW = el != undefined ? el.offsetWidth : HOVER_TOOLTIP_MAX_W;
+  const tooltipH = el != undefined ? el.offsetHeight : HOVER_TOOLTIP_MAX_H;
 
-    let left: number;
-    if (spaceRight >= tooltipW + HOVER_TOOLTIP_OFFSET_PX) {
-      left = displayPos.clientX + HOVER_TOOLTIP_OFFSET_PX;
-    } else if (spaceLeft >= tooltipW + HOVER_TOOLTIP_OFFSET_PX) {
-      left = displayPos.clientX - tooltipW - HOVER_TOOLTIP_OFFSET_PX;
-    } else {
-      left = Math.max(bounds.left, bounds.right - tooltipW);
-    }
-
-    let top: number;
-    if (spaceBelow >= tooltipH + HOVER_TOOLTIP_OFFSET_PX) {
-      top = displayPos.clientY + HOVER_TOOLTIP_OFFSET_PX;
-    } else if (spaceAbove >= tooltipH + HOVER_TOOLTIP_OFFSET_PX) {
-      top = displayPos.clientY - tooltipH - HOVER_TOOLTIP_OFFSET_PX;
-    } else {
-      top = Math.max(bounds.top, bounds.bottom - tooltipH);
-    }
-
-    el.style.left = `${left}px`;
-    el.style.top = `${top}px`;
-  });
+  const tooltipLeft = clampTooltipAxis(
+    displayPos.clientX,
+    tooltipW,
+    bounds.left,
+    bounds.right,
+    HOVER_TOOLTIP_OFFSET_PX,
+  );
+  const tooltipTop = clampTooltipAxis(
+    displayPos.clientY,
+    tooltipH,
+    bounds.top,
+    bounds.bottom,
+    HOVER_TOOLTIP_OFFSET_PX,
+  );
 
   // Cleanup timers on unmount.
   useEffect(() => {
@@ -296,8 +272,8 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
       className={classes.root}
       elevation={8}
       style={{
-        left: -9999,
-        top: -9999,
+        left: tooltipLeft,
+        top: tooltipTop,
         pointerEvents: interactive ? "auto" : "none",
         cursor: mode === "click-pinned" ? "default" : undefined,
       }}

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
@@ -3,97 +3,14 @@
 
 import { Divider, Paper, Typography } from "@mui/material";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { makeStyles } from "tss-react/mui";
 
-import { customTypography } from "@lichtblick/theme";
-
-/** Grace period (ms) before tooltip hides after entities clear. */
-const GRACE_PERIOD_MS = 400;
-/** Delay (ms) before tooltip hides after mouse leaves the tooltip. */
-const LEAVE_DELAY_MS = 300;
-/** Pixel offset from cursor to tooltip edge. */
-const TOOLTIP_OFFSET = 6;
-
-const useStyles = makeStyles()((theme) => ({
-  root: {
-    position: "fixed",
-    zIndex: theme.zIndex.tooltip,
-    maxWidth: 620,
-    maxHeight: 480,
-    overflow: "auto",
-    padding: theme.spacing(1, 1.5),
-    transition: "opacity 0.15s ease",
-    scrollbarColor: `${theme.palette.action.disabled} ${theme.palette.action.hover}`,
-    "&::-webkit-scrollbar": {
-      width: 16,
-      height: 16,
-    },
-    "&::-webkit-scrollbar-track": {
-      background: theme.palette.action.hover,
-      borderRadius: theme.shape.borderRadius,
-    },
-    "&::-webkit-scrollbar-thumb": {
-      background: theme.palette.action.disabled,
-      borderRadius: theme.shape.borderRadius,
-      border: `2px solid ${theme.palette.background.paper}`,
-      "&:hover": {
-        background: theme.palette.action.active,
-      },
-    },
-  },
-  entitySection: {
-    marginBottom: theme.spacing(0.75),
-    "&:last-child": {
-      marginBottom: 0,
-    },
-  },
-  entityId: {
-    fontWeight: theme.typography.fontWeightMedium,
-    color: theme.palette.info.main,
-    fontSize: "0.75rem",
-  },
-  topicLine: {
-    color: theme.palette.text.secondary,
-    fontSize: "0.7rem",
-    marginBottom: theme.spacing(0.25),
-  },
-  divider: {
-    margin: theme.spacing(0.75, 0),
-  },
-  table: {
-    width: "100%",
-    borderCollapse: "collapse",
-    marginTop: theme.spacing(0.25),
-  },
-  tableRow: {
-    "&:nth-of-type(odd)": {
-      backgroundColor: theme.palette.action.hover,
-    },
-  },
-  keyCell: {
-    color: theme.palette.text.secondary,
-    fontSize: "0.75rem",
-    whiteSpace: "nowrap",
-    paddingRight: theme.spacing(2),
-    paddingTop: 1,
-    paddingBottom: 1,
-    verticalAlign: "top",
-  },
-  valueCell: {
-    fontSize: "0.75rem",
-    fontFamily: customTypography.fontMonospace,
-    textAlign: "right",
-    wordBreak: "break-all",
-    paddingTop: 1,
-    paddingBottom: 1,
-  },
-}));
-
-export type HoverEntityInfo = {
-  topic: string;
-  entityId: string;
-  metadata: { key: string; value: string }[];
-};
+import {
+  HOVER_TOOLTIP_GRACE_PERIOD_MS,
+  HOVER_TOOLTIP_LEAVE_DELAY_MS,
+  HOVER_TOOLTIP_OFFSET_PX,
+} from "./constants";
+import { useStyles } from "./HoverTooltip.style";
+import type { HoverEntityInfo } from "./types";
 
 type TooltipMode = "hidden" | "following" | "grace" | "hover-pinned" | "click-pinned";
 
@@ -147,7 +64,7 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
             setMode("hidden");
             setVisibleEntities([]);
           }
-        }, GRACE_PERIOD_MS);
+        }, HOVER_TOOLTIP_GRACE_PERIOD_MS);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -180,7 +97,7 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
         setMode("hidden");
         setVisibleEntities([]);
       }
-    }, LEAVE_DELAY_MS);
+    }, HOVER_TOOLTIP_LEAVE_DELAY_MS);
   }, []);
 
   const onTooltipClick = useCallback((e: React.MouseEvent) => {
@@ -253,19 +170,19 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
     const spaceAbove = displayPos.clientY - bounds.top;
 
     let left: number;
-    if (spaceRight >= tooltipW + TOOLTIP_OFFSET) {
-      left = displayPos.clientX + TOOLTIP_OFFSET;
-    } else if (spaceLeft >= tooltipW + TOOLTIP_OFFSET) {
-      left = displayPos.clientX - tooltipW - TOOLTIP_OFFSET;
+    if (spaceRight >= tooltipW + HOVER_TOOLTIP_OFFSET_PX) {
+      left = displayPos.clientX + HOVER_TOOLTIP_OFFSET_PX;
+    } else if (spaceLeft >= tooltipW + HOVER_TOOLTIP_OFFSET_PX) {
+      left = displayPos.clientX - tooltipW - HOVER_TOOLTIP_OFFSET_PX;
     } else {
       left = Math.max(bounds.left, bounds.right - tooltipW);
     }
 
     let top: number;
-    if (spaceBelow >= tooltipH + TOOLTIP_OFFSET) {
-      top = displayPos.clientY + TOOLTIP_OFFSET;
-    } else if (spaceAbove >= tooltipH + TOOLTIP_OFFSET) {
-      top = displayPos.clientY - tooltipH - TOOLTIP_OFFSET;
+    if (spaceBelow >= tooltipH + HOVER_TOOLTIP_OFFSET_PX) {
+      top = displayPos.clientY + HOVER_TOOLTIP_OFFSET_PX;
+    } else if (spaceAbove >= tooltipH + HOVER_TOOLTIP_OFFSET_PX) {
+      top = displayPos.clientY - tooltipH - HOVER_TOOLTIP_OFFSET_PX;
     } else {
       top = Math.max(bounds.top, bounds.bottom - tooltipH);
     }

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
@@ -4,12 +4,12 @@
 import { Divider, Paper, Typography } from "@mui/material";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
+import { useStyles } from "./HoverTooltip.style";
 import {
   HOVER_TOOLTIP_GRACE_PERIOD_MS,
   HOVER_TOOLTIP_LEAVE_DELAY_MS,
   HOVER_TOOLTIP_OFFSET_PX,
 } from "./constants";
-import { useStyles } from "./HoverTooltip.style";
 import type { HoverEntityInfo } from "./types";
 
 type TooltipMode = "hidden" | "following" | "grace" | "hover-pinned" | "click-pinned";
@@ -30,7 +30,7 @@ type Props = {
  */
 export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.Element | ReactNull {
   const { classes } = useStyles();
-  const paperRef = useRef<HTMLDivElement>(null);
+  const paperRef = useRef<HTMLDivElement>(ReactNull);
   const graceTimer = useRef<ReturnType<typeof setTimeout>>();
   const leaveTimer = useRef<ReturnType<typeof setTimeout>>();
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
@@ -6,13 +6,24 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 
 import { useStyles } from "./HoverTooltip.style";
 import {
+  HOVER_TOOLTIP_DWELL_MS,
   HOVER_TOOLTIP_GRACE_PERIOD_MS,
   HOVER_TOOLTIP_LEAVE_DELAY_MS,
   HOVER_TOOLTIP_OFFSET_PX,
 } from "./constants";
 import type { HoverEntityInfo } from "./types";
 
-type TooltipMode = "hidden" | "following" | "grace" | "hover-pinned" | "click-pinned";
+/**
+ * Tooltip display modes:
+ * - `following`  – tooltip follows cursor and updates immediately (fast browsing).
+ * - `settled`    – user dwelled 700 ms on one object; tooltip still follows cursor
+ *                  but any change to hovered objects triggers a grace delay.
+ * - `grace`      – position frozen; waiting for the user to reach the tooltip or
+ *                  for the grace timer to expire and apply the pending update.
+ * - `hover-pinned` – mouse is on the tooltip; content is frozen.
+ * - `click-pinned` – user clicked to pin; fully static until explicit dismiss.
+ */
+type TooltipMode = "hidden" | "following" | "settled" | "grace" | "hover-pinned" | "click-pinned";
 
 type Props = {
   entities: HoverEntityInfo[];
@@ -32,7 +43,15 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
   const { classes } = useStyles();
   const paperRef = useRef<HTMLDivElement>(ReactNull);
   const graceTimer = useRef<ReturnType<typeof setTimeout>>();
+  const dwellTimer = useRef<ReturnType<typeof setTimeout>>();
   const leaveTimer = useRef<ReturnType<typeof setTimeout>>();
+  /** Entities queued during a grace period; applied when the timer expires. */
+  const pendingEntities = useRef<HoverEntityInfo[]>([]);
+  /**
+   * Stable key for the currently displayed set of entities. Used to detect
+   * when the hovered object actually changes vs. the same pick being re-sent.
+   */
+  const lastEntityKey = useRef<string>("");
 
   const [mode, setMode] = useState<TooltipMode>("hidden");
   const [visibleEntities, setVisibleEntities] = useState<HoverEntityInfo[]>([]);
@@ -46,33 +65,96 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
   // React to incoming entity / position changes from the 3D scene
   // ---------------------------------------------------------------------------
   useEffect(() => {
+    const currentMode = modeRef.current;
+
+    // These modes are fully frozen – the user is actively interacting with the
+    // tooltip, so we must not disturb its content or position.
+    if (currentMode === "click-pinned" || currentMode === "hover-pinned") {
+      return;
+    }
+
+    const newKey = entities.map((e) => `${e.topic ?? ""}::${e.entityId}`).join("|");
+    const keyChanged = newKey !== lastEntityKey.current;
+    lastEntityKey.current = newKey;
+
     if (entities.length > 0) {
-      setVisibleEntities(entities);
-      clearTimeout(graceTimer.current);
-      if (modeRef.current === "hidden" || modeRef.current === "grace") {
-        setMode("following");
+      if (currentMode === "hidden" || currentMode === "following") {
+        // Fast mode: update content immediately as the user browses.
+        setVisibleEntities(entities);
+        clearTimeout(graceTimer.current);
+        if (currentMode === "hidden") {
+          setMode("following");
+        }
+        // Start (or reset) the dwell timer only when the hovered object changes.
+        // Staying on the same object keeps the timer counting toward "settled".
+        if (keyChanged) {
+          clearTimeout(dwellTimer.current);
+          dwellTimer.current = setTimeout(() => {
+            if (modeRef.current === "following") {
+              setMode("settled");
+            }
+          }, HOVER_TOOLTIP_DWELL_MS);
+        }
+      } else if (currentMode === "settled") {
+        if (!keyChanged) {
+          return; // Still on the same object – stay settled.
+        }
+        // The user moved to a different object while settled.
+        // Freeze the tooltip and give them time to reach it before updating.
+        setFrozenPosition(position); // eslint-disable-line react-hooks/exhaustive-deps
+        pendingEntities.current = entities;
+        clearTimeout(dwellTimer.current);
+        clearTimeout(graceTimer.current);
+        setMode("grace");
+        graceTimer.current = setTimeout(() => {
+          if (modeRef.current !== "grace") {
+            return;
+          }
+          const pending = pendingEntities.current;
+          if (pending.length > 0) {
+            setVisibleEntities(pending);
+            setMode("following");
+            // Start dwell timer for the newly visible object.
+            dwellTimer.current = setTimeout(() => {
+              if (modeRef.current === "following") {
+                setMode("settled");
+              }
+            }, HOVER_TOOLTIP_DWELL_MS);
+          } else {
+            setMode("hidden");
+            setVisibleEntities([]);
+          }
+        }, HOVER_TOOLTIP_GRACE_PERIOD_MS);
+      } else if (currentMode === "grace") {
+        // Queue the latest entities to be shown when the grace period ends.
+        pendingEntities.current = entities;
       }
     } else {
-      // Entities became empty.
-      if (modeRef.current === "following") {
-        // Freeze position and give the user time to reach the tooltip.
-        setFrozenPosition(position);
-        setMode("grace");
+      // Entities cleared.
+      if (currentMode === "following" || currentMode === "settled") {
+        clearTimeout(dwellTimer.current);
         clearTimeout(graceTimer.current);
+        setFrozenPosition(position); // eslint-disable-line react-hooks/exhaustive-deps
+        pendingEntities.current = [];
+        setMode("grace");
         graceTimer.current = setTimeout(() => {
           if (modeRef.current === "grace") {
             setMode("hidden");
             setVisibleEntities([]);
           }
         }, HOVER_TOOLTIP_GRACE_PERIOD_MS);
+      } else if (currentMode === "grace") {
+        // Already in grace – just clear pending so the timer hides the tooltip.
+        pendingEntities.current = [];
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entities]);
 
-  // Track position while following so it's available when transitioning.
+  // Track position while following/settled so the frozen position is current
+  // when we transition into grace.
   useEffect(() => {
-    if (mode === "following") {
+    if (mode === "following" || mode === "settled") {
       setFrozenPosition(position);
     }
   }, [position, mode]);
@@ -82,8 +164,10 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
   // ---------------------------------------------------------------------------
   const onMouseEnter = useCallback(() => {
     clearTimeout(graceTimer.current);
+    clearTimeout(dwellTimer.current);
     clearTimeout(leaveTimer.current);
-    if (modeRef.current === "grace" || modeRef.current === "following") {
+    const m = modeRef.current;
+    if (m === "grace" || m === "following" || m === "settled") {
       setMode("hover-pinned");
     }
   }, []);
@@ -155,7 +239,7 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
     if (!el) {
       return;
     }
-    const displayPos = mode === "following" ? position : frozenPosition;
+    const displayPos = mode === "following" || mode === "settled" ? position : frozenPosition;
     const tooltipW = el.offsetWidth;
     const tooltipH = el.offsetHeight;
 
@@ -195,6 +279,7 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
   useEffect(() => {
     return () => {
       clearTimeout(graceTimer.current);
+      clearTimeout(dwellTimer.current);
       clearTimeout(leaveTimer.current);
     };
   }, []);
@@ -226,9 +311,11 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
           <Typography variant="caption" className={classes.entityId}>
             {entity.entityId}
           </Typography>
-          <Typography variant="caption" className={classes.topicLine}>
-            {entity.topic}
-          </Typography>
+          {entity.topic != undefined && (
+            <Typography variant="caption" className={classes.topicLine}>
+              {entity.topic}
+            </Typography>
+          )}
           <table className={classes.table}>
             <tbody>
               {entity.metadata.map((kv, rowIdx) => (
@@ -241,6 +328,11 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
           </table>
         </div>
       ))}
+      {interactive && mode !== "click-pinned" && (
+        <Typography variant="caption" className={classes.pinHint}>
+          Click to pin
+        </Typography>
+      )}
     </Paper>
   );
 }

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
@@ -1,0 +1,329 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { Divider, Paper, Typography } from "@mui/material";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { makeStyles } from "tss-react/mui";
+
+import { customTypography } from "@lichtblick/theme";
+
+/** Grace period (ms) before tooltip hides after entities clear. */
+const GRACE_PERIOD_MS = 400;
+/** Delay (ms) before tooltip hides after mouse leaves the tooltip. */
+const LEAVE_DELAY_MS = 300;
+/** Pixel offset from cursor to tooltip edge. */
+const TOOLTIP_OFFSET = 6;
+
+const useStyles = makeStyles()((theme) => ({
+  root: {
+    position: "fixed",
+    zIndex: theme.zIndex.tooltip,
+    maxWidth: 620,
+    maxHeight: 480,
+    overflow: "auto",
+    padding: theme.spacing(1, 1.5),
+    transition: "opacity 0.15s ease",
+    scrollbarColor: `${theme.palette.action.disabled} ${theme.palette.action.hover}`,
+    "&::-webkit-scrollbar": {
+      width: 16,
+      height: 16,
+    },
+    "&::-webkit-scrollbar-track": {
+      background: theme.palette.action.hover,
+      borderRadius: theme.shape.borderRadius,
+    },
+    "&::-webkit-scrollbar-thumb": {
+      background: theme.palette.action.disabled,
+      borderRadius: theme.shape.borderRadius,
+      border: `2px solid ${theme.palette.background.paper}`,
+      "&:hover": {
+        background: theme.palette.action.active,
+      },
+    },
+  },
+  entitySection: {
+    marginBottom: theme.spacing(0.75),
+    "&:last-child": {
+      marginBottom: 0,
+    },
+  },
+  entityId: {
+    fontWeight: theme.typography.fontWeightMedium,
+    color: theme.palette.info.main,
+    fontSize: "0.75rem",
+  },
+  topicLine: {
+    color: theme.palette.text.secondary,
+    fontSize: "0.7rem",
+    marginBottom: theme.spacing(0.25),
+  },
+  divider: {
+    margin: theme.spacing(0.75, 0),
+  },
+  table: {
+    width: "100%",
+    borderCollapse: "collapse",
+    marginTop: theme.spacing(0.25),
+  },
+  tableRow: {
+    "&:nth-of-type(odd)": {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+  keyCell: {
+    color: theme.palette.text.secondary,
+    fontSize: "0.75rem",
+    whiteSpace: "nowrap",
+    paddingRight: theme.spacing(2),
+    paddingTop: 1,
+    paddingBottom: 1,
+    verticalAlign: "top",
+  },
+  valueCell: {
+    fontSize: "0.75rem",
+    fontFamily: customTypography.fontMonospace,
+    textAlign: "right",
+    wordBreak: "break-all",
+    paddingTop: 1,
+    paddingBottom: 1,
+  },
+}));
+
+export type HoverEntityInfo = {
+  topic: string;
+  entityId: string;
+  metadata: { key: string; value: string }[];
+};
+
+type TooltipMode = "hidden" | "following" | "grace" | "hover-pinned" | "click-pinned";
+
+type Props = {
+  entities: HoverEntityInfo[];
+  position: { clientX: number; clientY: number };
+  /** Canvas element used to constrain tooltip within the 3D panel bounds. */
+  canvas: HTMLCanvasElement | ReactNull;
+};
+
+/**
+ * Tooltip that follows the mouse cursor and shows metadata for hovered 3D
+ * objects. When the user moves the mouse onto the tooltip itself (e.g. to
+ * scroll long content), the tooltip becomes interactive and stays visible
+ * until the mouse leaves it. Clicking on the tooltip pins it in place until
+ * an outside click or the Escape key dismisses it.
+ */
+export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.Element | ReactNull {
+  const { classes } = useStyles();
+  const paperRef = useRef<HTMLDivElement>(null);
+  const graceTimer = useRef<ReturnType<typeof setTimeout>>();
+  const leaveTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  const [mode, setMode] = useState<TooltipMode>("hidden");
+  const [visibleEntities, setVisibleEntities] = useState<HoverEntityInfo[]>([]);
+  const [frozenPosition, setFrozenPosition] = useState(position);
+
+  // Keep a ref to the current mode so timers always read the latest value.
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
+
+  // ---------------------------------------------------------------------------
+  // React to incoming entity / position changes from the 3D scene
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (entities.length > 0) {
+      setVisibleEntities(entities);
+      clearTimeout(graceTimer.current);
+      if (modeRef.current === "hidden" || modeRef.current === "grace") {
+        setMode("following");
+      }
+    } else {
+      // Entities became empty.
+      if (modeRef.current === "following") {
+        // Freeze position and give the user time to reach the tooltip.
+        setFrozenPosition(position);
+        setMode("grace");
+        clearTimeout(graceTimer.current);
+        graceTimer.current = setTimeout(() => {
+          if (modeRef.current === "grace") {
+            setMode("hidden");
+            setVisibleEntities([]);
+          }
+        }, GRACE_PERIOD_MS);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entities]);
+
+  // Track position while following so it's available when transitioning.
+  useEffect(() => {
+    if (mode === "following") {
+      setFrozenPosition(position);
+    }
+  }, [position, mode]);
+
+  // ---------------------------------------------------------------------------
+  // Mouse interaction on the tooltip paper
+  // ---------------------------------------------------------------------------
+  const onMouseEnter = useCallback(() => {
+    clearTimeout(graceTimer.current);
+    clearTimeout(leaveTimer.current);
+    if (modeRef.current === "grace" || modeRef.current === "following") {
+      setMode("hover-pinned");
+    }
+  }, []);
+
+  const onMouseLeave = useCallback(() => {
+    if (modeRef.current === "click-pinned") {
+      return; // click-pinned stays until explicit dismiss
+    }
+    leaveTimer.current = setTimeout(() => {
+      if (modeRef.current === "hover-pinned") {
+        setMode("hidden");
+        setVisibleEntities([]);
+      }
+    }, LEAVE_DELAY_MS);
+  }, []);
+
+  const onTooltipClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (modeRef.current !== "click-pinned") {
+      setMode("click-pinned");
+    }
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Click outside to dismiss click-pinned tooltip
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (mode !== "click-pinned") {
+      return undefined;
+    }
+    const handler = (e: MouseEvent) => {
+      if (paperRef.current && !paperRef.current.contains(e.target as Node)) {
+        setMode("hidden");
+        setVisibleEntities([]);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => {
+      document.removeEventListener("mousedown", handler);
+    };
+  }, [mode]);
+
+  // ---------------------------------------------------------------------------
+  // Escape key dismisses the tooltip in any active mode
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (mode === "hidden") {
+      return undefined;
+    }
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        clearTimeout(graceTimer.current);
+        clearTimeout(leaveTimer.current);
+        setMode("hidden");
+        setVisibleEntities([]);
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => {
+      document.removeEventListener("keydown", handler);
+    };
+  }, [mode]);
+
+  // ---------------------------------------------------------------------------
+  // Smart positioning: keep tooltip inside the 3D panel (or viewport)
+  // ---------------------------------------------------------------------------
+  useLayoutEffect(() => {
+    const el = paperRef.current;
+    if (!el) {
+      return;
+    }
+    const displayPos = mode === "following" ? position : frozenPosition;
+    const tooltipW = el.offsetWidth;
+    const tooltipH = el.offsetHeight;
+
+    // Use canvas bounds when available; fall back to viewport.
+    const bounds = canvas
+      ? canvas.getBoundingClientRect()
+      : { left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight };
+
+    const spaceRight = bounds.right - displayPos.clientX;
+    const spaceLeft = displayPos.clientX - bounds.left;
+    const spaceBelow = bounds.bottom - displayPos.clientY;
+    const spaceAbove = displayPos.clientY - bounds.top;
+
+    let left: number;
+    if (spaceRight >= tooltipW + TOOLTIP_OFFSET) {
+      left = displayPos.clientX + TOOLTIP_OFFSET;
+    } else if (spaceLeft >= tooltipW + TOOLTIP_OFFSET) {
+      left = displayPos.clientX - tooltipW - TOOLTIP_OFFSET;
+    } else {
+      left = Math.max(bounds.left, bounds.right - tooltipW);
+    }
+
+    let top: number;
+    if (spaceBelow >= tooltipH + TOOLTIP_OFFSET) {
+      top = displayPos.clientY + TOOLTIP_OFFSET;
+    } else if (spaceAbove >= tooltipH + TOOLTIP_OFFSET) {
+      top = displayPos.clientY - tooltipH - TOOLTIP_OFFSET;
+    } else {
+      top = Math.max(bounds.top, bounds.bottom - tooltipH);
+    }
+
+    el.style.left = `${left}px`;
+    el.style.top = `${top}px`;
+  });
+
+  // Cleanup timers on unmount.
+  useEffect(() => {
+    return () => {
+      clearTimeout(graceTimer.current);
+      clearTimeout(leaveTimer.current);
+    };
+  }, []);
+
+  if (mode === "hidden" || visibleEntities.length === 0) {
+    return ReactNull;
+  }
+
+  const interactive = mode !== "following";
+
+  return (
+    <Paper
+      ref={paperRef}
+      className={classes.root}
+      elevation={8}
+      style={{
+        left: -9999,
+        top: -9999,
+        pointerEvents: interactive ? "auto" : "none",
+        cursor: mode === "click-pinned" ? "default" : undefined,
+      }}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={onTooltipClick}
+    >
+      {visibleEntities.map((entity, idx) => (
+        <div key={`${entity.topic}::${entity.entityId}::${idx}`} className={classes.entitySection}>
+          {idx > 0 && <Divider className={classes.divider} />}
+          <Typography variant="caption" className={classes.entityId}>
+            {entity.entityId}
+          </Typography>
+          <Typography variant="caption" className={classes.topicLine}>
+            {entity.topic}
+          </Typography>
+          <table className={classes.table}>
+            <tbody>
+              {entity.metadata.map((kv, rowIdx) => (
+                <tr key={`${entity.entityId}::${kv.key}::${rowIdx}`} className={classes.tableRow}>
+                  <td className={classes.keyCell}>{kv.key}</td>
+                  <td className={classes.valueCell}>{kv.value}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </Paper>
+  );
+}

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/HoverTooltip.tsx
@@ -101,7 +101,7 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
         }
         // The user moved to a different object while settled.
         // Freeze the tooltip and give them time to reach it before updating.
-        setFrozenPosition(position); // eslint-disable-line react-hooks/exhaustive-deps
+        setFrozenPosition(position);
         pendingEntities.current = entities;
         clearTimeout(dwellTimer.current);
         clearTimeout(graceTimer.current);
@@ -125,7 +125,7 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
             setVisibleEntities([]);
           }
         }, HOVER_TOOLTIP_GRACE_PERIOD_MS);
-      } else if (currentMode === "grace") {
+      } else {
         // Queue the latest entities to be shown when the grace period ends.
         pendingEntities.current = entities;
       }
@@ -134,7 +134,7 @@ export function HoverTooltip({ entities, position, canvas }: Props): React.JSX.E
       if (currentMode === "following" || currentMode === "settled") {
         clearTimeout(dwellTimer.current);
         clearTimeout(graceTimer.current);
-        setFrozenPosition(position); // eslint-disable-line react-hooks/exhaustive-deps
+        setFrozenPosition(position);
         pendingEntities.current = [];
         setMode("grace");
         graceTimer.current = setTimeout(() => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/constants.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/constants.ts
@@ -28,24 +28,3 @@ export const HOVER_TOOLTIP_MAX_W = 620;
 
 /** Maximum tooltip height (px) – used for positioning calculations. Must match CSS maxHeight. */
 export const HOVER_TOOLTIP_MAX_H = 480;
-
-/**
- * Clamp a tooltip along a single axis so it stays inside the given bounds.
- * Prefers placing it after the cursor; flips before if there isn't space;
- * falls back to the nearest edge otherwise.
- */
-export function clampTooltipAxis(
-  cursor: number,
-  size: number,
-  boundsStart: number,
-  boundsEnd: number,
-  offset: number,
-): number {
-  if (boundsEnd - cursor >= size + offset) {
-    return cursor + offset;
-  }
-  if (cursor - boundsStart >= size + offset) {
-    return cursor - size - offset;
-  }
-  return Math.max(boundsStart, boundsEnd - size);
-}

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/constants.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/constants.ts
@@ -22,3 +22,30 @@ export const HOVER_TOOLTIP_LEAVE_DELAY_MS = 300;
 
 /** Pixel offset from cursor to tooltip edge. */
 export const HOVER_TOOLTIP_OFFSET_PX = 6;
+
+/** Maximum tooltip width (px) – used for positioning calculations. Must match CSS maxWidth. */
+export const HOVER_TOOLTIP_MAX_W = 620;
+
+/** Maximum tooltip height (px) – used for positioning calculations. Must match CSS maxHeight. */
+export const HOVER_TOOLTIP_MAX_H = 480;
+
+/**
+ * Clamp a tooltip along a single axis so it stays inside the given bounds.
+ * Prefers placing it after the cursor; flips before if there isn't space;
+ * falls back to the nearest edge otherwise.
+ */
+export function clampTooltipAxis(
+  cursor: number,
+  size: number,
+  boundsStart: number,
+  boundsEnd: number,
+  offset: number,
+): number {
+  if (boundsEnd - cursor >= size + offset) {
+    return cursor + offset;
+  }
+  if (cursor - boundsStart >= size + offset) {
+    return cursor - size - offset;
+  }
+  return Math.max(boundsStart, boundsEnd - size);
+}

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/constants.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/constants.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+/** Grace period (ms) before tooltip hides after entities clear. */
+export const HOVER_TOOLTIP_GRACE_PERIOD_MS = 400;
+
+/** Delay (ms) before tooltip hides after mouse leaves the tooltip. */
+export const HOVER_TOOLTIP_LEAVE_DELAY_MS = 300;
+
+/** Pixel offset from cursor to tooltip edge. */
+export const HOVER_TOOLTIP_OFFSET_PX = 6;

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/constants.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/constants.ts
@@ -1,8 +1,21 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-/** Grace period (ms) before tooltip hides after entities clear. */
-export const HOVER_TOOLTIP_GRACE_PERIOD_MS = 400;
+/**
+ * Time (ms) the user must dwell on a single object before the tooltip
+ * "settles". Once settled, moving to a new object delays the update by
+ * HOVER_TOOLTIP_GRACE_PERIOD_MS, giving the user time to reach the tooltip.
+ */
+export const HOVER_TOOLTIP_DWELL_MS = 700;
+
+/**
+ * Grace period (ms) used in two situations:
+ *  1. After the cursor leaves a settled object – delays updating to the next
+ *     object so the user can move onto the tooltip and pin it.
+ *  2. After entities clear completely – keeps the tooltip visible so the user
+ *     has time to reach it.
+ */
+export const HOVER_TOOLTIP_GRACE_PERIOD_MS = 350;
 
 /** Delay (ms) before tooltip hides after mouse leaves the tooltip. */
 export const HOVER_TOOLTIP_LEAVE_DELAY_MS = 300;

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/helpers.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/helpers.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * Clamp a tooltip along a single axis so it stays inside the given bounds.
+ * Prefers placing it after the cursor; flips before if there isn't space;
+ * falls back to the nearest edge otherwise.
+ */
+export function clampTooltipAxis(
+  cursor: number,
+  size: number,
+  boundsStart: number,
+  boundsEnd: number,
+  offset: number,
+): number {
+  if (boundsEnd - cursor >= size + offset) {
+    return cursor + offset;
+  }
+  if (cursor - boundsStart >= size + offset) {
+    return cursor - size - offset;
+  }
+  return Math.max(boundsStart, boundsEnd - size);
+}

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/types.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/types.ts
@@ -31,3 +31,28 @@ export type HoverEntityInfo = {
   entityId: string;
   metadata: { key: string; value: string }[];
 };
+
+/**
+ * Tooltip display modes:
+ * - `following`  – tooltip follows cursor and updates immediately (fast browsing).
+ * - `settled`    – user dwelled 700 ms on one object; tooltip still follows cursor
+ *                  but any change to hovered objects triggers a grace delay.
+ * - `grace`      – position frozen; waiting for the user to reach the tooltip or
+ *                  for the grace timer to expire and apply the pending update.
+ * - `hover-pinned` – mouse is on the tooltip; content is frozen.
+ * - `click-pinned` – user clicked to pin; fully static until explicit dismiss.
+ */
+export type TooltipMode =
+  | "hidden"
+  | "following"
+  | "settled"
+  | "grace"
+  | "hover-pinned"
+  | "click-pinned";
+
+export type HoverTooltipProperties = {
+  entities: HoverEntityInfo[];
+  position: { clientX: number; clientY: number };
+  /** Canvas element used to constrain tooltip within the 3D panel bounds. */
+  canvas: HTMLCanvasElement | ReactNull;
+};

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/types.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/types.ts
@@ -25,3 +25,9 @@ export type InteractionData = {
 };
 export type Interactive<T> = T & { interactionData: InteractionData };
 export type SelectedObject = { object: Marker; instanceIndex?: number };
+
+export type HoverEntityInfo = {
+  topic: string;
+  entityId: string;
+  metadata: { key: string; value: string }[];
+};

--- a/packages/suite-base/src/panels/ThreeDeeRender/Interactions/types.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Interactions/types.ts
@@ -27,7 +27,7 @@ export type Interactive<T> = T & { interactionData: InteractionData };
 export type SelectedObject = { object: Marker; instanceIndex?: number };
 
 export type HoverEntityInfo = {
-  topic: string;
+  topic?: string;
   entityId: string;
   metadata: { key: string; value: string }[];
 };

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -15,6 +15,7 @@ import { Asset, DraggedMessagePath } from "@lichtblick/suite-base/components/Pan
 import { Renderer } from "@lichtblick/suite-base/panels/ThreeDeeRender/Renderer";
 import { DEFAULT_SCENE_EXTENSION_CONFIG } from "@lichtblick/suite-base/panels/ThreeDeeRender/SceneExtensionConfig";
 import { DEFAULT_CAMERA_STATE } from "@lichtblick/suite-base/panels/ThreeDeeRender/camera";
+import { HOVER_PICK_THROTTLE_MS } from "@lichtblick/suite-base/panels/ThreeDeeRender/constants";
 import { CameraStateSettings } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/CameraStateSettings";
 import { DEFAULT_PUBLISH_SETTINGS } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/PublishSettings";
 import { TFMessage } from "@lichtblick/suite-base/panels/ThreeDeeRender/ros";
@@ -280,14 +281,18 @@ describe("3D Renderer", () => {
       );
     }
 
-    it("emits renderableHovered at most once per 100ms while moving the mouse", () => {
+    function createHoverRenderer(): { renderer: Renderer; hoverCanvas: HTMLCanvasElement } {
       const hoverParent = document.createElement("div");
       const hoverCanvas = document.createElement("canvas");
       hoverParent.appendChild(hoverCanvas);
       prepareDomForInput(hoverCanvas, hoverParent);
-
       const renderer = new Renderer({ ...defaultRendererProps, canvas: hoverCanvas });
       renderer.setPickingEnabled(true);
+      return { renderer, hoverCanvas };
+    }
+
+    it("emits renderableHovered at most once per HOVER_PICK_THROTTLE_MS while moving the mouse", () => {
+      const { renderer, hoverCanvas } = createHoverRenderer();
 
       const hoveredSpy = jest.fn();
       renderer.addListener("renderableHovered", hoveredSpy);
@@ -298,7 +303,7 @@ describe("3D Renderer", () => {
 
       expect(hoveredSpy).toHaveBeenCalledTimes(1);
 
-      jest.advanceTimersByTime(100);
+      jest.advanceTimersByTime(HOVER_PICK_THROTTLE_MS);
       hoverCanvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 13, clientY: 13 }));
       expect(hoveredSpy).toHaveBeenCalledTimes(2);
 
@@ -306,13 +311,7 @@ describe("3D Renderer", () => {
     });
 
     it("does not hover-pick while mouse is down, then resumes after mouseup", () => {
-      const hoverParent = document.createElement("div");
-      const hoverCanvas = document.createElement("canvas");
-      hoverParent.appendChild(hoverCanvas);
-      prepareDomForInput(hoverCanvas, hoverParent);
-
-      const renderer = new Renderer({ ...defaultRendererProps, canvas: hoverCanvas });
-      renderer.setPickingEnabled(true);
+      const { renderer, hoverCanvas } = createHoverRenderer();
 
       const hoveredSpy = jest.fn();
       renderer.addListener("renderableHovered", hoveredSpy);
@@ -341,7 +340,7 @@ describe("3D Renderer", () => {
       renderer.addListener("renderableHovered", hoveredSpy);
 
       hoverCanvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 10, clientY: 10 }));
-      jest.advanceTimersByTime(200);
+      jest.advanceTimersByTime(HOVER_PICK_THROTTLE_MS * 2);
       hoverCanvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 11, clientY: 11 }));
 
       expect(hoveredSpy).toHaveBeenCalledTimes(0);

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -23,6 +23,20 @@ import { BasicBuilder } from "@lichtblick/test-builders";
 
 import { RendererConfig } from "./IRenderer";
 
+jest.mock("./Picker", () => {
+  const actual = jest.requireActual("./Picker");
+  return {
+    ...actual,
+    Picker: jest.fn().mockImplementation(() => {
+      return {
+        pick: jest.fn(() => -1),
+        pickInstance: jest.fn(() => -1),
+        dispose: jest.fn(),
+      };
+    }),
+  };
+});
+
 // Jest doesn't support ES module imports fully yet, so we need to mock the wasm file
 jest.mock("three/examples/jsm/libs/draco/draco_decoder.wasm", () => "");
 
@@ -235,6 +249,105 @@ describe("3D Renderer", () => {
     }).not.toThrow();
 
     renderer.dispose();
+  });
+
+  describe("hover picking", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    function prepareDomForInput(canvas: HTMLCanvasElement, parent: HTMLDivElement) {
+      // Input relies on clientWidth/clientHeight of the canvas parent.
+      Object.defineProperty(parent, "clientWidth", { configurable: true, value: 300 });
+      Object.defineProperty(parent, "clientHeight", { configurable: true, value: 300 });
+      canvas.getBoundingClientRect = jest.fn(
+        () =>
+          ({
+            left: 0,
+            top: 0,
+            right: 300,
+            bottom: 300,
+            width: 300,
+            height: 300,
+            x: 0,
+            y: 0,
+            toJSON: () => "",
+          }) as DOMRect,
+      );
+    }
+
+    it("emits renderableHovered at most once per 100ms while moving the mouse", () => {
+      const parent = document.createElement("div");
+      const canvas = document.createElement("canvas");
+      parent.appendChild(canvas);
+      prepareDomForInput(canvas, parent);
+
+      const renderer = new Renderer({ ...defaultRendererProps, canvas });
+      renderer.setPickingEnabled(true);
+
+      const hoveredSpy = jest.fn();
+      renderer.addListener("renderableHovered", hoveredSpy);
+
+      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 10, clientY: 10 }));
+      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 11, clientY: 11 }));
+      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 12, clientY: 12 }));
+
+      expect(hoveredSpy).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(100);
+      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 13, clientY: 13 }));
+      expect(hoveredSpy).toHaveBeenCalledTimes(2);
+
+      renderer.dispose();
+    });
+
+    it("does not hover-pick while mouse is down, then resumes after mouseup", () => {
+      const parent = document.createElement("div");
+      const canvas = document.createElement("canvas");
+      parent.appendChild(canvas);
+      prepareDomForInput(canvas, parent);
+
+      const renderer = new Renderer({ ...defaultRendererProps, canvas });
+      renderer.setPickingEnabled(true);
+
+      const hoveredSpy = jest.fn();
+      renderer.addListener("renderableHovered", hoveredSpy);
+
+      canvas.dispatchEvent(new MouseEvent("mousedown", { clientX: 10, clientY: 10 }));
+      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 11, clientY: 11 }));
+      expect(hoveredSpy).toHaveBeenCalledTimes(0);
+
+      canvas.dispatchEvent(new MouseEvent("mouseup", { clientX: 11, clientY: 11 }));
+      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 12, clientY: 12 }));
+      expect(hoveredSpy).toHaveBeenCalledTimes(1);
+
+      renderer.dispose();
+    });
+
+    it("does not emit renderableHovered when picking is disabled", () => {
+      const parent = document.createElement("div");
+      const canvas = document.createElement("canvas");
+      parent.appendChild(canvas);
+      prepareDomForInput(canvas, parent);
+
+      const renderer = new Renderer({ ...defaultRendererProps, canvas });
+      renderer.setPickingEnabled(false);
+
+      const hoveredSpy = jest.fn();
+      renderer.addListener("renderableHovered", hoveredSpy);
+
+      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 10, clientY: 10 }));
+      jest.advanceTimersByTime(200);
+      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 11, clientY: 11 }));
+
+      expect(hoveredSpy).toHaveBeenCalledTimes(0);
+
+      renderer.dispose();
+    });
   });
 
   it("updates color scheme to dark", () => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -260,11 +260,11 @@ describe("3D Renderer", () => {
       jest.useRealTimers();
     });
 
-    function prepareDomForInput(canvas: HTMLCanvasElement, parent: HTMLDivElement) {
+    function prepareDomForInput(inputCanvas: HTMLCanvasElement, inputParent: HTMLDivElement) {
       // Input relies on clientWidth/clientHeight of the canvas parent.
-      Object.defineProperty(parent, "clientWidth", { configurable: true, value: 300 });
-      Object.defineProperty(parent, "clientHeight", { configurable: true, value: 300 });
-      canvas.getBoundingClientRect = jest.fn(
+      Object.defineProperty(inputParent, "clientWidth", { configurable: true, value: 300 });
+      Object.defineProperty(inputParent, "clientHeight", { configurable: true, value: 300 });
+      inputCanvas.getBoundingClientRect = jest.fn(
         () =>
           ({
             left: 0,
@@ -281,68 +281,68 @@ describe("3D Renderer", () => {
     }
 
     it("emits renderableHovered at most once per 100ms while moving the mouse", () => {
-      const parent = document.createElement("div");
-      const canvas = document.createElement("canvas");
-      parent.appendChild(canvas);
-      prepareDomForInput(canvas, parent);
+      const hoverParent = document.createElement("div");
+      const hoverCanvas = document.createElement("canvas");
+      hoverParent.appendChild(hoverCanvas);
+      prepareDomForInput(hoverCanvas, hoverParent);
 
-      const renderer = new Renderer({ ...defaultRendererProps, canvas });
+      const renderer = new Renderer({ ...defaultRendererProps, canvas: hoverCanvas });
       renderer.setPickingEnabled(true);
 
       const hoveredSpy = jest.fn();
       renderer.addListener("renderableHovered", hoveredSpy);
 
-      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 10, clientY: 10 }));
-      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 11, clientY: 11 }));
-      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 12, clientY: 12 }));
+      hoverCanvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 10, clientY: 10 }));
+      hoverCanvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 11, clientY: 11 }));
+      hoverCanvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 12, clientY: 12 }));
 
       expect(hoveredSpy).toHaveBeenCalledTimes(1);
 
       jest.advanceTimersByTime(100);
-      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 13, clientY: 13 }));
+      hoverCanvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 13, clientY: 13 }));
       expect(hoveredSpy).toHaveBeenCalledTimes(2);
 
       renderer.dispose();
     });
 
     it("does not hover-pick while mouse is down, then resumes after mouseup", () => {
-      const parent = document.createElement("div");
-      const canvas = document.createElement("canvas");
-      parent.appendChild(canvas);
-      prepareDomForInput(canvas, parent);
+      const hoverParent = document.createElement("div");
+      const hoverCanvas = document.createElement("canvas");
+      hoverParent.appendChild(hoverCanvas);
+      prepareDomForInput(hoverCanvas, hoverParent);
 
-      const renderer = new Renderer({ ...defaultRendererProps, canvas });
+      const renderer = new Renderer({ ...defaultRendererProps, canvas: hoverCanvas });
       renderer.setPickingEnabled(true);
 
       const hoveredSpy = jest.fn();
       renderer.addListener("renderableHovered", hoveredSpy);
 
-      canvas.dispatchEvent(new MouseEvent("mousedown", { clientX: 10, clientY: 10 }));
-      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 11, clientY: 11 }));
+      hoverCanvas.dispatchEvent(new MouseEvent("mousedown", { clientX: 10, clientY: 10 }));
+      hoverCanvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 11, clientY: 11 }));
       expect(hoveredSpy).toHaveBeenCalledTimes(0);
 
-      canvas.dispatchEvent(new MouseEvent("mouseup", { clientX: 11, clientY: 11 }));
-      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 12, clientY: 12 }));
+      hoverCanvas.dispatchEvent(new MouseEvent("mouseup", { clientX: 11, clientY: 11 }));
+      hoverCanvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 12, clientY: 12 }));
       expect(hoveredSpy).toHaveBeenCalledTimes(1);
 
       renderer.dispose();
     });
 
     it("does not emit renderableHovered when picking is disabled", () => {
-      const parent = document.createElement("div");
-      const canvas = document.createElement("canvas");
-      parent.appendChild(canvas);
-      prepareDomForInput(canvas, parent);
+      const hoverParent = document.createElement("div");
+      const hoverCanvas = document.createElement("canvas");
+      hoverParent.appendChild(hoverCanvas);
+      prepareDomForInput(hoverCanvas, hoverParent);
 
-      const renderer = new Renderer({ ...defaultRendererProps, canvas });
+      const renderer = new Renderer({ ...defaultRendererProps, canvas: hoverCanvas });
       renderer.setPickingEnabled(false);
 
       const hoveredSpy = jest.fn();
       renderer.addListener("renderableHovered", hoveredSpy);
 
-      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 10, clientY: 10 }));
+      hoverCanvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 10, clientY: 10 }));
       jest.advanceTimersByTime(200);
-      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 11, clientY: 11 }));
+      hoverCanvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 11, clientY: 11 }));
 
       expect(hoveredSpy).toHaveBeenCalledTimes(0);
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -344,6 +344,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     });
 
     // Throttled hover picking: perform GPU pick on mousemove at 10 Hz
+    // Mouse position is emitted on every move for smooth tooltip following.
     let hoverThrottleTimer: ReturnType<typeof setTimeout> | undefined;
     let isMouseDown = false;
     this.input.on("mousedown", () => {
@@ -353,7 +354,11 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       isMouseDown = false;
     });
     this.input.on("mousemove", (cursorCoords) => {
-      if (isMouseDown || !this.#pickingEnabled || hoverThrottleTimer != undefined) {
+      if (isMouseDown || !this.#pickingEnabled) {
+        return;
+      }
+      this.emit("hoverMoved", cursorCoords, this);
+      if (hoverThrottleTimer != undefined) {
         return;
       }
       hoverThrottleTimer = setTimeout(() => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -64,6 +64,7 @@ import { SettingsManager, SettingsTreeEntry } from "./SettingsManager";
 import { SharedGeometry } from "./SharedGeometry";
 import { CameraState } from "./camera";
 import { DARK_OUTLINE, LIGHT_OUTLINE, stringToRgb } from "./color";
+import { HOVER_PICK_THROTTLE_MS } from "./constants";
 import { FRAME_TRANSFORMS_DATATYPES, FRAME_TRANSFORM_DATATYPES } from "./foxglove";
 import { DetailLevel, msaaSamples } from "./lod";
 import {
@@ -357,7 +358,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       }
       hoverThrottleTimer = setTimeout(() => {
         hoverThrottleTimer = undefined;
-      }, 100);
+      }, HOVER_PICK_THROTTLE_MS);
       this.#hoverHandler(cursorCoords);
     });
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -342,6 +342,25 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       this.#clickHandler(cursorCoords);
     });
 
+    // Throttled hover picking: perform GPU pick on mousemove at 10 Hz
+    let hoverThrottleTimer: ReturnType<typeof setTimeout> | undefined;
+    let isMouseDown = false;
+    this.input.on("mousedown", () => {
+      isMouseDown = true;
+    });
+    this.input.on("mouseup", () => {
+      isMouseDown = false;
+    });
+    this.input.on("mousemove", (cursorCoords) => {
+      if (isMouseDown || !this.#pickingEnabled || hoverThrottleTimer != undefined) {
+        return;
+      }
+      hoverThrottleTimer = setTimeout(() => {
+        hoverThrottleTimer = undefined;
+      }, 100);
+      this.#hoverHandler(cursorCoords);
+    });
+
     this.#picker = new Picker(this.gl, this.#scene);
 
     this.#selectionBackdrop = new ScreenOverlay(this);
@@ -1423,6 +1442,33 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
     log.debug(`Clicked ${selections.length} renderable(s)`);
     this.emit("renderablesClicked", selections, cursorCoords, this);
+  };
+
+  #hoverHandler = (cursorCoords: THREE.Vector2): void => {
+    if (!this.#pickingEnabled) {
+      return;
+    }
+    // Disable hover picking while a tool is active
+    if (this.measurementTool.state !== "idle" || this.publishClickTool.state !== "idle") {
+      return;
+    }
+
+    const camera = this.cameraHandler.getActiveCamera();
+    const selections: PickedRenderable[] = [];
+    let curSelection: PickedRenderable | undefined;
+    while (
+      (curSelection = this.#pickSingleObject(cursorCoords)) &&
+      selections.length < MAX_SELECTIONS
+    ) {
+      selections.push(curSelection);
+      curSelection.renderable.visible = false;
+      this.gl.render(this.#scene, camera);
+    }
+    for (const selection of selections) {
+      selection.renderable.visible = true;
+    }
+    this.animationFrame();
+    this.emit("renderableHovered", selections, cursorCoords, this);
   };
 
   #handleFrameTransform = ({ message }: MessageEvent<DeepPartial<FrameTransform>>): void => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.test.tsx
@@ -147,6 +147,7 @@ describe("<RendererOverlay /> hover wiring", () => {
     const renderable = {
       topic: "/my_topic",
       name: "my_entity on /my_topic",
+      userData: { entityId: "my_entity" },
       details: jest.fn(() => details),
       instanceDetails: jest.fn(),
     };
@@ -222,6 +223,7 @@ describe("<RendererOverlay /> hover wiring", () => {
     const renderable = {
       topic: "/t",
       name: "n",
+      userData: { entityId: "n" },
       details: jest.fn(() => ({ metadata: [{ key: "wrong", value: "wrong" }] })),
       instanceDetails: jest.fn(() => ({ metadata: [{ key: "ok", value: "yes" }], id: 9 })),
     };
@@ -306,6 +308,7 @@ describe("<RendererOverlay /> hover wiring", () => {
     const renderable = {
       topic: undefined,
       name: "af949d5a-8243-4e53-8b39-dfb05aac50ba",
+      userData: {},
       details: jest.fn(() => undefined),
       instanceDetails: jest.fn(() => undefined),
     };

--- a/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.test.tsx
@@ -130,6 +130,8 @@ describe("<RendererOverlay /> hover wiring", () => {
 
     const cb = mockRendererEventCallbacks.get("renderableHovered");
     expect(cb).toBeDefined();
+    const hoverMovedCb = mockRendererEventCallbacks.get("hoverMoved");
+    expect(hoverMovedCb).toBeDefined();
 
     const details = {
       metadata: [
@@ -150,6 +152,7 @@ describe("<RendererOverlay /> hover wiring", () => {
     };
 
     act(() => {
+      hoverMovedCb?.({ x: 10, y: 20 } as any);
       cb?.(
         [
           {

--- a/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.test.tsx
@@ -111,18 +111,19 @@ describe("<RendererOverlay /> hover wiring", () => {
 
   it("maps hovered selections into HoverTooltip entities and absolute client position", async () => {
     const canvas = document.createElement("canvas");
-    canvas.getBoundingClientRect = jest.fn(() =>
-      ({
-        left: 100,
-        top: 200,
-        right: 500,
-        bottom: 600,
-        width: 400,
-        height: 400,
-        x: 100,
-        y: 200,
-        toJSON: () => "",
-      }) as DOMRect,
+    canvas.getBoundingClientRect = jest.fn(
+      () =>
+        ({
+          left: 100,
+          top: 200,
+          right: 500,
+          bottom: 600,
+          width: 400,
+          height: 400,
+          x: 100,
+          y: 200,
+          toJSON: () => "",
+        }) as DOMRect,
     );
 
     renderOverlay(canvas);
@@ -149,13 +150,15 @@ describe("<RendererOverlay /> hover wiring", () => {
     };
 
     act(() => {
-      cb?.([
-        {
-          renderable,
-          instanceIndex: undefined,
-        },
-      ] as any,
-      { x: 10, y: 20 } as any);
+      cb?.(
+        [
+          {
+            renderable,
+            instanceIndex: undefined,
+          },
+        ] as any,
+        { x: 10, y: 20 } as any,
+      );
     });
 
     await waitFor(() => {
@@ -186,23 +189,26 @@ describe("<RendererOverlay /> hover wiring", () => {
     );
 
     // nested objects are excluded
-    expect(entity.metadata).not.toEqual(expect.arrayContaining([{ key: "nested", value: "[object Object]" }]));
+    expect(entity.metadata).not.toEqual(
+      expect.arrayContaining([{ key: "nested", value: "[object Object]" }]),
+    );
   });
 
   it("uses instanceDetails when instanceIndex is provided", async () => {
     const canvas = document.createElement("canvas");
-    canvas.getBoundingClientRect = jest.fn(() =>
-      ({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 100,
-        width: 100,
-        height: 100,
-        x: 0,
-        y: 0,
-        toJSON: () => "",
-      }) as DOMRect,
+    canvas.getBoundingClientRect = jest.fn(
+      () =>
+        ({
+          left: 0,
+          top: 0,
+          right: 100,
+          bottom: 100,
+          width: 100,
+          height: 100,
+          x: 0,
+          y: 0,
+          toJSON: () => "",
+        }) as DOMRect,
     );
 
     renderOverlay(canvas);
@@ -243,18 +249,19 @@ describe("<RendererOverlay /> hover wiring", () => {
 
   it("clears hovered entities when selections are empty", async () => {
     const canvas = document.createElement("canvas");
-    canvas.getBoundingClientRect = jest.fn(() =>
-      ({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 100,
-        width: 100,
-        height: 100,
-        x: 0,
-        y: 0,
-        toJSON: () => "",
-      }) as DOMRect,
+    canvas.getBoundingClientRect = jest.fn(
+      () =>
+        ({
+          left: 0,
+          top: 0,
+          right: 100,
+          bottom: 100,
+          width: 100,
+          height: 100,
+          x: 0,
+          y: 0,
+          toJSON: () => "",
+        }) as DOMRect,
     );
 
     renderOverlay(canvas);
@@ -267,6 +274,53 @@ describe("<RendererOverlay /> hover wiring", () => {
     });
 
     await waitFor(() => {
+      expect(mockLastHoverTooltipProps.entities).toEqual([]);
+    });
+  });
+
+  it("does not create tooltip entries for selections with no topic and no metadata", async () => {
+    const canvas = document.createElement("canvas");
+    canvas.getBoundingClientRect = jest.fn(
+      () =>
+        ({
+          left: 0,
+          top: 0,
+          right: 100,
+          bottom: 100,
+          width: 100,
+          height: 100,
+          x: 0,
+          y: 0,
+          toJSON: () => "",
+        }) as DOMRect,
+    );
+
+    renderOverlay(canvas);
+
+    const cb = mockRendererEventCallbacks.get("renderableHovered");
+    expect(cb).toBeDefined();
+
+    const renderable = {
+      topic: undefined,
+      name: "af949d5a-8243-4e53-8b39-dfb05aac50ba",
+      details: jest.fn(() => undefined),
+      instanceDetails: jest.fn(() => undefined),
+    };
+
+    act(() => {
+      cb?.(
+        [
+          {
+            renderable,
+            instanceIndex: undefined,
+          },
+        ] as any,
+        { x: 10, y: 20 } as any,
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockLastHoverTooltipProps).toBeDefined();
       expect(mockLastHoverTooltipProps.entities).toEqual([]);
     });
   });

--- a/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.test.tsx
@@ -1,0 +1,273 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import "@testing-library/jest-dom";
+
+import { act, render, waitFor } from "@testing-library/react";
+
+import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
+
+import { RendererOverlay } from "./RendererOverlay";
+
+let mockLastHoverTooltipProps: any = undefined;
+
+jest.mock("./Interactions/HoverTooltip", () => {
+  return {
+    __esModule: true,
+    HoverTooltip: (props: any) => {
+      mockLastHoverTooltipProps = props;
+      return undefined;
+    },
+  };
+});
+
+jest.mock("./Interactions", () => {
+  return {
+    __esModule: true,
+    InteractionContextMenu: () => undefined,
+    Interactions: () => undefined,
+  };
+});
+
+jest.mock("@lichtblick/suite-base/hooks/usePanelMousePresence", () => {
+  return {
+    __esModule: true,
+    usePanelMousePresence: () => true,
+  };
+});
+
+jest.mock("react-use", () => {
+  return {
+    __esModule: true,
+    useLongPress: () => ({}),
+  };
+});
+
+jest.mock("@lichtblick/suite-base/panels/ThreeDeeRender/HUD", () => {
+  return {
+    __esModule: true,
+    HUD: () => undefined,
+  };
+});
+
+jest.mock("./Stats", () => {
+  return {
+    __esModule: true,
+    Stats: () => undefined,
+  };
+});
+
+const mockRendererEventCallbacks = new Map<string, (...args: any[]) => void>();
+const mockRenderer = {
+  setPickingEnabled: jest.fn(),
+  setSelectedRenderable: jest.fn(),
+  canResetView: jest.fn(() => false),
+  getContextMenuItems: jest.fn(() => []),
+  fixedFrameId: undefined,
+};
+
+jest.mock("./RendererContext", () => {
+  return {
+    __esModule: true,
+    useRenderer: () => mockRenderer,
+    useRendererEvent: (eventName: string, cb: (...args: any[]) => void) => {
+      mockRendererEventCallbacks.set(eventName, cb);
+    },
+  };
+});
+
+describe("<RendererOverlay /> hover wiring", () => {
+  beforeEach(() => {
+    mockRendererEventCallbacks.clear();
+    mockLastHoverTooltipProps = undefined;
+    jest.clearAllMocks();
+  });
+
+  function renderOverlay(canvas: HTMLCanvasElement | ReactNull) {
+    return render(
+      <ThemeProvider isDark={false}>
+        <RendererOverlay
+          addPanel={jest.fn() as any}
+          canPublish={false}
+          canvas={canvas}
+          enableStats={false}
+          interfaceMode="3d"
+          measureActive={false}
+          onChangePublishClickType={jest.fn()}
+          onClickMeasure={jest.fn()}
+          onClickPublish={jest.fn()}
+          onShowTopicSettings={jest.fn()}
+          onTogglePerspective={jest.fn()}
+          perspective={false}
+          publishActive={false}
+          publishClickType="point"
+          timezone={undefined}
+        />
+      </ThemeProvider>,
+    );
+  }
+
+  it("maps hovered selections into HoverTooltip entities and absolute client position", async () => {
+    const canvas = document.createElement("canvas");
+    canvas.getBoundingClientRect = jest.fn(() =>
+      ({
+        left: 100,
+        top: 200,
+        right: 500,
+        bottom: 600,
+        width: 400,
+        height: 400,
+        x: 100,
+        y: 200,
+        toJSON: () => "",
+      }) as DOMRect,
+    );
+
+    renderOverlay(canvas);
+
+    const cb = mockRendererEventCallbacks.get("renderableHovered");
+    expect(cb).toBeDefined();
+
+    const details = {
+      metadata: [
+        { key: "m1", value: "mv1" },
+        { key: 123, value: true },
+      ],
+      id: 42,
+      frame_id: "map",
+      enabled: false,
+      nested: { a: 1 },
+    };
+
+    const renderable = {
+      topic: "/my_topic",
+      name: "my_entity on /my_topic",
+      details: jest.fn(() => details),
+      instanceDetails: jest.fn(),
+    };
+
+    act(() => {
+      cb?.([
+        {
+          renderable,
+          instanceIndex: undefined,
+        },
+      ] as any,
+      { x: 10, y: 20 } as any);
+    });
+
+    await waitFor(() => {
+      expect(mockLastHoverTooltipProps).toBeDefined();
+      expect(mockLastHoverTooltipProps.position).toEqual({ clientX: 110, clientY: 220 });
+      expect(mockLastHoverTooltipProps.entities).toHaveLength(1);
+    });
+
+    const entity = mockLastHoverTooltipProps.entities[0];
+    expect(entity.topic).toBe("/my_topic");
+    expect(entity.entityId).toBe("my_entity");
+
+    // metadata[] is included and coerced to strings
+    expect(entity.metadata).toEqual(
+      expect.arrayContaining([
+        { key: "m1", value: "mv1" },
+        { key: "123", value: "true" },
+      ]),
+    );
+
+    // primitive top-level fields are included
+    expect(entity.metadata).toEqual(
+      expect.arrayContaining([
+        { key: "id", value: "42" },
+        { key: "frame_id", value: "map" },
+        { key: "enabled", value: "false" },
+      ]),
+    );
+
+    // nested objects are excluded
+    expect(entity.metadata).not.toEqual(expect.arrayContaining([{ key: "nested", value: "[object Object]" }]));
+  });
+
+  it("uses instanceDetails when instanceIndex is provided", async () => {
+    const canvas = document.createElement("canvas");
+    canvas.getBoundingClientRect = jest.fn(() =>
+      ({
+        left: 0,
+        top: 0,
+        right: 100,
+        bottom: 100,
+        width: 100,
+        height: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => "",
+      }) as DOMRect,
+    );
+
+    renderOverlay(canvas);
+
+    const cb = mockRendererEventCallbacks.get("renderableHovered");
+    expect(cb).toBeDefined();
+
+    const renderable = {
+      topic: "/t",
+      name: "n",
+      details: jest.fn(() => ({ metadata: [{ key: "wrong", value: "wrong" }] })),
+      instanceDetails: jest.fn(() => ({ metadata: [{ key: "ok", value: "yes" }], id: 9 })),
+    };
+
+    act(() => {
+      cb?.(
+        [
+          {
+            renderable,
+            instanceIndex: 3,
+          },
+        ] as any,
+        { x: 1, y: 2 } as any,
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockLastHoverTooltipProps.entities).toHaveLength(1);
+    });
+
+    expect(renderable.instanceDetails).toHaveBeenCalledWith(3);
+    expect(renderable.details).not.toHaveBeenCalled();
+
+    const entity = mockLastHoverTooltipProps.entities[0];
+    expect(entity.metadata).toEqual(expect.arrayContaining([{ key: "ok", value: "yes" }]));
+    expect(entity.metadata).toEqual(expect.arrayContaining([{ key: "id", value: "9" }]));
+  });
+
+  it("clears hovered entities when selections are empty", async () => {
+    const canvas = document.createElement("canvas");
+    canvas.getBoundingClientRect = jest.fn(() =>
+      ({
+        left: 0,
+        top: 0,
+        right: 100,
+        bottom: 100,
+        width: 100,
+        height: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => "",
+      }) as DOMRect,
+    );
+
+    renderOverlay(canvas);
+
+    const cb = mockRendererEventCallbacks.get("renderableHovered");
+    expect(cb).toBeDefined();
+
+    act(() => {
+      cb?.([] as any, { x: 0, y: 0 } as any);
+    });
+
+    await waitFor(() => {
+      expect(mockLastHoverTooltipProps.entities).toEqual([]);
+    });
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
@@ -158,77 +158,98 @@ export function RendererOverlay(props: Props): React.JSX.Element {
     }
   }, [interactionsTabType, renderer]);
 
-  useRendererEvent("renderablesClicked", (selections, cursorCoords) => {
-    const rect = props.canvas?.getBoundingClientRect();
-    if (rect) {
-      setClickedPosition({
-        clientX: rect.left + cursorCoords.x,
-        clientY: rect.top + cursorCoords.y,
-      });
-    }
-    setSelectedRenderables(selections);
-    setSelectedRenderable(selections.length === 1 ? selections[0] : undefined);
-  });
+  useRendererEvent(
+    "renderablesClicked",
+    useCallback(
+      (selections, cursorCoords) => {
+        const rect = props.canvas?.getBoundingClientRect();
+        if (rect) {
+          setClickedPosition({
+            clientX: rect.left + cursorCoords.x,
+            clientY: rect.top + cursorCoords.y,
+          });
+        }
+        setSelectedRenderables(selections);
+        setSelectedRenderable(selections.length === 1 ? selections[0] : undefined);
+      },
+      [props.canvas],
+    ),
+  );
 
   // Track mouse position at full framerate for smooth tooltip following.
-  useRendererEvent("hoverMoved", (cursorCoords) => {
-    const rect = props.canvas?.getBoundingClientRect();
-    if (rect) {
-      setHoverPosition({ clientX: rect.left + cursorCoords.x, clientY: rect.top + cursorCoords.y });
-    }
-  });
+  useRendererEvent(
+    "hoverMoved",
+    useCallback(
+      (cursorCoords) => {
+        const rect = props.canvas?.getBoundingClientRect();
+        if (rect) {
+          setHoverPosition({
+            clientX: rect.left + cursorCoords.x,
+            clientY: rect.top + cursorCoords.y,
+          });
+        }
+      },
+      [props.canvas],
+    ),
+  );
 
-  useRendererEvent("renderableHovered", (selections) => {
-    const infos: HoverEntityInfo[] = [];
-    for (const pickedRenderable of selections) {
-      const topic = pickedRenderable.renderable.topic;
-      const details: Record<string, unknown> | undefined =
-        pickedRenderable.instanceIndex != undefined
-          ? (pickedRenderable.renderable.instanceDetails(pickedRenderable.instanceIndex) as
-              | Record<string, unknown>
-              | undefined)
-          : (pickedRenderable.renderable.details() as Record<string, unknown> | undefined);
+  useRendererEvent(
+    "renderableHovered",
+    useCallback(
+      (selections) => {
+        const infos: HoverEntityInfo[] = [];
+        for (const pickedRenderable of selections) {
+          const topic = pickedRenderable.renderable.topic;
+          const details: Record<string, unknown> | undefined =
+            pickedRenderable.instanceIndex != undefined
+              ? (pickedRenderable.renderable.instanceDetails(pickedRenderable.instanceIndex) as
+                  | Record<string, unknown>
+                  | undefined)
+              : (pickedRenderable.renderable.details() as Record<string, unknown> | undefined);
 
-      const metadata: { key: string; value: string }[] = [];
+          const metadata: { key: string; value: string }[] = [];
 
-      if (details != undefined) {
-        const entityMeta = details.metadata;
-        if (Array.isArray(entityMeta)) {
-          for (const kv of entityMeta) {
-            if (kv != undefined && typeof kv === "object" && "key" in kv && "value" in kv) {
-              metadata.push({
-                key: String((kv as { key: unknown }).key),
-                value: String((kv as { value: unknown }).value),
-              });
+          if (details != undefined) {
+            const entityMeta = details.metadata;
+            if (Array.isArray(entityMeta)) {
+              for (const kv of entityMeta) {
+                if (kv != undefined && typeof kv === "object" && "key" in kv && "value" in kv) {
+                  metadata.push({
+                    key: String((kv as { key: unknown }).key),
+                    value: String((kv as { value: unknown }).value),
+                  });
+                }
+              }
+            }
+            // Then add any remaining top-level primitive fields (id, frame_id, etc.)
+            for (const [k, v] of Object.entries(details)) {
+              if (
+                k !== "metadata" &&
+                v != undefined &&
+                (typeof v === "string" || typeof v === "number" || typeof v === "boolean")
+              ) {
+                metadata.push({ key: k, value: String(v) });
+              }
             }
           }
-        }
-        // Then add any remaining top-level primitive fields (id, frame_id, etc.)
-        for (const [k, v] of Object.entries(details)) {
-          if (
-            k !== "metadata" &&
-            v != undefined &&
-            (typeof v === "string" || typeof v === "number" || typeof v === "boolean")
-          ) {
-            metadata.push({ key: k, value: String(v) });
+
+          // Avoid showing tooltips for non-user-facing objects when hovering empty space.
+          // If a renderable has no associated topic and no metadata, it doesn't provide useful info.
+          if (topic == undefined && metadata.length === 0) {
+            continue;
           }
+
+          infos.push({
+            topic,
+            entityId: getHoverEntityId(pickedRenderable),
+            metadata,
+          });
         }
-      }
-
-      // Avoid showing tooltips for non-user-facing objects when hovering empty space.
-      // If a renderable has no associated topic and no metadata, it doesn't provide useful info.
-      if (topic == undefined && metadata.length === 0) {
-        continue;
-      }
-
-      infos.push({
-        topic,
-        entityId: getHoverEntityId(pickedRenderable),
-        metadata,
-      });
-    }
-    setHoveredEntities(infos);
-  });
+        setHoveredEntities(infos);
+      },
+      [getHoverEntityId],
+    ),
+  );
 
   const [showResetViewButton, setShowResetViewButton] = useState(renderer?.canResetView() ?? false);
   useRendererEvent(

--- a/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
@@ -139,14 +139,13 @@ export function RendererOverlay(props: Props): React.JSX.Element {
   const renderer = useRenderer();
 
   const getHoverEntityId = useCallback((pickedRenderable: PickedRenderable): string => {
+    const entityId = (pickedRenderable.renderable.userData as { entityId?: string }).entityId;
+    if (entityId != undefined) {
+      return entityId;
+    }
     const name = pickedRenderable.renderable.name;
     if (name.length === 0) {
       return `object-${pickedRenderable.instanceIndex ?? 0}`;
-    }
-
-    const topic = pickedRenderable.renderable.topic;
-    if (topic != undefined && name.endsWith(` on ${topic}`)) {
-      return name.slice(0, Math.max(0, name.length - ` on ${topic}`.length));
     }
     return name;
   }, []);

--- a/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
@@ -138,13 +138,13 @@ export function RendererOverlay(props: Props): React.JSX.Element {
   });
   const renderer = useRenderer();
 
-  const getHoverEntityId = useCallback((sel: PickedRenderable): string => {
-    const name = sel.renderable.name;
+  const getHoverEntityId = useCallback((pickedRenderable: PickedRenderable): string => {
+    const name = pickedRenderable.renderable.name;
     if (name.length === 0) {
-      return `object-${sel.instanceIndex ?? 0}`;
+      return `object-${pickedRenderable.instanceIndex ?? 0}`;
     }
 
-    const topic = sel.renderable.topic;
+    const topic = pickedRenderable.renderable.topic;
     if (topic != undefined && name.endsWith(` on ${topic}`)) {
       return name.slice(0, Math.max(0, name.length - ` on ${topic}`.length));
     }
@@ -170,20 +170,24 @@ export function RendererOverlay(props: Props): React.JSX.Element {
     setSelectedRenderable(selections.length === 1 ? selections[0] : undefined);
   });
 
-  useRendererEvent("renderableHovered", (selections, cursorCoords) => {
+  // Track mouse position at full framerate for smooth tooltip following.
+  useRendererEvent("hoverMoved", (cursorCoords) => {
     const rect = props.canvas?.getBoundingClientRect();
     if (rect) {
       setHoverPosition({ clientX: rect.left + cursorCoords.x, clientY: rect.top + cursorCoords.y });
     }
+  });
+
+  useRendererEvent("renderableHovered", (selections) => {
     const infos: HoverEntityInfo[] = [];
-    for (const sel of selections) {
-      const topic = sel.renderable.topic;
+    for (const pickedRenderable of selections) {
+      const topic = pickedRenderable.renderable.topic;
       const details: Record<string, unknown> | undefined =
-        sel.instanceIndex != undefined
-          ? (sel.renderable.instanceDetails(sel.instanceIndex) as
+        pickedRenderable.instanceIndex != undefined
+          ? (pickedRenderable.renderable.instanceDetails(pickedRenderable.instanceIndex) as
               | Record<string, unknown>
               | undefined)
-          : (sel.renderable.details() as Record<string, unknown> | undefined);
+          : (pickedRenderable.renderable.details() as Record<string, unknown> | undefined);
 
       const metadata: { key: string; value: string }[] = [];
 
@@ -219,7 +223,7 @@ export function RendererOverlay(props: Props): React.JSX.Element {
 
       infos.push({
         topic,
-        entityId: getHoverEntityId(sel),
+        entityId: getHoverEntityId(pickedRenderable),
         metadata,
       });
     }

--- a/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
@@ -36,7 +36,8 @@ import { HUD } from "@lichtblick/suite-base/panels/ThreeDeeRender/HUD";
 import { customTypography } from "@lichtblick/theme";
 
 import { InteractionContextMenu, Interactions, SelectionObject, TabType } from "./Interactions";
-import { HoverTooltip, HoverEntityInfo } from "./Interactions/HoverTooltip";
+import { HoverTooltip } from "./Interactions/HoverTooltip";
+import type { HoverEntityInfo } from "./Interactions/types";
 import type { PickedRenderable } from "./Picker";
 import { Renderable } from "./Renderable";
 import { useRenderer, useRendererEvent } from "./RendererContext";
@@ -176,6 +177,7 @@ export function RendererOverlay(props: Props): React.JSX.Element {
     }
     const infos: HoverEntityInfo[] = [];
     for (const sel of selections) {
+      const topic = sel.renderable.topic;
       const details: Record<string, unknown> | undefined =
         sel.instanceIndex != undefined
           ? (sel.renderable.instanceDetails(sel.instanceIndex) as
@@ -209,8 +211,14 @@ export function RendererOverlay(props: Props): React.JSX.Element {
         }
       }
 
+      // Avoid showing tooltips for non-user-facing objects when hovering empty space.
+      // If a renderable has no associated topic and no metadata, it doesn't provide useful info.
+      if (topic == undefined && metadata.length === 0) {
+        continue;
+      }
+
       infos.push({
-        topic: sel.renderable.topic ?? "unknown",
+        topic: topic ?? "unknown",
         entityId: getHoverEntityId(sel),
         metadata,
       });

--- a/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
@@ -218,7 +218,7 @@ export function RendererOverlay(props: Props): React.JSX.Element {
       }
 
       infos.push({
-        topic: topic ?? "unknown",
+        topic,
         entityId: getHoverEntityId(sel),
         metadata,
       });

--- a/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
@@ -36,6 +36,7 @@ import { HUD } from "@lichtblick/suite-base/panels/ThreeDeeRender/HUD";
 import { customTypography } from "@lichtblick/theme";
 
 import { InteractionContextMenu, Interactions, SelectionObject, TabType } from "./Interactions";
+import { HoverTooltip, HoverEntityInfo } from "./Interactions/HoverTooltip";
 import type { PickedRenderable } from "./Picker";
 import { Renderable } from "./Renderable";
 import { useRenderer, useRendererEvent } from "./RendererContext";
@@ -129,7 +130,25 @@ export function RendererOverlay(props: Props): React.JSX.Element {
     undefined,
   );
   const [interactionsTabType, setInteractionsTabType] = useState<TabType | undefined>(undefined);
+  const [hoveredEntities, setHoveredEntities] = useState<HoverEntityInfo[]>([]);
+  const [hoverPosition, setHoverPosition] = useState<{ clientX: number; clientY: number }>({
+    clientX: 0,
+    clientY: 0,
+  });
   const renderer = useRenderer();
+
+  const getHoverEntityId = useCallback((sel: PickedRenderable): string => {
+    const name = sel.renderable.name;
+    if (name.length === 0) {
+      return `object-${sel.instanceIndex ?? 0}`;
+    }
+
+    const topic = sel.renderable.topic;
+    if (topic != undefined && name.endsWith(` on ${topic}`)) {
+      return name.slice(0, Math.max(0, name.length - ` on ${topic}`.length));
+    }
+    return name;
+  }, []);
 
   // Toggle object selection mode on/off in the renderer
   useEffect(() => {
@@ -139,10 +158,64 @@ export function RendererOverlay(props: Props): React.JSX.Element {
   }, [interactionsTabType, renderer]);
 
   useRendererEvent("renderablesClicked", (selections, cursorCoords) => {
-    const rect = props.canvas!.getBoundingClientRect();
-    setClickedPosition({ clientX: rect.left + cursorCoords.x, clientY: rect.top + cursorCoords.y });
+    const rect = props.canvas?.getBoundingClientRect();
+    if (rect) {
+      setClickedPosition({
+        clientX: rect.left + cursorCoords.x,
+        clientY: rect.top + cursorCoords.y,
+      });
+    }
     setSelectedRenderables(selections);
     setSelectedRenderable(selections.length === 1 ? selections[0] : undefined);
+  });
+
+  useRendererEvent("renderableHovered", (selections, cursorCoords) => {
+    const rect = props.canvas?.getBoundingClientRect();
+    if (rect) {
+      setHoverPosition({ clientX: rect.left + cursorCoords.x, clientY: rect.top + cursorCoords.y });
+    }
+    const infos: HoverEntityInfo[] = [];
+    for (const sel of selections) {
+      const details: Record<string, unknown> | undefined =
+        sel.instanceIndex != undefined
+          ? (sel.renderable.instanceDetails(sel.instanceIndex) as
+              | Record<string, unknown>
+              | undefined)
+          : (sel.renderable.details() as Record<string, unknown> | undefined);
+
+      const metadata: { key: string; value: string }[] = [];
+
+      if (details != undefined) {
+        const entityMeta = details.metadata;
+        if (Array.isArray(entityMeta)) {
+          for (const kv of entityMeta) {
+            if (kv != undefined && typeof kv === "object" && "key" in kv && "value" in kv) {
+              metadata.push({
+                key: String((kv as { key: unknown }).key),
+                value: String((kv as { value: unknown }).value),
+              });
+            }
+          }
+        }
+        // Then add any remaining top-level primitive fields (id, frame_id, etc.)
+        for (const [k, v] of Object.entries(details)) {
+          if (
+            k !== "metadata" &&
+            v != undefined &&
+            (typeof v === "string" || typeof v === "number" || typeof v === "boolean")
+          ) {
+            metadata.push({ key: k, value: String(v) });
+          }
+        }
+      }
+
+      infos.push({
+        topic: sel.renderable.topic ?? "unknown",
+        entityId: getHoverEntityId(sel),
+        metadata,
+      });
+    }
+    setHoveredEntities(infos);
   });
 
   const [showResetViewButton, setShowResetViewButton] = useState(renderer?.canResetView() ?? false);
@@ -400,6 +473,7 @@ export function RendererOverlay(props: Props): React.JSX.Element {
         />
       )}
       <HUD renderer={renderer} />
+      <HoverTooltip entities={hoveredEntities} position={hoverPosition} canvas={props.canvas} />
       {stats}
       {resetViewButton}
     </>

--- a/packages/suite-base/src/panels/ThreeDeeRender/constants.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/constants.ts
@@ -12,3 +12,6 @@ export const PANEL_STYLE: React.CSSProperties = {
 export const MAX_TRANSFORM_MESSAGES = 10_000;
 
 export const DEFAULT_FOLLOW_MODE = "follow-pose";
+
+// Throttle hover GPU picking to reduce load (10 Hz)
+export const HOVER_PICK_THROTTLE_MS = 100;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
@@ -147,6 +147,7 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
         if (!renderable) {
           renderable = this.primitivePool.acquire(primitiveType);
           renderable.name = `${entity.id}:${primitiveType} on ${this.topic}`;
+          renderable.userData.entityId = `${entity.id}:${primitiveType}`;
           renderable.userData.settingsPath = this.userData.settingsPath;
           renderable.setColorScheme(this.renderer.colorScheme);
           // @ts-expect-error TS doesn't know that renderable matches primitiveType

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/primitives/RenderablePrimitive.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/primitives/RenderablePrimitive.ts
@@ -17,6 +17,7 @@ import { LayerSettingsEntity } from "../../settings";
 export type EntityRenderableUserData = BaseUserData & {
   topic?: string;
   entity?: SceneEntity;
+  entityId?: string;
   expiresAt?: bigint;
   settings?: LayerSettingsEntity;
 };


### PR DESCRIPTION
## User-Facing Changes

In 'inspect mode' of 3D panel a tooltip is shown on mouse-over of elements, showing the metadata 
for the hovered-over object.

## Description

<img width="605" height="704" alt="image" src="https://github.com/user-attachments/assets/e3fc66cc-5ddc-4f0f-9d34-4342a4399efc" />

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
