### PR TITLE
Associate sonarqube check with PR that triggered it

### DIFF
--- a/.github/workflows/scripts/create-check-run.js
+++ b/.github/workflows/scripts/create-check-run.js
@@ -1,0 +1,17 @@
+/** @param {import("@actions/github/lib/utils").GitHub} github */
+/** @param {import("@actions/github").context} context */
+module.exports = async ({ github, context }) => {
+  const { data } = await github.rest.checks.create({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    name: "SonarCloud (workflow_run PR)",
+    head_sha: process.env.HEAD_SHA,
+    status: "in_progress",
+    details_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+    output: {
+      title: "SonarCloud PR scan",
+      summary: "SonarCloud analysis is running…",
+    },
+  });
+  return String(data.id);
+};

--- a/.github/workflows/scripts/create-check-run.js
+++ b/.github/workflows/scripts/create-check-run.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
 /** @param {import("@actions/github/lib/utils").GitHub} github */
 /** @param {import("@actions/github").context} context */
 module.exports = async ({ github, context }) => {

--- a/.github/workflows/scripts/update-check-run-status.js
+++ b/.github/workflows/scripts/update-check-run-status.js
@@ -1,0 +1,17 @@
+/** @param {import("@actions/github/lib/utils").GitHub} github */
+/** @param {import("@actions/github").context} context */
+module.exports = async ({ github, context }) => {
+  const conclusion = process.env.JOB_STATUS === "success" ? "success" : "failure";
+  await github.rest.checks.update({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    check_run_id: parseInt(process.env.CHECK_RUN_ID, 10),
+    status: "completed",
+    conclusion,
+    details_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+    output: {
+      title: "SonarCloud PR scan",
+      summary: `SonarCloud analysis completed with status: ${conclusion}.`,
+    },
+  });
+};

--- a/.github/workflows/scripts/update-check-run-status.js
+++ b/.github/workflows/scripts/update-check-run-status.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
 /** @param {import("@actions/github/lib/utils").GitHub} github */
 /** @param {import("@actions/github").context} context */
 module.exports = async ({ github, context }) => {

--- a/.github/workflows/sonar-fork-reports.yml
+++ b/.github/workflows/sonar-fork-reports.yml
@@ -1,4 +1,4 @@
-name: Sonar Prep
+name: Sonar Fork Reports
 
 on:
   pull_request:

--- a/.github/workflows/sonar-prep.yml
+++ b/.github/workflows/sonar-prep.yml
@@ -8,6 +8,7 @@ jobs:
   prepare-sonar-artifacts:
     name: Prepare Sonar artifacts
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/sonar-prep.yml
+++ b/.github/workflows/sonar-prep.yml
@@ -40,8 +40,9 @@ jobs:
           jq -n \
             --arg number "${{ github.event.pull_request.number }}" \
             --arg head_ref "${{ github.event.pull_request.head.ref }}" \
+            --arg head_sha "${{ github.event.pull_request.head.sha }}" \
             --arg base_ref "${{ github.event.pull_request.base.ref }}" \
-            '{number: $number, head_ref: $head_ref, base_ref: $base_ref}' > pr-metadata.json
+            '{number: $number, head_ref: $head_ref, head_sha: $head_sha, base_ref: $base_ref}' > pr-metadata.json
 
       - name: Generate lint report and normalize file paths
         run: |

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -63,6 +63,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     permissions:
       actions: read
+      checks: write
       contents: read
       pull-requests: read
     steps:
@@ -79,6 +80,7 @@ jobs:
         run: |
           echo "number=$(jq -r '.number' ./.sonar-pr/pr-metadata.json)" >> "$GITHUB_OUTPUT"
           echo "head_ref=$(jq -r '.head_ref' ./.sonar-pr/pr-metadata.json)" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(jq -r '.head_sha' ./.sonar-pr/pr-metadata.json)" >> "$GITHUB_OUTPUT"
           echo "base_ref=$(jq -r '.base_ref' ./.sonar-pr/pr-metadata.json)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v6
@@ -115,3 +117,26 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+
+      - name: Publish PR check run
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          JOB_STATUS: ${{ job.status }}
+          HEAD_SHA: ${{ steps.metadata.outputs.head_sha }}
+        with:
+          script: |
+            const conclusion = process.env.JOB_STATUS === "success" ? "success" : "failure";
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "SonarCloud (workflow_run PR)",
+              head_sha: process.env.HEAD_SHA,
+              status: "completed",
+              conclusion,
+              details_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              output: {
+                title: "SonarCloud PR scan",
+                summary: `SonarCloud workflow_run scan completed with status: ${conclusion}.`,
+              },
+            });

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   internal-scan:
-    name: SonarCloud (internal)
+    name: Internal scan
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
@@ -60,7 +60,7 @@ jobs:
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
 
   external-fork-scan:
-    name: SonarCloud (external fork PR)
+    name: External fork scan
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.pull_request.labels.name == 'quality-check' }}
     permissions:
@@ -142,8 +142,8 @@ jobs:
             const script = require('./.github/workflows/scripts/update-check-run-status.js');
             await script({ github, context });
 
-  sonar-gate:
-    name: SonarCloud
+  sonar-result-check:
+    name: Analysis result check
     runs-on: ubuntu-latest
     if: always()
     needs: [internal-scan, external-fork-scan]

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -93,19 +93,8 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const { data } = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: "SonarCloud (workflow_run PR)",
-              head_sha: process.env.HEAD_SHA,
-              status: "in_progress",
-              details_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              output: {
-                title: "SonarCloud PR scan",
-                summary: "SonarCloud analysis is running…",
-              },
-            });
-            return String(data.id);
+            const script = require('./.github/workflows/scripts/create-check-run.ts');
+            return await script({ github, context });
 
       - uses: actions/checkout@v6
         with:
@@ -150,16 +139,5 @@ jobs:
           CHECK_RUN_ID: ${{ steps.check.outputs.result }}
         with:
           script: |
-            const conclusion = process.env.JOB_STATUS === "success" ? "success" : "failure";
-            await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: parseInt(process.env.CHECK_RUN_ID, 10),
-              status: "completed",
-              conclusion,
-              details_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              output: {
-                title: "SonarCloud PR scan",
-                summary: `SonarCloud analysis completed with status: ${conclusion}.`,
-              },
-            });
+            const script = require('./.github/workflows/scripts/update-check-run-status.js');
+            await script({ github, context });

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_run:
-    workflows: ["Sonar Prep"]
+    workflows: ["Sonar Fork Reports"]
     types: [completed]
   workflow_dispatch:
 

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -83,6 +83,28 @@ jobs:
           echo "head_sha=$(jq -r '.head_sha' ./.sonar-pr/pr-metadata.json)" >> "$GITHUB_OUTPUT"
           echo "base_ref=$(jq -r '.base_ref' ./.sonar-pr/pr-metadata.json)" >> "$GITHUB_OUTPUT"
 
+      - name: Create in-progress PR check run
+        id: check
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ steps.metadata.outputs.head_sha }}
+        with:
+          result-encoding: string
+          script: |
+            const { data } = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "SonarCloud (workflow_run PR)",
+              head_sha: process.env.HEAD_SHA,
+              status: "in_progress",
+              details_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              output: {
+                title: "SonarCloud PR scan",
+                summary: "SonarCloud analysis is running…",
+              },
+            });
+            return String(data.id);
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -118,25 +140,24 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
 
-      - name: Publish PR check run
+      - name: Complete PR check run
         if: always()
         uses: actions/github-script@v7
         env:
           JOB_STATUS: ${{ job.status }}
-          HEAD_SHA: ${{ steps.metadata.outputs.head_sha }}
+          CHECK_RUN_ID: ${{ steps.check.outputs.result }}
         with:
           script: |
             const conclusion = process.env.JOB_STATUS === "success" ? "success" : "failure";
-            await github.rest.checks.create({
+            await github.rest.checks.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: "SonarCloud (workflow_run PR)",
-              head_sha: process.env.HEAD_SHA,
+              check_run_id: parseInt(process.env.CHECK_RUN_ID, 10),
               status: "completed",
               conclusion,
               details_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               output: {
                 title: "SonarCloud PR scan",
-                summary: `SonarCloud workflow_run scan completed with status: ${conclusion}.`,
+                summary: `SonarCloud analysis completed with status: ${conclusion}.`,
               },
             });

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["develop"]
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
   workflow_run:
     workflows: ["Sonar Fork Reports"]
     types: [completed]
@@ -62,7 +62,7 @@ jobs:
   external-fork-scan:
     name: SonarCloud (external fork PR)
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.pull_request.labels.name == 'quality-check' }}
     permissions:
       actions: read
       checks: write
@@ -141,3 +141,14 @@ jobs:
           script: |
             const script = require('./.github/workflows/scripts/update-check-run-status.js');
             await script({ github, context });
+
+  sonar-gate:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [internal-scan, external-fork-scan]
+    steps:
+      - run: |
+          if [[ "${{ needs.internal-scan.result }}" == "failure" || "${{ needs.external-fork-scan.result }}" == "failure" ]]; then
+            exit 1
+          fi

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -3,6 +3,8 @@ name: SonarCloud
 on:
   push:
     branches: ["develop"]
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_run:
     workflows: ["Sonar Prep"]
     types: [completed]
@@ -12,10 +14,10 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  push-and-manual-scan:
-    name: SonarCloud (push/manual)
+  internal-scan:
+    name: SonarCloud (internal)
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -57,8 +59,8 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
 
-  pr-scan:
-    name: SonarCloud (workflow_run PR)
+  external-fork-scan:
+    name: SonarCloud (external fork PR)
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     permissions:


### PR DESCRIPTION
## User-Facing Changes

N/A

## Description

- Improved PR checks visibility for Sonar analysis in fork-safe workflow mode.
- Sonar analysis triggered via workflow_run is now explicitly associated with the PR commit SHA, so the SonarCloud check appears in the GitHub PR checks UI.
- Added steps for Sonar triggered via workflow_run to be added to the GitHub UI 
- Added final job that verifies analysis results abstract of the source of the PR so SonarQube workflow can be added to repo's rulesets and not be blocked by the fact that only one job (internal or external) will ever run at time

<img width="941" height="1037" alt="image" src="https://github.com/user-attachments/assets/d6d22a98-0f7e-4bca-9e99-ef380dec312e" />


## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
