### PR TITLE
Bugfix - Update how layout chages are calculated

### DIFF
--- a/packages/suite-base/package.json
+++ b/packages/suite-base/package.json
@@ -128,7 +128,6 @@
     "intervals-fn": "3.0.3",
     "jest-canvas-mock": "2.5.2",
     "jszip": "3.10.1",
-    "just-diff": "6.0.2",
     "leaflet": "1.9.4",
     "leaflet-ellipse": "0.9.1",
     "lodash-es": "4.17.23",

--- a/packages/suite-base/src/services/LayoutManager/utils/isLayoutEqual.test.ts
+++ b/packages/suite-base/src/services/LayoutManager/utils/isLayoutEqual.test.ts
@@ -40,15 +40,15 @@ describe("isLayoutEqual", () => {
   describe("when comparing layouts with differences", () => {
     it("should return false when panel configuration changes", () => {
       // Given
-      const painelId = BasicBuilder.string();
+      const panelId = BasicBuilder.string();
       const layoutA = LayoutBuilder.data({
         configById: {
-          [painelId]: { id: "panel1", type: "3DPanel" },
+          [panelId]: { id: "panel1", type: "3DPanel" },
         },
       });
       const layoutB = LayoutBuilder.data({
         configById: {
-          [painelId]: { id: "panel1", type: "MapPanel" }, // different type
+          [panelId]: { id: "panel1", type: "MapPanel" },
         },
       });
 
@@ -57,6 +57,76 @@ describe("isLayoutEqual", () => {
 
       // Then
       expect(result).toBe(false);
+    });
+
+    it("should return false when a config key present in a is absent in b", () => {
+      // Given
+      const panelId = BasicBuilder.string();
+      const layoutA = LayoutBuilder.data({
+        configById: {
+          [panelId]: { topic: "/markers" },
+        },
+      });
+      const layoutB = LayoutBuilder.data({
+        configById: {
+          [panelId]: {},
+        },
+      });
+
+      // When
+      const result = isLayoutEqual(layoutA, layoutB);
+
+      // Then
+      expect(result).toBe(false);
+    });
+
+    it("should return false when a top-level field differs", () => {
+      // Given
+      const layoutA = LayoutBuilder.data({ globalVariables: { speed: 10 } });
+      const layoutB = LayoutBuilder.data({ globalVariables: { speed: 99 } });
+
+      // When
+      const result = isLayoutEqual(layoutA, layoutB);
+
+      // Then
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("when b has additional entries not present in a (additive tolerance)", () => {
+    it("should return true when b has a new panel ID not present in a", () => {
+      // Given
+      const panelId = BasicBuilder.string();
+      const newPanelId = BasicBuilder.string();
+      const base = LayoutBuilder.data({ configById: { [panelId]: { topic: "/markers" } } });
+      const layoutA = base;
+      const layoutB = {
+        ...base,
+        configById: { [panelId]: { topic: "/markers" }, [newPanelId]: { topic: "/new" } },
+      };
+
+      // When
+      const result = isLayoutEqual(layoutA, layoutB);
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it("should return true when b's panel config has a new key not present in a", () => {
+      // Given
+      const panelId = BasicBuilder.string();
+      const base = LayoutBuilder.data({ configById: { [panelId]: { topic: "/markers" } } });
+      const layoutA = base;
+      const layoutB = {
+        ...base,
+        configById: { [panelId]: { topic: "/markers", newKey: "defaultValue" } },
+      };
+
+      // When
+      const result = isLayoutEqual(layoutA, layoutB);
+
+      // Then
+      expect(result).toBe(true);
     });
   });
 

--- a/packages/suite-base/src/services/LayoutManager/utils/isLayoutEqual.test.ts
+++ b/packages/suite-base/src/services/LayoutManager/utils/isLayoutEqual.test.ts
@@ -26,11 +26,11 @@ describe("isLayoutEqual", () => {
 
     it("should return true for layouts with identical content", () => {
       // Given
-      const layoutA = LayoutBuilder.data();
-      const layoutB = layoutA;
+      const layoutBaseline = LayoutBuilder.data();
+      const layoutCurrent = layoutBaseline;
 
       // When
-      const result = isLayoutEqual(layoutA, layoutB);
+      const result = isLayoutEqual(layoutBaseline, layoutCurrent);
 
       // Then
       expect(result).toBe(true);
@@ -41,121 +41,125 @@ describe("isLayoutEqual", () => {
     it("should return false when panel configuration changes", () => {
       // Given
       const panelId = BasicBuilder.string();
-      const layoutA = LayoutBuilder.data({
+      const layoutBaseline = LayoutBuilder.data({
         configById: {
           [panelId]: { id: "panel1", type: "3DPanel" },
         },
       });
-      const layoutB = LayoutBuilder.data({
+      const layoutCurrent = LayoutBuilder.data({
         configById: {
           [panelId]: { id: "panel1", type: "MapPanel" },
         },
       });
 
       // When
-      const result = isLayoutEqual(layoutA, layoutB);
+      const result = isLayoutEqual(layoutBaseline, layoutCurrent);
 
       // Then
       expect(result).toBe(false);
     });
 
-    it("should return false when a config key present in a is absent in b", () => {
+    it("should return false when a config key present in baseline is absent in current layout", () => {
       // Given
       const panelId = BasicBuilder.string();
-      const layoutA = LayoutBuilder.data({
+      const layoutBaseline = LayoutBuilder.data({
         configById: {
-          [panelId]: { topic: "/markers" },
+          [panelId]: { topic: BasicBuilder.string() },
         },
       });
-      const layoutB = LayoutBuilder.data({
+      const layoutCurrent = LayoutBuilder.data({
         configById: {
           [panelId]: {},
         },
       });
 
       // When
-      const result = isLayoutEqual(layoutA, layoutB);
+      const result = isLayoutEqual(layoutBaseline, layoutCurrent);
 
       // Then
       expect(result).toBe(false);
     });
 
-    it("should return false when a top-level field differs", () => {
+    it("should return false when baseline top-level field differs", () => {
+      const speedA = BasicBuilder.number();
+      const speedB = speedA + BasicBuilder.number();
       // Given
-      const layoutA = LayoutBuilder.data({ globalVariables: { speed: 10 } });
-      const layoutB = LayoutBuilder.data({ globalVariables: { speed: 99 } });
+      const layoutBaseline = LayoutBuilder.data({ globalVariables: { speed: speedA } });
+      const layoutCurrent = LayoutBuilder.data({ globalVariables: { speed: speedB } });
 
       // When
-      const result = isLayoutEqual(layoutA, layoutB);
+      const result = isLayoutEqual(layoutBaseline, layoutCurrent);
 
       // Then
       expect(result).toBe(false);
     });
   });
 
-  describe("when b has additional entries not present in a (additive tolerance)", () => {
-    it("should return true when b has a new panel ID not present in a", () => {
+  describe("when current layout has additional entries not present in baseline (additive tolerance)", () => {
+    const topicA = BasicBuilder.string();
+    const topicB = BasicBuilder.string();
+    it("should return true when current layout has a new panel ID not present in baseline", () => {
       // Given
       const panelId = BasicBuilder.string();
       const newPanelId = BasicBuilder.string();
-      const base = LayoutBuilder.data({ configById: { [panelId]: { topic: "/markers" } } });
-      const layoutA = base;
-      const layoutB = {
+      const base = LayoutBuilder.data({ configById: { [panelId]: { topic: topicA } } });
+      const layoutBaseline = base;
+      const layoutCurrent = {
         ...base,
-        configById: { [panelId]: { topic: "/markers" }, [newPanelId]: { topic: "/new" } },
+        configById: { [panelId]: { topic: topicA }, [newPanelId]: { topic: topicB } },
       };
 
       // When
-      const result = isLayoutEqual(layoutA, layoutB);
+      const result = isLayoutEqual(layoutBaseline, layoutCurrent);
 
       // Then
       expect(result).toBe(true);
     });
 
-    it("should return true when b's panel config has a new key not present in a", () => {
+    it("should return true when current layout's panel config has a new key not present in baseline", () => {
       // Given
       const panelId = BasicBuilder.string();
-      const base = LayoutBuilder.data({ configById: { [panelId]: { topic: "/markers" } } });
-      const layoutA = base;
-      const layoutB = {
+      const base = LayoutBuilder.data({ configById: { [panelId]: { topic: topicA } } });
+      const layoutBaseline = base;
+      const layoutCurrent = {
         ...base,
-        configById: { [panelId]: { topic: "/markers", newKey: "defaultValue" } },
+        configById: { [panelId]: { topic: topicA, newKey: BasicBuilder.string() } },
       };
 
       // When
-      const result = isLayoutEqual(layoutA, layoutB);
+      const result = isLayoutEqual(layoutBaseline, layoutCurrent);
 
       // Then
       expect(result).toBe(true);
     });
   });
 
-  describe("when second layout has additional undefined fields", () => {
-    it("should return true when layout B has extra undefined fields", () => {
+  describe("when current layout has additional undefined fields", () => {
+    it("should return true when current layout has extra undefined fields", () => {
       // Given
-      const layoutA = LayoutBuilder.data();
-      const layoutB = {
-        ...layoutA,
+      const layoutBaseline = LayoutBuilder.data();
+      const layoutCurrent = {
+        ...layoutBaseline,
         extraField: undefined,
       } as LayoutData & { extraField: undefined };
 
       // When
-      const result = isLayoutEqual(layoutA, layoutB);
+      const result = isLayoutEqual(layoutBaseline, layoutCurrent);
 
       // Then
       expect(result).toBe(true);
     });
 
-    it("should return false when layout B has extra defined fields", () => {
+    it("should return false when current layout has extra defined fields", () => {
       // Given
-      const layoutA = LayoutBuilder.data();
-      const layoutB = {
-        ...layoutA,
+      const layoutBaseline = LayoutBuilder.data();
+      const layoutCurrent = {
+        ...layoutBaseline,
         extraField: BasicBuilder.string(),
       } as LayoutData & { extraField: string };
 
       // When
-      const result = isLayoutEqual(layoutA, layoutB);
+      const result = isLayoutEqual(layoutBaseline, layoutCurrent);
 
       // Then
       expect(result).toBe(false);

--- a/packages/suite-base/src/services/LayoutManager/utils/isLayoutEqual.ts
+++ b/packages/suite-base/src/services/LayoutManager/utils/isLayoutEqual.ts
@@ -28,28 +28,28 @@ import { LayoutData } from "@lichtblick/suite-base/context/CurrentLayoutContext/
  * Existing keys that are present in a and have a different value in b (including removal,
  * i.e., the key is absent in b) are always treated as real differences.
  */
-export function isLayoutEqual(a: LayoutData, b: LayoutData): boolean {
-  const { configById: configByIdA, ...restA } = a;
-  const { configById: configByIdB, ...restB } = b;
+export function isLayoutEqual(baseline: LayoutData, current: LayoutData): boolean {
+  const { configById: configByIdBaseline, ...restBaseline } = baseline;
+  const { configById: configByIdCurrent, ...restCurrent } = current;
 
   // All top-level fields other than configById must be deeply equal.
-  // Strip keys whose value is undefined in b so extra undefined entries don't
+  // Strip keys whose value is undefined in current so extra undefined entries don't
   // register as differences (preserving the original behaviour).
-  const strippedRestB = _.omitBy(restB, _.isUndefined);
-  if (!_.isEqual(_.omitBy(restA, _.isUndefined), strippedRestB)) {
+  const strippedRestCurrent = _.omitBy(restCurrent, _.isUndefined);
+  if (!_.isEqual(_.omitBy(restBaseline, _.isUndefined), strippedRestCurrent)) {
     return false;
   }
 
   // For configById, only check panel IDs that existed in the baseline (a).
   // New panel entries added by panel initialization are not considered user edits.
-  for (const panelId of Object.keys(configByIdA)) {
-    const panelConfigA = configByIdA[panelId] ?? {};
-    const panelConfigB = configByIdB[panelId] ?? {};
+  for (const panelId of Object.keys(configByIdBaseline)) {
+    const panelConfigBaseline = configByIdBaseline[panelId] ?? {};
+    const panelConfigCurrent = configByIdCurrent[panelId] ?? {};
 
     // For each key in the baseline panel config, check it still has the same value.
-    // New keys added to b's panel config are ignored (panel default initialization).
-    for (const configKey of Object.keys(panelConfigA)) {
-      if (!_.isEqual(panelConfigA[configKey], panelConfigB[configKey])) {
+    // New keys added to current's panel config are ignored (panel default initialization).
+    for (const configKey of Object.keys(panelConfigBaseline)) {
+      if (!_.isEqual(panelConfigBaseline[configKey], panelConfigCurrent[configKey])) {
         return false;
       }
     }

--- a/packages/suite-base/src/services/LayoutManager/utils/isLayoutEqual.ts
+++ b/packages/suite-base/src/services/LayoutManager/utils/isLayoutEqual.ts
@@ -5,7 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { diff } from "just-diff";
+import * as _ from "lodash-es";
 
 import { LayoutData } from "@lichtblick/suite-base/context/CurrentLayoutContext/actions";
 
@@ -14,25 +14,46 @@ import { LayoutData } from "@lichtblick/suite-base/context/CurrentLayoutContext/
  * considered "equal" then the function returns true. If the two instances are not equal it returns
  * false.
  *
- * Layout instances are considered equal if they have all of the same fields and all of the same
- * values in those fields - recursively. An exception is made for where _b_ only differes from _a_
- * by introducing new fields which are _undefined_. If _b_ has an extra field with value undefined,
- * it will still be considered equal to _a_.
+ * The comparison is intentionally additive-lenient in two dimensions:
+ *
+ * 1. Top-level non-configById fields: extra undefined fields in b are ignored.
+ * 2. configById (panel configs): two levels of additive tolerance are applied.
+ *    a. New panel IDs in b that were not in a are ignored — a panel can be added to the
+ *       mosaic but its first saveConfig call is not a user edit.
+ *    b. New config keys in b's panel config that were not in a's panel config are ignored —
+ *       panels populate their own default config keys during initialization, and treating
+ *       those additions as user edits would create false "unsaved changes" indicators on
+ *       shared/team layouts.
+ *
+ * Existing keys that are present in a and have a different value in b (including removal,
+ * i.e., the key is absent in b) are always treated as real differences.
  */
 export function isLayoutEqual(a: LayoutData, b: LayoutData): boolean {
-  const res = diff(a, b);
-  for (const item of res) {
-    // Any replace or remove is treated as a diff
-    if (item.op === "replace" || item.op === "remove") {
-      return false;
-    }
+  const { configById: configByIdA, ...restA } = a;
+  const { configById: configByIdB, ...restB } = b;
 
-    // If a field is added but the value is anything other than undefined, the layouts are not the same
-    if (item.value != undefined) {
-      return false;
+  // All top-level fields other than configById must be deeply equal.
+  // Strip keys whose value is undefined in b so extra undefined entries don't
+  // register as differences (preserving the original behaviour).
+  const strippedRestB = _.omitBy(restB, _.isUndefined);
+  if (!_.isEqual(_.omitBy(restA, _.isUndefined), strippedRestB)) {
+    return false;
+  }
+
+  // For configById, only check panel IDs that existed in the baseline (a).
+  // New panel entries added by panel initialization are not considered user edits.
+  for (const panelId of Object.keys(configByIdA)) {
+    const panelConfigA = configByIdA[panelId] ?? {};
+    const panelConfigB = configByIdB[panelId] ?? {};
+
+    // For each key in the baseline panel config, check it still has the same value.
+    // New keys added to b's panel config are ignored (panel default initialization).
+    for (const configKey of Object.keys(panelConfigA)) {
+      if (!_.isEqual(panelConfigA[configKey], panelConfigB[configKey])) {
+        return false;
+      }
     }
   }
 
-  // No actual diff, so the values are the same
   return true;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3435,7 +3435,6 @@ __metadata:
     intervals-fn: 3.0.3
     jest-canvas-mock: 2.5.2
     jszip: 3.10.1
-    just-diff: 6.0.2
     leaflet: 1.9.4
     leaflet-ellipse: 0.9.1
     lodash-es: 4.17.23
@@ -14820,13 +14819,6 @@ __metadata:
     readable-stream: ~2.3.6
     setimmediate: ^1.0.5
   checksum: abc77bfbe33e691d4d1ac9c74c8851b5761fba6a6986630864f98d876f3fcc2d36817dfc183779f32c00157b5d53a016796677298272a714ae096dfe6b1c8b60
-  languageName: node
-  linkType: hard
-
-"just-diff@npm:6.0.2":
-  version: 6.0.2
-  resolution: "just-diff@npm:6.0.2"
-  checksum: 1a0c7524f640cb88ab013862733e710f840927834208fd3b85cbc5da2ced97acc75e7dcfe493268ac6a6514c51dd8624d2fd9d057050efba3c02b81a6dcb7ff9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## User-Facing Changes

Fixed a bug where the "unsaved changes" indicator was incorrectly shown after opening a layout, even when no edits had been made by the user.

## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
