### PR TITLE
[Sonar Issue] sort() should use a compare function 

### DIFF
--- a/packages/suite-base/src/components/TopicList/TopicList.tsx
+++ b/packages/suite-base/src/components/TopicList/TopicList.tsx
@@ -67,7 +67,7 @@ export function TopicList(): React.JSX.Element {
 
   const getSelectedItemsAsDraggedMessagePaths = useCallback(() => {
     return filterMap(
-      Array.from(getSelectedIndexes()).sort(),
+      Array.from(getSelectedIndexes()).sort((a, b) => a - b),
       (index): DraggedMessagePath | undefined => {
         const item = latestTreeItems.current[index];
         return item ? getDraggedMessagePath(item) : undefined;


### PR DESCRIPTION
## User-Facing Changes

N/A

## Description

The default sort order is lexicographic (dictionary) order, based on the string representation of the elements. This means that when sorting an array of strings, numbers, or other elements, they are converted to strings and sorted according to their Unicode code points (UTF-16). For most cases, this default behavior is suitable when sorting an array of strings.

However, it’s essential to be aware of potential pitfalls when sorting arrays of non-string elements, particularly numbers. The lexicographic order may not always produce the expected results for numbers:
```typescript
const numbers = [10, 2, 30, 1, 5];
numbers.sort(); // Noncompliant: lexicographic sort
console.log(numbers); // Output: [1, 10, 2, 30, 5]
```
To sort numbers correctly, you must provide a custom comparison function that returns the correct ordering:

```typescript
const numbers = [10, 2, 30, 1, 5];
numbers.sort((a, b) => a - b);
console.log(numbers); // Output: [1, 2, 5, 10, 30]
Even to sort strings, the default sort order may give unexpected results. Not only does it not support localization, it also doesn’t fully support Unicode, as it only considers UTF-16 code units. For example, in the code below, "eΔ" is surprisingly before and after "éΔ". To guarantee that the sorting is reliable and remains as such in the long run, it is necessary to provide a compare function that is both locale and Unicode aware - typically String.localeCompare.
```
```typescript
const code1 = '\u00e9\u0394'; // "éΔ"
const code2 = '\u0065\u0301\u0394'; // "éΔ" using Unicode combining marks
const code3 = '\u0065\u0394'; // "eΔ"
console.log([code1, code2, code3].sort()); // Noncompliant: ["éΔ", "eΔ", "éΔ"], "eΔ" position is inconsistent
console.log([code1, code2, code3].sort((a, b) => a.localeCompare(b))); // ["eΔ", "éΔ", "éΔ"]
```

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

