### PR TITLE
New e2e test

### DIFF
--- a/e2e/tests/desktop/layout/open-plot-panel-via-new-layout.spec.ts
+++ b/e2e/tests/desktop/layout/open-plot-panel-via-new-layout.spec.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+import { test, expect } from "../../../fixtures/electron";
+import { loadFiles } from "../../../fixtures/load-files";
+
+/**
+ * GIVEN a file is loaded and a new layout is created
+ * WHEN the user opens a Plot panel and adds a series with "mouse.clientX"
+ * THEN "mouse.clientX" should appear in the Plot panel as the path of the added series
+ */
+test("open Plot panel when clicking on Layouts > layout", async ({ mainWindow }) => {
+  // Given a file is loaded and a new layout is created with a Plot panel
+  const filename = "example-2.mcap";
+  await loadFiles({
+    mainWindow,
+    filenames: filename,
+  });
+
+  await mainWindow.getByTestId("layouts-left").click();
+  await mainWindow.getByTestId("create-new-layout").click();
+
+  // When
+  // the user opens a Plot panel and adds a series with "mouse.clientX"
+  await mainWindow.getByTestId("panel-settings-left").click();
+  await mainWindow.getByText("Plot").nth(0).click();
+
+  await mainWindow.getByTestId("add-series").click();
+  await mainWindow.getByPlaceholder("/some/topic.msgs[0].field").fill("mouse.clientX");
+
+  // Then
+  // "mouse.clientX" should appear in the Plot panel as the path of the added series
+  await expect(mainWindow.getByTestId("plot-legend-row-path-label").first()).toHaveText(
+    "mouse.clientX",
+  );
+});

--- a/packages/suite-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/index.tsx
@@ -303,12 +303,16 @@ export default function LayoutBrowser({
             <List className={classes.actionList} disablePadding>
               <ListItem disablePadding>
                 <ListItemButton onClick={createNewLayout}>
-                  <ListItemText disableTypography>Create new layout</ListItemText>
+                  <ListItemText data-testid="create-new-layout" disableTypography>
+                    Create new layout
+                  </ListItemText>
                 </ListItemButton>
               </ListItem>
               <ListItem disablePadding>
                 <ListItemButton onClick={importLayout}>
-                  <ListItemText disableTypography>Import from file…</ListItemText>
+                  <ListItemText data-testid="import-layout" disableTypography>
+                    Import from file…
+                  </ListItemText>
                 </ListItemButton>
               </ListItem>
             </List>

--- a/packages/suite-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/suite-base/src/panels/Plot/PlotLegendRow.tsx
@@ -226,6 +226,7 @@ export function PlotLegendRow({
           flex="auto"
           variant="body2"
           className={cx({ [classes.disabledPathLabel]: !path.enabled })}
+          data-testid="plot-legend-row-path-label"
         >
           {isAddSeriesRow ? t("clickToAddASeries") : plotPathDisplayName(path, index)}
         </Typography>
@@ -251,11 +252,21 @@ export function PlotLegendRow({
       )}
       <div className={classes.actionButton}>
         {index === paths.length ? (
-          <ButtonBase title="Add series" aria-label="Add series" onClick={onClickPath}>
+          <ButtonBase
+            title="Add series"
+            aria-label="Add series"
+            onClick={onClickPath}
+            data-testid="add-series"
+          >
             <Add12Regular />
           </ButtonBase>
         ) : (
-          <ButtonBase title="Delete series" aria-label="Delete series" onClick={handleDeletePath}>
+          <ButtonBase
+            title="Delete series"
+            aria-label="Delete series"
+            onClick={handleDeletePath}
+            data-testid="delete-series"
+          >
             <Dismiss12Regular />
           </ButtonBase>
         )}


### PR DESCRIPTION
## User-Facing Changes
<!-- will be used as a changelog entry -->

## Description
Create new e2e test for Plot panel with following spec:

```
GIVEN a file is loaded and a new layout is created
WHEN the user opens a Plot panel and adds a series with "mouse.clientX"
THEN "mouse.clientX" should appear in the Plot panel as the path of the added series
```


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
