### PR TITLE
fix: trigger SonarCloud after release and remove redundant main push …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,3 +110,8 @@ jobs:
             dist/latest-linux.yml
             dist/latest-mac.yml
             dist/latest.yml
+
+      - name: Trigger SonarCloud analysis
+        run: gh workflow run sonarqube.yml --ref main
+        env:
+          GH_TOKEN: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -2,7 +2,7 @@ name: SonarCloud
 
 on:
   push:
-    branches: ["main", "develop"]
+    branches: ["develop"]
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:


### PR DESCRIPTION
## User-Facing Changes

N/A

## Description

After a release, the SonarCloud analysis on `main` was showing an outdated project version and stale code coverage because:

1. The `release.yml` commit uses `[skip actions]`, which skips all workflows — including SonarCloud
2. The previous push-triggered Sonar analysis ran on the merge commit (before the version bump), so it always reported the old version

This PR fixes the issue by:

- **Adding a step in `release.yml`** to explicitly trigger the SonarCloud workflow on `main` via `gh workflow run` after the release is complete — ensuring analysis runs with the correct version
- **Removing `main` from the push trigger in `sonarqube.yml`** to avoid a redundant (and outdated) Sonar run on every merge to `main`

Related to #1009

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated