### PR TITLE
separating sonarqube analysis into 2 jobs

### DIFF
--- a/.github/workflows/sonar-prep.yml
+++ b/.github/workflows/sonar-prep.yml
@@ -1,0 +1,86 @@
+name: Sonar Prep
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  prepare-sonar-artifacts:
+    name: Prepare Sonar artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable corepack
+        run: corepack enable yarn
+
+      - name: Restore cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            .yarn/cache
+            **/node_modules
+          key: v5-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: v5-${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Save PR metadata
+        run: |
+          jq -n \
+            --arg number "${{ github.event.pull_request.number }}" \
+            --arg head_ref "${{ github.event.pull_request.head.ref }}" \
+            --arg base_ref "${{ github.event.pull_request.base.ref }}" \
+            '{number: $number, head_ref: $head_ref, base_ref: $base_ref}' > pr-metadata.json
+
+      - name: Generate lint report and normalize file paths
+        run: |
+          yarn lint:ci:report
+          sed -i 's|/home/runner/work/lichtblick/lichtblick/|./|g' eslint-report.json
+        continue-on-error: true
+
+      - name: Test and coverage
+        run: yarn test:coverage
+        continue-on-error: true
+
+      - name: Ensure Sonar artifacts exist
+        run: |
+          [[ -f eslint-report.json ]] || echo "[]" > eslint-report.json
+          mkdir -p coverage
+          [[ -f coverage/lcov.info ]] || : > coverage/lcov.info
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v7
+        with:
+          name: sonar-pr-metadata
+          path: pr-metadata.json
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload ESLint report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sonar-eslint-report
+          path: eslint-report.json
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload coverage lcov
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sonar-coverage-lcov
+          path: coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -3,18 +3,19 @@ name: SonarCloud
 on:
   push:
     branches: ["develop"]
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["Sonar Prep"]
+    types: [completed]
   workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  build:
-    name: SonarCloud
+  push-and-manual-scan:
+    name: SonarCloud (push/manual)
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -52,6 +53,65 @@ jobs:
 
       - name: ScanCloud Scan
         uses: sonarsource/sonarqube-scan-action@v7.1.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+
+  pr-scan:
+    name: SonarCloud (workflow_run PR)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Download PR metadata artifact
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: sonar-pr-metadata
+          path: ./.sonar-pr
+
+      - name: Read PR metadata
+        id: metadata
+        run: |
+          echo "number=$(jq -r '.number' ./.sonar-pr/pr-metadata.json)" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(jq -r '.head_ref' ./.sonar-pr/pr-metadata.json)" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$(jq -r '.base_ref' ./.sonar-pr/pr-metadata.json)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: refs/pull/${{ steps.metadata.outputs.number }}/head
+
+      - name: Download ESLint report artifact
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: sonar-eslint-report
+          path: .
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: sonar-coverage-lcov
+          path: ./coverage
+
+      - name: Fetch PR base branch
+        run: git fetch origin ${{ steps.metadata.outputs.base_ref }}:${{ steps.metadata.outputs.base_ref }}
+
+      - name: ScanCloud PR Scan
+        uses: sonarsource/sonarqube-scan-action@v7.1.0
+        with:
+          args: >
+            -Dsonar.pullrequest.key=${{ steps.metadata.outputs.number }}
+            -Dsonar.pullrequest.branch=${{ steps.metadata.outputs.head_ref }}
+            -Dsonar.pullrequest.base=${{ steps.metadata.outputs.base_ref }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}


### PR DESCRIPTION
## User-Facing Changes

 No user-facing product changes.

## Description

This PR restructures the SonarQube GitHub Actions setup into two workflows:

1. `Sonar Prep`
   Runs on `pull_request`, generates the existing Sonar inputs, and uploads:
   - PR metadata
   - `eslint-report.json`
   - `coverage/lcov.info`

2. `SonarCloud`
   Keeps the existing push/manual branch analysis path, and adds a `workflow_run`-based PR scan path that consumes artifacts from `Sonar Prep`.

The goal is to support SonarQube analysis for PRs opened from forks without exposing `SONAR_TOKEN` to untrusted `pull_request` workflows.

Important limitation:
GitHub only evaluates `workflow_run` triggers from workflow files that already exist on the default branch. Because of that, the new PR scan workflow cannot be fully end-to-end validated from this feature branch alone. Before merge, only the `Sonar Prep` portion can be exercised directly from a fork PR. Full validation of the chained workflow requires the workflow definition to be present on `develop` or in a temporary repository where this branch is the default branch.

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated