### PR TITLE
Making small adjust on Y calculation for state transitions data lines

### DIFF
--- a/packages/suite-base/src/panels/StateTransitions/hooks/constants.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/constants.ts
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-export const ROW_SPACING = 12;
+export const ROW_SPACING = 9;
 export const ROW_MARGIN = ROW_SPACING / 4;

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useStateTransitionsData.test.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useStateTransitionsData.test.ts
@@ -57,7 +57,7 @@ describe("useStateTransitionsData", () => {
 
     expect(result.current.data.datasets).toHaveLength(4);
     expect(result.current.pathState).toHaveLength(2);
-    expect(result.current.minY).toBe(-27);
+    expect(result.current.minY).toBe(-20.25);
 
     expect(mockMessagesToDataset).toHaveBeenCalledTimes(4);
     expect(mockDatasetContainsArray).toHaveBeenCalledTimes(2);
@@ -79,7 +79,7 @@ describe("useStateTransitionsData", () => {
 
     expect(result.current.data.datasets).toHaveLength(1);
     expect(result.current.pathState).toHaveLength(1);
-    expect(result.current.minY).toBe(-15);
+    expect(result.current.minY).toBe(-11.25);
 
     expect(mockMessagesToDataset).toHaveBeenCalledTimes(1);
     expect(mockDatasetContainsArray).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## User-Facing Changes

Adjust Y calculation to make data lines be closed to data labels

Improves #981 

## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
