### PR TITLE
Allow manual triggering of SonarCloud workflow

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: SonarCloud
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Description

This change allows the SonarCloud workflow to be triggered manually in addition to being triggered on push events.



