### PR TITLE
fix: enable Teleop directional pad on mobile/touch devices

### DIFF
--- a/packages/suite-base/src/panels/Teleop/DirectionalPad.style.ts
+++ b/packages/suite-base/src/panels/Teleop/DirectionalPad.style.ts
@@ -9,6 +9,7 @@ export const useStyles = makeStyles<void, "buttonIcon">()((theme, _params, class
     label: "DirectionalPad-svg",
     maxHeight: "100%",
     maxWidth: "100%",
+    touchAction: "none",
   },
   button: {
     label: "DirectionalPad-button",

--- a/packages/suite-base/src/panels/Teleop/DirectionalPad.test.tsx
+++ b/packages/suite-base/src/panels/Teleop/DirectionalPad.test.tsx
@@ -9,14 +9,14 @@ import DirectionalPad from "@lichtblick/suite-base/panels/Teleop/DirectionalPad"
 import { DirectionalPadAction } from "@lichtblick/suite-base/panels/Teleop/types";
 
 describe("DirectionalPad", () => {
-  it("should call onAction and update state when UP button is clicked", () => {
+  it("should call onAction and update state when UP button is pressed", () => {
     // given
     const onAction = jest.fn();
     const { container } = render(<DirectionalPad onAction={onAction} />);
     const upButton = container.querySelector('g[role="button"]');
 
     // when
-    fireEvent.mouseDown(upButton!);
+    fireEvent.pointerDown(upButton!);
 
     // then
     expect(onAction).toHaveBeenCalledWith(DirectionalPadAction.UP);
@@ -30,7 +30,7 @@ describe("DirectionalPad", () => {
     const upButton = container.querySelector('g[role="button"]');
 
     // when
-    fireEvent.mouseDown(upButton!);
+    fireEvent.pointerDown(upButton!);
 
     // then
     expect(onAction).not.toHaveBeenCalled();
@@ -43,7 +43,7 @@ describe("DirectionalPad", () => {
     const upButton = container.querySelector('g[role="button"]');
 
     // when
-    fireEvent.mouseDown(upButton!);
+    fireEvent.pointerDown(upButton!);
 
     // then
     expect(upButton?.parentElement?.querySelector(".active")).toBeTruthy();
@@ -65,10 +65,40 @@ describe("DirectionalPad", () => {
     ];
 
     buttons.forEach((button, index) => {
-      fireEvent.mouseDown(button);
+      fireEvent.pointerDown(button);
       expect(onAction).toHaveBeenCalledWith(actions[index]);
       expect(button.parentElement?.querySelector(".active")).toBeTruthy();
-      fireEvent.mouseUp(button);
+      fireEvent.pointerUp(button);
     });
+  });
+
+  it("should stop action on pointerCancel", () => {
+    // given
+    const onAction = jest.fn();
+    const { container } = render(<DirectionalPad onAction={onAction} />);
+    const upButton = container.querySelector('g[role="button"]');
+
+    // when
+    fireEvent.pointerDown(upButton!);
+    onAction.mockClear();
+    fireEvent.pointerCancel(upButton!);
+
+    // then
+    expect(onAction).toHaveBeenCalledWith();
+  });
+
+  it("should stop action on pointerLeave", () => {
+    // given
+    const onAction = jest.fn();
+    const { container } = render(<DirectionalPad onAction={onAction} />);
+    const upButton = container.querySelector('g[role="button"]');
+
+    // when
+    fireEvent.pointerDown(upButton!);
+    onAction.mockClear();
+    fireEvent.pointerLeave(upButton!);
+
+    // then
+    expect(onAction).toHaveBeenCalledWith();
   });
 });

--- a/packages/suite-base/src/panels/Teleop/DirectionalPad.tsx
+++ b/packages/suite-base/src/panels/Teleop/DirectionalPad.tsx
@@ -23,7 +23,7 @@ function DirectionalPad(props: Readonly<DirectionalPadProps>): React.JSX.Element
 
   const { classes, cx } = useStyles();
 
-  const handleMouseDown = useCallback(
+  const handlePointerDown = useCallback(
     (action: DirectionalPadAction) => {
       setCurrentAction(action);
       onAction?.(action);
@@ -31,7 +31,7 @@ function DirectionalPad(props: Readonly<DirectionalPadProps>): React.JSX.Element
     [onAction],
   );
 
-  const handleMouseUp = useCallback(() => {
+  const handlePointerUp = useCallback(() => {
     if (currentAction == undefined) {
       return;
     }
@@ -39,18 +39,21 @@ function DirectionalPad(props: Readonly<DirectionalPadProps>): React.JSX.Element
     onAction?.();
   }, [onAction, currentAction]);
 
-  const makeMouseHandlers = (action: DirectionalPadAction) =>
+  const makePointerHandlers = (action: DirectionalPadAction) =>
     disabled
       ? undefined
       : {
-          onMouseDown: () => {
-            handleMouseDown(action);
+          onPointerDown: () => {
+            handlePointerDown(action);
           },
-          onMouseUp: () => {
-            handleMouseUp();
+          onPointerUp: () => {
+            handlePointerUp();
           },
-          onMouseLeave: () => {
-            handleMouseUp();
+          onPointerLeave: () => {
+            handlePointerUp();
+          },
+          onPointerCancel: () => {
+            handlePointerUp();
           },
         };
 
@@ -65,7 +68,7 @@ function DirectionalPad(props: Readonly<DirectionalPadProps>): React.JSX.Element
       <svg className={classes.svg} viewBox="0 0 256 256">
         <g opacity={1}>
           {/* UP button */}
-          <g {...makeMouseHandlers(DirectionalPadAction.UP)} role="button">
+          <g {...makePointerHandlers(DirectionalPadAction.UP)} role="button">
             <path
               className={cx(classes.button, {
                 active: currentAction === DirectionalPadAction.UP,
@@ -77,7 +80,7 @@ function DirectionalPad(props: Readonly<DirectionalPadProps>): React.JSX.Element
           </g>
 
           {/* DOWN button */}
-          <g {...makeMouseHandlers(DirectionalPadAction.DOWN)} role="button">
+          <g {...makePointerHandlers(DirectionalPadAction.DOWN)} role="button">
             <path
               className={cx(classes.button, {
                 active: currentAction === DirectionalPadAction.DOWN,
@@ -91,7 +94,7 @@ function DirectionalPad(props: Readonly<DirectionalPadProps>): React.JSX.Element
 
         <g opacity={1}>
           {/* LEFT button */}
-          <g {...makeMouseHandlers(DirectionalPadAction.LEFT)} role="button">
+          <g {...makePointerHandlers(DirectionalPadAction.LEFT)} role="button">
             <path
               className={cx(classes.button, {
                 active: currentAction === DirectionalPadAction.LEFT,
@@ -103,7 +106,7 @@ function DirectionalPad(props: Readonly<DirectionalPadProps>): React.JSX.Element
           </g>
 
           {/* RIGHT button */}
-          <g {...makeMouseHandlers(DirectionalPadAction.RIGHT)} role="button">
+          <g {...makePointerHandlers(DirectionalPadAction.RIGHT)} role="button">
             <path
               className={cx(classes.button, {
                 active: currentAction === DirectionalPadAction.RIGHT,


### PR DESCRIPTION
## User-Facing Changes

Teleop panel directional pad buttons now respond to touch input on mobile devices.

## Description

Fixes #969

The DirectionalPad component used mouse-only event handlers (`onMouseDown`/`onMouseUp`/`onMouseLeave`), which mobile browsers do not reliably fire for touch interactions on SVG elements. This caused the d-pad to be completely unresponsive on touch devices (reported on Android 16, Chrome Mobile 145).

Replaced mouse events with pointer events (`onPointerDown`/`onPointerUp`/`onPointerLeave`/`onPointerCancel`), which handle both mouse and touch input through a single unified API. Also added `touch-action: none` to the SVG element to prevent the browser from intercepting touches for scrolling.

### Changes

- `DirectionalPad.tsx`: Replace `makeMouseHandlers` with `makePointerHandlers` using pointer events
- `DirectionalPad.style.ts`: Add `touchAction: "none"` to the SVG container
- `DirectionalPad.test.tsx`: Update existing tests to use pointer events, add `pointerCancel` and `pointerLeave` test cases

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated