### PR TITLE
Fix - Support typed arrays in raw messages panel

### DIFF
--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -244,12 +244,23 @@ function RawMessages(props: PropsRawMessages) {
                 if (rawVal == undefined) {
                   return rawVal;
                 }
-                const idValue = (rawVal as Record<string, unknown>)[diffLabels.ID.labelText];
-                const addedValue = (rawVal as Record<string, unknown>)[diffLabels.ADDED.labelText];
-                const changedValue = (rawVal as Record<string, unknown>)[
+
+                // react-json-tree treats typed arrays as opaque objects; convert them
+                // to regular arrays so users can expand and inspect element values.
+                const toDisplayValue =
+                  ArrayBuffer.isView(rawVal) && !(rawVal instanceof DataView)
+                    ? Array.from(rawVal as unknown as ArrayLike<unknown>)
+                    : rawVal;
+                const idValue = (toDisplayValue as Record<string, unknown>)[
+                  diffLabels.ID.labelText
+                ];
+                const addedValue = (toDisplayValue as Record<string, unknown>)[
+                  diffLabels.ADDED.labelText
+                ];
+                const changedValue = (toDisplayValue as Record<string, unknown>)[
                   diffLabels.CHANGED.labelText
                 ];
-                const deletedValue = (rawVal as Record<string, unknown>)[
+                const deletedValue = (toDisplayValue as Record<string, unknown>)[
                   diffLabels.DELETED.labelText
                 ];
                 if (
@@ -259,9 +270,12 @@ function RawMessages(props: PropsRawMessages) {
                     1 &&
                   idValue == undefined
                 ) {
-                  return addedValue ?? changedValue ?? deletedValue;
+                  const unwrappedValue = addedValue ?? changedValue ?? deletedValue;
+                  return ArrayBuffer.isView(unwrappedValue) && !(unwrappedValue instanceof DataView)
+                    ? Array.from(unwrappedValue as unknown as ArrayLike<unknown>)
+                    : unwrappedValue;
                 }
-                return rawVal;
+                return toDisplayValue;
               }}
               theme={{
                 ...jsonTreeTheme,

--- a/packages/suite-base/src/panels/RawMessages/index.tsx
+++ b/packages/suite-base/src/panels/RawMessages/index.tsx
@@ -3,7 +3,7 @@
 
 import { Checkbox, FormControlLabel, Typography, useTheme } from "@mui/material";
 import * as _ from "lodash-es";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import Tree from "react-json-tree";
 
 import { useDataSourceInfo } from "@lichtblick/suite-base/PanelAPI";
@@ -42,6 +42,7 @@ import {
   dataWithoutWrappingArray,
   getSingleValue,
   isSingleElemArray,
+  typedArrayToArray,
 } from "@lichtblick/suite-base/panels/RawMessagesCommon/utils";
 import { useJsonTreeTheme } from "@lichtblick/suite-base/util/globalConstants";
 
@@ -86,6 +87,11 @@ function RawMessages(props: PropsRawMessages) {
     onTopicPathChange,
     openSiblingPanel,
   });
+
+  // Cache typed-array → regular-array conversions so Array.from() is called at most
+  // once per unique typed array object. The WeakMap lets the cached arrays be GC'd
+  // whenever the originals are released (e.g. when a new message arrives).
+  const typedArrayCache = useRef(new WeakMap<object, unknown[]>());
 
   const defaultGetItemString = useGetItemStringWithTimezone();
   const getItemString = useMemo(
@@ -247,10 +253,9 @@ function RawMessages(props: PropsRawMessages) {
 
                 // react-json-tree treats typed arrays as opaque objects; convert them
                 // to regular arrays so users can expand and inspect element values.
-                const toDisplayValue =
-                  ArrayBuffer.isView(rawVal) && !(rawVal instanceof DataView)
-                    ? Array.from(rawVal as unknown as ArrayLike<unknown>)
-                    : rawVal;
+                // Results are cached in a WeakMap so Array.from() runs at most once per
+                // unique typed array instance instead of on every render call.
+                const toDisplayValue = typedArrayToArray(rawVal, typedArrayCache.current);
                 const idValue = (toDisplayValue as Record<string, unknown>)[
                   diffLabels.ID.labelText
                 ];
@@ -270,10 +275,10 @@ function RawMessages(props: PropsRawMessages) {
                     1 &&
                   idValue == undefined
                 ) {
-                  const unwrappedValue = addedValue ?? changedValue ?? deletedValue;
-                  return ArrayBuffer.isView(unwrappedValue) && !(unwrappedValue instanceof DataView)
-                    ? Array.from(unwrappedValue as unknown as ArrayLike<unknown>)
-                    : unwrappedValue;
+                  return typedArrayToArray(
+                    addedValue ?? changedValue ?? deletedValue,
+                    typedArrayCache.current,
+                  );
                 }
                 return toDisplayValue;
               }}

--- a/packages/suite-base/src/panels/RawMessagesCommon/getValueActionForValue.ts
+++ b/packages/suite-base/src/panels/RawMessagesCommon/getValueActionForValue.ts
@@ -148,9 +148,10 @@ export const getValueActionForValue = (
       // We currently don't support looking inside them.
       return undefined;
     } else {
-      throw new Error(
-        `Invalid structureType: ${state.structureItem?.structureType} for value/pathItem.`,
-      );
+      // Unexpected path/value/schema combinations can happen for synthetic keys
+      // (e.g. array internals). This path is only used for optional hover actions,
+      // so fail gracefully instead of crashing the panel.
+      return undefined;
     }
   }
 

--- a/packages/suite-base/src/panels/RawMessagesCommon/getValueActionForValue.ts
+++ b/packages/suite-base/src/panels/RawMessagesCommon/getValueActionForValue.ts
@@ -151,6 +151,10 @@ export const getValueActionForValue = (
       // Unexpected path/value/schema combinations can happen for synthetic keys
       // (e.g. array internals). This path is only used for optional hover actions,
       // so fail gracefully instead of crashing the panel.
+      console.warn(
+        "getValueActionForValue: unexpected structureType",
+        state.structureItem?.structureType,
+      );
       return undefined;
     }
   }

--- a/packages/suite-base/src/panels/RawMessagesCommon/utils.test.tsx
+++ b/packages/suite-base/src/panels/RawMessagesCommon/utils.test.tsx
@@ -21,6 +21,7 @@ import {
   getValueString,
   isSingleElemArray,
   toggleExpansion,
+  typedArrayToArray,
 } from "@lichtblick/suite-base/panels/RawMessagesCommon/utils";
 import { BasicBuilder } from "@lichtblick/test-builders";
 
@@ -806,6 +807,125 @@ describe("getValueString", () => {
         // Then
         expect(result.itemLabel).toBe(`${value} (TIME_CONSTANT)`);
       });
+    });
+  });
+});
+
+describe("typedArrayToArray", () => {
+  describe("when handling typed arrays", () => {
+    it("should convert Float32Array to a plain array", () => {
+      // Given
+      const cache = new WeakMap<object, unknown[]>();
+      const input = new Float32Array([1.5, 2.5, 3.5]);
+
+      // When
+      const result = typedArrayToArray(input, cache);
+
+      // Then
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toEqual([Math.fround(1.5), Math.fround(2.5), Math.fround(3.5)]);
+    });
+
+    it("should convert Uint8Array to a plain array", () => {
+      // Given
+      const cache = new WeakMap<object, unknown[]>();
+      const input = new Uint8Array([1, 2, 3]);
+
+      // When
+      const result = typedArrayToArray(input, cache);
+
+      // Then
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it("should convert Int32Array to a plain array", () => {
+      // Given
+      const cache = new WeakMap<object, unknown[]>();
+      const input = new Int32Array([-1, 0, 1]);
+
+      // When
+      const result = typedArrayToArray(input, cache);
+
+      // Then
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toEqual([-1, 0, 1]);
+    });
+  });
+
+  describe("when using the cache", () => {
+    it("should return the same reference for the same typed array instance", () => {
+      // Given
+      const cache = new WeakMap<object, unknown[]>();
+      const input = new Float32Array([1.0, 2.0]);
+
+      // When
+      const first = typedArrayToArray(input, cache);
+      const second = typedArrayToArray(input, cache);
+
+      // Then
+      expect(first).toBe(second);
+    });
+  });
+
+  describe("when handling non-typed-array values", () => {
+    it("should return plain objects unchanged", () => {
+      // Given
+      const cache = new WeakMap<object, unknown[]>();
+      const obj = { foo: "bar" };
+
+      // When
+      const result = typedArrayToArray(obj, cache);
+
+      // Then
+      expect(result).toBe(obj);
+    });
+
+    it("should return strings unchanged", () => {
+      // Given
+      const cache = new WeakMap<object, unknown[]>();
+      const value = "string";
+
+      // When
+      const result = typedArrayToArray(value, cache);
+
+      // Then
+      expect(result).toBe(value);
+    });
+
+    it("should return numbers unchanged", () => {
+      // Given
+      const cache = new WeakMap<object, unknown[]>();
+      const value = 42;
+
+      // When
+      const result = typedArrayToArray(value, cache);
+
+      // Then
+      expect(result).toBe(value);
+    });
+
+    it("should return undefined unchanged", () => {
+      // Given
+      const cache = new WeakMap<object, unknown[]>();
+
+      // When
+      const result = typedArrayToArray(undefined, cache);
+
+      // Then
+      expect(result).toBeUndefined();
+    });
+
+    it("should not convert DataView", () => {
+      // Given
+      const cache = new WeakMap<object, unknown[]>();
+      const dv = new DataView(new ArrayBuffer(8));
+
+      // When
+      const result = typedArrayToArray(dv, cache);
+
+      // Then
+      expect(result).toBe(dv);
     });
   });
 });

--- a/packages/suite-base/src/panels/RawMessagesCommon/utils.tsx
+++ b/packages/suite-base/src/panels/RawMessagesCommon/utils.tsx
@@ -165,6 +165,25 @@ export function getConstantNameByKeyPath(
   return undefined;
 }
 
+/**
+ * Converts a typed array (e.g. Float32Array, Uint8Array) to a plain JS array,
+ * using a WeakMap cache so Array.from() is called at most once per unique instance.
+ * Pass a fresh `WeakMap` (e.g. from a `useRef`) to scope the cache lifetime.
+ * Returns non-typed-array values unchanged.
+ */
+export function typedArrayToArray(val: unknown, cache: WeakMap<object, unknown[]>): unknown {
+  if (!(ArrayBuffer.isView(val) && !(val instanceof DataView))) {
+    return val;
+  }
+  const cached = cache.get(val);
+  if (cached != undefined) {
+    return cached;
+  }
+  const converted = Array.from(val as unknown as ArrayLike<unknown>);
+  cache.set(val, converted);
+  return converted;
+}
+
 export const isSingleElemArray = (obj: unknown): obj is unknown[] => {
   if (!Array.isArray(obj)) {
     return false;

--- a/packages/suite-base/src/panels/RawMessagesVirtual/RawMessagesVirtual.tsx
+++ b/packages/suite-base/src/panels/RawMessagesVirtual/RawMessagesVirtual.tsx
@@ -107,15 +107,20 @@ const RawMessagesVirtual = (props: PropsRawMessagesVirtual): React.JSX.Element =
         if (obj == undefined || typeof obj !== "object") {
           return;
         }
-        const entries = Array.isArray(obj)
-          ? obj.map((item, index) => [index, item] as [number, unknown])
-          : Object.entries(obj);
+        // Typed arrays are iterable by index; treat them like regular arrays
+        const iterableObj =
+          ArrayBuffer.isView(obj) && !(obj instanceof DataView)
+            ? Array.from(obj as unknown as ArrayLike<unknown>)
+            : obj;
+        const entries = Array.isArray(iterableObj)
+          ? iterableObj.map((item, index) => [index, item] as [number, unknown])
+          : Object.entries(iterableObj as Record<string, unknown>);
 
         for (const [key, value] of entries) {
           const nodePath = prefix ? `${key}${PATH_NAME_AGGREGATOR}${prefix}` : String(key);
           allNodes.add(nodePath);
 
-          if (value != undefined && typeof value === "object" && !ArrayBuffer.isView(value)) {
+          if (value != undefined && typeof value === "object") {
             generatePaths(value, nodePath);
           }
         }

--- a/packages/suite-base/src/panels/RawMessagesVirtual/VirtualizedTree.tsx
+++ b/packages/suite-base/src/panels/RawMessagesVirtual/VirtualizedTree.tsx
@@ -32,8 +32,13 @@ export const VirtualizedTree = memo(function VirtualizedTree({
   // eslint-disable-next-line no-restricted-syntax
   const parentRef = useRef<HTMLDivElement>(null);
 
+  // Cache typed-array → regular-array conversions so Array.from() is called at most
+  // once per unique typed array object across re-renders caused by node expand/collapse.
+
+  const typedArrayCache = useRef(new WeakMap<object, unknown[]>());
+
   const flatData = useMemo(() => {
-    return flattenTreeData(data, expandedNodes);
+    return flattenTreeData(data, expandedNodes, "", 0, [], typedArrayCache.current);
   }, [data, expandedNodes]);
 
   const getScrollElement = useCallback(() => parentRef.current, []);

--- a/packages/suite-base/src/panels/RawMessagesVirtual/flattenTreeData.test.ts
+++ b/packages/suite-base/src/panels/RawMessagesVirtual/flattenTreeData.test.ts
@@ -116,7 +116,7 @@ describe("flattenTreeData", () => {
 
       // Then
       expect(result).toHaveLength(3);
-      expect(result[0]).toEqual(
+      expect(result[0]).toEqual(expect.objectContaining({ key: "0", value: 10 }));
         expect.objectContaining({ key: "0", value: 10 }),
       );
     });

--- a/packages/suite-base/src/panels/RawMessagesVirtual/flattenTreeData.test.ts
+++ b/packages/suite-base/src/panels/RawMessagesVirtual/flattenTreeData.test.ts
@@ -117,8 +117,6 @@ describe("flattenTreeData", () => {
       // Then
       expect(result).toHaveLength(3);
       expect(result[0]).toEqual(expect.objectContaining({ key: "0", value: 10 }));
-        expect.objectContaining({ key: "0", value: 10 }),
-      );
     });
 
     it("should return empty array given an empty typed array", () => {

--- a/packages/suite-base/src/panels/RawMessagesVirtual/flattenTreeData.test.ts
+++ b/packages/suite-base/src/panels/RawMessagesVirtual/flattenTreeData.test.ts
@@ -60,7 +60,7 @@ describe("flattenTreeData", () => {
   });
 
   describe("when data is an ArrayBuffer view", () => {
-    it("should return empty array given a Uint8Array", () => {
+    it("should flatten Uint8Array elements as indexed nodes", () => {
       // Given
       const data = new Uint8Array([1, 2, 3]);
 
@@ -68,10 +68,16 @@ describe("flattenTreeData", () => {
       const result = flattenTreeData(data, expandedNodes);
 
       // Then
-      expect(result).toEqual([]);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual(
+        expect.objectContaining({ key: "0", label: "0", value: 1, depth: 0 }),
+      );
+      expect(result[2]).toEqual(
+        expect.objectContaining({ key: "2", label: "2", value: 3, depth: 0 }),
+      );
     });
 
-    it("should return empty array given a Float32Array", () => {
+    it("should flatten Float32Array elements as indexed nodes", () => {
       // Given
       const data = new Float32Array([1.5, 2.5, 3.5]);
 
@@ -79,12 +85,42 @@ describe("flattenTreeData", () => {
       const result = flattenTreeData(data, expandedNodes);
 
       // Then
-      expect(result).toEqual([]);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          key: "0",
+          label: "0",
+          value: Math.fround(1.5),
+          depth: 0,
+        }),
+      );
+      expect(result[1]).toEqual(
+        expect.objectContaining({
+          key: "1",
+          label: "1",
+          value: Math.fround(2.5),
+          depth: 0,
+        }),
+      );
     });
 
-    it("should return empty array given an Int16Array", () => {
+    it("should flatten Int16Array elements as indexed nodes", () => {
       // Given
       const data = new Int16Array([10, 20, 30]);
+
+      // When
+      const result = flattenTreeData(data, expandedNodes);
+
+      // Then
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual(
+        expect.objectContaining({ key: "0", value: 10 }),
+      );
+    });
+
+    it("should return empty array given an empty typed array", () => {
+      // Given
+      const data = new Float32Array([]);
 
       // When
       const result = flattenTreeData(data, expandedNodes);
@@ -154,10 +190,49 @@ describe("flattenTreeData", () => {
       expect(result[1]?.isExpandable).toBe(false);
     });
 
-    it("should mark ArrayBuffer views as not expandable", () => {
+    it("should mark non-empty typed array values as expandable", () => {
       // Given
       const data = {
         buffer: new Uint8Array([1, 2, 3]),
+      };
+
+      // When
+      const result = flattenTreeData(data, expandedNodes);
+
+      // Then
+      expect(result).toHaveLength(1);
+      expect(result[0]?.isExpandable).toBe(true);
+    });
+
+    it("should expand typed array children when node is expanded", () => {
+      // Given
+      const data = {
+        values: new Float32Array([1.5, 2.5, 3.5]),
+      };
+      expandedNodes = new Set<string>(["values"]);
+
+      // When
+      const result = flattenTreeData(data, expandedNodes);
+
+      // Then
+      expect(result).toHaveLength(4);
+      expect(result[0]?.key).toBe("values");
+      expect(result[0]?.isExpandable).toBe(true);
+      expect(result[1]).toEqual(
+        expect.objectContaining({ key: "0~values", value: Math.fround(1.5), depth: 1 }),
+      );
+      expect(result[2]).toEqual(
+        expect.objectContaining({ key: "1~values", value: Math.fround(2.5), depth: 1 }),
+      );
+      expect(result[3]).toEqual(
+        expect.objectContaining({ key: "2~values", value: Math.fround(3.5), depth: 1 }),
+      );
+    });
+
+    it("should mark empty typed array values as not expandable", () => {
+      // Given
+      const data = {
+        buffer: new Uint8Array([]),
       };
 
       // When

--- a/packages/suite-base/src/panels/RawMessagesVirtual/flattenTreeData.test.ts
+++ b/packages/suite-base/src/panels/RawMessagesVirtual/flattenTreeData.test.ts
@@ -11,6 +11,9 @@ import { flattenTreeData } from "./flattenTreeData";
 
 describe("flattenTreeData", () => {
   let expandedNodes = new Set<string>();
+  beforeEach(() => {
+    expandedNodes = new Set<string>();
+  });
   describe("when data is null or undefined", () => {
     it("should return empty array given undefined data", () => {
       // Given

--- a/packages/suite-base/src/panels/RawMessagesVirtual/flattenTreeData.ts
+++ b/packages/suite-base/src/panels/RawMessagesVirtual/flattenTreeData.ts
@@ -9,6 +9,7 @@
 
 import { PATH_NAME_AGGREGATOR } from "@lichtblick/suite-base/panels/RawMessagesCommon/constants";
 import { TreeNode } from "@lichtblick/suite-base/panels/RawMessagesCommon/types";
+import { typedArrayToArray } from "@lichtblick/suite-base/panels/RawMessagesCommon/utils";
 
 function isExpandable(value: unknown): boolean {
   if (value == null) {
@@ -20,7 +21,8 @@ function isExpandable(value: unknown): boolean {
   }
 
   if (ArrayBuffer.isView(value)) {
-    return false;
+    // Typed arrays (excluding DataView) are expandable when non-empty
+    return !(value instanceof DataView) && (value as unknown as ArrayLike<unknown>).length > 0;
   }
 
   if (Array.isArray(value)) {
@@ -36,6 +38,7 @@ export function flattenTreeData(
   parentPath: string = "",
   depth: number = 0,
   keyPath: (string | number)[] = [],
+  cache = new WeakMap<object, unknown[]>(),
 ): TreeNode[] {
   const nodes: TreeNode[] = [];
 
@@ -43,13 +46,17 @@ export function flattenTreeData(
     return nodes;
   }
 
-  if (ArrayBuffer.isView(data)) {
+  // Convert typed arrays to regular arrays so their elements can be iterated.
+  // The original typed array value is preserved in each TreeNode for display purposes.
+  const iterableData = typedArrayToArray(data, cache);
+
+  if (iterableData == null || typeof iterableData !== "object") {
     return nodes;
   }
 
-  const entries = Array.isArray(data)
-    ? data.map((item, index) => [index, item] as [number, unknown])
-    : Object.entries(data);
+  const entries = Array.isArray(iterableData)
+    ? iterableData.map((item, index) => [index, item] as [number, unknown])
+    : Object.entries(iterableData as Record<string, unknown>);
 
   return entries.flatMap(([key, value]) => {
     const currentKeyPath = [key, ...keyPath];
@@ -68,7 +75,10 @@ export function flattenTreeData(
     // If node is expandable and expanded, return node + children
     // Otherwise just return the node
     if (node.isExpandable && expandedNodes.has(nodePath)) {
-      return [node, ...flattenTreeData(value, expandedNodes, nodePath, depth + 1, currentKeyPath)];
+      return [
+        node,
+        ...flattenTreeData(value, expandedNodes, nodePath, depth + 1, currentKeyPath, cache),
+      ];
     }
 
     return [node];


### PR DESCRIPTION
## User-Facing Changes

<!-- will be used as a changelog entry -->

Previously the Raw Messages Panel was unable to show values from typed arrays.
<img width="572" height="408" alt="image" src="https://github.com/user-attachments/assets/4090759a-01b3-4d29-9a21-59751517e055" />

Now typed array entries are expandable and will be displayed.
Also the value hint is corrected from "{} x keys" to "[] x items".
<img width="572" height="408" alt="image" src="https://github.com/user-attachments/assets/f7d4c825-16a9-483a-8d09-fc5d29164337" />


## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

This PR fixes the Issue #927.

The problem was that typed arrays are treated as opaque objects which hides their values.
Converting them to normal JS Arrays before rendering solved the issue.

Also the hover action was throwing errors for these arrays sometimes.
Because the hover action function only returns optional actions, a graceful fail prevents crashing the whole panel.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Raw Messages now treats typed arrays (excluding `DataView`) as expandable lists for easier inspection, including in nested/virtualized views.

* **Bug Fixes**
  * Prevented the Raw Messages panel from crashing on unexpected structure/type combinations by failing gracefully with a warning.
  * Improved performance by caching typed-array-to-array conversions during rendering and virtualized tree flattening.

* **Tests**
  * Expanded typed-array test coverage for conversion caching and correct expandability/flattening behavior (including numeric normalization and empty typed-array handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->