### PR TITLE
[codex] add h265 support for CompressedVideo

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,12 +76,15 @@
     "react-dnd": "patch:react-dnd@npm:16.0.1#./patches/react-dnd.patch",
     "@types/react": "18.3.12",
     "esbuild": "0.25.0",
-    "dompurify": "3.3.2",
+    "dompurify": "3.4.0",
     "js-yaml": "4.1.1",
     "qs": "6.14.1",
     "tar": "7.5.11",
     "undici": "6.24.1",
-    "flatted": "3.4.2"
+    "flatted": "3.4.2",
+    "@xmldom/xmldom@npm:^0.8.8": "0.8.13",
+    "postcss": "8.5.10",
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@actions/core": "1.11.1",

--- a/packages/den/video/VideoPlayer.test.ts
+++ b/packages/den/video/VideoPlayer.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
 /** @jest-environment jsdom */
 
 import { DecodeFramesResult, VideoPlayer } from "./VideoPlayer";
@@ -46,6 +49,8 @@ describe("VideoPlayer", () => {
 
     class MockVideoDecoder {
       public state: "configured" | "closed" | "unconfigured" = "unconfigured";
+      public decodeQueueSize = 0;
+      public ondequeue: ((event: Event) => void) | null = null;
       readonly #init: VideoDecoderInit;
 
       public constructor(init: VideoDecoderInit) {
@@ -57,15 +62,22 @@ describe("VideoPlayer", () => {
       }
 
       public decode(chunk: MockEncodedVideoChunk): void {
-        outputFrames.set(chunk.timestamp, this.#init.output);
+        this.decodeQueueSize++;
+        outputFrames.set(chunk.timestamp, (frame) => {
+          this.#init.output(frame);
+          this.decodeQueueSize--;
+          this.ondequeue?.(new Event("dequeue"));
+        });
       }
 
       public reset(): void {
+        this.decodeQueueSize = 0;
         outputFrames.clear();
       }
 
       public close(): void {
         this.state = "closed";
+        this.decodeQueueSize = 0;
         outputFrames.clear();
       }
     }
@@ -76,7 +88,9 @@ describe("VideoPlayer", () => {
     const player = new VideoPlayer();
     await player.init({ codec: "hvc1.1.6.L93.B0" });
 
-    const decodePromise = player.decodeFrames([{ data: new Uint8Array([1]), timestampMicros: 1000, type: "key" }]);
+    const decodePromise = player.decodeFrames([
+      { data: new Uint8Array([1]), timestampMicros: 1000, type: "key" },
+    ]);
     await Promise.resolve();
 
     const targetFrame = createFrame(1000);
@@ -144,6 +158,8 @@ describe("VideoPlayer", () => {
 
     class MockVideoDecoder {
       public state: "configured" | "closed" | "unconfigured" = "unconfigured";
+      public decodeQueueSize = 0;
+      public ondequeue: ((event: Event) => void) | null = null;
       readonly #init: VideoDecoderInit;
 
       public constructor(init: VideoDecoderInit) {
@@ -155,15 +171,22 @@ describe("VideoPlayer", () => {
       }
 
       public decode(chunk: MockEncodedVideoChunk): void {
-        outputFrames.set(chunk.timestamp, this.#init.output);
+        this.decodeQueueSize++;
+        outputFrames.set(chunk.timestamp, (frame) => {
+          this.#init.output(frame);
+          this.decodeQueueSize--;
+          this.ondequeue?.(new Event("dequeue"));
+        });
       }
 
       public reset(): void {
+        this.decodeQueueSize = 0;
         outputFrames.clear();
       }
 
       public close(): void {
         this.state = "closed";
+        this.decodeQueueSize = 0;
         outputFrames.clear();
       }
     }
@@ -182,7 +205,9 @@ describe("VideoPlayer", () => {
     await jest.advanceTimersByTimeAsync(30);
 
     outputFrames.get(0)?.(createFrame(0));
-    await expect(Promise.race([decodePromise, Promise.resolve("pending")])).resolves.toBe("pending");
+    await expect(Promise.race([decodePromise, Promise.resolve("pending")])).resolves.toBe(
+      "pending",
+    );
 
     const targetFrame = createFrame(33333);
     outputFrames.get(33333)?.(targetFrame);
@@ -198,8 +223,6 @@ describe("VideoPlayer", () => {
     class MockVideoDecoder {
       public state: "configured" | "closed" | "unconfigured" = "unconfigured";
 
-      public constructor(_: VideoDecoderInit) {}
-
       public configure(): void {
         this.state = "configured";
       }
@@ -217,7 +240,9 @@ describe("VideoPlayer", () => {
     const player = new VideoPlayer();
     await player.init({ codec: "hvc1.1.6.L93.B0" });
 
-    const decodePromise = player.decodeFrames([{ data: new Uint8Array([1]), timestampMicros: 0, type: "key" }]);
+    const decodePromise = player.decodeFrames([
+      { data: new Uint8Array([1]), timestampMicros: 0, type: "key" },
+    ]);
     await jest.advanceTimersByTimeAsync(2000);
 
     await expect(decodePromise).resolves.toEqual({ type: "timeout" });
@@ -227,8 +252,6 @@ describe("VideoPlayer", () => {
     class MockVideoDecoder {
       public state: "configured" | "closed" | "unconfigured" = "unconfigured";
 
-      public constructor(_: VideoDecoderInit) {}
-
       public configure(): void {
         this.state = "configured";
       }
@@ -246,21 +269,19 @@ describe("VideoPlayer", () => {
     const player = new VideoPlayer();
     await player.init({ codec: "hvc1.1.6.L93.B0" });
 
-    const decodePromise = player.decodeFrames([{ data: new Uint8Array([1]), timestampMicros: 0, type: "key" }]);
+    const decodePromise = player.decodeFrames([
+      { data: new Uint8Array([1]), timestampMicros: 0, type: "key" },
+    ]);
     await Promise.resolve();
     player.resetForSeek();
 
     await expect(decodePromise).resolves.toEqual({ type: "aborted", frame: undefined });
-    expect(player.decoderConfig()).toEqual(
-      expect.objectContaining({ codec: "hvc1.1.6.L93.B0" }),
-    );
+    expect(player.decoderConfig()).toEqual(expect.objectContaining({ codec: "hvc1.1.6.L93.B0" }));
   });
 
   it("should clear decoder config on close", async () => {
     class MockVideoDecoder {
       public state: "configured" | "closed" | "unconfigured" = "unconfigured";
-
-      public constructor(_: VideoDecoderInit) {}
 
       public configure(): void {
         this.state = "configured";
@@ -284,17 +305,17 @@ describe("VideoPlayer", () => {
   });
 
   it("should wait for decode queue drain", async () => {
-    let decoder: MockVideoDecoder | undefined;
+    const decoders: MockVideoDecoder[] = [];
+    let output: VideoDecoderInit["output"] | undefined;
 
     class MockVideoDecoder {
       public state: "configured" | "closed" | "unconfigured" = "unconfigured";
       public decodeQueueSize = 0;
       public ondequeue: ((event: Event) => void) | null = null;
-      readonly #init: VideoDecoderInit;
 
       public constructor(init: VideoDecoderInit) {
-        this.#init = init;
-        decoder = this;
+        output = init.output;
+        decoders.push(this);
       }
 
       public configure(): void {
@@ -304,9 +325,12 @@ describe("VideoPlayer", () => {
       public decode(chunk: MockEncodedVideoChunk): void {
         this.decodeQueueSize++;
         setTimeout(() => {
-          this.#init.output(createFrame(chunk.timestamp));
-          this.decodeQueueSize--;
-          this.ondequeue?.(new Event("dequeue"));
+          output?.(createFrame(chunk.timestamp));
+          const decoder = decoders[0];
+          if (decoder) {
+            decoder.decodeQueueSize--;
+            decoder.ondequeue?.(new Event("dequeue"));
+          }
         }, 40);
       }
 
@@ -331,11 +355,11 @@ describe("VideoPlayer", () => {
     ]);
     await Promise.resolve();
 
-    expect(decoder?.ondequeue).toBeDefined();
+    expect(decoders[0]?.ondequeue).toBeDefined();
     await jest.advanceTimersByTimeAsync(40);
 
     await expect(decodePromise).resolves.toMatchObject({ type: "target" });
-    expect(decoder?.ondequeue).toBeNull();
+    expect(decoders[0]?.ondequeue).toBeNull();
   });
 
   it("should reject non-increasing timestamps until reset", async () => {
@@ -435,8 +459,6 @@ describe("VideoPlayer", () => {
 
     class MockVideoDecoder {
       public state: "configured" | "closed" | "unconfigured" = "unconfigured";
-
-      public constructor(_: VideoDecoderInit) {}
 
       public configure(config: VideoDecoderConfig): void {
         configure(config);

--- a/packages/den/video/VideoPlayer.test.ts
+++ b/packages/den/video/VideoPlayer.test.ts
@@ -1,0 +1,476 @@
+/** @jest-environment jsdom */
+
+import { DecodeFramesResult, VideoPlayer } from "./VideoPlayer";
+
+class MockEncodedVideoChunk {
+  public readonly type: "key" | "delta";
+  public readonly data: Uint8Array;
+  public readonly timestamp: number;
+
+  public constructor(init: { type: "key" | "delta"; data: Uint8Array; timestamp: number }) {
+    this.type = init.type;
+    this.data = init.data;
+    this.timestamp = init.timestamp;
+  }
+}
+
+describe("VideoPlayer", () => {
+  const originalVideoDecoder = globalThis.VideoDecoder;
+  const originalEncodedVideoChunk = globalThis.EncodedVideoChunk;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    globalThis.VideoDecoder = originalVideoDecoder;
+    globalThis.EncodedVideoChunk = originalEncodedVideoChunk;
+    jest.restoreAllMocks();
+  });
+
+  function createFrame(timestamp: number): VideoFrame {
+    return {
+      timestamp,
+      codedWidth: 640,
+      codedHeight: 480,
+      close: jest.fn(),
+      clone: jest.fn().mockImplementation(function () {
+        return this;
+      }),
+    } as unknown as VideoFrame;
+  }
+
+  it("should return the target frame when it arrives before timeout", async () => {
+    const outputFrames = new Map<number, (frame: VideoFrame) => void>();
+
+    class MockVideoDecoder {
+      public state: "configured" | "closed" | "unconfigured" = "unconfigured";
+      readonly #init: VideoDecoderInit;
+
+      public constructor(init: VideoDecoderInit) {
+        this.#init = init;
+      }
+
+      public configure(): void {
+        this.state = "configured";
+      }
+
+      public decode(chunk: MockEncodedVideoChunk): void {
+        outputFrames.set(chunk.timestamp, this.#init.output);
+      }
+
+      public reset(): void {
+        outputFrames.clear();
+      }
+
+      public close(): void {
+        this.state = "closed";
+        outputFrames.clear();
+      }
+    }
+
+    globalThis.VideoDecoder = MockVideoDecoder as unknown as typeof VideoDecoder;
+    globalThis.EncodedVideoChunk = MockEncodedVideoChunk as unknown as typeof EncodedVideoChunk;
+
+    const player = new VideoPlayer();
+    await player.init({ codec: "hvc1.1.6.L93.B0" });
+
+    const decodePromise = player.decodeFrames([{ data: new Uint8Array([1]), timestampMicros: 1000, type: "key" }]);
+    await Promise.resolve();
+
+    const targetFrame = createFrame(1000);
+    outputFrames.get(1000)?.(targetFrame);
+
+    await expect(decodePromise).resolves.toEqual<DecodeFramesResult>({
+      type: "target",
+      frame: targetFrame,
+    });
+  });
+
+  it("should return an intermediate frame when target is late", async () => {
+    const outputFrames = new Map<number, (frame: VideoFrame) => void>();
+
+    class MockVideoDecoder {
+      public state: "configured" | "closed" | "unconfigured" = "unconfigured";
+      readonly #init: VideoDecoderInit;
+
+      public constructor(init: VideoDecoderInit) {
+        this.#init = init;
+      }
+
+      public configure(): void {
+        this.state = "configured";
+      }
+
+      public decode(chunk: MockEncodedVideoChunk): void {
+        outputFrames.set(chunk.timestamp, this.#init.output);
+      }
+
+      public reset(): void {
+        outputFrames.clear();
+      }
+
+      public close(): void {
+        this.state = "closed";
+        outputFrames.clear();
+      }
+    }
+
+    globalThis.VideoDecoder = MockVideoDecoder as unknown as typeof VideoDecoder;
+    globalThis.EncodedVideoChunk = MockEncodedVideoChunk as unknown as typeof EncodedVideoChunk;
+
+    const player = new VideoPlayer();
+    await player.init({ codec: "avc1.64001f" });
+
+    const decodePromise = player.decodeFrames([
+      { data: new Uint8Array([1]), timestampMicros: 0, type: "key" },
+      { data: new Uint8Array([2]), timestampMicros: 33333, type: "delta" },
+    ]);
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(10);
+
+    const intermediateFrame = createFrame(0);
+    outputFrames.get(0)?.(intermediateFrame);
+
+    await expect(decodePromise).resolves.toEqual<DecodeFramesResult>({
+      type: "intermediate",
+      frame: intermediateFrame,
+    });
+  });
+
+  it("should not return an intermediate HEVC frame before decode queue drain", async () => {
+    const outputFrames = new Map<number, (frame: VideoFrame) => void>();
+
+    class MockVideoDecoder {
+      public state: "configured" | "closed" | "unconfigured" = "unconfigured";
+      readonly #init: VideoDecoderInit;
+
+      public constructor(init: VideoDecoderInit) {
+        this.#init = init;
+      }
+
+      public configure(): void {
+        this.state = "configured";
+      }
+
+      public decode(chunk: MockEncodedVideoChunk): void {
+        outputFrames.set(chunk.timestamp, this.#init.output);
+      }
+
+      public reset(): void {
+        outputFrames.clear();
+      }
+
+      public close(): void {
+        this.state = "closed";
+        outputFrames.clear();
+      }
+    }
+
+    globalThis.VideoDecoder = MockVideoDecoder as unknown as typeof VideoDecoder;
+    globalThis.EncodedVideoChunk = MockEncodedVideoChunk as unknown as typeof EncodedVideoChunk;
+
+    const player = new VideoPlayer();
+    await player.init({ codec: "hvc1.1.6.L93.B0" });
+
+    const decodePromise = player.decodeFrames([
+      { data: new Uint8Array([1]), timestampMicros: 0, type: "key" },
+      { data: new Uint8Array([2]), timestampMicros: 33333, type: "delta" },
+    ]);
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(30);
+
+    outputFrames.get(0)?.(createFrame(0));
+    await expect(Promise.race([decodePromise, Promise.resolve("pending")])).resolves.toBe("pending");
+
+    const targetFrame = createFrame(33333);
+    outputFrames.get(33333)?.(targetFrame);
+    await jest.advanceTimersByTimeAsync(2000);
+
+    await expect(decodePromise).resolves.toEqual<DecodeFramesResult>({
+      type: "target",
+      frame: targetFrame,
+    });
+  });
+
+  it("should return timeout when no frame is produced", async () => {
+    class MockVideoDecoder {
+      public state: "configured" | "closed" | "unconfigured" = "unconfigured";
+
+      public constructor(_: VideoDecoderInit) {}
+
+      public configure(): void {
+        this.state = "configured";
+      }
+
+      public decode(): void {}
+      public reset(): void {}
+      public close(): void {
+        this.state = "closed";
+      }
+    }
+
+    globalThis.VideoDecoder = MockVideoDecoder as unknown as typeof VideoDecoder;
+    globalThis.EncodedVideoChunk = MockEncodedVideoChunk as unknown as typeof EncodedVideoChunk;
+
+    const player = new VideoPlayer();
+    await player.init({ codec: "hvc1.1.6.L93.B0" });
+
+    const decodePromise = player.decodeFrames([{ data: new Uint8Array([1]), timestampMicros: 0, type: "key" }]);
+    await jest.advanceTimersByTimeAsync(2000);
+
+    await expect(decodePromise).resolves.toEqual({ type: "timeout" });
+  });
+
+  it("should return aborted on resetForSeek", async () => {
+    class MockVideoDecoder {
+      public state: "configured" | "closed" | "unconfigured" = "unconfigured";
+
+      public constructor(_: VideoDecoderInit) {}
+
+      public configure(): void {
+        this.state = "configured";
+      }
+
+      public decode(): void {}
+      public reset(): void {}
+      public close(): void {
+        this.state = "closed";
+      }
+    }
+
+    globalThis.VideoDecoder = MockVideoDecoder as unknown as typeof VideoDecoder;
+    globalThis.EncodedVideoChunk = MockEncodedVideoChunk as unknown as typeof EncodedVideoChunk;
+
+    const player = new VideoPlayer();
+    await player.init({ codec: "hvc1.1.6.L93.B0" });
+
+    const decodePromise = player.decodeFrames([{ data: new Uint8Array([1]), timestampMicros: 0, type: "key" }]);
+    await Promise.resolve();
+    player.resetForSeek();
+
+    await expect(decodePromise).resolves.toEqual({ type: "aborted", frame: undefined });
+    expect(player.decoderConfig()).toEqual(
+      expect.objectContaining({ codec: "hvc1.1.6.L93.B0" }),
+    );
+  });
+
+  it("should clear decoder config on close", async () => {
+    class MockVideoDecoder {
+      public state: "configured" | "closed" | "unconfigured" = "unconfigured";
+
+      public constructor(_: VideoDecoderInit) {}
+
+      public configure(): void {
+        this.state = "configured";
+      }
+
+      public decode(): void {}
+      public reset(): void {}
+      public close(): void {
+        this.state = "closed";
+      }
+    }
+
+    globalThis.VideoDecoder = MockVideoDecoder as unknown as typeof VideoDecoder;
+    globalThis.EncodedVideoChunk = MockEncodedVideoChunk as unknown as typeof EncodedVideoChunk;
+
+    const player = new VideoPlayer();
+    await player.init({ codec: "hvc1.1.6.L93.B0" });
+    player.close();
+
+    expect(player.decoderConfig()).toBeUndefined();
+  });
+
+  it("should wait for decode queue drain", async () => {
+    let decoder: MockVideoDecoder | undefined;
+
+    class MockVideoDecoder {
+      public state: "configured" | "closed" | "unconfigured" = "unconfigured";
+      public decodeQueueSize = 0;
+      public ondequeue: ((event: Event) => void) | null = null;
+      readonly #init: VideoDecoderInit;
+
+      public constructor(init: VideoDecoderInit) {
+        this.#init = init;
+        decoder = this;
+      }
+
+      public configure(): void {
+        this.state = "configured";
+      }
+
+      public decode(chunk: MockEncodedVideoChunk): void {
+        this.decodeQueueSize++;
+        setTimeout(() => {
+          this.#init.output(createFrame(chunk.timestamp));
+          this.decodeQueueSize--;
+          this.ondequeue?.(new Event("dequeue"));
+        }, 40);
+      }
+
+      public reset(): void {
+        this.decodeQueueSize = 0;
+      }
+
+      public close(): void {
+        this.state = "closed";
+        this.decodeQueueSize = 0;
+      }
+    }
+
+    globalThis.VideoDecoder = MockVideoDecoder as unknown as typeof VideoDecoder;
+    globalThis.EncodedVideoChunk = MockEncodedVideoChunk as unknown as typeof EncodedVideoChunk;
+
+    const player = new VideoPlayer();
+    await player.init({ codec: "hvc1.1.6.L93.B0" });
+
+    const decodePromise = player.decodeFrames([
+      { data: new Uint8Array([1]), timestampMicros: 1000, type: "key" },
+    ]);
+    await Promise.resolve();
+
+    expect(decoder?.ondequeue).toBeDefined();
+    await jest.advanceTimersByTimeAsync(40);
+
+    await expect(decodePromise).resolves.toMatchObject({ type: "target" });
+    expect(decoder?.ondequeue).toBeNull();
+  });
+
+  it("should reject non-increasing timestamps until reset", async () => {
+    const errors: Error[] = [];
+
+    class MockVideoDecoder {
+      public state: "configured" | "closed" | "unconfigured" = "unconfigured";
+      public decodeQueueSize = 0;
+      public ondequeue: ((event: Event) => void) | null = null;
+      readonly #init: VideoDecoderInit;
+
+      public constructor(init: VideoDecoderInit) {
+        this.#init = init;
+      }
+
+      public configure(): void {
+        this.state = "configured";
+      }
+
+      public decode(chunk: MockEncodedVideoChunk): void {
+        this.#init.output(createFrame(chunk.timestamp));
+      }
+
+      public reset(): void {}
+      public close(): void {
+        this.state = "closed";
+      }
+    }
+
+    globalThis.VideoDecoder = MockVideoDecoder as unknown as typeof VideoDecoder;
+    globalThis.EncodedVideoChunk = MockEncodedVideoChunk as unknown as typeof EncodedVideoChunk;
+
+    const player = new VideoPlayer();
+    player.on("error", (error) => errors.push(error));
+    await player.init({ codec: "hvc1.1.6.L93.B0" });
+
+    await expect(
+      player.decodeFrames([{ data: new Uint8Array([1]), timestampMicros: 1000, type: "key" }]),
+    ).resolves.toMatchObject({ type: "target" });
+    await expect(
+      player.decodeFrames([{ data: new Uint8Array([2]), timestampMicros: 1000, type: "delta" }]),
+    ).resolves.toEqual({ type: "timeout" });
+    expect(errors.at(-1)?.message).toContain("timestamp must increase");
+
+    player.resetForSeek();
+    await expect(
+      player.decodeFrames([{ data: new Uint8Array([3]), timestampMicros: 1000, type: "key" }]),
+    ).resolves.toMatchObject({ type: "target" });
+  });
+
+  it("should abort pending decode on decoder error", async () => {
+    class MockVideoDecoder {
+      public state: "configured" | "closed" | "unconfigured" = "unconfigured";
+      public decodeQueueSize = 1;
+      public ondequeue: ((event: Event) => void) | null = null;
+      readonly #init: VideoDecoderInit;
+
+      public constructor(init: VideoDecoderInit) {
+        this.#init = init;
+      }
+
+      public configure(): void {
+        this.state = "configured";
+      }
+
+      public decode(): void {
+        this.#init.error(new DOMException("Decoding error", "EncodingError"));
+      }
+
+      public reset(): void {}
+      public close(): void {
+        this.state = "closed";
+      }
+    }
+
+    globalThis.VideoDecoder = MockVideoDecoder as unknown as typeof VideoDecoder;
+    globalThis.EncodedVideoChunk = MockEncodedVideoChunk as unknown as typeof EncodedVideoChunk;
+
+    const errors: Error[] = [];
+    const player = new VideoPlayer();
+    player.on("error", (error) => errors.push(error));
+    await player.init({ codec: "hvc1.1.6.L93.B0" });
+
+    await expect(
+      player.decodeFrames([{ data: new Uint8Array([1]), timestampMicros: 1000, type: "key" }]),
+    ).resolves.toEqual({ type: "aborted", frame: undefined });
+    expect(errors.at(-1)?.message).toBe("Decoding error @ frame timestamp: 0.001s");
+  });
+
+  it("should retry configure with no-preference when default config fails", async () => {
+    const configure = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("Unsupported configuration");
+      })
+      .mockImplementationOnce(() => undefined);
+
+    class MockVideoDecoder {
+      public state: "configured" | "closed" | "unconfigured" = "unconfigured";
+
+      public constructor(_: VideoDecoderInit) {}
+
+      public configure(config: VideoDecoderConfig): void {
+        configure(config);
+        this.state = "configured";
+      }
+
+      public decode(): void {}
+      public reset(): void {}
+      public close(): void {
+        this.state = "closed";
+      }
+    }
+
+    globalThis.VideoDecoder = MockVideoDecoder as unknown as typeof VideoDecoder;
+    globalThis.EncodedVideoChunk = MockEncodedVideoChunk as unknown as typeof EncodedVideoChunk;
+
+    const player = new VideoPlayer();
+    await player.init({ codec: "hvc1.1.6.L93.B0" });
+
+    expect(configure).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        codec: "hvc1.1.6.L93.B0",
+        optimizeForLatency: true,
+      }),
+    );
+    expect(configure.mock.calls[0]![0]).not.toHaveProperty("hardwareAcceleration");
+    expect(configure).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        codec: "hvc1.1.6.L93.B0",
+        hardwareAcceleration: "no-preference",
+        optimizeForLatency: true,
+      }),
+    );
+  });
+});

--- a/packages/den/video/VideoPlayer.ts
+++ b/packages/den/video/VideoPlayer.ts
@@ -92,12 +92,9 @@ export class VideoPlayer extends EventEmitter<VideoPlayerEventTypes> {
           this.#currentDecodeTimestampMicros != undefined
             ? ` @ frame timestamp: ${this.#currentDecodeTimestampMicros / 1_000_000}s`
             : "";
-        const decodeError = new DOMException(
-          `${error.message}${timestampSec}`,
-          error.name,
-        );
-        const abortedFrame = this.#dequeueNewestFrame();
-        this.#pendingDecode?.resolve({ type: "aborted", frame: abortedFrame });
+        const decodeError = new DOMException(`${error.message}${timestampSec}`, error.name);
+        const newestFrame = this.#dequeueNewestFrame();
+        this.#pendingDecode?.resolve({ type: "aborted", frame: newestFrame });
         this.#pendingDecode = undefined;
         this.#targetWaiter?.reject(decodeError);
         this.#targetWaiter = undefined;
@@ -307,11 +304,11 @@ export class VideoPlayer extends EventEmitter<VideoPlayerEventTypes> {
     return await new Promise<VideoFrame>((resolve, reject) => {
       this.#targetWaiter = {
         targetTimestampMicros,
-        resolve: (frame) => {
+        resolve: (targetFrame) => {
           if (this.#targetWaiter?.resolve === resolve) {
             this.#targetWaiter = undefined;
           }
-          resolve(frame);
+          resolve(targetFrame);
         },
         reject: (error) => {
           if (this.#targetWaiter?.reject === reject) {
@@ -359,14 +356,12 @@ export class VideoPlayer extends EventEmitter<VideoPlayerEventTypes> {
   }
 
   #waitForDecodeQueueDrain(timeoutMs: number, onDrain: () => void): void {
-    if (this.#decoder.decodeQueueSize == undefined || this.#decoder.decodeQueueSize === 0) {
+    if (this.#decoder.decodeQueueSize === 0) {
       onDrain();
       return;
     }
 
     const previousOndequeue = this.#decoder.ondequeue;
-    let timeoutId: ReturnType<typeof setTimeout>;
-
     const handleDequeue = (event: Event) => {
       previousOndequeue?.call(this.#decoder, event);
       if (this.#decoder.decodeQueueSize > 0) {
@@ -379,7 +374,7 @@ export class VideoPlayer extends EventEmitter<VideoPlayerEventTypes> {
       onDrain();
     };
 
-    timeoutId = setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       if (this.#decoder.ondequeue === handleDequeue) {
         this.#decoder.ondequeue = previousOndequeue;
       }

--- a/packages/den/video/VideoPlayer.ts
+++ b/packages/den/video/VideoPlayer.ts
@@ -8,11 +8,36 @@
 import { Mutex } from "async-mutex";
 import EventEmitter from "eventemitter3";
 
-import Logger from "@lichtblick/log";
-
 // foxglove-depcheck-used: @types/dom-webcodecs
 
-const MAX_DECODE_WAIT_MS = 30;
+const DEFAULT_TARGET_FRAME_WAIT_MS = 10;
+const DEFAULT_MAX_DECODE_WAIT_MS = 30;
+const HEVC_MAX_DECODE_WAIT_MS = 2000;
+const HEVC_TARGET_FRAME_WAIT_MS = HEVC_MAX_DECODE_WAIT_MS;
+
+export type EncodedVideoFrame = {
+  data: Uint8Array;
+  timestampMicros: number;
+  type: "key" | "delta";
+};
+
+export type DecodeFramesResult =
+  | { type: "target"; frame: VideoFrame }
+  | { type: "intermediate"; frame: VideoFrame }
+  | { type: "timeout" }
+  | { type: "aborted"; frame?: VideoFrame };
+
+type PendingDecode = {
+  targetTimestampMicros: number;
+  targetDeadlineMs: number;
+  waitForQueueDrain: boolean;
+  drained: boolean;
+  resolvedResult?: DecodeFramesResult;
+  resolve: (result: DecodeFramesResult) => void;
+  reject: (error: Error) => void;
+  targetTimeoutId?: ReturnType<typeof setTimeout>;
+  overallTimeoutId: ReturnType<typeof setTimeout>;
+};
 
 export type VideoPlayerEventTypes = {
   frame: (frame: VideoFrame) => void;
@@ -21,27 +46,28 @@ export type VideoPlayerEventTypes = {
   error: (error: Error) => void;
 };
 
-const log = Logger.getLogger(__filename);
-
-/**
- * A wrapper around the WebCodecs VideoDecoder API that is safe to use from
- * multiple asynchronous contexts, is keyframe-aware, exposes a simple decode
- * method that takes a chunk of encoded video bitstream representing a single
- * frame and returns the decoded VideoFrame, and emits events for debugging
- * and error handling.
- */
 export class VideoPlayer extends EventEmitter<VideoPlayerEventTypes> {
   readonly #decoderInit: VideoDecoderInit;
   #decoder: VideoDecoder;
   #decoderConfig: VideoDecoderConfig | undefined;
   readonly #mutex = new Mutex();
-  #timeoutId: ReturnType<typeof setTimeout> | undefined;
-  #pendingFrame: VideoFrame | undefined;
+  readonly #pendingFrames = new Map<number, VideoFrame>();
+  readonly #pendingFrameOrder: number[] = [];
+  #pendingDecode: PendingDecode | undefined;
+  #pendingTargetTimestampMicros: number | undefined;
+  #lastSubmittedTimestampMicros: number | undefined;
+  #currentDecodeTimestampMicros: number | undefined;
+  #targetWaiter:
+    | {
+        targetTimestampMicros: number;
+        resolve: (frame: VideoFrame) => void;
+        reject: (error: Error) => void;
+      }
+    | undefined;
   #codedSize: { width: number; height: number } | undefined;
-  // Stores the last decoded frame as an ImageBitmap, should be set after decode()
   public lastImageBitmap: ImageBitmap | undefined;
+  public lastVideoFrame: VideoFrame | undefined;
 
-  /** Reports whether video decoding is supported in this browser session */
   public static IsSupported(): boolean {
     return self.isSecureContext && "VideoDecoder" in globalThis;
   }
@@ -50,189 +76,452 @@ export class VideoPlayer extends EventEmitter<VideoPlayerEventTypes> {
     super();
     this.#decoderInit = {
       output: (videoFrame: VideoFrame) => {
-        this.#pendingFrame?.close();
-        this.#pendingFrame = videoFrame;
+        const timestampMicros = Number(videoFrame.timestamp);
+        const previousFrame = this.#pendingFrames.get(timestampMicros);
+        if (previousFrame) {
+          previousFrame.close();
+        } else {
+          this.#pendingFrameOrder.push(timestampMicros);
+        }
+        this.#pendingFrames.set(timestampMicros, videoFrame);
+        this.#handleDecodedFrame(timestampMicros);
         this.emit("frame", videoFrame);
       },
-      error: (error) => this.emit("error", error),
+      error: (error) => {
+        const timestampSec =
+          this.#currentDecodeTimestampMicros != undefined
+            ? ` @ frame timestamp: ${this.#currentDecodeTimestampMicros / 1_000_000}s`
+            : "";
+        const decodeError = new DOMException(
+          `${error.message}${timestampSec}`,
+          error.name,
+        );
+        const abortedFrame = this.#dequeueNewestFrame();
+        this.#pendingDecode?.resolve({ type: "aborted", frame: abortedFrame });
+        this.#pendingDecode = undefined;
+        this.#targetWaiter?.reject(decodeError);
+        this.#targetWaiter = undefined;
+        this.emit("error", decodeError);
+      },
     };
     this.#decoder = new VideoDecoder(this.#decoderInit);
   }
 
-  /**
-   * Configures the VideoDecoder with the given VideoDecoderConfig. This must
-   * be called before decode() will return a VideoFrame.
-   */
   public async init(decoderConfig: VideoDecoderConfig): Promise<void> {
     await this.#mutex.runExclusive(async () => {
-      // Optimize for latency means we do not have to call flush() in every decode() call
-      // See <https://github.com/w3c/webcodecs/issues/206>
-      decoderConfig.optimizeForLatency = true;
-
-      // Try with 'prefer-hardware' first
-      let modifiedConfig = { ...decoderConfig };
-      modifiedConfig.hardwareAcceleration = "prefer-hardware";
-
-      let support = await VideoDecoder.isConfigSupported(modifiedConfig);
-      if (support.supported !== true) {
-        log.warn(
-          `VideoDecoder does not support configuration ${JSON.stringify(modifiedConfig)}. Trying without 'prefer-hardware'`,
-        );
-        // If 'prefer-hardware' is not supported, try without it
-        modifiedConfig = { ...decoderConfig };
-        support = await VideoDecoder.isConfigSupported(modifiedConfig);
-      }
-
-      if (support.supported !== true) {
-        const err = new Error(
-          `VideoDecoder does not support configuration ${JSON.stringify(decoderConfig)}`,
-        );
-        this.emit("error", err);
-        return;
-      }
+      const preferredConfig: VideoDecoderConfig = {
+        ...decoderConfig,
+        optimizeForLatency: true,
+      };
+      const fallbackConfig: VideoDecoderConfig = {
+        ...decoderConfig,
+        optimizeForLatency: true,
+        hardwareAcceleration: "no-preference",
+      };
 
       if (this.#decoder.state === "closed") {
         this.emit("debug", "VideoDecoder is closed, creating a new one");
         this.#decoder = new VideoDecoder(this.#decoderInit);
       }
 
-      this.emit("debug", `Configuring VideoDecoder with ${JSON.stringify(decoderConfig)}`);
-      this.#decoder.configure(decoderConfig);
-      this.#decoderConfig = decoderConfig;
+      this.emit("debug", `Configuring VideoDecoder with ${JSON.stringify(preferredConfig)}`);
+      try {
+        this.#decoder.configure(preferredConfig);
+        this.#decoderConfig = preferredConfig;
+      } catch {
+        this.emit(
+          "warn",
+          `Failed to configure VideoDecoder with ${JSON.stringify(preferredConfig)}. Retrying with no-preference hardware acceleration`,
+        );
+        try {
+          this.#decoder.configure(fallbackConfig);
+          this.#decoderConfig = fallbackConfig;
+        } catch (fallbackError) {
+          const err = new Error(
+            `Failed to configure VideoDecoder with ${JSON.stringify(fallbackConfig)}: ${(fallbackError as Error).message}`,
+          );
+          this.emit("error", err);
+          return;
+        }
+      }
+
       this.#codedSize = undefined;
-      if (decoderConfig.codedWidth != undefined && decoderConfig.codedHeight != undefined) {
-        this.#codedSize = { width: decoderConfig.codedWidth, height: decoderConfig.codedHeight };
+      this.#lastSubmittedTimestampMicros = undefined;
+      this.#currentDecodeTimestampMicros = undefined;
+      if (
+        this.#decoderConfig.codedWidth != undefined &&
+        this.#decoderConfig.codedHeight != undefined
+      ) {
+        this.#codedSize = {
+          width: this.#decoderConfig.codedWidth,
+          height: this.#decoderConfig.codedHeight,
+        };
       }
     });
   }
 
-  /** Returns true if the VideoDecoder is open and configured, ready for decoding. */
   public isInitialized(): boolean {
     return this.#decoder.state === "configured";
   }
 
-  /** Returns the VideoDecoderConfig given to init(), or undefined if init() has not been called. */
   public decoderConfig(): VideoDecoderConfig | undefined {
     return this.#decoderConfig;
   }
 
-  /** Returns the dimensions of the coded video frames, if known. */
   public codedSize(): { width: number; height: number } | undefined {
     return this.#codedSize;
   }
 
-  /**
-   * Takes a chunk of encoded video bitstream, sends it to the VideoDecoder,
-   * and returns a Promise that resolves to the decoded VideoFrame. If the
-   * VideoDecoder is not yet configured, we are waiting on a keyframe, or we
-   * time out waiting for the decoder to return a frame, this will return
-   * undefined.
-   *
-   * @param data A chunk of encoded video bitstream
-   * @param timestampMicros The timestamp of the chunk of encoded video
-   *   bitstream in microseconds relative to the start of the stream
-   * @param type "key" if this chunk contains a keyframe, "delta" otherwise
-   * @returns A VideoFrame or undefined if no frame was decoded
-   */
   public async decode(
     data: Uint8Array,
     timestampMicros: number,
     type: "key" | "delta",
   ): Promise<VideoFrame | undefined> {
-    return await this.#mutex.runExclusive(async () => {
-      if (this.#decoder.state === "closed") {
-        this.emit("warn", "VideoDecoder is closed, creating a new one");
-        this.#decoder = new VideoDecoder(this.#decoderInit);
-      }
+    const result = await this.decodeFrames([{ data, timestampMicros, type }]);
+    if (result.type === "target" || result.type === "intermediate" || result.type === "aborted") {
+      return result.frame;
+    }
+    return undefined;
+  }
 
-      if (this.#decoder.state === "unconfigured") {
-        this.emit("debug", "Waiting for initialization...");
-        return undefined;
-      }
+  public async decodeFrames(frames: EncodedVideoFrame[]): Promise<DecodeFramesResult> {
+    if (frames.length === 0) {
+      return { type: "timeout" };
+    }
+    if (this.#pendingDecode) {
+      throw new Error("decodeFrames called while a previous decode is still in progress");
+    }
 
-      await new Promise<void>((resolve) => {
-        const frameHandler = () => {
-          if (this.#timeoutId != undefined) {
-            clearTimeout(this.#timeoutId);
+    if (this.#decoder.state === "closed") {
+      this.emit("warn", "VideoDecoder is closed, creating a new one");
+      this.#decoder = new VideoDecoder(this.#decoderInit);
+      if (this.#decoderConfig != undefined) {
+        this.#decoder.configure(this.#decoderConfig);
+      }
+    }
+
+    if (this.#decoder.state === "unconfigured") {
+      this.emit("debug", "Waiting for initialization...");
+      return { type: "timeout" };
+    }
+
+    const isHevc =
+      this.#decoderConfig?.codec.startsWith("hev1") === true ||
+      this.#decoderConfig?.codec.startsWith("hvc1") === true;
+    const targetFrameWaitMs = isHevc ? HEVC_TARGET_FRAME_WAIT_MS : DEFAULT_TARGET_FRAME_WAIT_MS;
+    const maxDecodeWaitMs = isHevc ? HEVC_MAX_DECODE_WAIT_MS : DEFAULT_MAX_DECODE_WAIT_MS;
+    const targetFrame = frames[frames.length - 1]!;
+
+    this.#pendingTargetTimestampMicros = targetFrame.timestampMicros;
+
+    return await new Promise<DecodeFramesResult>((resolve, reject) => {
+      const pendingDecode: PendingDecode = {
+        targetTimestampMicros: targetFrame.timestampMicros,
+        targetDeadlineMs: performance.now() + targetFrameWaitMs,
+        waitForQueueDrain: isHevc,
+        drained: !isHevc,
+        resolve: (result) => {
+          if (pendingDecode.targetTimeoutId != undefined) {
+            clearTimeout(pendingDecode.targetTimeoutId);
           }
-          resolve();
-        };
+          clearTimeout(pendingDecode.overallTimeoutId);
+          if (this.#pendingDecode === pendingDecode) {
+            this.#pendingDecode = undefined;
+          }
+          resolve(result);
+        },
+        reject: (error) => {
+          if (pendingDecode.targetTimeoutId != undefined) {
+            clearTimeout(pendingDecode.targetTimeoutId);
+          }
+          clearTimeout(pendingDecode.overallTimeoutId);
+          if (this.#pendingDecode === pendingDecode) {
+            this.#pendingDecode = undefined;
+          }
+          reject(error);
+        },
+        overallTimeoutId: undefined as unknown as ReturnType<typeof setTimeout>,
+      };
 
-        if (this.#timeoutId != undefined) {
-          clearTimeout(this.#timeoutId);
+      pendingDecode.targetTimeoutId = setTimeout(() => {
+        this.#handleDecodedFrame();
+      }, targetFrameWaitMs);
+
+      pendingDecode.overallTimeoutId = setTimeout(() => {
+        if (this.#pendingDecode !== pendingDecode) {
+          return;
         }
-
-        this.#timeoutId = setTimeout(() => {
-          this.removeListener("frame", frameHandler);
-          this.emit(
-            "warn",
-            `Timed out decoding ${data.byteLength} byte chunk at time ${timestampMicros}`,
-          );
-          resolve(undefined);
-        }, MAX_DECODE_WAIT_MS);
-
-        this.once("frame", frameHandler);
-
-        try {
-          this.#decoder.decode(new EncodedVideoChunk({ type, data, timestamp: timestampMicros }));
-        } catch (unk) {
-          clearTimeout(this.#timeoutId);
-          this.removeListener("frame", frameHandler);
-
-          const error = new Error(
-            `Failed to decode ${data.byteLength} byte chunk at time ${timestampMicros}: ${
-              (unk as Error).message
-            }`,
-          );
-          this.emit("error", error);
-          resolve();
+        const frame = this.#dequeueNewestFrame();
+        if (frame) {
+          pendingDecode.resolve({ type: "intermediate", frame });
+          return;
         }
-      });
+        this.emit(
+          "warn",
+          `Timed out decoding ${targetFrame.data.byteLength} byte chunk at time ${targetFrame.timestampMicros}`,
+        );
+        pendingDecode.resolve({ type: "timeout" });
+      }, maxDecodeWaitMs);
 
-      const maybeVideoFrame = this.#pendingFrame;
-      this.#pendingFrame = undefined;
+      this.#pendingDecode = pendingDecode;
 
-      // Update the coded and display sizes if we have a new frame
-      if (maybeVideoFrame) {
-        if (!this.#codedSize) {
-          this.#codedSize = { width: 0, height: 0 };
+      try {
+        for (const frame of frames) {
+          if (!this.#decodeChunk(frame.data, frame.timestampMicros, frame.type)) {
+            pendingDecode.resolve({ type: "timeout" });
+            return;
+          }
         }
-        this.#codedSize.width = maybeVideoFrame.codedWidth;
-        this.#codedSize.height = maybeVideoFrame.codedHeight;
+      } catch (error) {
+        pendingDecode.reject(error as Error);
+        return;
       }
 
-      return maybeVideoFrame;
+      this.#waitForDecodeQueueDrain(maxDecodeWaitMs, () => {
+        pendingDecode.drained = true;
+        if (pendingDecode.resolvedResult != undefined) {
+          pendingDecode.resolve(pendingDecode.resolvedResult);
+          return;
+        }
+        this.#handleDecodedFrame();
+      });
+      this.#handleDecodedFrame();
     });
   }
 
-  /**
-   * Reset the VideoDecoder and clear any pending frames, but do not clear any
-   * cached stream information or decoder configuration. This should be called
-   * when seeking to a new position in the stream.
-   */
+  public async awaitTargetFrame(): Promise<VideoFrame> {
+    const targetTimestampMicros =
+      this.#pendingDecode?.targetTimestampMicros ?? this.#pendingTargetTimestampMicros;
+    if (targetTimestampMicros == undefined) {
+      throw new Error("awaitTargetFrame called without a pending target");
+    }
+
+    const frame = this.#dequeueFrame(targetTimestampMicros);
+    if (frame) {
+      return frame;
+    }
+    if (this.#targetWaiter) {
+      throw new Error("awaitTargetFrame called while a previous target wait is still in progress");
+    }
+
+    return await new Promise<VideoFrame>((resolve, reject) => {
+      this.#targetWaiter = {
+        targetTimestampMicros,
+        resolve: (frame) => {
+          if (this.#targetWaiter?.resolve === resolve) {
+            this.#targetWaiter = undefined;
+          }
+          resolve(frame);
+        },
+        reject: (error) => {
+          if (this.#targetWaiter?.reject === reject) {
+            this.#targetWaiter = undefined;
+          }
+          reject(error);
+        },
+      };
+      this.#handleDecodedFrame();
+    });
+  }
+
+  #decodeChunk(data: Uint8Array, timestampMicros: number, type: "key" | "delta"): boolean {
+    if (
+      this.#lastSubmittedTimestampMicros != undefined &&
+      timestampMicros <= this.#lastSubmittedTimestampMicros
+    ) {
+      const error = new Error(
+        `Failed to decode ${data.byteLength} byte chunk at time ${timestampMicros}: timestamp must increase`,
+      );
+      this.emit("error", error);
+      return false;
+    }
+
+    try {
+      const chunkData =
+        data.byteOffset !== 0 || data.byteLength !== data.buffer.byteLength ? data.slice() : data;
+      this.#currentDecodeTimestampMicros = timestampMicros;
+      const chunkInit: EncodedVideoChunkInit & { transfer?: ArrayBuffer[] } = {
+        type,
+        data: chunkData,
+        timestamp: timestampMicros,
+        transfer: chunkData.buffer instanceof ArrayBuffer ? [chunkData.buffer] : undefined,
+      };
+      this.#decoder.decode(new EncodedVideoChunk(chunkInit));
+      this.#lastSubmittedTimestampMicros = timestampMicros;
+      return true;
+    } catch (unk) {
+      const error = new Error(
+        `Failed to decode ${data.byteLength} byte chunk at time ${timestampMicros}: ${(unk as Error).message}`,
+      );
+      this.emit("error", error);
+      return false;
+    }
+  }
+
+  #waitForDecodeQueueDrain(timeoutMs: number, onDrain: () => void): void {
+    if (this.#decoder.decodeQueueSize == undefined || this.#decoder.decodeQueueSize === 0) {
+      onDrain();
+      return;
+    }
+
+    const previousOndequeue = this.#decoder.ondequeue;
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const handleDequeue = (event: Event) => {
+      previousOndequeue?.call(this.#decoder, event);
+      if (this.#decoder.decodeQueueSize > 0) {
+        return;
+      }
+      clearTimeout(timeoutId);
+      if (this.#decoder.ondequeue === handleDequeue) {
+        this.#decoder.ondequeue = previousOndequeue;
+      }
+      onDrain();
+    };
+
+    timeoutId = setTimeout(() => {
+      if (this.#decoder.ondequeue === handleDequeue) {
+        this.#decoder.ondequeue = previousOndequeue;
+      }
+      onDrain();
+    }, timeoutMs);
+
+    this.#decoder.ondequeue = handleDequeue;
+  }
+
+  #handleDecodedFrame(timestampMicros?: number): void {
+    if (this.#targetWaiter) {
+      const frame = this.#dequeueFrame(this.#targetWaiter.targetTimestampMicros);
+      if (frame) {
+        this.#pendingTargetTimestampMicros = undefined;
+        this.#targetWaiter.resolve(frame);
+        return;
+      }
+    }
+
+    if (!this.#pendingDecode) {
+      return;
+    }
+
+    const targetFrame = this.#dequeueFrame(this.#pendingDecode.targetTimestampMicros);
+    if (targetFrame) {
+      this.#pendingTargetTimestampMicros = undefined;
+      this.#resolvePendingDecodeWhenReady({ type: "target", frame: targetFrame });
+      return;
+    }
+
+    if (
+      performance.now() >= this.#pendingDecode.targetDeadlineMs &&
+      (timestampMicros != undefined || this.#pendingFrameOrder.length > 0)
+    ) {
+      const frame =
+        (timestampMicros != undefined ? this.#dequeueFrame(timestampMicros) : undefined) ??
+        this.#dequeueNewestFrame();
+      if (frame) {
+        this.#resolvePendingDecodeWhenReady({ type: "intermediate", frame });
+      }
+    }
+  }
+
+  #resolvePendingDecodeWhenReady(result: DecodeFramesResult): void {
+    const pendingDecode = this.#pendingDecode;
+    if (!pendingDecode) {
+      return;
+    }
+    if (pendingDecode.waitForQueueDrain && !pendingDecode.drained) {
+      pendingDecode.resolvedResult = result;
+      return;
+    }
+    pendingDecode.resolve(result);
+  }
+
+  #dequeueFrame(targetTimestampMicros?: number): VideoFrame | undefined {
+    let timestampMicros: number | undefined;
+    if (targetTimestampMicros != undefined) {
+      if (!this.#pendingFrames.has(targetTimestampMicros)) {
+        return undefined;
+      }
+      timestampMicros = targetTimestampMicros;
+      const index = this.#pendingFrameOrder.indexOf(targetTimestampMicros);
+      if (index >= 0) {
+        this.#pendingFrameOrder.splice(index, 1);
+      }
+    } else {
+      timestampMicros = this.#pendingFrameOrder.shift();
+    }
+
+    return this.#takePendingFrame(timestampMicros);
+  }
+
+  #dequeueNewestFrame(): VideoFrame | undefined {
+    const timestampMicros = this.#pendingFrameOrder.pop();
+    return this.#takePendingFrame(timestampMicros);
+  }
+
+  #takePendingFrame(timestampMicros: number | undefined): VideoFrame | undefined {
+    const maybeVideoFrame =
+      timestampMicros != undefined ? this.#pendingFrames.get(timestampMicros) : undefined;
+    if (timestampMicros != undefined) {
+      this.#pendingFrames.delete(timestampMicros);
+    }
+
+    if (maybeVideoFrame) {
+      if (!this.#codedSize) {
+        this.#codedSize = { width: 0, height: 0 };
+      }
+      this.#codedSize.width = maybeVideoFrame.codedWidth;
+      this.#codedSize.height = maybeVideoFrame.codedHeight;
+      this.lastVideoFrame?.close();
+      this.lastVideoFrame = maybeVideoFrame.clone();
+    }
+
+    return maybeVideoFrame;
+  }
+
   public resetForSeek(): void {
     if (this.#decoder.state === "configured") {
       this.#decoder.reset();
     }
-    if (this.#timeoutId != undefined) {
-      clearTimeout(this.#timeoutId);
+    const abortedFrame = this.#dequeueNewestFrame();
+    this.#pendingDecode?.resolve({ type: "aborted", frame: abortedFrame });
+    this.#pendingDecode = undefined;
+    this.#pendingTargetTimestampMicros = undefined;
+    this.#lastSubmittedTimestampMicros = undefined;
+    this.#currentDecodeTimestampMicros = undefined;
+    this.#targetWaiter?.reject(new Error("Decoder reset"));
+    this.#targetWaiter = undefined;
+    for (const frame of this.#pendingFrames.values()) {
+      frame.close();
     }
-    this.#pendingFrame?.close();
-    this.#pendingFrame = undefined;
+    this.#pendingFrames.clear();
+    this.#pendingFrameOrder.length = 0;
+    this.lastVideoFrame?.close();
+    this.lastVideoFrame = undefined;
+    this.lastImageBitmap?.close();
+    this.lastImageBitmap = undefined;
   }
 
-  /**
-   * Close the VideoDecoder and clear any pending frames. Also clear any cached
-   * stream information or decoder configuration.
-   */
   public close(): void {
     if (this.#decoder.state !== "closed") {
       this.#decoder.close();
     }
-    if (this.#timeoutId != undefined) {
-      clearTimeout(this.#timeoutId);
+    const abortedFrame = this.#dequeueNewestFrame();
+    this.#pendingDecode?.resolve({ type: "aborted", frame: abortedFrame });
+    this.#pendingDecode = undefined;
+    this.#pendingTargetTimestampMicros = undefined;
+    this.#lastSubmittedTimestampMicros = undefined;
+    this.#currentDecodeTimestampMicros = undefined;
+    this.#targetWaiter?.reject(new Error("Decoder closed"));
+    this.#targetWaiter = undefined;
+    for (const frame of this.#pendingFrames.values()) {
+      frame.close();
     }
-    this.#pendingFrame?.close();
-    this.#pendingFrame = undefined;
+    this.#pendingFrames.clear();
+    this.#pendingFrameOrder.length = 0;
+    this.lastVideoFrame?.close();
+    this.lastVideoFrame = undefined;
+    this.lastImageBitmap?.close();
+    this.lastImageBitmap = undefined;
+    this.#decoderConfig = undefined;
   }
 }

--- a/packages/den/video/h265/H265.test.ts
+++ b/packages/den/video/h265/H265.test.ts
@@ -1,0 +1,169 @@
+import { H265 } from "./H265";
+import { H265NaluType, H265SliceType } from "./types";
+
+function lengthPrefixedNalu(naluType: number, payload: number[] = [0x01]): number[] {
+  const naluHeader = (naluType << 1) | 1;
+  const naluLength = payload.length + 2;
+  return [
+    (naluLength >>> 24) & 0xff,
+    (naluLength >>> 16) & 0xff,
+    (naluLength >>> 8) & 0xff,
+    naluLength & 0xff,
+    naluHeader,
+    0x01,
+    ...payload,
+  ];
+}
+
+function annexBNalu(naluType: number, payload: number[] = [0x01]): number[] {
+  const naluHeader = (naluType << 1) | 1;
+  return [0x00, 0x00, 0x00, 0x01, naluHeader, 0x01, ...payload];
+}
+
+function frameData(nalus: number[][]): Uint8Array {
+  return new Uint8Array(nalus.flat());
+}
+
+function slicePayload(naluType: number, sliceType: H265SliceType): number[] {
+  if (naluType >= H265NaluType.BLA_W_LP && naluType <= H265NaluType.RSV_IRAP_VCL23) {
+    return [sliceType === H265SliceType.B ? 0xb0 : sliceType === H265SliceType.P ? 0xa8 : 0xac];
+  }
+  return [sliceType === H265SliceType.B ? 0xe0 : sliceType === H265SliceType.P ? 0xd0 : 0xd8];
+}
+
+function slice(naluType: number, sliceType: H265SliceType): number[] {
+  return annexBNalu(naluType, slicePayload(naluType, sliceType));
+}
+
+function keyframeWithParameterSets(): Uint8Array {
+  return frameData([
+    annexBNalu(H265NaluType.VPS_NUT),
+    annexBNalu(H265NaluType.SPS_NUT),
+    annexBNalu(H265NaluType.PPS_NUT, [0xc0]),
+    slice(H265NaluType.IDR_W_RADL, H265SliceType.I),
+  ]);
+}
+
+function keyframeOnly(sliceType = H265SliceType.I): Uint8Array {
+  return frameData([slice(H265NaluType.IDR_W_RADL, sliceType)]);
+}
+
+function deltaFrame(sliceType = H265SliceType.P): Uint8Array {
+  return frameData([slice(1, sliceType)]);
+}
+
+function deltaFrameWithPps(sliceType = H265SliceType.P): Uint8Array {
+  return frameData([annexBNalu(H265NaluType.PPS_NUT, [0xc0]), slice(1, sliceType)]);
+}
+
+describe("H265", () => {
+  it("should detect IRAP I slices as keyframes", () => {
+    expect(H265.IsKeyframe(keyframeWithParameterSets())).toBe(true);
+  });
+
+  it("should normalize length-prefixed frames to Annex B", () => {
+    const frame = frameData([
+      lengthPrefixedNalu(H265NaluType.IDR_W_RADL, []),
+      lengthPrefixedNalu(1, []),
+    ]);
+
+    expect(H265.ToAnnexB(frame)).toEqual(
+      frameData([
+        annexBNalu(H265NaluType.IDR_W_RADL, []),
+        annexBNalu(1, []),
+      ]),
+    );
+  });
+
+  it("should return a generic decoder config for supported h265 frames", () => {
+    const frame = frameData([slice(1, H265SliceType.P)]);
+
+    expect(H265.ParseDecoderConfig(frame)).toEqual({ codec: "hvc1.1.6.L93.B0" });
+  });
+
+  it("should extract parameter sets without including the next start code", () => {
+    const frame = frameData([
+      annexBNalu(H265NaluType.VPS_NUT, []),
+      annexBNalu(H265NaluType.IDR_W_RADL, []),
+    ]);
+
+    const frameInfo = H265.InspectFrame(frame);
+    expect(frameInfo.parameterSets).toEqual(
+      new Uint8Array(annexBNalu(H265NaluType.VPS_NUT, [])),
+    );
+    expect(frameInfo.hasParameterSets).toBe(true);
+    expect(frameInfo.hasRequiredParameterSets).toBe(false);
+  });
+
+  it("should strip parameter sets", () => {
+    const frame = frameData([
+      annexBNalu(H265NaluType.VPS_NUT),
+      annexBNalu(H265NaluType.SPS_NUT),
+      annexBNalu(H265NaluType.PPS_NUT, [0xc0]),
+      slice(1, H265SliceType.P),
+    ]);
+
+    expect(H265.StripParameterSets(frame)).toEqual(new Uint8Array(slice(1, H265SliceType.P)));
+  });
+
+  it("should detect complete VPS SPS PPS parameter sets", () => {
+    const parameterSets = [
+      annexBNalu(H265NaluType.VPS_NUT),
+      annexBNalu(H265NaluType.SPS_NUT, [0x02]),
+      annexBNalu(H265NaluType.PPS_NUT, [0x03]),
+    ];
+    const frame = frameData([
+      ...parameterSets,
+      annexBNalu(H265NaluType.IDR_W_RADL, [0x04]),
+    ]);
+
+    const frameInfo = H265.InspectFrame(frame);
+    expect(frameInfo.hasParameterSets).toBe(true);
+    expect(frameInfo.hasRequiredParameterSets).toBe(true);
+    expect(frameInfo.parameterSets).toEqual(frameData(parameterSets));
+  });
+
+  it("should detect I, P, and B slice types from slice headers", () => {
+    expect(H265.InspectFrame(keyframeWithParameterSets()).frameType).toBe("I");
+    expect(H265.InspectFrame(deltaFrameWithPps(H265SliceType.P)).frameType).toBe("P");
+    expect(H265.InspectFrame(deltaFrameWithPps(H265SliceType.B)).frameType).toBe("B");
+  });
+
+  it("should mark IRAP P slices as keyframes", () => {
+    const frameInfo = H265.InspectFrame(
+      frameData([
+        annexBNalu(H265NaluType.VPS_NUT),
+        annexBNalu(H265NaluType.SPS_NUT),
+        annexBNalu(H265NaluType.PPS_NUT, [0xc0]),
+        slice(H265NaluType.IDR_W_RADL, H265SliceType.P),
+      ]),
+    );
+
+    expect(frameInfo.frameType).toBe("P");
+    expect(frameInfo.isKeyframe).toBe(true);
+    expect(frameInfo.isRandomAccess).toBe(true);
+  });
+
+  it("should use cached parameter sets to parse slice types", () => {
+    const frameInfo = H265.InspectFrame(deltaFrame(H265SliceType.P), {
+      parameterSets: frameData([
+        annexBNalu(H265NaluType.PPS_NUT, [0xc0]),
+      ]),
+    });
+
+    expect(frameInfo.frameType).toBe("P");
+    expect(frameInfo.hasUnparsedVclSlice).toBe(false);
+  });
+
+  it("should mark IRAP frames as keyframes even when PPS is missing", () => {
+    const frameInfo = H265.InspectFrame(keyframeOnly(H265SliceType.I));
+
+    expect(frameInfo.frameType).toBe("unknown");
+    expect(frameInfo.hasUnparsedVclSlice).toBe(true);
+    expect(frameInfo.isKeyframe).toBe(true);
+  });
+
+  it("should return undefined for unsupported h265 bitstreams", () => {
+    expect(H265.ParseDecoderConfig(new Uint8Array([0x01, 0x02, 0x03]))).toBeUndefined();
+  });
+});

--- a/packages/den/video/h265/H265.test.ts
+++ b/packages/den/video/h265/H265.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
 import { H265 } from "./H265";
 import { H265NaluType, H265SliceType } from "./types";
 
@@ -68,10 +71,7 @@ describe("H265", () => {
     ]);
 
     expect(H265.ToAnnexB(frame)).toEqual(
-      frameData([
-        annexBNalu(H265NaluType.IDR_W_RADL, []),
-        annexBNalu(1, []),
-      ]),
+      frameData([annexBNalu(H265NaluType.IDR_W_RADL, []), annexBNalu(1, [])]),
     );
   });
 
@@ -88,9 +88,7 @@ describe("H265", () => {
     ]);
 
     const frameInfo = H265.InspectFrame(frame);
-    expect(frameInfo.parameterSets).toEqual(
-      new Uint8Array(annexBNalu(H265NaluType.VPS_NUT, [])),
-    );
+    expect(frameInfo.parameterSets).toEqual(new Uint8Array(annexBNalu(H265NaluType.VPS_NUT, [])));
     expect(frameInfo.hasParameterSets).toBe(true);
     expect(frameInfo.hasRequiredParameterSets).toBe(false);
   });
@@ -112,10 +110,7 @@ describe("H265", () => {
       annexBNalu(H265NaluType.SPS_NUT, [0x02]),
       annexBNalu(H265NaluType.PPS_NUT, [0x03]),
     ];
-    const frame = frameData([
-      ...parameterSets,
-      annexBNalu(H265NaluType.IDR_W_RADL, [0x04]),
-    ]);
+    const frame = frameData([...parameterSets, annexBNalu(H265NaluType.IDR_W_RADL, [0x04])]);
 
     const frameInfo = H265.InspectFrame(frame);
     expect(frameInfo.hasParameterSets).toBe(true);
@@ -146,9 +141,7 @@ describe("H265", () => {
 
   it("should use cached parameter sets to parse slice types", () => {
     const frameInfo = H265.InspectFrame(deltaFrame(H265SliceType.P), {
-      parameterSets: frameData([
-        annexBNalu(H265NaluType.PPS_NUT, [0xc0]),
-      ]),
+      parameterSets: frameData([annexBNalu(H265NaluType.PPS_NUT, [0xc0])]),
     });
 
     expect(frameInfo.frameType).toBe("P");

--- a/packages/den/video/h265/H265.ts
+++ b/packages/den/video/h265/H265.ts
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export enum H265NaluType {
+  BLA_W_LP = 16,
+  BLA_W_RADL = 17,
+  BLA_N_LP = 18,
+  IDR_W_RADL = 19,
+  IDR_N_LP = 20,
+  CRA_NUT = 21,
+  VPS_NUT = 32,
+  SPS_NUT = 33,
+  PPS_NUT = 34,
+}
+
+const H265_KEYFRAME_TYPES = new Set<number>([
+  H265NaluType.BLA_W_LP,
+  H265NaluType.BLA_W_RADL,
+  H265NaluType.BLA_N_LP,
+  H265NaluType.IDR_W_RADL,
+  H265NaluType.IDR_N_LP,
+  H265NaluType.CRA_NUT,
+]);
+
+const DEFAULT_HEVC_CODEC = "hev1.1.6.L153.B0";
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export class H265 {
+  public static AnnexBBoxSize(data: Uint8Array): number | undefined {
+    if (data.length < 4) {
+      return undefined;
+    }
+
+    if (data[0] === 0 && data[1] === 0) {
+      if (data[2] === 1) {
+        return 3;
+      } else if (data[2] === 0 && data[3] === 1) {
+        return 4;
+      }
+    }
+
+    return undefined;
+  }
+
+  public static IsKeyframe(data: Uint8Array): boolean {
+    const boxSize = H265.AnnexBBoxSize(data);
+    if (boxSize == undefined) {
+      return false;
+    }
+
+    let i = boxSize;
+    while (i < data.length) {
+      const naluType = (data[i]! >> 1) & 0x3f;
+      if (H265_KEYFRAME_TYPES.has(naluType)) {
+        return true;
+      }
+
+      i = H265.FindNextStartCodeEnd(data, i + 1);
+    }
+
+    return false;
+  }
+
+  public static ParseDecoderConfig(data: Uint8Array): VideoDecoderConfig | undefined {
+    const boxSize = H265.AnnexBBoxSize(data);
+    if (boxSize == undefined) {
+      return undefined;
+    }
+
+    let hasParameterSet = false;
+    let i = boxSize;
+    while (i < data.length) {
+      const naluType = (data[i]! >> 1) & 0x3f;
+      if (
+        naluType === H265NaluType.VPS_NUT ||
+        naluType === H265NaluType.SPS_NUT ||
+        naluType === H265NaluType.PPS_NUT
+      ) {
+        hasParameterSet = true;
+        break;
+      }
+
+      i = H265.FindNextStartCodeEnd(data, i + 1);
+    }
+
+    if (!hasParameterSet) {
+      return undefined;
+    }
+
+    // HEVC Annex B streams can be configured without description bytes if the
+    // keyframe contains VPS/SPS/PPS. We use a broadly supported Main-profile
+    // codec string here so browsers with HEVC-capable WebCodecs can initialize.
+    return { codec: DEFAULT_HEVC_CODEC };
+  }
+
+  public static FindNextStartCodeEnd(data: Uint8Array, start: number): number {
+    let i = start;
+    while (i < data.length - 3) {
+      const isStartCode3Bytes = data[i + 0] === 0 && data[i + 1] === 0 && data[i + 2] === 1;
+      if (isStartCode3Bytes) {
+        return i + 3;
+      }
+      const isStartCode4Bytes =
+        i + 3 < data.length &&
+        data[i + 0] === 0 &&
+        data[i + 1] === 0 &&
+        data[i + 2] === 0 &&
+        data[i + 3] === 1;
+      if (isStartCode4Bytes) {
+        return i + 4;
+      }
+      i++;
+    }
+    return data.length;
+  }
+}

--- a/packages/den/video/h265/H265.ts
+++ b/packages/den/video/h265/H265.ts
@@ -5,8 +5,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Bitstream } from "../h264/Bitstream";
-
 import { DEFAULT_HEVC_CODEC, H265_RANDOM_ACCESS_TYPES } from "./constants";
 import {
   H265FrameInfo,
@@ -15,6 +13,7 @@ import {
   H265ParserContext,
   H265SliceType,
 } from "./types";
+import { Bitstream } from "../h264/Bitstream";
 
 type H265PpsInfo = {
   ppsId: number;
@@ -24,6 +23,7 @@ type H265PpsInfo = {
   numExtraSliceHeaderBits: number;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class H265 {
   public static AnnexBBoxSize(data: Uint8Array): number | undefined {
     if (data.length < 4) {

--- a/packages/den/video/h265/H265.ts
+++ b/packages/den/video/h265/H265.ts
@@ -28,6 +28,15 @@ const H265_KEYFRAME_TYPES = new Set<number>([
 
 const DEFAULT_HEVC_CODEC = "hev1.1.6.L153.B0";
 
+type H265BitstreamFormat = "annex-b" | "length-prefixed" | "unknown";
+
+export type H265FrameInfo = {
+  bitstreamFormat: H265BitstreamFormat;
+  hasParameterSet: boolean;
+  isKeyframe: boolean;
+  normalizedData?: Uint8Array;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class H265 {
   public static AnnexBBoxSize(data: Uint8Array): number | undefined {
@@ -47,47 +56,12 @@ export class H265 {
   }
 
   public static IsKeyframe(data: Uint8Array): boolean {
-    const boxSize = H265.AnnexBBoxSize(data);
-    if (boxSize == undefined) {
-      return false;
-    }
-
-    let i = boxSize;
-    while (i < data.length) {
-      const naluType = (data[i]! >> 1) & 0x3f;
-      if (H265_KEYFRAME_TYPES.has(naluType)) {
-        return true;
-      }
-
-      i = H265.FindNextStartCodeEnd(data, i + 1);
-    }
-
-    return false;
+    return H265.InspectFrame(data).isKeyframe;
   }
 
   public static ParseDecoderConfig(data: Uint8Array): VideoDecoderConfig | undefined {
-    const boxSize = H265.AnnexBBoxSize(data);
-    if (boxSize == undefined) {
-      return undefined;
-    }
-
-    let hasParameterSet = false;
-    let i = boxSize;
-    while (i < data.length) {
-      const naluType = (data[i]! >> 1) & 0x3f;
-      if (
-        naluType === H265NaluType.VPS_NUT ||
-        naluType === H265NaluType.SPS_NUT ||
-        naluType === H265NaluType.PPS_NUT
-      ) {
-        hasParameterSet = true;
-        break;
-      }
-
-      i = H265.FindNextStartCodeEnd(data, i + 1);
-    }
-
-    if (!hasParameterSet) {
+    const info = H265.InspectFrame(data);
+    if (!info.hasParameterSet) {
       return undefined;
     }
 
@@ -95,6 +69,52 @@ export class H265 {
     // keyframe contains VPS/SPS/PPS. We use a broadly supported Main-profile
     // codec string here so browsers with HEVC-capable WebCodecs can initialize.
     return { codec: DEFAULT_HEVC_CODEC };
+  }
+
+  public static InspectFrame(data: Uint8Array): H265FrameInfo {
+    const annexBData = H265.ToAnnexB(data);
+    if (annexBData == undefined) {
+      return {
+        bitstreamFormat: "unknown",
+        hasParameterSet: false,
+        isKeyframe: false,
+      };
+    }
+
+    let hasParameterSet = false;
+    let isKeyframe = false;
+    const boxSize = H265.AnnexBBoxSize(annexBData)!;
+    let i = boxSize;
+    while (i < annexBData.length) {
+      const naluType = (annexBData[i]! >> 1) & 0x3f;
+      if (
+        naluType === H265NaluType.VPS_NUT ||
+        naluType === H265NaluType.SPS_NUT ||
+        naluType === H265NaluType.PPS_NUT
+      ) {
+        hasParameterSet = true;
+      }
+      if (H265_KEYFRAME_TYPES.has(naluType)) {
+        isKeyframe = true;
+      }
+
+      i = H265.FindNextStartCodeEnd(annexBData, i + 1);
+    }
+
+    return {
+      bitstreamFormat: H265.AnnexBBoxSize(data) != undefined ? "annex-b" : "length-prefixed",
+      hasParameterSet,
+      isKeyframe,
+      normalizedData: annexBData,
+    };
+  }
+
+  public static ToAnnexB(data: Uint8Array): Uint8Array | undefined {
+    if (H265.AnnexBBoxSize(data) != undefined) {
+      return data;
+    }
+
+    return H265.LengthPrefixedToAnnexB(data);
   }
 
   public static FindNextStartCodeEnd(data: Uint8Array, start: number): number {
@@ -116,5 +136,47 @@ export class H265 {
       i++;
     }
     return data.length;
+  }
+
+  private static LengthPrefixedToAnnexB(data: Uint8Array): Uint8Array | undefined {
+    if (data.length < 6) {
+      return undefined;
+    }
+
+    const converted: number[] = [];
+    let offset = 0;
+    let foundNalu = false;
+    while (offset + 4 <= data.length) {
+      const naluLength =
+        (((data[offset]! << 24) >>> 0) |
+          (data[offset + 1]! << 16) |
+          (data[offset + 2]! << 8) |
+          data[offset + 3]!) >>>
+        0;
+      offset += 4;
+
+      if (naluLength <= 0 || offset + naluLength > data.length) {
+        return undefined;
+      }
+
+      const naluHeader = data[offset]!;
+      const naluType = (naluHeader >> 1) & 0x3f;
+      if (naluType > 63) {
+        return undefined;
+      }
+
+      converted.push(0, 0, 0, 1);
+      for (let i = 0; i < naluLength; i++) {
+        converted.push(data[offset + i]!);
+      }
+      offset += naluLength;
+      foundNalu = true;
+    }
+
+    if (!foundNalu || offset !== data.length) {
+      return undefined;
+    }
+
+    return new Uint8Array(converted);
   }
 }

--- a/packages/den/video/h265/H265.ts
+++ b/packages/den/video/h265/H265.ts
@@ -5,39 +5,25 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-export enum H265NaluType {
-  BLA_W_LP = 16,
-  BLA_W_RADL = 17,
-  BLA_N_LP = 18,
-  IDR_W_RADL = 19,
-  IDR_N_LP = 20,
-  CRA_NUT = 21,
-  VPS_NUT = 32,
-  SPS_NUT = 33,
-  PPS_NUT = 34,
-}
+import { Bitstream } from "../h264/Bitstream";
 
-const H265_KEYFRAME_TYPES = new Set<number>([
-  H265NaluType.BLA_W_LP,
-  H265NaluType.BLA_W_RADL,
-  H265NaluType.BLA_N_LP,
-  H265NaluType.IDR_W_RADL,
-  H265NaluType.IDR_N_LP,
-  H265NaluType.CRA_NUT,
-]);
+import { DEFAULT_HEVC_CODEC, H265_RANDOM_ACCESS_TYPES } from "./constants";
+import {
+  H265FrameInfo,
+  H265FrameType,
+  H265NaluType,
+  H265ParserContext,
+  H265SliceType,
+} from "./types";
 
-const DEFAULT_HEVC_CODEC = "hev1.1.6.L153.B0";
-
-type H265BitstreamFormat = "annex-b" | "length-prefixed" | "unknown";
-
-export type H265FrameInfo = {
-  bitstreamFormat: H265BitstreamFormat;
-  hasParameterSet: boolean;
-  isKeyframe: boolean;
-  normalizedData?: Uint8Array;
+type H265PpsInfo = {
+  ppsId: number;
+  spsId: number;
+  dependentSliceSegmentsEnabledFlag: boolean;
+  outputFlagPresentFlag: boolean;
+  numExtraSliceHeaderBits: number;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class H265 {
   public static AnnexBBoxSize(data: Uint8Array): number | undefined {
     if (data.length < 4) {
@@ -47,7 +33,8 @@ export class H265 {
     if (data[0] === 0 && data[1] === 0) {
       if (data[2] === 1) {
         return 3;
-      } else if (data[2] === 0 && data[3] === 1) {
+      }
+      if (data[2] === 0 && data[3] === 1) {
         return 4;
       }
     }
@@ -56,56 +43,100 @@ export class H265 {
   }
 
   public static IsKeyframe(data: Uint8Array): boolean {
-    return H265.InspectFrame(data).isKeyframe;
+    const annexBData = H265.ToAnnexB(data);
+    if (annexBData == undefined) {
+      return false;
+    }
+
+    for (const nalu of H265.Nalus(annexBData)) {
+      if (H265_RANDOM_ACCESS_TYPES.has(nalu.type)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public static ParseDecoderConfig(data: Uint8Array): VideoDecoderConfig | undefined {
-    const info = H265.InspectFrame(data);
-    if (!info.hasParameterSet) {
-      return undefined;
-    }
-
-    // HEVC Annex B streams can be configured without description bytes if the
-    // keyframe contains VPS/SPS/PPS. We use a broadly supported Main-profile
-    // codec string here so browsers with HEVC-capable WebCodecs can initialize.
-    return { codec: DEFAULT_HEVC_CODEC };
+    return H265.ToAnnexB(data) != undefined ? { codec: DEFAULT_HEVC_CODEC } : undefined;
   }
 
-  public static InspectFrame(data: Uint8Array): H265FrameInfo {
+  public static InspectFrame(data: Uint8Array, context?: H265ParserContext): H265FrameInfo {
     const annexBData = H265.ToAnnexB(data);
     if (annexBData == undefined) {
       return {
         bitstreamFormat: "unknown",
-        hasParameterSet: false,
         isKeyframe: false,
+        isRandomAccess: false,
+        frameType: "unknown",
+        sliceTypes: [],
+        hasUnparsedVclSlice: false,
+        hasParameterSets: false,
+        hasRequiredParameterSets: false,
       };
     }
 
-    let hasParameterSet = false;
-    let isKeyframe = false;
-    const boxSize = H265.AnnexBBoxSize(annexBData)!;
-    let i = boxSize;
-    while (i < annexBData.length) {
-      const naluType = (annexBData[i]! >> 1) & 0x3f;
-      if (
-        naluType === H265NaluType.VPS_NUT ||
-        naluType === H265NaluType.SPS_NUT ||
-        naluType === H265NaluType.PPS_NUT
-      ) {
-        hasParameterSet = true;
-      }
-      if (H265_KEYFRAME_TYPES.has(naluType)) {
-        isKeyframe = true;
-      }
+    const ppsById = H265.ParsePpsMap(context?.parameterSets);
+    const parameterSetParts: number[] = [];
+    const sliceTypes: H265SliceType[] = [];
+    let hasRandomAccessNaluType = false;
+    let hasUnparsedVclSlice = false;
+    let hasVps = false;
+    let hasSps = false;
+    let hasPps = false;
 
-      i = H265.FindNextStartCodeEnd(annexBData, i + 1);
+    for (const nalu of H265.Nalus(annexBData)) {
+      if (H265_RANDOM_ACCESS_TYPES.has(nalu.type)) {
+        hasRandomAccessNaluType = true;
+      }
+      if (
+        nalu.type === H265NaluType.VPS_NUT ||
+        nalu.type === H265NaluType.SPS_NUT ||
+        nalu.type === H265NaluType.PPS_NUT
+      ) {
+        hasVps ||= nalu.type === H265NaluType.VPS_NUT;
+        hasSps ||= nalu.type === H265NaluType.SPS_NUT;
+        hasPps ||= nalu.type === H265NaluType.PPS_NUT;
+        for (let index = nalu.startCodeStart; index < nalu.end; index++) {
+          parameterSetParts.push(annexBData[index]!);
+        }
+        if (nalu.type === H265NaluType.PPS_NUT) {
+          const pps = H265.ParsePps(nalu.data);
+          if (pps != undefined) {
+            ppsById.set(pps.ppsId, pps);
+          }
+        }
+      }
     }
 
+    for (const nalu of H265.Nalus(annexBData)) {
+      if (!H265.IsVclNaluType(nalu.type)) {
+        continue;
+      }
+      const sliceType = H265.ParseSliceType(nalu.data, nalu.type, ppsById);
+      if (sliceType == undefined) {
+        hasUnparsedVclSlice = true;
+        continue;
+      }
+      sliceTypes.push(sliceType);
+    }
+
+    const frameType = H265.FrameType(sliceTypes);
+    const isRandomAccess = hasRandomAccessNaluType;
+    const hasParameterSets = parameterSetParts.length > 0;
+    const hasRequiredParameterSets = hasVps && hasSps && hasPps;
+    const annexBBoxSize = H265.AnnexBBoxSize(data);
+
     return {
-      bitstreamFormat: H265.AnnexBBoxSize(data) != undefined ? "annex-b" : "length-prefixed",
-      hasParameterSet,
-      isKeyframe,
+      bitstreamFormat: annexBBoxSize != undefined ? "annex-b" : "length-prefixed",
+      isKeyframe: isRandomAccess,
+      isRandomAccess,
+      frameType,
+      sliceTypes,
+      hasUnparsedVclSlice,
       normalizedData: annexBData,
+      parameterSets: hasParameterSets ? new Uint8Array(parameterSetParts) : undefined,
+      hasParameterSets,
+      hasRequiredParameterSets,
     };
   }
 
@@ -117,12 +148,35 @@ export class H265 {
     return H265.LengthPrefixedToAnnexB(data);
   }
 
-  public static FindNextStartCodeEnd(data: Uint8Array, start: number): number {
+  public static StripParameterSets(data: Uint8Array): Uint8Array | undefined {
+    const annexBData = H265.ToAnnexB(data);
+    if (annexBData == undefined) {
+      return undefined;
+    }
+
+    const parts: number[] = [];
+    for (const nalu of H265.Nalus(annexBData)) {
+      if (
+        nalu.type === H265NaluType.VPS_NUT ||
+        nalu.type === H265NaluType.SPS_NUT ||
+        nalu.type === H265NaluType.PPS_NUT
+      ) {
+        continue;
+      }
+      for (let index = nalu.startCodeStart; index < nalu.end; index++) {
+        parts.push(annexBData[index]!);
+      }
+    }
+
+    return parts.length > 0 ? new Uint8Array(parts) : undefined;
+  }
+
+  public static FindNextStartCode(data: Uint8Array, start: number): number {
     let i = start;
     while (i < data.length - 3) {
       const isStartCode3Bytes = data[i + 0] === 0 && data[i + 1] === 0 && data[i + 2] === 1;
       if (isStartCode3Bytes) {
-        return i + 3;
+        return i;
       }
       const isStartCode4Bytes =
         i + 3 < data.length &&
@@ -131,11 +185,149 @@ export class H265 {
         data[i + 2] === 0 &&
         data[i + 3] === 1;
       if (isStartCode4Bytes) {
-        return i + 4;
+        return i;
       }
       i++;
     }
     return data.length;
+  }
+
+  public static FindNextStartCodeEnd(data: Uint8Array, start: number): number {
+    const nextStartCode = H265.FindNextStartCode(data, start);
+    return nextStartCode === data.length
+      ? data.length
+      : nextStartCode + (H265.AnnexBBoxSize(data.subarray(nextStartCode)) ?? 0);
+  }
+
+  private static *Nalus(data: Uint8Array): Generator<{
+    type: number;
+    data: Uint8Array;
+    startCodeStart: number;
+    start: number;
+    end: number;
+  }> {
+    let startCodeStart = H265.FindNextStartCode(data, 0);
+    while (startCodeStart !== data.length) {
+      const startCodeLength = H265.AnnexBBoxSize(data.subarray(startCodeStart)) ?? 0;
+      const start = startCodeStart + startCodeLength;
+      const nextStartCode = H265.FindNextStartCode(data, start + 1);
+      if (start + 2 <= nextStartCode) {
+        yield {
+          type: (data[start]! >> 1) & 0x3f,
+          data: data.subarray(start, nextStartCode),
+          startCodeStart,
+          start,
+          end: nextStartCode,
+        };
+      }
+      startCodeStart = nextStartCode;
+    }
+  }
+
+  private static ParsePpsMap(data: Uint8Array | undefined): Map<number, H265PpsInfo> {
+    const ppsById = new Map<number, H265PpsInfo>();
+    if (data == undefined) {
+      return ppsById;
+    }
+    const annexBData = H265.ToAnnexB(data);
+    if (annexBData == undefined) {
+      return ppsById;
+    }
+    for (const nalu of H265.Nalus(annexBData)) {
+      if (nalu.type !== H265NaluType.PPS_NUT) {
+        continue;
+      }
+      const pps = H265.ParsePps(nalu.data);
+      if (pps != undefined) {
+        ppsById.set(pps.ppsId, pps);
+      }
+    }
+    return ppsById;
+  }
+
+  private static ParsePps(nalu: Uint8Array): H265PpsInfo | undefined {
+    if (nalu.length < 3) {
+      return undefined;
+    }
+    try {
+      const bitstream = new Bitstream(nalu.subarray(2));
+      const ppsId = bitstream.ue_v();
+      const spsId = bitstream.ue_v();
+      const dependentSliceSegmentsEnabledFlag = bitstream.u_1() === 1;
+      const outputFlagPresentFlag = bitstream.u_1() === 1;
+      const numExtraSliceHeaderBits = bitstream.u(3);
+      return {
+        ppsId,
+        spsId,
+        dependentSliceSegmentsEnabledFlag,
+        outputFlagPresentFlag,
+        numExtraSliceHeaderBits,
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  private static ParseSliceType(
+    nalu: Uint8Array,
+    naluType: number,
+    ppsById: Map<number, H265PpsInfo>,
+  ): H265SliceType | undefined {
+    if (nalu.length < 3) {
+      return undefined;
+    }
+    try {
+      const bitstream = new Bitstream(nalu.subarray(2));
+      const firstSliceSegmentInPicFlag = bitstream.u_1();
+      if (H265_RANDOM_ACCESS_TYPES.has(naluType)) {
+        bitstream.u_1();
+      }
+      const ppsId = bitstream.ue_v();
+      const pps = ppsById.get(ppsId);
+      if (pps == undefined) {
+        return undefined;
+      }
+      if (firstSliceSegmentInPicFlag === 0) {
+        return undefined;
+      }
+      if (pps.outputFlagPresentFlag) {
+        bitstream.u_1();
+      }
+      for (let i = 0; i < pps.numExtraSliceHeaderBits; i++) {
+        bitstream.u_1();
+      }
+      const sliceType = bitstream.ue_v();
+      if (
+        sliceType !== H265SliceType.B &&
+        sliceType !== H265SliceType.P &&
+        sliceType !== H265SliceType.I
+      ) {
+        return undefined;
+      }
+      return sliceType;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private static FrameType(sliceTypes: H265SliceType[]): H265FrameType {
+    if (sliceTypes.length === 0) {
+      return "unknown";
+    }
+    if (sliceTypes.every((sliceType) => sliceType === H265SliceType.I)) {
+      return "I";
+    }
+    if (sliceTypes.some((sliceType) => sliceType === H265SliceType.B)) {
+      return "B";
+    }
+    if (sliceTypes.some((sliceType) => sliceType === H265SliceType.P)) {
+      return "P";
+    }
+    return "unknown";
+  }
+
+  private static IsVclNaluType(naluType: number): boolean {
+    return naluType >= 0 && naluType <= 31;
   }
 
   private static LengthPrefixedToAnnexB(data: Uint8Array): Uint8Array | undefined {
@@ -143,9 +335,11 @@ export class H265 {
       return undefined;
     }
 
-    const converted: number[] = [];
+    const result = new Uint8Array(data.length);
     let offset = 0;
+    let writeOffset = 0;
     let foundNalu = false;
+
     while (offset + 4 <= data.length) {
       const naluLength =
         (((data[offset]! << 24) >>> 0) |
@@ -159,16 +353,13 @@ export class H265 {
         return undefined;
       }
 
-      const naluHeader = data[offset]!;
-      const naluType = (naluHeader >> 1) & 0x3f;
-      if (naluType > 63) {
-        return undefined;
-      }
+      result[writeOffset++] = 0;
+      result[writeOffset++] = 0;
+      result[writeOffset++] = 0;
+      result[writeOffset++] = 1;
+      result.set(data.subarray(offset, offset + naluLength), writeOffset);
+      writeOffset += naluLength;
 
-      converted.push(0, 0, 0, 1);
-      for (let i = 0; i < naluLength; i++) {
-        converted.push(data[offset + i]!);
-      }
       offset += naluLength;
       foundNalu = true;
     }
@@ -177,6 +368,6 @@ export class H265 {
       return undefined;
     }
 
-    return new Uint8Array(converted);
+    return result;
   }
 }

--- a/packages/den/video/h265/constants.ts
+++ b/packages/den/video/h265/constants.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { H265NaluType } from "./types";
+
+export const DEFAULT_HEVC_CODEC = "hvc1.1.6.L93.B0";
+
+export const H265_RANDOM_ACCESS_TYPES = new Set<number>([
+  H265NaluType.BLA_W_LP,
+  H265NaluType.BLA_W_RADL,
+  H265NaluType.BLA_N_LP,
+  H265NaluType.IDR_W_RADL,
+  H265NaluType.IDR_N_LP,
+  H265NaluType.CRA_NUT,
+  H265NaluType.RSV_IRAP_VCL22,
+  H265NaluType.RSV_IRAP_VCL23,
+]);

--- a/packages/den/video/h265/index.ts
+++ b/packages/den/video/h265/index.ts
@@ -5,6 +5,4 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-export * from "./h264";
-export * from "./h265";
-export * from "./VideoPlayer";
+export * from "./H265";

--- a/packages/den/video/h265/index.ts
+++ b/packages/den/video/h265/index.ts
@@ -5,4 +5,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+export * from "./constants";
 export * from "./H265";
+export * from "./types";

--- a/packages/den/video/h265/types.ts
+++ b/packages/den/video/h265/types.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export enum H265NaluType {
+  BLA_W_LP = 16,
+  BLA_W_RADL = 17,
+  BLA_N_LP = 18,
+  IDR_W_RADL = 19,
+  IDR_N_LP = 20,
+  CRA_NUT = 21,
+  RSV_IRAP_VCL22 = 22,
+  RSV_IRAP_VCL23 = 23,
+  VPS_NUT = 32,
+  SPS_NUT = 33,
+  PPS_NUT = 34,
+}
+
+export enum H265SliceType {
+  B = 0,
+  P = 1,
+  I = 2,
+}
+
+export type H265FrameType = "B" | "P" | "I" | "unknown";
+export type H265BitstreamFormat = "annex-b" | "length-prefixed" | "unknown";
+
+export type H265ParserContext = {
+  parameterSets?: Uint8Array;
+};
+
+export type H265FrameInfo = {
+  bitstreamFormat: H265BitstreamFormat;
+  isKeyframe: boolean;
+  isRandomAccess: boolean;
+  frameType: H265FrameType;
+  sliceTypes: H265SliceType[];
+  hasUnparsedVclSlice: boolean;
+  normalizedData?: Uint8Array;
+  parameterSets?: Uint8Array;
+  hasParameterSets: boolean;
+  hasRequiredParameterSets: boolean;
+  diagnostics?: string;
+};

--- a/packages/suite-base/package.json
+++ b/packages/suite-base/package.json
@@ -108,7 +108,7 @@
     "css-loader": "6.8.1",
     "cytoscape": "3.31.1",
     "cytoscape-dagre": "2.5.0",
-    "dompurify": "3.3.2",
+    "dompurify": "3.4.0",
     "dotenv": "17.2.2",
     "esbuild-loader": "4.3.0",
     "eventemitter3": "5.0.1",

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -275,7 +275,6 @@ export class ImageMode
         subscription: {
           handler: this.messageHandler.handleCompressedVideo,
           shouldSubscribe: this.imageShouldSubscribe,
-          filterQueue: this.#filterMessageQueue.bind(this),
         },
       },
     ];
@@ -304,6 +303,7 @@ export class ImageMode
     // To avoid flickering while seeking or changing subscriptions, we avoid clearing the
     // ImageRenderable for a short timeout. When a new image message arrives, we cancel the timeout,
     // so the old image will continue displaying until the new one has been decoded.
+    this.imageRenderable?.videoPlayer?.resetForSeek();
     if (this.#removeImageTimeout == undefined) {
       this.#removeImageTimeout = setTimeout(() => {
         this.#removeImageTimeout = undefined;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -146,7 +146,6 @@ export class Images extends SceneExtension<ImageRenderable> {
         schemaNames: COMPRESSED_VIDEO_DATATYPES,
         subscription: {
           handler: this.#handleCompressedVideo,
-          filterQueue: onlyLastByTopicMessage,
         },
       },
     ];

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -6,7 +6,10 @@
 import * as THREE from "three";
 
 import { PinholeCameraModel } from "@lichtblick/den/image";
+import { H265SliceType } from "@lichtblick/den/video";
+import { toNanoSec } from "@lichtblick/rostime";
 import { IRenderer } from "@lichtblick/suite-base/panels/ThreeDeeRender/IRenderer";
+import H265FrameBuilder from "@lichtblick/suite-base/testing/builders/H265FrameBuilder";
 import { BasicBuilder } from "@lichtblick/test-builders";
 
 import {
@@ -59,13 +62,24 @@ const sampleImage = {
   header: { frame_id: "camera", stamp: { sec: 0, nsec: 1 } },
 };
 
-function createH265Frame(data: Uint8Array) {
+const h265Keyframe = H265FrameBuilder.keyframeWithParameterSets();
+const h265DeltaFrame = H265FrameBuilder.deltaFrame();
+const h265BFrame = H265FrameBuilder.deltaFrameWithPps(H265SliceType.B);
+
+function createH265Frame(data: Uint8Array, timestamp = { sec: 0, nsec: 1 }) {
+  return H265FrameBuilder.frame({ data, frame_id: "camera", timestamp });
+}
+
+function createDecodedVideoFrame(timestamp = 0): VideoFrame {
   return {
-    format: "h265",
-    data,
-    frame_id: "camera",
-    timestamp: { sec: 0, nsec: 1 },
-  };
+    timestamp,
+    codedWidth: 640,
+    codedHeight: 480,
+    close: jest.fn(),
+    clone: jest.fn().mockImplementation(function () {
+      return this;
+    }),
+  } as unknown as VideoFrame;
 }
 
 describe("ImageRenderable", () => {
@@ -97,12 +111,16 @@ describe("ImageRenderable", () => {
     renderable.userData.texture = new THREE.Texture();
     renderable.userData.material = new THREE.ShaderMaterial();
     renderable.userData.geometry = new THREE.PlaneGeometry();
+    renderable.videoPlayer = {
+      close: jest.fn(),
+    } as unknown as ImageRenderable["videoPlayer"];
 
     // @ts-expect-error isDisposed is protected, but ok to use on tests
     expect(renderable.isDisposed()).toBe(false);
 
     renderable.dispose();
 
+    expect(renderable.videoPlayer?.close).toHaveBeenCalled();
     // @ts-expect-error isDisposed is protected, but ok to use on tests
     expect(renderable.isDisposed()).toBe(true);
   });
@@ -202,44 +220,35 @@ describe("ImageRenderable error handling", () => {
     expect(mockRemoveFromTopic).toHaveBeenCalledWith(mockUserData.topic, "decode");
   });
 
-  it("should reuse cached h265 decoder config for later keyframes", async () => {
+  it("should initialize h265 decoding for a keyframe with VPS SPS PPS", async () => {
     const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
     const init = jest.fn().mockResolvedValue(undefined);
-    const decode = jest.fn().mockResolvedValue(undefined);
+    const decodeFrames = jest.fn().mockResolvedValue({
+      type: "target",
+      frame: createDecodedVideoFrame(),
+    });
     renderable.videoPlayer = {
       isInitialized: jest.fn().mockReturnValue(false),
       init,
-      decode,
+      decode: jest.fn(),
+      decodeFrames,
       codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue(undefined),
+      resetForSeek: jest.fn(),
     } as unknown as ImageRenderable["videoPlayer"];
 
-    const keyframeWithParameterSet = createH265Frame(
-      new Uint8Array([
-        0x00,
-        0x00,
-        0x00,
-        0x02,
-        (32 << 1) | 1,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x02,
-        (19 << 1) | 1,
-        0x01,
-      ]),
-    );
-    const keyframeWithoutParameterSet = createH265Frame(
-      new Uint8Array([0x00, 0x00, 0x00, 0x02, (19 << 1) | 1, 0x01]),
-    );
+    const keyframe = createH265Frame(h265Keyframe);
+
+    const originalCreateImageBitmap = self.createImageBitmap;
+    const createImageBitmapSpy = jest.fn().mockResolvedValue(new ImageBitmap());
+    // @ts-expect-error test override
+    self.createImageBitmap = createImageBitmapSpy;
 
     // @ts-expect-error decodeImage is protected, but ok to use on tests
-    await renderable.decodeImage(keyframeWithParameterSet, 100);
-    // @ts-expect-error decodeImage is protected, but ok to use on tests
-    await renderable.decodeImage(keyframeWithoutParameterSet, 100);
+    await renderable.decodeImage(keyframe, 100);
 
-    expect(init).toHaveBeenNthCalledWith(1, { codec: "hev1.1.6.L153.B0" });
-    expect(init).toHaveBeenNthCalledWith(2, { codec: "hev1.1.6.L153.B0" });
+    expect(init).toHaveBeenCalledWith({ codec: "hvc1.1.6.L93.B0" });
+    self.createImageBitmap = originalCreateImageBitmap;
   });
 
   it("should report detailed h265 diagnostics before decoder init", async () => {
@@ -248,13 +257,42 @@ describe("ImageRenderable error handling", () => {
       isInitialized: jest.fn().mockReturnValue(false),
       init: jest.fn(),
       decode: jest.fn(),
+      decodeFrames: jest.fn(),
       codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue(undefined),
+      resetForSeek: jest.fn(),
     } as unknown as ImageRenderable["videoPlayer"];
 
     // @ts-expect-error decodeImage is protected, but ok to use on tests
-    await expect(renderable.decodeImage(createH265Frame(new Uint8Array([0x01, 0x02, 0x03])), 100)).rejects.toThrow(
-      "Waiting for keyframe (unsupported H.265 bitstream format)",
-    );
+    await expect(
+      renderable.decodeImage(createH265Frame(new Uint8Array([0x01, 0x02, 0x03])), 100),
+    ).rejects.toThrow("Waiting for keyframe (unsupported H.265 bitstream format)");
+  });
+
+  it("should wait silently for h265 frames without decoder config before init", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    const lastImageBitmap = new ImageBitmap();
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(false),
+      init: jest.fn(),
+      decode: jest.fn(),
+      decodeFrames: jest.fn(),
+      codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue(undefined),
+      resetForSeek: jest.fn(),
+      lastImageBitmap,
+      lastVideoFrame: undefined,
+      awaitTargetFrame: jest.fn(),
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    const bitmap =
+      // @ts-expect-error decodeImage is protected, but ok to use on tests
+      await renderable.decodeImage(
+        createH265Frame(h265DeltaFrame),
+        100,
+      );
+
+    expect(bitmap).not.toBe(lastImageBitmap);
   });
 
   it("should wait silently on h265 delta frames before decoder init", async () => {
@@ -264,38 +302,473 @@ describe("ImageRenderable error handling", () => {
       isInitialized: jest.fn().mockReturnValue(false),
       init,
       decode: jest.fn(),
+      decodeFrames: jest.fn().mockResolvedValue({
+        type: "target",
+        frame: createDecodedVideoFrame(),
+      }),
       codedSize: jest.fn(),
       lastImageBitmap: undefined,
+      decoderConfig: jest.fn().mockReturnValue(undefined),
+      resetForSeek: jest.fn(),
+      awaitTargetFrame: jest.fn(),
     } as unknown as ImageRenderable["videoPlayer"];
 
+    const originalCreateImageBitmap = self.createImageBitmap;
+    const createImageBitmapSpy = jest.fn().mockResolvedValue(new ImageBitmap());
+    // @ts-expect-error test override
+    self.createImageBitmap = createImageBitmapSpy;
+
     // @ts-expect-error decodeImage is protected, but ok to use on tests
-    await renderable.decodeImage(
-      createH265Frame(
-        new Uint8Array([
-          0x00,
-          0x00,
-          0x00,
-          0x02,
-          (32 << 1) | 1,
-          0x01,
-          0x00,
-          0x00,
-          0x00,
-          0x02,
-          (19 << 1) | 1,
-          0x01,
-        ]),
-      ),
-      100,
-    );
+    await renderable.decodeImage(createH265Frame(h265Keyframe), 100);
     const bitmap =
       // @ts-expect-error decodeImage is protected, but ok to use on tests
       await renderable.decodeImage(
-        createH265Frame(new Uint8Array([0x00, 0x00, 0x00, 0x02, (1 << 1) | 1, 0x01])),
+        createH265Frame(h265DeltaFrame),
         100,
       );
 
     expect(bitmap).toBeInstanceOf(ImageBitmap);
     expect(init).toHaveBeenCalledTimes(1);
+    self.createImageBitmap = originalCreateImageBitmap;
+  });
+
+  it("should reset the video player when timestamps go backwards", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    const resetForSeek = jest.fn();
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(false),
+      init: jest.fn().mockResolvedValue(undefined),
+      decode: jest.fn(),
+      decodeFrames: jest.fn().mockResolvedValue({
+        type: "target",
+        frame: createDecodedVideoFrame(),
+      }),
+      codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue(undefined),
+      resetForSeek,
+      lastImageBitmap: undefined,
+      awaitTargetFrame: jest.fn(),
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    const keyframe = h265Keyframe;
+
+    const originalCreateImageBitmap = self.createImageBitmap;
+    const createImageBitmapSpy = jest.fn().mockResolvedValue(new ImageBitmap());
+    // @ts-expect-error test override
+    self.createImageBitmap = createImageBitmapSpy;
+
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(keyframe, { sec: 2, nsec: 0 }), 100);
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(keyframe, { sec: 1, nsec: 0 }), 100);
+
+    expect(resetForSeek).toHaveBeenCalledTimes(1);
+    self.createImageBitmap = originalCreateImageBitmap;
+  });
+
+  it("should ignore small backward timestamp jitter for h265 frames", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    const resetForSeek = jest.fn();
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(false),
+      init: jest.fn().mockResolvedValue(undefined),
+      decode: jest.fn(),
+      decodeFrames: jest.fn().mockResolvedValue({
+        type: "target",
+        frame: createDecodedVideoFrame(),
+      }),
+      codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue(undefined),
+      resetForSeek,
+      lastImageBitmap: undefined,
+      awaitTargetFrame: jest.fn(),
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    const originalCreateImageBitmap = self.createImageBitmap;
+    const createImageBitmapSpy = jest.fn().mockResolvedValue(new ImageBitmap());
+    // @ts-expect-error test override
+    self.createImageBitmap = createImageBitmapSpy;
+
+    const keyframe = h265Keyframe;
+
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(keyframe, { sec: 2, nsec: 10_000_000 }), 100);
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(keyframe, { sec: 2, nsec: 8_000_000 }), 100);
+
+    expect(resetForSeek).not.toHaveBeenCalled();
+    self.createImageBitmap = originalCreateImageBitmap;
+  });
+
+  it("should serialize h264 video decoding and keep only the latest pending frame", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    const decodeResolvers = new Map<number, () => void>();
+    const decodeOrder: number[] = [];
+
+    jest.spyOn(renderable, "update").mockImplementation(() => undefined);
+
+    const keyframe = h265Keyframe;
+
+    let resolveLatestDecoded!: () => void;
+    const latestDecoded = new Promise<void>((resolve) => {
+      resolveLatestDecoded = resolve;
+    });
+    let resolveLatestDecodeStarted!: () => void;
+    const latestDecodeStarted = new Promise<void>((resolve) => {
+      resolveLatestDecodeStarted = resolve;
+    });
+
+    jest
+      // @ts-expect-error decodeImage is protected, but ok to use on tests
+      .spyOn(renderable, "decodeImage")
+      .mockImplementation(async (image: (typeof mockUserData)["image"] & { timestamp: { sec: number; nsec: number } }) => {
+        const timestampMicros = Number(
+          (BigInt(image.timestamp.sec) * 1000000000n + BigInt(image.timestamp.nsec)) / 1000n,
+        );
+        decodeOrder.push(timestampMicros);
+        if (timestampMicros === 33333) {
+          resolveLatestDecodeStarted();
+        }
+        await new Promise<void>((resolve) => {
+          decodeResolvers.set(timestampMicros, resolve);
+        });
+        return {} as ImageData;
+      });
+
+    renderable.setImage({ ...createH265Frame(keyframe, { sec: 0, nsec: 0 }), format: "h264" });
+    renderable.setImage({ ...createH265Frame(keyframe, { sec: 0, nsec: 16666666 }), format: "h264" });
+    renderable.setImage({ ...createH265Frame(keyframe, { sec: 0, nsec: 33333333 }), format: "h264" }, undefined, () => {
+      resolveLatestDecoded();
+    });
+    await Promise.resolve();
+
+    expect(decodeOrder).toEqual([0]);
+
+    decodeResolvers.get(0)?.();
+    await latestDecodeStarted;
+    expect(decodeOrder).toEqual([0, 33333]);
+
+    decodeResolvers.get(33333)?.();
+    await latestDecoded;
+  });
+
+  it("should decode every pending h265 frame in order", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    jest.spyOn(renderable, "update").mockImplementation(() => undefined);
+
+    const decode = jest
+      .fn<Promise<VideoFrame | undefined>, [Uint8Array, number, "key" | "delta"]>()
+      .mockResolvedValueOnce(createDecodedVideoFrame(0))
+      .mockResolvedValueOnce(createDecodedVideoFrame(16666))
+      .mockResolvedValueOnce(createDecodedVideoFrame(33333));
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(true),
+      init: jest.fn().mockResolvedValue(undefined),
+      decode,
+      codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue({ codec: "hvc1.1.6.L93.B0" }),
+      resetForSeek: jest.fn(),
+      lastImageBitmap: undefined,
+      lastVideoFrame: undefined,
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    const originalCreateImageBitmap = self.createImageBitmap;
+    const createImageBitmapSpy = jest.fn().mockResolvedValue(new ImageBitmap());
+    // @ts-expect-error test override
+    self.createImageBitmap = createImageBitmapSpy;
+
+    let releaseFirstDecode!: () => void;
+    const firstDecodeBlocked = new Promise<void>((resolve) => {
+      releaseFirstDecode = resolve;
+    });
+    let latestDecoded!: () => void;
+    const latestDecodedPromise = new Promise<void>((resolve) => {
+      latestDecoded = resolve;
+    });
+
+    jest
+      // @ts-expect-error decodeImage is protected, but ok to use on tests
+      .spyOn(renderable, "decodeImage")
+      .mockImplementation(async (image, resizeWidth) => {
+        if (toNanoSec((image as CompressedVideo).timestamp) === 0n) {
+          await firstDecodeBlocked;
+        }
+        return await ImageRenderable.prototype.decodeImage.call(renderable, image, resizeWidth);
+      });
+
+    renderable.setImage(createH265Frame(h265Keyframe, { sec: 0, nsec: 0 }));
+    renderable.setImage(createH265Frame(h265DeltaFrame, { sec: 0, nsec: 16666666 }));
+    renderable.setImage(createH265Frame(h265DeltaFrame, { sec: 0, nsec: 33333333 }), undefined, () => {
+      latestDecoded();
+    });
+    await Promise.resolve();
+
+    releaseFirstDecode();
+    await latestDecodedPromise;
+
+    expect(decode).toHaveBeenNthCalledWith(1, expect.any(Uint8Array), 0, "key");
+    expect(decode).toHaveBeenNthCalledWith(2, expect.any(Uint8Array), 16666, "delta");
+    expect(decode).toHaveBeenNthCalledWith(3, expect.any(Uint8Array), 33333, "delta");
+
+    self.createImageBitmap = originalCreateImageBitmap;
+  });
+
+  it("should skip duplicate pending h265 frame timestamps", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    jest.spyOn(renderable, "update").mockImplementation(() => undefined);
+
+    const decode = jest
+      .fn<Promise<VideoFrame | undefined>, [Uint8Array, number, "key" | "delta"]>()
+      .mockResolvedValueOnce(createDecodedVideoFrame(0))
+      .mockResolvedValueOnce(createDecodedVideoFrame(16666));
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(true),
+      init: jest.fn().mockResolvedValue(undefined),
+      decode,
+      codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue({ codec: "hvc1.1.6.L93.B0" }),
+      resetForSeek: jest.fn(),
+      lastImageBitmap: undefined,
+      lastVideoFrame: undefined,
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    const originalCreateImageBitmap = self.createImageBitmap;
+    // @ts-expect-error test override
+    self.createImageBitmap = jest.fn().mockResolvedValue(new ImageBitmap());
+
+    let latestDecoded!: () => void;
+    const latestDecodedPromise = new Promise<void>((resolve) => {
+      latestDecoded = resolve;
+    });
+
+    renderable.setImage(createH265Frame(h265Keyframe, { sec: 0, nsec: 0 }));
+    renderable.setImage(createH265Frame(h265Keyframe, { sec: 0, nsec: 0 }));
+    renderable.setImage(createH265Frame(h265DeltaFrame, { sec: 0, nsec: 16666666 }), undefined, () => {
+      latestDecoded();
+    });
+    await latestDecodedPromise;
+
+    expect(decode).toHaveBeenCalledTimes(2);
+    expect(decode).toHaveBeenNthCalledWith(1, expect.any(Uint8Array), 0, "key");
+    expect(decode).toHaveBeenNthCalledWith(2, expect.any(Uint8Array), 16666, "delta");
+
+    self.createImageBitmap = originalCreateImageBitmap;
+  });
+
+  it("should reuse the last image bitmap when h265 decode times out", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    const lastImageBitmap = new ImageBitmap();
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(true),
+      init: jest.fn().mockResolvedValue(undefined),
+      decode: jest.fn().mockResolvedValue(undefined),
+      codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue({ codec: "hvc1.1.6.L93.B0" }),
+      resetForSeek: jest.fn(),
+      lastImageBitmap,
+      lastVideoFrame: undefined,
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    const bitmap = await renderable.decodeImage(createH265Frame(h265Keyframe, { sec: 0, nsec: 0 }), 100);
+
+    expect(bitmap).toBe(lastImageBitmap);
+  });
+
+  it("should reset the video player when a decode error is reported", () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    const resetForSeek = jest.fn();
+    renderable.videoPlayer = {
+      resetForSeek,
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    // @ts-expect-error handleVideoPlayerError is protected, but ok to use on tests
+    renderable.handleVideoPlayerError(new Error("Decoding error"));
+    (console.error as jest.Mock).mockClear();
+
+    expect(resetForSeek).toHaveBeenCalledTimes(1);
+    expect(mockAdd).toHaveBeenCalledWith(
+      ["imageMode", "imageTopic"],
+      "CreateBitmap",
+      "Error decoding video: Decoding error",
+    );
+  });
+
+  it("should skip unsupported h265 B frames", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    const lastImageBitmap = new ImageBitmap();
+    const decode = jest.fn();
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(true),
+      init: jest.fn().mockResolvedValue(undefined),
+      decode,
+      codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue({ codec: "hvc1.1.6.L93.B0" }),
+      resetForSeek: jest.fn(),
+      lastImageBitmap,
+      lastVideoFrame: undefined,
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    const bitmap = await renderable.decodeImage(createH265Frame(h265BFrame, { sec: 0, nsec: 33333333 }), 100);
+
+    expect(bitmap).toBe(lastImageBitmap);
+    expect(decode).not.toHaveBeenCalled();
+  });
+
+  it("should decode continuous h265 frames one-by-one after the nearest keyframe", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    const decode = jest
+      .fn<Promise<VideoFrame | undefined>, [Uint8Array, number, "key" | "delta"]>()
+      .mockResolvedValueOnce(createDecodedVideoFrame(0))
+      .mockResolvedValueOnce(createDecodedVideoFrame(16666))
+      .mockResolvedValueOnce(createDecodedVideoFrame(33333));
+    const init = jest.fn().mockResolvedValue(undefined);
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(true),
+      init,
+      decode,
+      codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue({ codec: "hvc1.1.6.L93.B0" }),
+      resetForSeek: jest.fn(),
+      lastImageBitmap: undefined,
+      lastVideoFrame: undefined,
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    const originalCreateImageBitmap = self.createImageBitmap;
+    const createImageBitmapSpy = jest.fn().mockResolvedValue(new ImageBitmap());
+    // @ts-expect-error test override
+    self.createImageBitmap = createImageBitmapSpy;
+
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(h265Keyframe, { sec: 0, nsec: 0 }), 100);
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(h265DeltaFrame, { sec: 0, nsec: 16666666 }), 100);
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(h265DeltaFrame, { sec: 0, nsec: 33333333 }), 100);
+
+    expect(decode).toHaveBeenNthCalledWith(1, expect.any(Uint8Array), 0, "key");
+    expect(decode).toHaveBeenNthCalledWith(2, expect.any(Uint8Array), 16666, "delta");
+    expect(decode).toHaveBeenNthCalledWith(3, expect.any(Uint8Array), 33333, "delta");
+    expect(init).not.toHaveBeenCalled();
+
+    self.createImageBitmap = originalCreateImageBitmap;
+  });
+
+  it("should replay h265 GOP when seeking to a P frame", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    const replayFrame = createDecodedVideoFrame(33333);
+    const consumeData = (data: Uint8Array) => {
+      expect(data.byteLength).toBeGreaterThan(0);
+      data.fill(0);
+    };
+    const decode = jest.fn(
+      async (data: Uint8Array, timestampMicros: number): Promise<VideoFrame | undefined> => {
+        consumeData(data);
+        return createDecodedVideoFrame(timestampMicros);
+      },
+    );
+    const decodeFrames = jest.fn(async (frames: { data: Uint8Array }[]) => {
+      for (const frame of frames) {
+        expect(frame.data.byteLength).toBeGreaterThan(0);
+        expect(frame.data.some((value) => value !== 0)).toBe(true);
+        consumeData(frame.data);
+      }
+      return { type: "target", frame: replayFrame };
+    });
+    const init = jest.fn().mockResolvedValue(undefined);
+    const resetForSeek = jest.fn();
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(true),
+      init,
+      decode,
+      decodeFrames,
+      codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue({ codec: "hvc1.1.6.L93.B0" }),
+      resetForSeek,
+      lastImageBitmap: undefined,
+      lastVideoFrame: undefined,
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    const originalCreateImageBitmap = self.createImageBitmap;
+    const replayBitmap = new ImageBitmap();
+    // @ts-expect-error test override
+    self.createImageBitmap = jest.fn().mockResolvedValue(replayBitmap);
+
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(h265Keyframe.slice(), { sec: 0, nsec: 0 }), 100);
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(h265DeltaFrame.slice(), { sec: 0, nsec: 33333333 }), 100);
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(h265DeltaFrame.slice(), { sec: 0, nsec: 66666666 }), 100);
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    const bitmap = await renderable.decodeImage(createH265Frame(h265DeltaFrame.slice(), { sec: 0, nsec: 33333333 }), 100);
+
+    expect(bitmap).toBe(replayBitmap);
+    expect(resetForSeek).toHaveBeenCalled();
+    expect(init).toHaveBeenCalledWith({ codec: "hvc1.1.6.L93.B0" });
+    expect(decodeFrames).toHaveBeenCalledWith([
+      { data: expect.any(Uint8Array), timestampMicros: 0, type: "key" },
+      { data: expect.any(Uint8Array), timestampMicros: 33333, type: "delta" },
+    ]);
+
+    self.createImageBitmap = originalCreateImageBitmap;
+  });
+
+  it("should wait for a new h265 keyframe after a decode error", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    const init = jest.fn().mockResolvedValue(undefined);
+    const decode = jest
+      .fn<Promise<VideoFrame | undefined>, [Uint8Array, number, "key" | "delta"]>()
+      .mockResolvedValueOnce(createDecodedVideoFrame(0))
+      .mockResolvedValueOnce(createDecodedVideoFrame(33333))
+      .mockResolvedValueOnce(createDecodedVideoFrame(66666));
+    const resetForSeek = jest.fn(() => {
+      if (renderable.videoPlayer) {
+        renderable.videoPlayer.lastImageBitmap = undefined;
+      }
+    });
+    const lastImageBitmap = new ImageBitmap();
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(true),
+      init,
+      decode,
+      codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue({ codec: "hvc1.1.6.L93.B0" }),
+      resetForSeek,
+      lastImageBitmap,
+      lastVideoFrame: undefined,
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    const originalCreateImageBitmap = self.createImageBitmap;
+    const createImageBitmapSpy = jest.fn().mockImplementation(async () => new ImageBitmap());
+    // @ts-expect-error test override
+    self.createImageBitmap = createImageBitmapSpy;
+
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(h265Keyframe, { sec: 0, nsec: 0 }), 100);
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(h265DeltaFrame, { sec: 0, nsec: 33333333 }), 100);
+
+    const bitmapBeforeError = renderable.videoPlayer.lastImageBitmap;
+
+    // @ts-expect-error handleVideoPlayerError is protected, but ok to use on tests
+    renderable.handleVideoPlayerError(new Error("Decoding error"));
+    (console.error as jest.Mock).mockClear();
+
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    const skipped = await renderable.decodeImage(createH265Frame(h265DeltaFrame, { sec: 0, nsec: 66666666 }), 100);
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(createH265Frame(h265Keyframe, { sec: 0, nsec: 83333333 }), 100);
+
+    expect(skipped).not.toBe(bitmapBeforeError);
+    expect(decode).toHaveBeenCalledTimes(3);
+    expect(decode).toHaveBeenNthCalledWith(1, expect.any(Uint8Array), 0, "key");
+    expect(decode).toHaveBeenNthCalledWith(2, expect.any(Uint8Array), 33333, "delta");
+    expect(decode).toHaveBeenNthCalledWith(3, expect.any(Uint8Array), 83333, "key");
+    expect(resetForSeek).toHaveBeenCalledTimes(1);
+    expect(init).toHaveBeenCalledTimes(1);
+
+    self.createImageBitmap = originalCreateImageBitmap;
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -59,6 +59,15 @@ const sampleImage = {
   header: { frame_id: "camera", stamp: { sec: 0, nsec: 1 } },
 };
 
+function createH265Frame(data: Uint8Array) {
+  return {
+    format: "h265",
+    data,
+    frame_id: "camera",
+    timestamp: { sec: 0, nsec: 1 },
+  };
+}
+
 describe("ImageRenderable", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -191,5 +200,102 @@ describe("ImageRenderable error handling", () => {
     renderable.removeError("decode");
     expect(mockRemove).toHaveBeenCalledWith(["imageMode", "imageTopic"], "decode");
     expect(mockRemoveFromTopic).toHaveBeenCalledWith(mockUserData.topic, "decode");
+  });
+
+  it("should reuse cached h265 decoder config for later keyframes", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    const init = jest.fn().mockResolvedValue(undefined);
+    const decode = jest.fn().mockResolvedValue(undefined);
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(false),
+      init,
+      decode,
+      codedSize: jest.fn(),
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    const keyframeWithParameterSet = createH265Frame(
+      new Uint8Array([
+        0x00,
+        0x00,
+        0x00,
+        0x02,
+        (32 << 1) | 1,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x02,
+        (19 << 1) | 1,
+        0x01,
+      ]),
+    );
+    const keyframeWithoutParameterSet = createH265Frame(
+      new Uint8Array([0x00, 0x00, 0x00, 0x02, (19 << 1) | 1, 0x01]),
+    );
+
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(keyframeWithParameterSet, 100);
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(keyframeWithoutParameterSet, 100);
+
+    expect(init).toHaveBeenNthCalledWith(1, { codec: "hev1.1.6.L153.B0" });
+    expect(init).toHaveBeenNthCalledWith(2, { codec: "hev1.1.6.L153.B0" });
+  });
+
+  it("should report detailed h265 diagnostics before decoder init", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(false),
+      init: jest.fn(),
+      decode: jest.fn(),
+      codedSize: jest.fn(),
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await expect(renderable.decodeImage(createH265Frame(new Uint8Array([0x01, 0x02, 0x03])), 100)).rejects.toThrow(
+      "Waiting for keyframe (unsupported H.265 bitstream format)",
+    );
+  });
+
+  it("should wait silently on h265 delta frames before decoder init", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    const init = jest.fn().mockResolvedValue(undefined);
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(false),
+      init,
+      decode: jest.fn(),
+      codedSize: jest.fn(),
+      lastImageBitmap: undefined,
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    // @ts-expect-error decodeImage is protected, but ok to use on tests
+    await renderable.decodeImage(
+      createH265Frame(
+        new Uint8Array([
+          0x00,
+          0x00,
+          0x00,
+          0x02,
+          (32 << 1) | 1,
+          0x01,
+          0x00,
+          0x00,
+          0x00,
+          0x02,
+          (19 << 1) | 1,
+          0x01,
+        ]),
+      ),
+      100,
+    );
+    const bitmap =
+      // @ts-expect-error decodeImage is protected, but ok to use on tests
+      await renderable.decodeImage(
+        createH265Frame(new Uint8Array([0x00, 0x00, 0x00, 0x02, (1 << 1) | 1, 0x01])),
+        100,
+      );
+
+    expect(bitmap).toBeInstanceOf(ImageBitmap);
+    expect(init).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -7,7 +7,6 @@ import * as THREE from "three";
 
 import { PinholeCameraModel } from "@lichtblick/den/image";
 import { H265SliceType } from "@lichtblick/den/video";
-import { toNanoSec } from "@lichtblick/rostime";
 import { IRenderer } from "@lichtblick/suite-base/panels/ThreeDeeRender/IRenderer";
 import H265FrameBuilder from "@lichtblick/suite-base/testing/builders/H265FrameBuilder";
 import { BasicBuilder } from "@lichtblick/test-builders";
@@ -111,8 +110,9 @@ describe("ImageRenderable", () => {
     renderable.userData.texture = new THREE.Texture();
     renderable.userData.material = new THREE.ShaderMaterial();
     renderable.userData.geometry = new THREE.PlaneGeometry();
+    const close = jest.fn();
     renderable.videoPlayer = {
-      close: jest.fn(),
+      close,
     } as unknown as ImageRenderable["videoPlayer"];
 
     // @ts-expect-error isDisposed is protected, but ok to use on tests
@@ -120,7 +120,7 @@ describe("ImageRenderable", () => {
 
     renderable.dispose();
 
-    expect(renderable.videoPlayer?.close).toHaveBeenCalled();
+    expect(close).toHaveBeenCalled();
     // @ts-expect-error isDisposed is protected, but ok to use on tests
     expect(renderable.isDisposed()).toBe(true);
   });
@@ -287,10 +287,7 @@ describe("ImageRenderable error handling", () => {
 
     const bitmap =
       // @ts-expect-error decodeImage is protected, but ok to use on tests
-      await renderable.decodeImage(
-        createH265Frame(h265DeltaFrame),
-        100,
-      );
+      await renderable.decodeImage(createH265Frame(h265DeltaFrame), 100);
 
     expect(bitmap).not.toBe(lastImageBitmap);
   });
@@ -322,10 +319,7 @@ describe("ImageRenderable error handling", () => {
     await renderable.decodeImage(createH265Frame(h265Keyframe), 100);
     const bitmap =
       // @ts-expect-error decodeImage is protected, but ok to use on tests
-      await renderable.decodeImage(
-        createH265Frame(h265DeltaFrame),
-        100,
-      );
+      await renderable.decodeImage(createH265Frame(h265DeltaFrame), 100);
 
     expect(bitmap).toBeInstanceOf(ImageBitmap);
     expect(init).toHaveBeenCalledTimes(1);
@@ -421,25 +415,36 @@ describe("ImageRenderable error handling", () => {
     jest
       // @ts-expect-error decodeImage is protected, but ok to use on tests
       .spyOn(renderable, "decodeImage")
-      .mockImplementation(async (image: (typeof mockUserData)["image"] & { timestamp: { sec: number; nsec: number } }) => {
-        const timestampMicros = Number(
-          (BigInt(image.timestamp.sec) * 1000000000n + BigInt(image.timestamp.nsec)) / 1000n,
-        );
-        decodeOrder.push(timestampMicros);
-        if (timestampMicros === 33333) {
-          resolveLatestDecodeStarted();
-        }
-        await new Promise<void>((resolve) => {
-          decodeResolvers.set(timestampMicros, resolve);
-        });
-        return {} as ImageData;
-      });
+      .mockImplementation(
+        async (
+          image: (typeof mockUserData)["image"] & { timestamp: { sec: number; nsec: number } },
+        ) => {
+          const timestampMicros = Number(
+            (BigInt(image.timestamp.sec) * 1000000000n + BigInt(image.timestamp.nsec)) / 1000n,
+          );
+          decodeOrder.push(timestampMicros);
+          if (timestampMicros === 33333) {
+            resolveLatestDecodeStarted();
+          }
+          await new Promise<void>((resolve) => {
+            decodeResolvers.set(timestampMicros, resolve);
+          });
+          return {} as ImageData;
+        },
+      );
 
     renderable.setImage({ ...createH265Frame(keyframe, { sec: 0, nsec: 0 }), format: "h264" });
-    renderable.setImage({ ...createH265Frame(keyframe, { sec: 0, nsec: 16666666 }), format: "h264" });
-    renderable.setImage({ ...createH265Frame(keyframe, { sec: 0, nsec: 33333333 }), format: "h264" }, undefined, () => {
-      resolveLatestDecoded();
+    renderable.setImage({
+      ...createH265Frame(keyframe, { sec: 0, nsec: 16666666 }),
+      format: "h264",
     });
+    renderable.setImage(
+      { ...createH265Frame(keyframe, { sec: 0, nsec: 33333333 }), format: "h264" },
+      undefined,
+      () => {
+        resolveLatestDecoded();
+      },
+    );
     await Promise.resolve();
 
     expect(decodeOrder).toEqual([0]);
@@ -489,8 +494,8 @@ describe("ImageRenderable error handling", () => {
     jest
       // @ts-expect-error decodeImage is protected, but ok to use on tests
       .spyOn(renderable, "decodeImage")
-      .mockImplementation(async (image, resizeWidth) => {
-        if (toNanoSec((image as CompressedVideo).timestamp) === 0n) {
+      .mockImplementation(async (image: CompressedVideo, resizeWidth?: number) => {
+        if (image.timestamp.sec === 0 && image.timestamp.nsec === 0) {
           await firstDecodeBlocked;
         }
         return await ImageRenderable.prototype.decodeImage.call(renderable, image, resizeWidth);
@@ -498,9 +503,13 @@ describe("ImageRenderable error handling", () => {
 
     renderable.setImage(createH265Frame(h265Keyframe, { sec: 0, nsec: 0 }));
     renderable.setImage(createH265Frame(h265DeltaFrame, { sec: 0, nsec: 16666666 }));
-    renderable.setImage(createH265Frame(h265DeltaFrame, { sec: 0, nsec: 33333333 }), undefined, () => {
-      latestDecoded();
-    });
+    renderable.setImage(
+      createH265Frame(h265DeltaFrame, { sec: 0, nsec: 33333333 }),
+      undefined,
+      () => {
+        latestDecoded();
+      },
+    );
     await Promise.resolve();
 
     releaseFirstDecode();
@@ -543,9 +552,13 @@ describe("ImageRenderable error handling", () => {
 
     renderable.setImage(createH265Frame(h265Keyframe, { sec: 0, nsec: 0 }));
     renderable.setImage(createH265Frame(h265Keyframe, { sec: 0, nsec: 0 }));
-    renderable.setImage(createH265Frame(h265DeltaFrame, { sec: 0, nsec: 16666666 }), undefined, () => {
-      latestDecoded();
-    });
+    renderable.setImage(
+      createH265Frame(h265DeltaFrame, { sec: 0, nsec: 16666666 }),
+      undefined,
+      () => {
+        latestDecoded();
+      },
+    );
     await latestDecodedPromise;
 
     expect(decode).toHaveBeenCalledTimes(2);
@@ -570,7 +583,10 @@ describe("ImageRenderable error handling", () => {
     } as unknown as ImageRenderable["videoPlayer"];
 
     // @ts-expect-error decodeImage is protected, but ok to use on tests
-    const bitmap = await renderable.decodeImage(createH265Frame(h265Keyframe, { sec: 0, nsec: 0 }), 100);
+    const bitmap = await renderable.decodeImage(
+      createH265Frame(h265Keyframe, { sec: 0, nsec: 0 }),
+      100,
+    );
 
     expect(bitmap).toBe(lastImageBitmap);
   });
@@ -610,7 +626,10 @@ describe("ImageRenderable error handling", () => {
     } as unknown as ImageRenderable["videoPlayer"];
 
     // @ts-expect-error decodeImage is protected, but ok to use on tests
-    const bitmap = await renderable.decodeImage(createH265Frame(h265BFrame, { sec: 0, nsec: 33333333 }), 100);
+    const bitmap = await renderable.decodeImage(
+      createH265Frame(h265BFrame, { sec: 0, nsec: 33333333 }),
+      100,
+    );
 
     expect(bitmap).toBe(lastImageBitmap);
     expect(decode).not.toHaveBeenCalled();
@@ -698,11 +717,20 @@ describe("ImageRenderable error handling", () => {
     // @ts-expect-error decodeImage is protected, but ok to use on tests
     await renderable.decodeImage(createH265Frame(h265Keyframe.slice(), { sec: 0, nsec: 0 }), 100);
     // @ts-expect-error decodeImage is protected, but ok to use on tests
-    await renderable.decodeImage(createH265Frame(h265DeltaFrame.slice(), { sec: 0, nsec: 33333333 }), 100);
+    await renderable.decodeImage(
+      createH265Frame(h265DeltaFrame.slice(), { sec: 0, nsec: 33333333 }),
+      100,
+    );
     // @ts-expect-error decodeImage is protected, but ok to use on tests
-    await renderable.decodeImage(createH265Frame(h265DeltaFrame.slice(), { sec: 0, nsec: 66666666 }), 100);
+    await renderable.decodeImage(
+      createH265Frame(h265DeltaFrame.slice(), { sec: 0, nsec: 66666666 }),
+      100,
+    );
     // @ts-expect-error decodeImage is protected, but ok to use on tests
-    const bitmap = await renderable.decodeImage(createH265Frame(h265DeltaFrame.slice(), { sec: 0, nsec: 33333333 }), 100);
+    const bitmap = await renderable.decodeImage(
+      createH265Frame(h265DeltaFrame.slice(), { sec: 0, nsec: 33333333 }),
+      100,
+    );
 
     expect(bitmap).toBe(replayBitmap);
     expect(resetForSeek).toHaveBeenCalled();
@@ -757,7 +785,10 @@ describe("ImageRenderable error handling", () => {
     (console.error as jest.Mock).mockClear();
 
     // @ts-expect-error decodeImage is protected, but ok to use on tests
-    const skipped = await renderable.decodeImage(createH265Frame(h265DeltaFrame, { sec: 0, nsec: 66666666 }), 100);
+    const skipped = await renderable.decodeImage(
+      createH265Frame(h265DeltaFrame, { sec: 0, nsec: 66666666 }),
+      100,
+    );
     // @ts-expect-error decodeImage is protected, but ok to use on tests
     await renderable.decodeImage(createH265Frame(h265Keyframe, { sec: 0, nsec: 83333333 }), 100);
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -9,7 +9,7 @@ import * as _ from "lodash-es";
 import * as THREE from "three";
 import { assert } from "ts-essentials";
 
-import { VideoPlayer } from "@lichtblick/den/video";
+import { EncodedVideoFrame, VideoPlayer } from "@lichtblick/den/video";
 import Logger from "@lichtblick/log";
 import { toNanoSec } from "@lichtblick/rostime";
 import { ICameraModel } from "@lichtblick/suite";
@@ -31,6 +31,7 @@ import {
   emptyVideoFrame,
   prepareVideoFrame,
 } from "./decodeImage";
+import { PreparedVideoFrame } from "./types";
 import { CameraInfo } from "../../ros";
 import {
   DECODE_IMAGE_ERR_KEY,
@@ -68,6 +69,28 @@ export const IMAGE_RENDERABLE_DEFAULT_SETTINGS: ImageRenderableSettings = {
 };
 
 const VIDEO_FORMATS = new Set(["h264", "h265", "hevc"]);
+const VIDEO_DEPENDENCY_CHAIN_FORMATS = new Set(["h265", "hevc"]);
+const VIDEO_TIMESTAMP_JITTER_NS = 5_000_000n;
+const MAX_VIDEO_FRAME_HISTORY = 2000;
+
+type PendingVideoDecode = {
+  image: AnyImage;
+  resizeWidth?: number;
+  onDecoded?: () => void;
+  seq: number;
+};
+
+type PreparedIncomingVideoFrame = {
+  preparedFrame: PreparedVideoFrame;
+  messageTime: bigint;
+  timestampMicros: number;
+};
+
+type VideoFrameHistoryEntry = {
+  frame: CompressedVideo;
+  preparedFrame: PreparedVideoFrame;
+  timestampMicros: number;
+};
 
 export type ImageUserData = BaseUserData & {
   topic: string;
@@ -107,6 +130,15 @@ export class ImageRenderable extends Renderable<ImageUserData> {
   #displayedImageSequenceNumber = 0;
   #showingErrorImage = false;
   #cachedVideoDecoderConfig: VideoDecoderConfig | undefined;
+  #videoFirstMessageTime: bigint | undefined;
+  #lastVideoMessageTime: bigint | undefined;
+  #lastQueuedVideoMessageTime: bigint | undefined;
+  #waitingForVideoKeyframe = false;
+  #canReplayVideoGop = false;
+  #isDrainingVideoDecodes = false;
+  #pendingVideoDecode: PendingVideoDecode | undefined;
+  #pendingVideoDecodeQueue: PendingVideoDecode[] = [];
+  #videoFrameHistory: VideoFrameHistoryEntry[] = [];
 
   #disposed = false;
 
@@ -127,6 +159,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.userData.texture?.dispose();
     this.userData.material?.dispose();
     this.userData.geometry?.dispose();
+    this.videoPlayer?.close();
     this.decoder?.terminate();
     super.dispose();
   }
@@ -212,38 +245,88 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.userData.image = image;
 
     const seq = ++this.#receivedImageSequenceNumber;
-    const decodePromise = this.decodeImage(image, resizeWidth);
+    if ("format" in image && VIDEO_FORMATS.has(image.format)) {
+      const pendingDecode = { image, resizeWidth, onDecoded, seq };
+      if (VIDEO_DEPENDENCY_CHAIN_FORMATS.has(image.format)) {
+        const videoImage = image as CompressedVideo;
+        const messageTime = toNanoSec(videoImage.timestamp);
+        if (messageTime === this.#lastQueuedVideoMessageTime) {
+          return;
+        }
+        this.#lastQueuedVideoMessageTime = messageTime;
+        this.#pendingVideoDecodeQueue.push(pendingDecode);
+      } else {
+        this.#pendingVideoDecode = pendingDecode;
+      }
+      if (!this.#isDrainingVideoDecodes) {
+        this.#isDrainingVideoDecodes = true;
+        void this.#drainPendingVideoDecodes();
+      }
+      return;
+    }
 
-    decodePromise
-      .then((result) => {
-        if (this.isDisposed()) {
-          return;
-        }
-        // prevent displaying an image older than the one currently displayed
-        if (this.#displayedImageSequenceNumber > seq) {
-          return;
-        }
-        this.#displayedImageSequenceNumber = seq;
-        this.#decodedImage = result;
-        this.#textureNeedsUpdate = true;
-        this.update();
-        this.#showingErrorImage = false;
+    this.#startDecode(image, seq, resizeWidth, onDecoded);
+  }
 
-        onDecoded?.();
-        this.removeError(DECODE_IMAGE_ERR_KEY);
-        this.renderer.queueAnimationFrame();
-      })
-      .catch((err: unknown) => {
-        log.error(err);
-        if (this.isDisposed()) {
-          return;
+  async #drainPendingVideoDecodes(): Promise<void> {
+    try {
+      for (;;) {
+        const pendingDecode = this.#pendingVideoDecodeQueue.shift() ?? this.#pendingVideoDecode;
+        if (pendingDecode == undefined) {
+          break;
         }
-        // avoid needing to recreate error image if it already shown
-        if (!this.#showingErrorImage) {
-          void this.#setErrorImage(seq, onDecoded);
+        if (pendingDecode === this.#pendingVideoDecode) {
+          this.#pendingVideoDecode = undefined;
         }
-        this.addError(DECODE_IMAGE_ERR_KEY, `Error decoding image: ${(err as Error).message}`);
-      });
+        await this.#startDecode(
+          pendingDecode.image,
+          pendingDecode.seq,
+          pendingDecode.resizeWidth,
+          pendingDecode.onDecoded,
+        );
+      }
+    } finally {
+      this.#isDrainingVideoDecodes = false;
+      if (this.#pendingVideoDecodeQueue.length > 0 || this.#pendingVideoDecode != undefined) {
+        this.#isDrainingVideoDecodes = true;
+        void this.#drainPendingVideoDecodes();
+      }
+    }
+  }
+
+  async #startDecode(
+    image: AnyImage,
+    seq: number,
+    resizeWidth?: number,
+    onDecoded?: () => void,
+  ): Promise<void> {
+    try {
+      const result = await this.decodeImage(image, resizeWidth);
+      if (this.isDisposed()) {
+        return;
+      }
+      if (this.#displayedImageSequenceNumber > seq) {
+        return;
+      }
+      this.#displayedImageSequenceNumber = seq;
+      this.#decodedImage = result;
+      this.#textureNeedsUpdate = true;
+      this.update();
+      this.#showingErrorImage = false;
+
+      onDecoded?.();
+      this.removeError(DECODE_IMAGE_ERR_KEY);
+      this.renderer.queueAnimationFrame();
+    } catch (err) {
+      log.error(err);
+      if (this.isDisposed()) {
+        return;
+      }
+      if (!this.#showingErrorImage) {
+        await this.#setErrorImage(seq, onDecoded);
+      }
+      this.addError(DECODE_IMAGE_ERR_KEY, `Error decoding image: ${(err as Error).message}`);
+    }
   }
 
   async #setErrorImage(seq: number, onDecoded?: () => void): Promise<void> {
@@ -261,6 +344,127 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     // call ondecoded to display the error image when calibration is None
     onDecoded?.();
     this.renderer.queueAnimationFrame();
+  }
+
+  #prepareIncomingVideoFrame(frameMsg: CompressedVideo): PreparedIncomingVideoFrame {
+    const messageTime = toNanoSec(frameMsg.timestamp);
+    if (
+      this.#lastVideoMessageTime != undefined &&
+      messageTime < this.#lastVideoMessageTime &&
+      this.#lastVideoMessageTime - messageTime > VIDEO_TIMESTAMP_JITTER_NS
+    ) {
+      this.videoPlayer?.resetForSeek();
+      this.#waitingForVideoKeyframe = true;
+      this.#canReplayVideoGop = true;
+      this.#lastQueuedVideoMessageTime = messageTime;
+      this.#pendingVideoDecodeQueue.length = 0;
+    }
+    this.#lastVideoMessageTime = messageTime;
+    this.#videoFirstMessageTime ??= messageTime;
+
+    const preparedFrame = prepareVideoFrame(frameMsg);
+
+    if (preparedFrame.decoderConfig != undefined) {
+      this.#cachedVideoDecoderConfig = preparedFrame.decoderConfig;
+    }
+    assert(this.#videoFirstMessageTime != undefined, "firstMessageTime must be set");
+    const timestampMicros = Number((messageTime - this.#videoFirstMessageTime) / 1000n);
+    this.#rememberVideoFrame(frameMsg, preparedFrame, timestampMicros);
+
+    return { preparedFrame, messageTime, timestampMicros };
+  }
+
+  #rememberVideoFrame(
+    frame: CompressedVideo,
+    preparedFrame: PreparedVideoFrame,
+    timestampMicros: number,
+  ): void {
+    if (!VIDEO_DEPENDENCY_CHAIN_FORMATS.has(frame.format)) {
+      return;
+    }
+    const historyPreparedFrame: PreparedVideoFrame = {
+      ...preparedFrame,
+      data: preparedFrame.data.slice(),
+    };
+    const existingIndex = this.#videoFrameHistory.findIndex(
+      (entry) => entry.timestampMicros === timestampMicros,
+    );
+    if (existingIndex >= 0) {
+      this.#videoFrameHistory[existingIndex] = {
+        frame,
+        preparedFrame: historyPreparedFrame,
+        timestampMicros,
+      };
+      return;
+    }
+    this.#videoFrameHistory.push({ frame, preparedFrame: historyPreparedFrame, timestampMicros });
+    if (this.#videoFrameHistory.length > MAX_VIDEO_FRAME_HISTORY) {
+      this.#videoFrameHistory.splice(0, this.#videoFrameHistory.length - MAX_VIDEO_FRAME_HISTORY);
+    }
+  }
+
+  #gopForTargetFrame(targetTimestampMicros: number): VideoFrameHistoryEntry[] | undefined {
+    const targetIndex = this.#videoFrameHistory.findIndex(
+      (entry) => entry.timestampMicros === targetTimestampMicros,
+    );
+    if (targetIndex < 0) {
+      return undefined;
+    }
+    for (let index = targetIndex; index >= 0; index--) {
+      const entry = this.#videoFrameHistory[index]!;
+      if (entry.preparedFrame.type === "key") {
+        return this.#videoFrameHistory.slice(index, targetIndex + 1);
+      }
+    }
+    return undefined;
+  }
+
+  protected handleVideoPlayerError(err: Error): void {
+    this.#waitingForVideoKeyframe = true;
+    this.#canReplayVideoGop = false;
+    this.videoPlayer?.resetForSeek();
+    log.error(err);
+    this.addError(DECODE_IMAGE_ERR_KEY, `Error decoding video: ${err.message}`);
+  }
+
+  async #decodeVideoGopToTarget(
+    targetFrame: CompressedVideo,
+    resizeWidth?: number,
+  ): Promise<ImageBitmap | undefined> {
+    if (!this.videoPlayer || this.#videoFirstMessageTime == undefined) {
+      return undefined;
+    }
+    const targetTimestampMicros = Number(
+      (toNanoSec(targetFrame.timestamp) - this.#videoFirstMessageTime) / 1000n,
+    );
+    const gop = this.#gopForTargetFrame(targetTimestampMicros);
+    if (gop == undefined || gop.length === 0) {
+      return undefined;
+    }
+    const decoderConfig = gop[0]!.preparedFrame.decoderConfig ?? this.#cachedVideoDecoderConfig;
+    if (decoderConfig == undefined) {
+      return undefined;
+    }
+
+    this.videoPlayer.resetForSeek();
+    await this.videoPlayer.init(decoderConfig);
+    const result = await this.videoPlayer.decodeFrames(
+      gop.map<EncodedVideoFrame>((entry) => ({
+        data: entry.preparedFrame.data.slice(),
+        timestampMicros: entry.timestampMicros,
+        type: entry.preparedFrame.type,
+      })),
+    );
+    if (result.type !== "target") {
+      return undefined;
+    }
+
+    const imageBitmap = await self.createImageBitmap(result.frame, { resizeWidth });
+    this.videoPlayer.lastImageBitmap = imageBitmap;
+    result.frame.close();
+    this.#waitingForVideoKeyframe = false;
+    this.#canReplayVideoGop = false;
+    return imageBitmap;
   }
 
   protected async decodeImage(
@@ -290,40 +494,51 @@ export class ImageRenderable extends Renderable<ImageUserData> {
           }
           this.videoPlayer = new VideoPlayer();
           this.videoPlayer.on("error", (err) => {
-            log.error(err);
-            this.addError(DECODE_IMAGE_ERR_KEY, `Error decoding video: ${err.message}`);
+            this.handleVideoPlayerError(err);
           });
           this.videoPlayer.on("warn", (msg) => {
             log.warn(msg);
           });
         }
         const videoPlayer = this.videoPlayer;
-        const preparedFrame = prepareVideoFrame(frameMsg);
-        if (preparedFrame.decoderConfig != undefined) {
-          this.#cachedVideoDecoderConfig = preparedFrame.decoderConfig;
+        const { preparedFrame } = this.#prepareIncomingVideoFrame(frameMsg);
+
+        if (preparedFrame.diagnostics === "H.265 B frames are not supported") {
+          return videoPlayer.lastImageBitmap ?? (await emptyVideoFrame(videoPlayer, resizeWidth));
+        }
+        if (this.#waitingForVideoKeyframe && preparedFrame.type !== "key") {
+          const replayBitmap = this.#canReplayVideoGop
+            ? await this.#decodeVideoGopToTarget(frameMsg, resizeWidth)
+            : undefined;
+          return replayBitmap ?? (await emptyVideoFrame(videoPlayer, resizeWidth));
         }
 
         // Initialize the video player if needed
-        if (!videoPlayer.isInitialized()) {
+        if (!videoPlayer.isInitialized() || this.#waitingForVideoKeyframe) {
           const decoderConfig = preparedFrame.decoderConfig ?? this.#cachedVideoDecoderConfig;
           if (decoderConfig != undefined) {
             if (preparedFrame.type !== "key") {
-              return await emptyVideoFrame(videoPlayer, resizeWidth);
+              const replayBitmap = this.#canReplayVideoGop
+                ? await this.#decodeVideoGopToTarget(frameMsg, resizeWidth)
+                : undefined;
+              return replayBitmap ?? (await emptyVideoFrame(videoPlayer, resizeWidth));
             }
             await videoPlayer.init(decoderConfig);
+            this.#waitingForVideoKeyframe = false;
+            this.#canReplayVideoGop = false;
           } else {
             const detail = preparedFrame.diagnostics ?? "no decoder configuration available";
             throw new Error(`Waiting for keyframe (${detail})`);
           }
         }
 
-        assert(this.userData.firstMessageTime != undefined, "firstMessageTime must be set");
+        assert(this.#videoFirstMessageTime != undefined, "firstMessageTime must be set");
 
         return await decodeCompressedVideoToBitmap(
           frameMsg,
           preparedFrame,
           videoPlayer,
-          this.userData.firstMessageTime,
+          this.#videoFirstMessageTime,
           resizeWidth,
         );
       }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -67,7 +67,7 @@ export const IMAGE_RENDERABLE_DEFAULT_SETTINGS: ImageRenderableSettings = {
   contrast: INITIAL_CONTRAST,
 };
 
-const VIDEO_FORMATS = new Set(["h264"]);
+const VIDEO_FORMATS = new Set(["h264", "h265", "hevc"]);
 
 export type ImageUserData = BaseUserData & {
   topic: string;
@@ -284,6 +284,9 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         }
 
         if (!this.videoPlayer) {
+          if (!VideoPlayer.IsSupported()) {
+            throw new Error("WebCodecs VideoDecoder is not available in this browser");
+          }
           this.videoPlayer = new VideoPlayer();
           this.videoPlayer.on("error", (err) => {
             log.error(err);

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -29,7 +29,7 @@ import {
   decodeCompressedImageToBitmap,
   decodeCompressedVideoToBitmap,
   emptyVideoFrame,
-  getVideoDecoderConfig,
+  prepareVideoFrame,
 } from "./decodeImage";
 import { CameraInfo } from "../../ros";
 import {
@@ -106,6 +106,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
   #receivedImageSequenceNumber = 0;
   #displayedImageSequenceNumber = 0;
   #showingErrorImage = false;
+  #cachedVideoDecoderConfig: VideoDecoderConfig | undefined;
 
   #disposed = false;
 
@@ -297,15 +298,22 @@ export class ImageRenderable extends Renderable<ImageUserData> {
           });
         }
         const videoPlayer = this.videoPlayer;
+        const preparedFrame = prepareVideoFrame(frameMsg);
+        if (preparedFrame.decoderConfig != undefined) {
+          this.#cachedVideoDecoderConfig = preparedFrame.decoderConfig;
+        }
 
         // Initialize the video player if needed
         if (!videoPlayer.isInitialized()) {
-          const decoderConfig = getVideoDecoderConfig(frameMsg);
+          const decoderConfig = preparedFrame.decoderConfig ?? this.#cachedVideoDecoderConfig;
           if (decoderConfig != undefined) {
+            if (preparedFrame.type !== "key") {
+              return await emptyVideoFrame(videoPlayer, resizeWidth);
+            }
             await videoPlayer.init(decoderConfig);
           } else {
-            // Raise error so the caller can catch it
-            throw new Error("Waiting for keyframe");
+            const detail = preparedFrame.diagnostics ?? "no decoder configuration available";
+            throw new Error(`Waiting for keyframe (${detail})`);
           }
         }
 
@@ -313,6 +321,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
 
         return await decodeCompressedVideoToBitmap(
           frameMsg,
+          preparedFrame,
           videoPlayer,
           this.userData.firstMessageTime,
           resizeWidth,

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -265,7 +265,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       return;
     }
 
-    this.#startDecode(image, seq, resizeWidth, onDecoded);
+    void this.#startDecode(image, seq, resizeWidth, onDecoded);
   }
 
   async #drainPendingVideoDecodes(): Promise<void> {
@@ -367,7 +367,6 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     if (preparedFrame.decoderConfig != undefined) {
       this.#cachedVideoDecoderConfig = preparedFrame.decoderConfig;
     }
-    assert(this.#videoFirstMessageTime != undefined, "firstMessageTime must be set");
     const timestampMicros = Number((messageTime - this.#videoFirstMessageTime) / 1000n);
     this.#rememberVideoFrame(frameMsg, preparedFrame, timestampMicros);
 
@@ -449,11 +448,13 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.videoPlayer.resetForSeek();
     await this.videoPlayer.init(decoderConfig);
     const result = await this.videoPlayer.decodeFrames(
-      gop.map<EncodedVideoFrame>((entry) => ({
-        data: entry.preparedFrame.data.slice(),
-        timestampMicros: entry.timestampMicros,
-        type: entry.preparedFrame.type,
-      })),
+      gop.map(
+        (entry): EncodedVideoFrame => ({
+          data: entry.preparedFrame.data.slice(),
+          timestampMicros: entry.timestampMicros,
+          type: entry.preparedFrame.type,
+        }),
+      ),
     );
     if (result.type !== "target") {
       return undefined;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.test.ts
@@ -11,6 +11,7 @@ import {
   decodeCompressedImageToBitmap,
   isVideoKeyframe,
   getVideoDecoderConfig,
+  prepareVideoFrame,
   decodeCompressedVideoToBitmap,
   decodeRawImage,
   emptyVideoFrame,
@@ -98,25 +99,86 @@ describe("getVideoDecoderConfig", () => {
 describe("decodeCompressedVideoToBitmap", () => {
   it("should decode a compressed video frame to an ImageBitmap", async () => {
     const mockVideoFrame = createMockVideoFrame();
+    const preparedFrame = {
+      data: mockVideoFrame.data,
+      type: "delta" as const,
+    };
     const mockVideoPlayer = {
       isInitialized: jest.fn().mockReturnValue(true),
       decode: jest.fn().mockResolvedValue(new ImageBitmap()),
     } as unknown as VideoPlayer;
-    const bitmap = await decodeCompressedVideoToBitmap(mockVideoFrame, mockVideoPlayer, BigInt(0));
+    const bitmap = await decodeCompressedVideoToBitmap(
+      mockVideoFrame,
+      preparedFrame,
+      mockVideoPlayer,
+      BigInt(0),
+    );
     expect(bitmap).toBeInstanceOf(ImageBitmap);
     expect(mockVideoPlayer.lastImageBitmap).toBeDefined();
   });
 
   it("should return an empty video frame if the video player is not initialized", async () => {
     const mockVideoFrame = createMockVideoFrame();
+    const preparedFrame = {
+      data: mockVideoFrame.data,
+      type: "delta" as const,
+    };
     const mockVideoPlayer = {
       isInitialized: jest.fn().mockReturnValue(false),
       codedSize: jest.fn(),
     } as unknown as VideoPlayer;
 
-    const bitmap = await decodeCompressedVideoToBitmap(mockVideoFrame, mockVideoPlayer, BigInt(0));
+    const bitmap = await decodeCompressedVideoToBitmap(
+      mockVideoFrame,
+      preparedFrame,
+      mockVideoPlayer,
+      BigInt(0),
+    );
     expect(bitmap).toBeInstanceOf(ImageBitmap);
     expect(mockVideoPlayer.lastImageBitmap).toBeUndefined();
+  });
+});
+
+describe("prepareVideoFrame", () => {
+  it("should normalize length-prefixed h265 keyframes", () => {
+    const parameterSet = [(32 << 1) | 1, 0x01];
+    const keyframe = [(19 << 1) | 1, 0x01];
+    const mockVideoFrame = createMockVideoFrame({
+      format: "h265",
+      data: new Uint8Array([
+        0x00,
+        0x00,
+        0x00,
+        parameterSet.length,
+        ...parameterSet,
+        0x00,
+        0x00,
+        0x00,
+        keyframe.length,
+        ...keyframe,
+      ]),
+    });
+
+    const preparedFrame = prepareVideoFrame(mockVideoFrame);
+
+    expect(preparedFrame.type).toBe("key");
+    expect(preparedFrame.decoderConfig).toEqual({ codec: "hev1.1.6.L153.B0" });
+    expect(preparedFrame.data).toEqual(
+      new Uint8Array([0x00, 0x00, 0x00, 0x01, ...parameterSet, 0x00, 0x00, 0x00, 0x01, ...keyframe]),
+    );
+  });
+
+  it("should return detailed diagnostics for unsupported h265 bitstreams", () => {
+    const mockVideoFrame = createMockVideoFrame({
+      format: "h265",
+      data: new Uint8Array([0x01, 0x02, 0x03, 0x04]),
+    });
+
+    const preparedFrame = prepareVideoFrame(mockVideoFrame);
+
+    expect(preparedFrame.type).toBe("delta");
+    expect(preparedFrame.decoderConfig).toBeUndefined();
+    expect(preparedFrame.diagnostics).toBe("unsupported H.265 bitstream format");
   });
 });
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.test.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-import { H264, VideoPlayer } from "@lichtblick/den/video";
+import { H264, H265, VideoPlayer } from "@lichtblick/den/video";
 import RosTimeBuilder from "@lichtblick/suite-base/testing/builders/RosTimeBuilder";
 
 import { CompressedImageTypes, CompressedVideo } from "./ImageTypes";
@@ -56,6 +56,15 @@ describe("isVideoKeyframe", () => {
     jest.spyOn(H264, "IsKeyframe").mockReturnValue(false);
     expect(isVideoKeyframe(mockVideoFrame)).toBe(false);
   });
+
+  it("should use H265 keyframe detection for h265 format", () => {
+    const mockVideoFrame = createMockVideoFrame({
+      data: new Uint8Array([0x26]),
+      format: "h265",
+    });
+    jest.spyOn(H265, "IsKeyframe").mockReturnValue(true);
+    expect(isVideoKeyframe(mockVideoFrame)).toBe(true);
+  });
 });
 
 describe("getVideoDecoderConfig", () => {
@@ -73,6 +82,16 @@ describe("getVideoDecoderConfig", () => {
       data: new Uint8Array([0x00]),
     });
     expect(getVideoDecoderConfig(mockVideoFrame)).toBeUndefined();
+  });
+
+  it("should return a VideoDecoderConfig for h265 format", () => {
+    const mockVideoFrame = createMockVideoFrame({
+      data: new Uint8Array([0x00]),
+      format: "h265",
+    });
+    const mockConfig = { codec: "hev1.1.6.L153.B0" };
+    jest.spyOn(H265, "ParseDecoderConfig").mockReturnValue(mockConfig);
+    expect(getVideoDecoderConfig(mockVideoFrame)).toEqual(mockConfig);
   });
 });
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.test.ts
@@ -3,7 +3,8 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-import { H264, H265, VideoPlayer } from "@lichtblick/den/video";
+import { H264, H265, H265NaluType, H265SliceType, VideoPlayer } from "@lichtblick/den/video";
+import H265FrameBuilder from "@lichtblick/suite-base/testing/builders/H265FrameBuilder";
 import RosTimeBuilder from "@lichtblick/suite-base/testing/builders/RosTimeBuilder";
 
 import { CompressedImageTypes, CompressedVideo } from "./ImageTypes";
@@ -18,6 +19,10 @@ import {
 } from "./decodeImage";
 import { Image as RosImage } from "../../ros";
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 function createMockVideoFrame(override?: Partial<CompressedVideo>): CompressedVideo {
   return {
     data: new Uint8Array([]),
@@ -27,6 +32,7 @@ function createMockVideoFrame(override?: Partial<CompressedVideo>): CompressedVi
     ...override,
   };
 }
+
 
 describe("decodeCompressedImageToBitmap", () => {
   it("should decode a compressed image to an ImageBitmap", async () => {
@@ -90,7 +96,7 @@ describe("getVideoDecoderConfig", () => {
       data: new Uint8Array([0x00]),
       format: "h265",
     });
-    const mockConfig = { codec: "hev1.1.6.L153.B0" };
+    const mockConfig = { codec: "hvc1.1.6.L93.B0" };
     jest.spyOn(H265, "ParseDecoderConfig").mockReturnValue(mockConfig);
     expect(getVideoDecoderConfig(mockVideoFrame)).toEqual(mockConfig);
   });
@@ -117,6 +123,24 @@ describe("decodeCompressedVideoToBitmap", () => {
     expect(mockVideoPlayer.lastImageBitmap).toBeDefined();
   });
 
+  it("should use integer microsecond timestamps for video decode", async () => {
+    const mockVideoFrame = createMockVideoFrame({
+      timestamp: { sec: 0, nsec: 1500 },
+    });
+    const preparedFrame = {
+      data: mockVideoFrame.data,
+      type: "delta" as const,
+    };
+    const mockVideoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(true),
+      decode: jest.fn().mockResolvedValue(new ImageBitmap()),
+    } as unknown as VideoPlayer;
+
+    await decodeCompressedVideoToBitmap(mockVideoFrame, preparedFrame, mockVideoPlayer, 1000n);
+
+    expect(mockVideoPlayer.decode).toHaveBeenCalledWith(mockVideoFrame.data, 0, "delta");
+  });
+
   it("should return an empty video frame if the video player is not initialized", async () => {
     const mockVideoFrame = createMockVideoFrame();
     const preparedFrame = {
@@ -137,35 +161,68 @@ describe("decodeCompressedVideoToBitmap", () => {
     expect(bitmap).toBeInstanceOf(ImageBitmap);
     expect(mockVideoPlayer.lastImageBitmap).toBeUndefined();
   });
+
+  it("should reuse the last decoded frame when decode returns undefined", async () => {
+    const mockVideoFrame = createMockVideoFrame();
+    const lastVideoFrame = {
+      codedWidth: 2,
+      codedHeight: 2,
+      timestamp: 10,
+      close: jest.fn(),
+    } as unknown as VideoFrame;
+    const originalCreateImageBitmap = self.createImageBitmap;
+    const createImageBitmapSpy = jest.fn().mockResolvedValue(new ImageBitmap());
+    // @ts-expect-error test override
+    self.createImageBitmap = createImageBitmapSpy;
+    const preparedFrame = {
+      data: mockVideoFrame.data,
+      type: "delta" as const,
+    };
+    const mockVideoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(true),
+      decode: jest.fn().mockResolvedValue(undefined),
+      lastVideoFrame,
+    } as unknown as VideoPlayer;
+
+    const bitmap = await decodeCompressedVideoToBitmap(
+      mockVideoFrame,
+      preparedFrame,
+      mockVideoPlayer,
+      BigInt(0),
+    );
+    expect(bitmap).toBeInstanceOf(ImageBitmap);
+    expect(mockVideoPlayer.lastImageBitmap).toBeDefined();
+    expect(createImageBitmapSpy).toHaveBeenCalledWith(lastVideoFrame, { resizeWidth: undefined });
+    self.createImageBitmap = originalCreateImageBitmap;
+  });
 });
 
 describe("prepareVideoFrame", () => {
   it("should normalize length-prefixed h265 keyframes", () => {
-    const parameterSet = [(32 << 1) | 1, 0x01];
-    const keyframe = [(19 << 1) | 1, 0x01];
-    const mockVideoFrame = createMockVideoFrame({
-      format: "h265",
-      data: new Uint8Array([
-        0x00,
-        0x00,
-        0x00,
-        parameterSet.length,
-        ...parameterSet,
-        0x00,
-        0x00,
-        0x00,
-        keyframe.length,
-        ...keyframe,
-      ]),
-    });
+    const data = H265FrameBuilder.lengthPrefixedKeyframeWithParameterSets();
+    const mockVideoFrame = createMockVideoFrame({ format: "h265", data });
 
     const preparedFrame = prepareVideoFrame(mockVideoFrame);
 
     expect(preparedFrame.type).toBe("key");
-    expect(preparedFrame.decoderConfig).toEqual({ codec: "hev1.1.6.L153.B0" });
-    expect(preparedFrame.data).toEqual(
-      new Uint8Array([0x00, 0x00, 0x00, 0x01, ...parameterSet, 0x00, 0x00, 0x00, 0x01, ...keyframe]),
-    );
+    expect(preparedFrame.decoderConfig).toEqual({ codec: "hvc1.1.6.L93.B0" });
+    expect(preparedFrame.data).toEqual(H265FrameBuilder.keyframeWithParameterSets());
+  });
+
+  it("should strip parameter sets from h265 delta frames", () => {
+    const data = H265FrameBuilder.frameData([
+      H265FrameBuilder.annexBNalu(H265NaluType.VPS_NUT),
+      H265FrameBuilder.annexBNalu(H265NaluType.SPS_NUT),
+      H265FrameBuilder.annexBNalu(H265NaluType.PPS_NUT, [0xc0]),
+      H265FrameBuilder.slice(1, H265SliceType.P),
+    ]);
+    const mockVideoFrame = createMockVideoFrame({ format: "h265", data });
+
+    const preparedFrame = prepareVideoFrame(mockVideoFrame);
+
+    expect(preparedFrame.type).toBe("delta");
+    expect(preparedFrame.data).toEqual(new Uint8Array(H265FrameBuilder.slice(1, H265SliceType.P)));
+    expect(preparedFrame.parameterSets).toBeDefined();
   });
 
   it("should return detailed diagnostics for unsupported h265 bitstreams", () => {
@@ -179,6 +236,19 @@ describe("prepareVideoFrame", () => {
     expect(preparedFrame.type).toBe("delta");
     expect(preparedFrame.decoderConfig).toBeUndefined();
     expect(preparedFrame.diagnostics).toBe("unsupported H.265 bitstream format");
+  });
+
+  it("should skip unsupported h265 B frames", () => {
+    const mockVideoFrame = createMockVideoFrame({
+      format: "h265",
+      data: H265FrameBuilder.deltaFrameWithPps(H265SliceType.B),
+    });
+
+    const preparedFrame = prepareVideoFrame(mockVideoFrame);
+
+    expect(preparedFrame.type).toBe("delta");
+    expect(preparedFrame.decoderConfig).toBeUndefined();
+    expect(preparedFrame.diagnostics).toBe("H.265 B frames are not supported");
   });
 });
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.test.ts
@@ -33,7 +33,6 @@ function createMockVideoFrame(override?: Partial<CompressedVideo>): CompressedVi
   };
 }
 
-
 describe("decodeCompressedImageToBitmap", () => {
   it("should decode a compressed image to an ImageBitmap", async () => {
     const mockImage: CompressedImageTypes = {
@@ -131,14 +130,15 @@ describe("decodeCompressedVideoToBitmap", () => {
       data: mockVideoFrame.data,
       type: "delta" as const,
     };
+    const decode = jest.fn().mockResolvedValue(new ImageBitmap());
     const mockVideoPlayer = {
       isInitialized: jest.fn().mockReturnValue(true),
-      decode: jest.fn().mockResolvedValue(new ImageBitmap()),
+      decode,
     } as unknown as VideoPlayer;
 
     await decodeCompressedVideoToBitmap(mockVideoFrame, preparedFrame, mockVideoPlayer, 1000n);
 
-    expect(mockVideoPlayer.decode).toHaveBeenCalledWith(mockVideoFrame.data, 0, "delta");
+    expect(decode).toHaveBeenCalledWith(mockVideoFrame.data, 0, "delta");
   });
 
   it("should return an empty video frame if the video player is not initialized", async () => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
@@ -23,7 +23,7 @@ import {
   decodeUYVY,
   decodeYUYV,
 } from "@lichtblick/den/image";
-import { H264, VideoPlayer } from "@lichtblick/den/video";
+import { H264, H265, VideoPlayer } from "@lichtblick/den/video";
 import { toMicroSec } from "@lichtblick/rostime";
 
 import { CompressedImageTypes, CompressedVideo } from "./ImageTypes";
@@ -44,6 +44,10 @@ export function isVideoKeyframe(frameMsg: CompressedVideo): boolean {
       // Search for an IDR NAL unit to determine if this is a keyframe
       return H264.IsKeyframe(frameMsg.data);
     }
+    case "h265":
+    case "hevc": {
+      return H265.IsKeyframe(frameMsg.data);
+    }
   }
   return false;
 }
@@ -53,6 +57,10 @@ export function getVideoDecoderConfig(frameMsg: CompressedVideo): VideoDecoderCo
     case "h264": {
       // Search for an SPS NAL unit to initialize the decoder. This should precede each keyframe
       return H264.ParseDecoderConfig(frameMsg.data);
+    }
+    case "h265":
+    case "hevc": {
+      return H265.ParseDecoderConfig(frameMsg.data);
     }
   }
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
@@ -52,6 +52,13 @@ export function isVideoKeyframe(frameMsg: CompressedVideo): boolean {
   return false;
 }
 
+export type PreparedVideoFrame = {
+  data: Uint8Array;
+  decoderConfig?: VideoDecoderConfig;
+  diagnostics?: string;
+  type: "key" | "delta";
+};
+
 export function getVideoDecoderConfig(frameMsg: CompressedVideo): VideoDecoderConfig | undefined {
   switch (frameMsg.format) {
     case "h264": {
@@ -67,8 +74,38 @@ export function getVideoDecoderConfig(frameMsg: CompressedVideo): VideoDecoderCo
   return undefined;
 }
 
+export function prepareVideoFrame(frameMsg: CompressedVideo): PreparedVideoFrame {
+  switch (frameMsg.format) {
+    case "h265":
+    case "hevc": {
+      const frameInfo = H265.InspectFrame(frameMsg.data);
+      if (frameInfo.bitstreamFormat === "unknown" || frameInfo.normalizedData == undefined) {
+        return {
+          data: frameMsg.data,
+          diagnostics: "unsupported H.265 bitstream format",
+          type: "delta",
+        };
+      }
+
+      return {
+        data: frameInfo.normalizedData,
+        decoderConfig: frameInfo.hasParameterSet ? { codec: "hev1.1.6.L153.B0" } : undefined,
+        diagnostics: frameInfo.hasParameterSet ? undefined : "no VPS/SPS/PPS found",
+        type: frameInfo.isKeyframe ? "key" : "delta",
+      };
+    }
+    default:
+      return {
+        data: frameMsg.data,
+        decoderConfig: getVideoDecoderConfig(frameMsg),
+        type: isVideoKeyframe(frameMsg) ? "key" : "delta",
+      };
+  }
+}
+
 export async function decodeCompressedVideoToBitmap(
-  frameMsg: CompressedVideo,
+  frameMsg: Pick<CompressedVideo, "timestamp">,
+  preparedFrame: PreparedVideoFrame,
   videoPlayer: VideoPlayer,
   firstMessageTime: bigint,
   resizeWidth?: number,
@@ -81,11 +118,7 @@ export async function decodeCompressedVideoToBitmap(
   const firstTimestampMicros = Number(firstMessageTime / 1000n);
   const timestampMicros = toMicroSec(frameMsg.timestamp) - firstTimestampMicros;
 
-  const videoFrame = await videoPlayer.decode(
-    frameMsg.data,
-    timestampMicros,
-    isVideoKeyframe(frameMsg) ? "key" : "delta",
-  );
+  const videoFrame = await videoPlayer.decode(preparedFrame.data, timestampMicros, preparedFrame.type);
   if (videoFrame) {
     const imageBitmap = await self.createImageBitmap(videoFrame, { resizeWidth });
     videoPlayer.lastImageBitmap = imageBitmap;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
@@ -24,9 +24,10 @@ import {
   decodeYUYV,
 } from "@lichtblick/den/image";
 import { H264, H265, VideoPlayer } from "@lichtblick/den/video";
-import { toMicroSec } from "@lichtblick/rostime";
+import { toNanoSec } from "@lichtblick/rostime";
 
 import { CompressedImageTypes, CompressedVideo } from "./ImageTypes";
+import { PreparedVideoFrame, PrepareVideoFrameContext } from "./types";
 import { Image as RosImage } from "../../ros";
 import { ColorModeSettings, getColorConverter } from "../colorMode";
 
@@ -52,13 +53,6 @@ export function isVideoKeyframe(frameMsg: CompressedVideo): boolean {
   return false;
 }
 
-export type PreparedVideoFrame = {
-  data: Uint8Array;
-  decoderConfig?: VideoDecoderConfig;
-  diagnostics?: string;
-  type: "key" | "delta";
-};
-
 export function getVideoDecoderConfig(frameMsg: CompressedVideo): VideoDecoderConfig | undefined {
   switch (frameMsg.format) {
     case "h264": {
@@ -74,11 +68,14 @@ export function getVideoDecoderConfig(frameMsg: CompressedVideo): VideoDecoderCo
   return undefined;
 }
 
-export function prepareVideoFrame(frameMsg: CompressedVideo): PreparedVideoFrame {
+export function prepareVideoFrame(
+  frameMsg: CompressedVideo,
+  context?: PrepareVideoFrameContext,
+): PreparedVideoFrame {
   switch (frameMsg.format) {
     case "h265":
     case "hevc": {
-      const frameInfo = H265.InspectFrame(frameMsg.data);
+      const frameInfo = H265.InspectFrame(frameMsg.data, context?.h265);
       if (frameInfo.bitstreamFormat === "unknown" || frameInfo.normalizedData == undefined) {
         return {
           data: frameMsg.data,
@@ -86,12 +83,22 @@ export function prepareVideoFrame(frameMsg: CompressedVideo): PreparedVideoFrame
           type: "delta",
         };
       }
+      if (frameInfo.frameType === "B") {
+        return {
+          data: frameInfo.normalizedData,
+          diagnostics: "H.265 B frames are not supported",
+          type: "delta",
+        };
+      }
 
+      const type = frameInfo.isKeyframe ? "key" : "delta";
       return {
-        data: frameInfo.normalizedData,
-        decoderConfig: frameInfo.hasParameterSet ? { codec: "hev1.1.6.L153.B0" } : undefined,
-        diagnostics: frameInfo.hasParameterSet ? undefined : "no VPS/SPS/PPS found",
-        type: frameInfo.isKeyframe ? "key" : "delta",
+        data: type === "key" ? frameInfo.normalizedData : (H265.StripParameterSets(frameInfo.normalizedData) ?? frameInfo.normalizedData),
+        decoderConfig: H265.ParseDecoderConfig(frameInfo.normalizedData),
+        parameterSets: frameInfo.parameterSets,
+        hasParameterSets: frameInfo.hasParameterSets,
+        hasRequiredParameterSets: frameInfo.hasRequiredParameterSets,
+        type,
       };
     }
     default:
@@ -114,18 +121,22 @@ export async function decodeCompressedVideoToBitmap(
     return await emptyVideoFrame(videoPlayer, resizeWidth);
   }
 
-  // Get the timestamp of this frame as microseconds relative to the first frame
-  const firstTimestampMicros = Number(firstMessageTime / 1000n);
-  const timestampMicros = toMicroSec(frameMsg.timestamp) - firstTimestampMicros;
+  // Match Foxglove/WebCodecs behavior by using integer microseconds relative to the first frame.
+  const timestampMicros = Number((toNanoSec(frameMsg.timestamp) - firstMessageTime) / 1000n);
 
-  const videoFrame = await videoPlayer.decode(preparedFrame.data, timestampMicros, preparedFrame.type);
-  if (videoFrame) {
-    const imageBitmap = await self.createImageBitmap(videoFrame, { resizeWidth });
+  const videoFrame = await videoPlayer.decode(
+    preparedFrame.data,
+    timestampMicros,
+    preparedFrame.type,
+  );
+  const frameToRender = videoFrame ?? videoPlayer.lastVideoFrame;
+  if (frameToRender) {
+    const imageBitmap = await self.createImageBitmap(frameToRender, { resizeWidth });
     videoPlayer.lastImageBitmap = imageBitmap;
-    videoFrame.close();
+    videoFrame?.close();
     return imageBitmap;
   }
-  return await emptyVideoFrame(videoPlayer, resizeWidth);
+  return videoPlayer.lastImageBitmap ?? (await emptyVideoFrame(videoPlayer, resizeWidth));
 }
 
 export const IMAGE_DEFAULT_COLOR_MODE_SETTINGS: Required<

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
@@ -93,7 +93,10 @@ export function prepareVideoFrame(
 
       const type = frameInfo.isKeyframe ? "key" : "delta";
       return {
-        data: type === "key" ? frameInfo.normalizedData : (H265.StripParameterSets(frameInfo.normalizedData) ?? frameInfo.normalizedData),
+        data:
+          type === "key"
+            ? frameInfo.normalizedData
+            : (H265.StripParameterSets(frameInfo.normalizedData) ?? frameInfo.normalizedData),
         decoderConfig: H265.ParseDecoderConfig(frameInfo.normalizedData),
         parameterSets: frameInfo.parameterSets,
         hasParameterSets: frameInfo.hasParameterSets,

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/types.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/types.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { H265ParserContext } from "@lichtblick/den/video";
+
+export type PreparedVideoFrame = {
+  data: Uint8Array;
+  decoderConfig?: VideoDecoderConfig;
+  decoderConfigSignature?: string;
+  diagnostics?: string;
+  parameterSets?: Uint8Array;
+  hasParameterSets?: boolean;
+  hasRequiredParameterSets?: boolean;
+  type: "key" | "delta";
+};
+
+export type PrepareVideoFrameContext = {
+  h265?: H265ParserContext;
+};

--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -895,7 +895,9 @@ export class IterablePlayer implements Player {
   }
 
   async #expandVideoSeekBackfill(messages: MessageEvent[]): Promise<MessageEvent[]> {
-    const expandedMessages = new Map(messages.map((message) => [this.#messageKey(message), message]));
+    const expandedMessages = new Map(
+      messages.map((message) => [this.#messageKey(message), message]),
+    );
 
     for (const message of messages) {
       if (!this.#isHevcCompressedVideoMessage(message)) {
@@ -912,7 +914,9 @@ export class IterablePlayer implements Player {
       }
     }
 
-    return Array.from(expandedMessages.values()).sort((a, b) => compare(a.receiveTime, b.receiveTime));
+    return Array.from(expandedMessages.values()).sort((a, b) =>
+      compare(a.receiveTime, b.receiveTime),
+    );
   }
 
   async #readHevcGopForSeekTarget(targetMessage: MessageEvent): Promise<MessageEvent[]> {
@@ -933,7 +937,9 @@ export class IterablePlayer implements Player {
       if (candidate == undefined || !this.#isHevcCompressedVideoMessage(candidate)) {
         return [];
       }
-      if (reversedGop.some((message) => this.#messageKey(message) === this.#messageKey(candidate))) {
+      if (
+        reversedGop.some((message) => this.#messageKey(message) === this.#messageKey(candidate))
+      ) {
         return [];
       }
 

--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -11,6 +11,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { debouncePromise } from "@lichtblick/den/async";
 import { filterMap } from "@lichtblick/den/collection";
+import { H265 } from "@lichtblick/den/video";
 import Log from "@lichtblick/log";
 import {
   Time,
@@ -19,6 +20,7 @@ import {
   compare,
   fromMillis,
   fromNanoSec,
+  toNanoSec,
   toRFC3339String,
   toString,
 } from "@lichtblick/rostime";
@@ -82,6 +84,13 @@ const MAX_BLOCKS = 100;
 const SEEK_ON_START_NS = BigInt(99 * 1e6);
 
 const MEMORY_INFO_BUFFERED_MSGS = "Buffered messages";
+const FOXGLOVE_COMPRESSED_VIDEO_SCHEMA = "foxglove.CompressedVideo";
+const MAX_SEEK_BACKFILL_VIDEO_GOP_MESSAGES = 2000;
+
+type CompressedVideoLike = {
+  data?: Uint8Array;
+  format?: string;
+};
 
 const EMPTY_ARRAY = Object.freeze([]);
 export type IterablePlayerOptions = {
@@ -847,11 +856,12 @@ export class IterablePlayer implements Player {
 
     try {
       this.#abort = new AbortController();
-      const messages = await this.#bufferedSource.getBackfillMessages({
+      const backfillMessages = await this.#bufferedSource.getBackfillMessages({
         topics: this.#allTopics,
         time: targetTime,
         abortSignal: this.#abort.signal,
       });
+      const messages = await this.#expandVideoSeekBackfill(backfillMessages);
 
       // We've successfully loaded the messages and will emit those, no longer need the ackTimeout
       clearTimeout(seekAckTimeout);
@@ -882,6 +892,75 @@ export class IterablePlayer implements Player {
       clearTimeout(seekAckTimeout);
       this.#abort = undefined;
     }
+  }
+
+  async #expandVideoSeekBackfill(messages: MessageEvent[]): Promise<MessageEvent[]> {
+    const expandedMessages = new Map(messages.map((message) => [this.#messageKey(message), message]));
+
+    for (const message of messages) {
+      if (!this.#isHevcCompressedVideoMessage(message)) {
+        continue;
+      }
+      const video = message.message as CompressedVideoLike;
+      if (H265.IsKeyframe(video.data!)) {
+        continue;
+      }
+
+      const gopMessages = await this.#readHevcGopForSeekTarget(message);
+      for (const gopMessage of gopMessages) {
+        expandedMessages.set(this.#messageKey(gopMessage), gopMessage);
+      }
+    }
+
+    return Array.from(expandedMessages.values()).sort((a, b) => compare(a.receiveTime, b.receiveTime));
+  }
+
+  async #readHevcGopForSeekTarget(targetMessage: MessageEvent): Promise<MessageEvent[]> {
+    const topicSelection = new Map([[targetMessage.topic, { topic: targetMessage.topic }]]);
+    const reversedGop: MessageEvent[] = [];
+    let searchTime = targetMessage.receiveTime;
+
+    for (;;) {
+      if (reversedGop.length >= MAX_SEEK_BACKFILL_VIDEO_GOP_MESSAGES) {
+        return [];
+      }
+
+      const [candidate] = await this.#bufferedSource.getBackfillMessages({
+        topics: topicSelection,
+        time: searchTime,
+        abortSignal: this.#abort?.signal,
+      });
+      if (candidate == undefined || !this.#isHevcCompressedVideoMessage(candidate)) {
+        return [];
+      }
+      if (reversedGop.some((message) => this.#messageKey(message) === this.#messageKey(candidate))) {
+        return [];
+      }
+
+      reversedGop.push(candidate);
+      const video = candidate.message as CompressedVideoLike;
+      if (H265.IsKeyframe(video.data!)) {
+        return reversedGop.reverse();
+      }
+
+      const previousTimeNs = toNanoSec(candidate.receiveTime) - 1n;
+      if (previousTimeNs < 0n) {
+        return [];
+      }
+      searchTime = fromNanoSec(previousTimeNs);
+    }
+  }
+
+  #isHevcCompressedVideoMessage(message: MessageEvent): boolean {
+    if (message.schemaName !== FOXGLOVE_COMPRESSED_VIDEO_SCHEMA) {
+      return false;
+    }
+    const video = message.message as CompressedVideoLike;
+    return (video.format === "h265" || video.format === "hevc") && video.data instanceof Uint8Array;
+  }
+
+  #messageKey(message: MessageEvent): string {
+    return `${message.topic}:${message.receiveTime.sec}:${message.receiveTime.nsec}`;
   }
 
   /** Emit the player state to the registered listener */

--- a/packages/suite-base/src/testing/builders/H265FrameBuilder.ts
+++ b/packages/suite-base/src/testing/builders/H265FrameBuilder.ts
@@ -42,7 +42,10 @@ export default class H265FrameBuilder {
   }
 
   public static slice(naluType: number, sliceType: H265SliceType): number[] {
-    return H265FrameBuilder.annexBNalu(naluType, H265FrameBuilder.slicePayload(naluType, sliceType));
+    return H265FrameBuilder.annexBNalu(
+      naluType,
+      H265FrameBuilder.slicePayload(naluType, sliceType),
+    );
   }
 
   public static keyframeWithParameterSets(): Uint8Array {

--- a/packages/suite-base/src/testing/builders/H265FrameBuilder.ts
+++ b/packages/suite-base/src/testing/builders/H265FrameBuilder.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { H265NaluType, H265SliceType } from "@lichtblick/den/video";
+import { CompressedVideo } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/Images/ImageTypes";
+import RosTimeBuilder from "@lichtblick/suite-base/testing/builders/RosTimeBuilder";
+import { BasicBuilder, defaults } from "@lichtblick/test-builders";
+
+export default class H265FrameBuilder {
+  private static slicePayload(naluType: number, sliceType: H265SliceType): number[] {
+    if (naluType >= H265NaluType.BLA_W_LP && naluType <= H265NaluType.RSV_IRAP_VCL23) {
+      return [sliceType === H265SliceType.B ? 0xb0 : sliceType === H265SliceType.P ? 0xa8 : 0xac];
+    }
+    return [sliceType === H265SliceType.B ? 0xe0 : sliceType === H265SliceType.P ? 0xd0 : 0xd8];
+  }
+
+  public static lengthPrefixedNalu(naluType: number, payload: number[] = [0x01]): number[] {
+    const naluHeader = (naluType << 1) | 1;
+    const naluLength = payload.length + 2;
+    return [
+      (naluLength >>> 24) & 0xff,
+      (naluLength >>> 16) & 0xff,
+      (naluLength >>> 8) & 0xff,
+      naluLength & 0xff,
+      naluHeader,
+      0x01,
+      ...payload,
+    ];
+  }
+
+  public static annexBNalu(naluType: number, payload: number[] = [0x01]): number[] {
+    const naluHeader = (naluType << 1) | 1;
+    return [0x00, 0x00, 0x00, 0x01, naluHeader, 0x01, ...payload];
+  }
+
+  public static frameData(nalus: number[][]): Uint8Array {
+    return new Uint8Array(nalus.flat());
+  }
+
+  public static slice(naluType: number, sliceType: H265SliceType): number[] {
+    return H265FrameBuilder.annexBNalu(naluType, H265FrameBuilder.slicePayload(naluType, sliceType));
+  }
+
+  public static keyframeWithParameterSets(): Uint8Array {
+    return H265FrameBuilder.frameData([
+      H265FrameBuilder.annexBNalu(H265NaluType.VPS_NUT),
+      H265FrameBuilder.annexBNalu(H265NaluType.SPS_NUT),
+      H265FrameBuilder.annexBNalu(H265NaluType.PPS_NUT, [0xc0]),
+      H265FrameBuilder.slice(H265NaluType.IDR_W_RADL, H265SliceType.I),
+    ]);
+  }
+
+  public static lengthPrefixedKeyframeWithParameterSets(): Uint8Array {
+    return H265FrameBuilder.frameData([
+      H265FrameBuilder.lengthPrefixedNalu(H265NaluType.VPS_NUT),
+      H265FrameBuilder.lengthPrefixedNalu(H265NaluType.SPS_NUT),
+      H265FrameBuilder.lengthPrefixedNalu(H265NaluType.PPS_NUT, [0xc0]),
+      H265FrameBuilder.lengthPrefixedNalu(H265NaluType.IDR_W_RADL, [0xac]),
+    ]);
+  }
+
+  public static keyframeOnly(sliceType = H265SliceType.I): Uint8Array {
+    return H265FrameBuilder.frameData([H265FrameBuilder.slice(H265NaluType.IDR_W_RADL, sliceType)]);
+  }
+
+  public static deltaFrame(sliceType = H265SliceType.P): Uint8Array {
+    return H265FrameBuilder.frameData([H265FrameBuilder.slice(1, sliceType)]);
+  }
+
+  public static deltaFrameWithPps(sliceType = H265SliceType.P): Uint8Array {
+    return H265FrameBuilder.frameData([
+      H265FrameBuilder.annexBNalu(H265NaluType.PPS_NUT, [0xc0]),
+      H265FrameBuilder.slice(1, sliceType),
+    ]);
+  }
+
+  public static frame(props: Partial<CompressedVideo> = {}): CompressedVideo {
+    return defaults<CompressedVideo>(props, {
+      format: "h265",
+      data: H265FrameBuilder.keyframeWithParameterSets(),
+      frame_id: BasicBuilder.string(),
+      timestamp: RosTimeBuilder.time(),
+    });
+  }
+}

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -24,7 +24,7 @@
     "@types/randomstring": "1.3.0",
     "@types/tinycolor2": "1.4.4",
     "@types/utif": "^3.0.6",
-    "@xmldom/xmldom": "0.9.9",
+    "@xmldom/xmldom": "0.9.10",
     "async-mutex": "0.5.0",
     "builder-util": "*",
     "clean-webpack-plugin": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3492,7 +3492,7 @@ __metadata:
     css-loader: 6.8.1
     cytoscape: 3.31.1
     cytoscape-dagre: 2.5.0
-    dompurify: 3.3.2
+    dompurify: 3.4.0
     dotenv: 17.2.2
     esbuild-loader: 4.3.0
     eventemitter3: 5.0.1
@@ -3602,7 +3602,7 @@ __metadata:
     "@types/randomstring": 1.3.0
     "@types/tinycolor2": 1.4.4
     "@types/utif": ^3.0.6
-    "@xmldom/xmldom": 0.9.9
+    "@xmldom/xmldom": 0.9.10
     async-mutex: 0.5.0
     builder-util: "*"
     clean-webpack-plugin: 4.0.0
@@ -7176,17 +7176,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:0.9.9":
-  version: 0.9.9
-  resolution: "@xmldom/xmldom@npm:0.9.9"
-  checksum: 73bd69379f70b29cdef742eb834c299ef13268e9ce42ea6384a78ade1083c3e0c71c764019d3c8d860a76147c6c84b4cba5e6e5b2123ed2cd806d8621c4c9559
+"@xmldom/xmldom@npm:0.9.10":
+  version: 0.9.10
+  resolution: "@xmldom/xmldom@npm:0.9.10"
+  checksum: 420f3ba52316163384ce626cda087d06b0eb5888d393b00bbc5f56489bbaccc8633e9b078942ee05facda93fbf813b209a5deb5044f89a6e04373305a0e573c0
   languageName: node
   linkType: hard
 
 "@xmldom/xmldom@npm:^0.8.8":
-  version: 0.8.12
-  resolution: "@xmldom/xmldom@npm:0.8.12"
-  checksum: 609bbcd6f31fa24023f5cc836e804d49c60e3df83ca73f744da9caff7fed516221dcf2f23de44e5289d715951781ec35fa90adf57008c3eae944a7550c39e325
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: b5568a3dee6306c4c6256c94f27d74f904d7cc923607f0dcaa37998e370361ce37a6e99aa55e8e725f07079e619a6f8b3a7de218e76b522ba2b1aca3ada5265c
   languageName: node
   linkType: hard
 
@@ -10290,15 +10290,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.3.2":
-  version: 3.3.2
-  resolution: "dompurify@npm:3.3.2"
+"dompurify@npm:3.4.0":
+  version: 3.4.0
+  resolution: "dompurify@npm:3.4.0"
   dependencies:
     "@types/trusted-types": ^2.0.7
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 27856958c4088de2e2279b9514fcf3427c925e3cedf9d176957d9469a5199c39b572931a441cbb2025d1910c2890644280d0db8d5180b1366164cac309da08e5
+  checksum: 8c4286d3d379c6133ff2951d73d946974ef079f5d651d66cf90c1a6e57d8d2d304e7bc18280d27c38835200bbe03877fd93fb22f9f1fb9e086d68ffcd2d5dd16
   languageName: node
   linkType: hard
 
@@ -17571,14 +17571,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.3.11, postcss@npm:^8.4.21, postcss@npm:^8.4.33, postcss@npm:^8.5.8":
-  version: 8.5.8
-  resolution: "postcss@npm:8.5.8"
+"postcss@npm:8.5.10":
+  version: 8.5.10
+  resolution: "postcss@npm:8.5.10"
   dependencies:
     nanoid: ^3.3.11
     picocolors: ^1.1.1
     source-map-js: ^1.2.1
-  checksum: 118cbec9551c7107c7884a585b45d7cce1632159065c7f6e112bbb4c4811253e78d507e49082b36d9b89f36a02a611c5a8cd210548dead55795c20c4f37ab9e8
+  checksum: 9af9cd7f2f0d4b8456f6710e48d586328433509b695911fda942c24ac4db4e62c6fed8c6c6d8c8258326285f669494c2c36a4ff84aa160f0586eb545e5258bf5
   languageName: node
   linkType: hard
 
@@ -21385,30 +21385,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:11.1.0":
-  version: 11.1.0
-  resolution: "uuid@npm:11.1.0"
+"uuid@npm:14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
   bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 840f19758543c4631e58a29439e51b5b669d5f34b4dd2700b6a1d15c5708c7a6e0c3e2c8c4a2eae761a3a7caa7e9884d00c86c02622ba91137bd3deade6b4b4a
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
+    uuid: dist-node/bin/uuid
+  checksum: 08608584a79e987cdae000fa8eb724fa51dd8aafc136cd9fa9a8c87d07b246c56eec5fd9027fdb3e49a863eedf758bc19e325909ce281955c7a027fed67dc89e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add H.265 frame inspection that normalizes length-prefixed payloads into Annex B and surfaces keyframe/parameter-set diagnostics
- cache H.265 decoder configuration in the 3D image render path so later keyframes can initialize even when VPS/SPS/PPS are not repeated
- stop surfacing noisy decode errors while the renderer is still waiting on a usable keyframe, and extend tests around these paths

## Why
The initial H.265 support still failed on streams that start mid-GOP or arrive as length-prefixed HEVC payloads. In that state the renderer repeatedly logged `Waiting for keyframe`, even when the stream was otherwise recoverable after the next usable keyframe.

## Impact
Foxglove `CompressedVideo` topics encoded as H.265/HEVC now handle a wider set of payload layouts and avoid spurious error spam while waiting for decoder initialization. This makes playback behavior closer to Foxglove on streams that do not begin on a keyframe.

## Validation
- `corepack yarn test packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.test.ts --runInBand`
- `corepack yarn test packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts --runInBand`
