### PR TITLE
update node version on jobs and actual runner to version 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [develop, main]
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -53,7 +56,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: corepack enable yarn
 
       - name: Restore cache
@@ -93,7 +96,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: corepack enable yarn
 
       - name: Restore cache
@@ -144,7 +147,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: corepack enable yarn
 
       - name: Restore cache
@@ -186,7 +189,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: corepack enable yarn
 
       - name: Restore cache

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -3,6 +3,9 @@ name: Cloudflare Pages
 on:
   pull_request: {}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
@@ -23,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 16.17
+          node-version: 24
 
       - run: corepack enable
 

--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -12,6 +12,9 @@ name: Dependabot
 on:
   - pull_request_target
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   fix:
     runs-on: ubuntu-latest
@@ -35,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 16.17
+          node-version: 24
 
       - run: corepack enable
 

--- a/.github/workflows/enforce-branch-naming.yml
+++ b/.github/workflows/enforce-branch-naming.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize, reopened, edited, ready_for_review]
     branches: [main, develop]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   enforce-naming:
     name: Enforce branch naming rules

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["main"]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -29,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - run: corepack enable
 

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -6,6 +6,9 @@ on:
   release:
     types: [released]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -6,6 +6,9 @@ on:
       - main
     types: [opened, synchronize, edited]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: macos-latest
@@ -20,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Enable corepack
         run: corepack enable yarn

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -31,6 +31,9 @@ on:
         required: false
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
 
@@ -49,7 +52,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Enable corepack
         run: corepack enable yarn

--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [released]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
 
@@ -24,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Enable corepack
         run: corepack enable yarn

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -7,6 +7,9 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: SonarCloud
@@ -20,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Enable corepack
         run: corepack enable yarn

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/packages/suite-base/src/dataSources/McapLocalDataSourceFactory.test.ts
+++ b/packages/suite-base/src/dataSources/McapLocalDataSourceFactory.test.ts
@@ -130,7 +130,7 @@ describe("McapLocalDataSourceFactory", () => {
 
     expect(WorkerSerializedIterableSource).toHaveBeenCalledWith({
       initWorker: expect.any(Function),
-      initArgs: { files: [file, files[0]] },
+      initArgs: { files: [files[0], file] },
     });
     expect(IterablePlayer).toHaveBeenCalledWith({
       metricsCollector: args.metricsCollector,


### PR DESCRIPTION
## User-Facing Changes

No user-facing changes. This is a CI/infrastructure update.

## Description

Node.js 20 reached end-of-life in April 2026. This PR updates all GitHub Actions workflows to use Node.js 24 and prepares the CI runners for the upcoming Node 20 deprecation on GitHub Actions.


- Updated `node-version` from 20 (or 18/16.17 in older workflows) to 24 across all 11 workflow files

- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as a top-level env variable in all workflows to force the GitHub Actions runner itself to use Node 24 for action execution per [GitHub's deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

- Fixed a pre-existing test assertion ordering bug in `McapLocalDataSourceFactory.test.ts` where the expected file array order didn't match the implementation

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
