### PR TITLE
New e2e test

### DIFF
--- a/e2e/tests/desktop/panel/raw-messages/drag-and-drop-topic-on-raw-messages.spec.ts
+++ b/e2e/tests/desktop/panel/raw-messages/drag-and-drop-topic-on-raw-messages.spec.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { expect, test } from "../../../../fixtures/electron";
+import { loadFiles } from "../../../../fixtures/load-files";
+
+/**
+ * GIVEN a file is loaded and a new layout is created with a Raw Messages panel
+ * WHEN the user opens the Topics sidebar and drags a topic onto the panel
+ * THEN the topic message data is displayed in the Raw Messages panel
+ */
+test("open Raw Messages panel when clicking on Layouts > layout", async ({ mainWindow }) => {
+  // GIVEN a file is loaded and a new layout is created with a Raw Messages panel
+  const filename = "example-2.mcap";
+  await loadFiles({
+    mainWindow,
+    filenames: filename,
+  });
+
+  await mainWindow.getByTestId("layouts-left").click();
+  await mainWindow.getByTestId("create-new-layout").click();
+  await mainWindow.getByText("Raw Messages").nth(0).click();
+
+  // WHEN the user opens the Topics sidebar and drags a topic onto the panel
+  await mainWindow.getByTestId("topics-left").click();
+  await mainWindow.getByTestId("topic-row").dragTo(mainWindow.getByTestId("workspace-panels"));
+
+  // THEN the topic message data is displayed in the Raw Messages panel
+  const topicMessageClientX = mainWindow.getByText("clientX");
+  const topicMessageClientY = mainWindow.getByText("clientY");
+  await expect(topicMessageClientX).toBeVisible();
+  await expect(topicMessageClientY).toBeVisible();
+});

--- a/packages/suite-base/src/Workspace.tsx
+++ b/packages/suite-base/src/Workspace.tsx
@@ -593,13 +593,13 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
         >
           {/* To ensure no stale player state remains, we unmount all panels when players change */}
           <RemountOnValueChange value={playerId}>
-            <Stack>
+            <Stack data-testid="workspace-panels">
               <PanelLayout />
             </Stack>
           </RemountOnValueChange>
         </Sidebars>
         {play && pause && seek && (
-          <div style={{ flexShrink: 0 }}>
+          <div style={{ flexShrink: 0 }} data-testid="playback-controls">
             <PlaybackControls
               play={play}
               pause={pause}

--- a/packages/suite-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/index.tsx
@@ -303,12 +303,16 @@ export default function LayoutBrowser({
             <List className={classes.actionList} disablePadding>
               <ListItem disablePadding>
                 <ListItemButton onClick={createNewLayout}>
-                  <ListItemText disableTypography>Create new layout</ListItemText>
+                  <ListItemText data-testid="create-new-layout" disableTypography>
+                    Create new layout
+                  </ListItemText>
                 </ListItemButton>
               </ListItem>
               <ListItem disablePadding>
                 <ListItemButton onClick={importLayout}>
-                  <ListItemText disableTypography>Import from file…</ListItemText>
+                  <ListItemText data-testid="import-layout" disableTypography>
+                    Import from file…
+                  </ListItemText>
                 </ListItemButton>
               </ListItem>
             </List>

--- a/packages/suite-base/src/components/TopicList/TopicRow.tsx
+++ b/packages/suite-base/src/components/TopicList/TopicRow.tsx
@@ -134,6 +134,7 @@ export function TopicRow({
       style={{ ...style, cursor }}
       onClick={onClick}
       onContextMenu={onContextMenu}
+      data-testid="topic-row"
     >
       {draggedItemCount > 1 && (
         <Badge color="primary" className={classes.countBadge} badgeContent={draggedItemCount} />


### PR DESCRIPTION
## User-Facing Changes
<!-- will be used as a changelog entry -->

## Description
Create new e2e test for Raw Messages panel with following spec:

```
GIVEN a file is loaded and a new layout is created with a Raw Messages panel
WHEN the user opens the Topics sidebar and drags a topic onto the panel
THEN the topic message data is displayed in the Raw Messages panel
```


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
