### PR TITLE
Add option to get size of extensions from backend

### DIFF
--- a/packages/suite-base/src/api/extensions/types.ts
+++ b/packages/suite-base/src/api/extensions/types.ts
@@ -34,6 +34,7 @@ type RemoteExtension = Pick<
   | "qualifiedName"
   | "readme"
   | "version"
+  | "size"
 >;
 
 export interface IExtensionApiResponse extends GenericApiEntity, RemoteExtension {


### PR DESCRIPTION
## User-Facing Changes

Add option to get size of extensions from backend

## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
