### PR TITLE
bugfix: Add showOpenFilePicker Fallback

### DIFF
--- a/packages/suite-base/src/util/showOpenFilePicker.tsx
+++ b/packages/suite-base/src/util/showOpenFilePicker.tsx
@@ -9,14 +9,18 @@
  * Whether the File System Access API showOpenFilePicker is available.
  */
 function isShowOpenFilePickerSupported(): boolean {
-  return typeof window !== "undefined" && "showOpenFilePicker" in window && typeof window.showOpenFilePicker === "function";
+  return (
+    typeof window !== "undefined" &&
+    "showOpenFilePicker" in window &&
+    typeof window.showOpenFilePicker === "function"
+  );
 }
 
 /**
  * Fallback for environments that don't support showOpenFilePicker (e.g. Chrome Android):
  * use a hidden <input type="file"> and return handle-like objects so callers can still use getFile().
  */
-function showOpenFilePickerFallback(
+async function showOpenFilePickerFallback(
   options?: OpenFilePickerOptions,
 ): Promise<FileSystemFileHandle[] /* foxglove-depcheck-used: @types/wicg-file-system-access */> {
   return new Promise((resolve) => {
@@ -30,7 +34,9 @@ function showOpenFilePickerFallback(
         if (type.accept) {
           for (const [mime, exts] of Object.entries(type.accept)) {
             const extList = Array.isArray(exts) ? exts : [exts];
-            acceptParts.push(...extList.map((ext: string) => (ext.startsWith(".") ? ext : `.${ext}`)));
+            acceptParts.push(
+              ...extList.map((ext: string) => (ext.startsWith(".") ? ext : `.${ext}`)),
+            );
             acceptParts.push(mime);
           }
         }
@@ -38,13 +44,15 @@ function showOpenFilePickerFallback(
       input.accept = [...new Set(acceptParts)].join(",");
     }
 
-    input.oncancel = () => resolve([]);
+    input.oncancel = () => {
+      resolve([]);
+    };
     input.onchange = () => {
       const files = input.files ? Array.from(input.files) : [];
       const handles = files.map(
         (file) =>
           ({
-            getFile: () => Promise.resolve(file),
+            getFile: async () => Promise.resolve(file),
             name: file.name,
             kind: "file" as const,
           }) as FileSystemFileHandle,
@@ -70,7 +78,7 @@ export default async function showOpenFilePicker(
   }
 
   try {
-    return await window.showOpenFilePicker(options!);
+    return await window.showOpenFilePicker(options);
   } catch (err: unknown) {
     if ((err as Error).name === "AbortError") {
       return [];


### PR DESCRIPTION
## User-Facing Changes

- **Import layout from file** now works on Google chrome browsers and potentially others that do not support the File System Access API on the android platform. The app falls back to the native file input dialog instead of failing or doing nothing when `showOpenFilePicker` is not available.

---

## Description

This PR adds a fallback when `window.showOpenFilePicker` is not available (e.g. Chrome Android). The fallback uses a hidden `<input type="file">` and returns objects that implement the same handle-like interface (`getFile()`, `name`, `kind`) so existing callers (layout import, open file) work unchanged.

- Fixes import layout from file on environments without the File System Access API.
- No new dependencies; uses the standard file input when the API is missing.
- Fixes #766


---

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files `constants.ts`, `types.ts` and `*.style.ts` have been checked and relevant code snippets have been relocated
