### PR TITLE
bugfix: avoid dropping compressed video frames before decoding

### DIFF
--- a/packages/den/video/h264/SPS.ts
+++ b/packages/den/video/h264/SPS.ts
@@ -336,7 +336,7 @@ export class SPS {
         this.num_units_in_tick = bitstream.u(32);
         this.time_scale = bitstream.u(32);
         this.fixed_frame_rate_flag = bitstream.u_1();
-        if (this.num_units_in_tick !== 0 && this.time_scale !== 0 && this.num_units_in_tick !== 0) {
+        if (this.num_units_in_tick !== 0 && this.time_scale !== 0) {
           this.framesPerSecond = this.time_scale / (2 * this.num_units_in_tick);
         }
       }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -277,7 +277,6 @@ export class ImageMode
         subscription: {
           handler: this.messageHandler.handleCompressedVideo,
           shouldSubscribe: this.imageShouldSubscribe,
-          filterQueue: this.#filterMessageQueue.bind(this),
         },
       },
     ];

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -146,7 +146,6 @@ export class Images extends SceneExtension<ImageRenderable> {
         schemaNames: COMPRESSED_VIDEO_DATATYPES,
         subscription: {
           handler: this.#handleCompressedVideo,
-          filterQueue: onlyLastByTopicMessage,
         },
       },
     ];


### PR DESCRIPTION
## User-Facing Changes

<!-- will be used as a changelog entry -->
Fixes corrupted or unstable playback for compressed video streams by ensuring encoded frames are not filtered out before decoding.

## Description
Fix branch naming from #904 

This issue is not specific to H.264. The underlying problem is that `filterQueue` may drop encoded video `MessageEvent`s before they reach the WebCodecs decoder.

For compressed video streams, dropping frames before decoding can break frame dependencies and lead to incorrect output, especially at high playback speeds or when keyframe intervals are large.

This PR removes the pre-decode filtering step for compressed video and always feeds the decoder the full encoded frame sequence.

I reproduced and verified the issue using the sample MCAP below with H.264 at 5x playback speed. While the reproduction uses H.264, the fix applies more broadly to compressed video because the decoder must receive the complete encoded frame sequence.

https://drive.google.com/file/d/1z6PnopbkXyMWdln4h-u5rIw_p1pB6v15/view?usp=drive_link

This PR also removes a duplicated condition check inside an `if` statement to simplify the logic and improve code clarity.


## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
