### PR TITLE
feat: Add axis labels to plot and state transition panels

### DIFF
--- a/packages/suite-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/suite-base/src/components/TimeBasedChart/index.tsx
@@ -540,6 +540,10 @@ export default function TimeBasedChart(props: Props): React.JSX.Element {
         ...defaultXTicksSettings,
         ...xAxes?.ticks,
       },
+      title: {
+        ...xAxes?.title,
+        color: theme.palette.text.primary,
+      },
     };
 
     return scale;

--- a/packages/suite-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/suite-base/src/components/TimeBasedChart/index.tsx
@@ -369,12 +369,12 @@ export default function TimeBasedChart(props: Props): React.JSX.Element {
       });
     }
 
-    if (tooltipItems.length === 0) {
+    const element = tooltipItems[0]?.element;
+
+    if (!element) {
       setActiveTooltip(undefined);
       return;
     }
-
-    const element = tooltipItems[0]!.element;
 
     const canvasRect = canvasContainer.current?.getBoundingClientRect();
     if (canvasRect) {

--- a/packages/suite-base/src/i18n/en/plot.ts
+++ b/packages/suite-base/src/i18n/en/plot.ts
@@ -8,6 +8,7 @@
 export const plot = {
   accumulatedPath: "Path (accumulated)",
   addSeries: "Add series",
+  axisLabel: "Axis label",
   clickToAddASeries: "Click to add a series",
   color: "Color",
   currentPath: "Path (current)",

--- a/packages/suite-base/src/i18n/en/stateTransitions.ts
+++ b/packages/suite-base/src/i18n/en/stateTransitions.ts
@@ -9,6 +9,7 @@ export const stateTransitions = {
   addSeriesButton: "Click to add a series",
   labels: {
     addSeries: "Add series",
+    axisLabel: "Axis label",
     deleteSeries: "Delete series",
     general: "General",
     helpGeneral: "Display a point for every state transition message",

--- a/packages/suite-base/src/panels/Plot/ChartRenderer.test.ts
+++ b/packages/suite-base/src/panels/Plot/ChartRenderer.test.ts
@@ -224,6 +224,40 @@ describe("ChartRenderer", () => {
       expect(chartInstance.options.scales!.y!.ticks?.display).toBe(true);
     });
 
+    it("should set x-axis title when provided in update action", () => {
+      const xAxisLabel = BasicBuilder.string();
+      const { action, chartRenderer } = setup({
+        actionOverride: {
+          xAxisLabel,
+        },
+      });
+
+      chartRenderer.update(action);
+      const chartInstance: ChartType = (chartRenderer as any).getChartInstance();
+      expect(chartInstance.options.scales!.x!.title).toEqual({
+        display: true,
+        text: xAxisLabel,
+        color: OPTIONS_CHART.titleColor,
+      });
+    });
+
+    it("should set y-axis title when provided in update action", () => {
+      const yAxisLabel = BasicBuilder.string();
+      const { action, chartRenderer } = setup({
+        actionOverride: {
+          yAxisLabel,
+        },
+      });
+
+      chartRenderer.update(action);
+      const chartInstance: ChartType = (chartRenderer as any).getChartInstance();
+      expect(chartInstance.options.scales!.y!.title).toEqual({
+        display: true,
+        text: yAxisLabel,
+        color: OPTIONS_CHART.titleColor,
+      });
+    });
+
     it("should update chart on update action", () => {
       const { action, chartRenderer } = setup();
 

--- a/packages/suite-base/src/panels/Plot/ChartRenderer.test.ts
+++ b/packages/suite-base/src/panels/Plot/ChartRenderer.test.ts
@@ -26,6 +26,7 @@ const OPTIONS_CHART: ChartOptionsPlot = {
   devicePixelRatio: 2,
   gridColor: "#ccc",
   tickColor: "#000",
+  titleColor: "#111",
 };
 
 const SCALES_CHART: Record<string, Partial<Scale>> = {
@@ -149,6 +150,7 @@ describe("ChartRenderer", () => {
         devicePixelRatio: props.devicePixelRatio,
         gridColor: props.gridColor,
         tickColor: props.tickColor,
+        titleColor: props.titleColor,
       });
     });
   });

--- a/packages/suite-base/src/panels/Plot/ChartRenderer.ts
+++ b/packages/suite-base/src/panels/Plot/ChartRenderer.ts
@@ -36,9 +36,9 @@ import {
 
 export class ChartRenderer {
   #chartInstance: ChartType;
-  #titleColor: string;
   #fakeNodeEvents = new EventEmitter();
   #fakeDocumentEvents = new EventEmitter();
+  readonly #titleColor: string;
 
   public constructor(args: ChartRendererProps) {
     const fakeNode = {

--- a/packages/suite-base/src/panels/Plot/ChartRenderer.ts
+++ b/packages/suite-base/src/panels/Plot/ChartRenderer.ts
@@ -127,6 +127,26 @@ export class ChartRenderer {
       }
     }
 
+    if (action.yAxisLabel != undefined) {
+      const yScale = this.#chartInstance.options.scales?.y;
+      if (yScale) {
+        yScale.title = {
+          display: action.yAxisLabel.length > 0,
+          text: action.yAxisLabel,
+        };
+      }
+    }
+
+    if (action.xAxisLabel != undefined) {
+      const xScale = this.#chartInstance.options.scales?.x;
+      if (xScale) {
+        xScale.title = {
+          display: action.xAxisLabel.length > 0,
+          text: action.xAxisLabel,
+        };
+      }
+    }
+
     if (action.interactionEvents) {
       for (const event of action.interactionEvents) {
         this.#applyInteractionEvent(event);

--- a/packages/suite-base/src/panels/Plot/ChartRenderer.ts
+++ b/packages/suite-base/src/panels/Plot/ChartRenderer.ts
@@ -36,6 +36,7 @@ import {
 
 export class ChartRenderer {
   #chartInstance: ChartType;
+  #titleColor: string;
   #fakeNodeEvents = new EventEmitter();
   #fakeDocumentEvents = new EventEmitter();
 
@@ -49,10 +50,13 @@ export class ChartRenderer {
       },
     };
 
+    this.#titleColor = args.titleColor;
+
     const chartOptions = getChartOptions({
       devicePixelRatio: args.devicePixelRatio,
       gridColor: args.gridColor,
       tickColor: args.tickColor,
+      titleColor: args.titleColor,
     });
 
     const origZoomStart = ZoomPlugin.start?.bind(ZoomPlugin);
@@ -133,6 +137,7 @@ export class ChartRenderer {
         yScale.title = {
           display: action.yAxisLabel.length > 0,
           text: action.yAxisLabel,
+          color: this.#titleColor,
         };
       }
     }
@@ -143,6 +148,7 @@ export class ChartRenderer {
         xScale.title = {
           display: action.xAxisLabel.length > 0,
           text: action.xAxisLabel,
+          color: this.#titleColor,
         };
       }
     }

--- a/packages/suite-base/src/panels/Plot/ChartRenderer.worker.ts
+++ b/packages/suite-base/src/panels/Plot/ChartRenderer.worker.ts
@@ -30,6 +30,7 @@ type InitArgs = {
   devicePixelRatio: number;
   gridColor: string;
   tickColor: string;
+  titleColor: string;
 };
 
 export type Service<T> = {

--- a/packages/suite-base/src/panels/Plot/OffscreenCanvasRenderer.ts
+++ b/packages/suite-base/src/panels/Plot/OffscreenCanvasRenderer.ts
@@ -47,6 +47,7 @@ export class OffscreenCanvasRenderer {
           devicePixelRatio: window.devicePixelRatio,
           gridColor: this.#theme.palette.divider,
           tickColor: this.#theme.palette.text.secondary,
+          titleColor: this.#theme.palette.text.primary,
         },
         [this.#canvas],
       ),

--- a/packages/suite-base/src/panels/Plot/PlotCoordinator.test.ts
+++ b/packages/suite-base/src/panels/Plot/PlotCoordinator.test.ts
@@ -433,6 +433,38 @@ describe("PlotCoordinator", () => {
       });
     });
 
+    it("should pass xAxisLabel through to updateAction", () => {
+      const config = PlotBuilder.config({ xAxisLabel: "Time (s)", paths: [] });
+      jest.spyOn(plotCoordinator as any, "queueDispatchRender").mockImplementation(() => {});
+
+      plotCoordinator.handleConfig(config, "light", {});
+
+      expect(plotCoordinator["updateAction"].xAxisLabel).toBe("Time (s)");
+    });
+
+    it("should pass yAxisLabel through to updateAction", () => {
+      const config = PlotBuilder.config({ yAxisLabel: "Velocity", paths: [] });
+      jest.spyOn(plotCoordinator as any, "queueDispatchRender").mockImplementation(() => {});
+
+      plotCoordinator.handleConfig(config, "light", {});
+
+      expect(plotCoordinator["updateAction"].yAxisLabel).toBe("Velocity");
+    });
+
+    it("should pass undefined axis labels when not configured", () => {
+      const config = PlotBuilder.config({
+        xAxisLabel: undefined,
+        yAxisLabel: undefined,
+        paths: [],
+      });
+      jest.spyOn(plotCoordinator as any, "queueDispatchRender").mockImplementation(() => {});
+
+      plotCoordinator.handleConfig(config, "light", {});
+
+      expect(plotCoordinator["updateAction"].xAxisLabel).toBeUndefined();
+      expect(plotCoordinator["updateAction"].yAxisLabel).toBeUndefined();
+    });
+
     it("should correctly process paths and generate series", () => {
       const config = PlotBuilder.config();
       (parseMessagePath as jest.Mock).mockReturnValue(BasicBuilder.string());

--- a/packages/suite-base/src/panels/Plot/PlotCoordinator.ts
+++ b/packages/suite-base/src/panels/Plot/PlotCoordinator.ts
@@ -229,6 +229,8 @@ export class PlotCoordinator extends EventEmitter<PlotCoordinatorEventTypes> {
 
     this.updateAction.showXAxisLabels = config.showXAxisLabels;
     this.updateAction.showYAxisLabels = config.showYAxisLabels;
+    this.updateAction.xAxisLabel = config.xAxisLabel;
+    this.updateAction.yAxisLabel = config.yAxisLabel;
     this.updateAction.referenceLines = referenceLines;
 
     if (configYBoundsChanged) {

--- a/packages/suite-base/src/panels/Plot/PlotCoordinator.ts
+++ b/packages/suite-base/src/panels/Plot/PlotCoordinator.ts
@@ -507,10 +507,11 @@ export class PlotCoordinator extends EventEmitter<PlotCoordinatorEventTypes> {
   }
 
   private subscribeTopicRanges(seriesKeysByTopic: Map<string, Set<SeriesConfigKey>>): void {
-    if (!this.datasetsBuilder.handleMessageRange) {
+    const handleMessageRange = this.datasetsBuilder.handleMessageRange?.bind(this.datasetsBuilder);
+
+    if (!handleMessageRange) {
       return;
     }
-    const builder = this.datasetsBuilder;
 
     // Cancel subscriptions for topics that are no longer needed
     for (const topic of this.rangeSubscriptionCancels.keys()) {
@@ -541,7 +542,7 @@ export class PlotCoordinator extends EventEmitter<PlotCoordinatorEventTypes> {
             if (!startTime) {
               continue;
             }
-            builder.handleMessageRange!(batch, { isReset }, startTime);
+            handleMessageRange(batch, { isReset }, startTime);
             isReset = false;
             this.queueDispatchDownsample();
           }

--- a/packages/suite-base/src/panels/Plot/constants.ts
+++ b/packages/suite-base/src/panels/Plot/constants.ts
@@ -48,6 +48,8 @@ export const DEFAULT_PLOT_CONFIG: PlotConfig = {
   isSynced: true,
   xAxisVal: "timestamp",
   sidebarDimension: DEFAULT_SIDEBAR_DIMENSION,
+  xAxisLabel: undefined,
+  yAxisLabel: undefined,
 };
 
 export const DEFAULT_PLOT_PATH: PlotPath = Object.freeze({

--- a/packages/suite-base/src/panels/Plot/types.ts
+++ b/packages/suite-base/src/panels/Plot/types.ts
@@ -75,6 +75,8 @@ export type UpdateAction = {
   size?: { width: number; height: number };
   showXAxisLabels?: boolean;
   showYAxisLabels?: boolean;
+  xAxisLabel?: string;
+  yAxisLabel?: string;
   xBounds?: Partial<Bounds1D>;
   yBounds?: Partial<Bounds1D>;
   zoomMode?: "x" | "y" | "xy";

--- a/packages/suite-base/src/panels/Plot/types.ts
+++ b/packages/suite-base/src/panels/Plot/types.ts
@@ -149,6 +149,7 @@ export type ChartRendererProps = {
   devicePixelRatio: number;
   gridColor: string;
   tickColor: string;
+  titleColor: string;
 };
 
 export type ChartOptionsPlot = Omit<ChartRendererProps, "canvas">;

--- a/packages/suite-base/src/panels/Plot/utils/buildSettingsTree.test.ts
+++ b/packages/suite-base/src/panels/Plot/utils/buildSettingsTree.test.ts
@@ -14,6 +14,7 @@ import { buildSettingsTree } from "./buildSettingsTree";
 
 describe("buildSettingsTree", () => {
   const t: TFunction<"plot"> = jest.fn((key) => key) as unknown as TFunction<"plot">;
+  const axisLabel = BasicBuilder.string();
 
   beforeEach(() => {});
 
@@ -125,14 +126,14 @@ describe("buildSettingsTree", () => {
   });
 
   it("should include xAxisLabel field with provided value", () => {
-    const config: PlotConfig = PlotBuilder.config({ xAxisLabel: "Time (s)", paths: [] });
+    const config: PlotConfig = PlotBuilder.config({ xAxisLabel: axisLabel, paths: [] });
 
     const tree = buildSettingsTree(config, t);
 
     expect(tree.xAxis?.fields?.xAxisLabel).toEqual({
       label: "axisLabel",
       input: "string",
-      value: "Time (s)",
+      value: axisLabel,
     });
   });
 
@@ -149,14 +150,14 @@ describe("buildSettingsTree", () => {
   });
 
   it("should include yAxisLabel field with provided value", () => {
-    const config: PlotConfig = PlotBuilder.config({ yAxisLabel: "Velocity", paths: [] });
+    const config: PlotConfig = PlotBuilder.config({ yAxisLabel: axisLabel, paths: [] });
 
     const tree = buildSettingsTree(config, t);
 
     expect(tree.yAxis?.fields?.yAxisLabel).toEqual({
       label: "axisLabel",
       input: "string",
-      value: "Velocity",
+      value: axisLabel,
     });
   });
 

--- a/packages/suite-base/src/panels/Plot/utils/buildSettingsTree.test.ts
+++ b/packages/suite-base/src/panels/Plot/utils/buildSettingsTree.test.ts
@@ -124,6 +124,54 @@ describe("buildSettingsTree", () => {
     expect(tree.xAxis?.fields?.maxXValue?.error).toBe("maxXError");
   });
 
+  it("should include xAxisLabel field with provided value", () => {
+    const config: PlotConfig = PlotBuilder.config({ xAxisLabel: "Time (s)", paths: [] });
+
+    const tree = buildSettingsTree(config, t);
+
+    expect(tree.xAxis?.fields?.xAxisLabel).toEqual({
+      label: "axisLabel",
+      input: "string",
+      value: "Time (s)",
+    });
+  });
+
+  it("should include xAxisLabel field with undefined value when not set", () => {
+    const config: PlotConfig = PlotBuilder.config({ xAxisLabel: undefined, paths: [] });
+
+    const tree = buildSettingsTree(config, t);
+
+    expect(tree.xAxis?.fields?.xAxisLabel).toEqual({
+      label: "axisLabel",
+      input: "string",
+      value: undefined,
+    });
+  });
+
+  it("should include yAxisLabel field with provided value", () => {
+    const config: PlotConfig = PlotBuilder.config({ yAxisLabel: "Velocity", paths: [] });
+
+    const tree = buildSettingsTree(config, t);
+
+    expect(tree.yAxis?.fields?.yAxisLabel).toEqual({
+      label: "axisLabel",
+      input: "string",
+      value: "Velocity",
+    });
+  });
+
+  it("should include yAxisLabel field with undefined value when not set", () => {
+    const config: PlotConfig = PlotBuilder.config({ yAxisLabel: undefined, paths: [] });
+
+    const tree = buildSettingsTree(config, t);
+
+    expect(tree.yAxis?.fields?.yAxisLabel).toEqual({
+      label: "axisLabel",
+      input: "string",
+      value: undefined,
+    });
+  });
+
   describe("makeSeriesNode - reorderable and icon properties", () => {
     it("should set reorderable to true and icon to DragHandle when canReorder is true", () => {
       // Given: A config with multiple paths where nodes should be reorderable

--- a/packages/suite-base/src/panels/Plot/utils/buildSettingsTree.ts
+++ b/packages/suite-base/src/panels/Plot/utils/buildSettingsTree.ts
@@ -188,6 +188,11 @@ export function buildSettingsTree(config: PlotConfig, t: TFunction<"plot">): Set
       label: t("xAxis"),
       defaultExpansionState: "collapsed",
       fields: {
+        xAxisLabel: {
+          label: t("axisLabel"),
+          input: "string",
+          value: config.xAxisLabel,
+        },
         xAxisVal: {
           label: t("value"),
           input: "select",
@@ -208,11 +213,7 @@ export function buildSettingsTree(config: PlotConfig, t: TFunction<"plot">): Set
                 validTypes: PLOTABLE_ROS_TYPES,
               }
             : undefined,
-        xAxisLabel: {
-          label: t("axisLabel"),
-          input: "string",
-          value: config.xAxisLabel,
-        },
+
         showXAxisLabels: {
           label: t("showLabels"),
           input: "boolean",

--- a/packages/suite-base/src/panels/Plot/utils/buildSettingsTree.ts
+++ b/packages/suite-base/src/panels/Plot/utils/buildSettingsTree.ts
@@ -159,6 +159,11 @@ export function buildSettingsTree(config: PlotConfig, t: TFunction<"plot">): Set
       label: t("yAxis"),
       defaultExpansionState: "collapsed",
       fields: {
+        yAxisLabel: {
+          label: t("axisLabel"),
+          input: "string",
+          value: config.yAxisLabel,
+        },
         showYAxisLabels: {
           label: t("showLabels"),
           input: "boolean",
@@ -203,6 +208,11 @@ export function buildSettingsTree(config: PlotConfig, t: TFunction<"plot">): Set
                 validTypes: PLOTABLE_ROS_TYPES,
               }
             : undefined,
+        xAxisLabel: {
+          label: t("axisLabel"),
+          input: "string",
+          value: config.xAxisLabel,
+        },
         showXAxisLabels: {
           label: t("showLabels"),
           input: "boolean",

--- a/packages/suite-base/src/panels/Plot/utils/config.ts
+++ b/packages/suite-base/src/panels/Plot/utils/config.ts
@@ -91,6 +91,8 @@ export type PlotConfig = DeprecatedPlotConfig & {
   isSynced: boolean;
   xAxisVal: PlotXAxisVal;
   xAxisPath?: BasePlotPath;
+  xAxisLabel?: string;
+  yAxisLabel?: string;
   followingViewWidth?: number;
   sidebarDimension: number;
   [PANEL_TITLE_CONFIG_KEY]?: string;

--- a/packages/suite-base/src/panels/Plot/utils/getChartOptions.test.ts
+++ b/packages/suite-base/src/panels/Plot/utils/getChartOptions.test.ts
@@ -11,12 +11,14 @@ describe("getChartOptions", () => {
   const mockDevicePixelRatio = 2;
   const mockGridColor = "#cccccc";
   const mockTickColor = "#666666";
+  const mockTitleColor = "#333333";
 
   it("should return correct ChartOptions for scatter chart", () => {
     const options = getChartOptions({
       devicePixelRatio: mockDevicePixelRatio,
       gridColor: mockGridColor,
       tickColor: mockTickColor,
+      titleColor: mockTitleColor,
     });
 
     expect(options).toEqual<ChartOptions<"scatter">>({
@@ -97,6 +99,7 @@ describe("getChartOptions", () => {
       devicePixelRatio,
       gridColor: mockGridColor,
       tickColor: mockTickColor,
+      titleColor: mockTitleColor,
     });
 
     expect(options.devicePixelRatio).toBe(devicePixelRatio);
@@ -109,6 +112,7 @@ describe("getChartOptions", () => {
       devicePixelRatio: mockDevicePixelRatio,
       gridColor,
       tickColor,
+      titleColor: mockTitleColor,
     });
 
     expect(options.scales?.x?.grid?.color).toBe(gridColor);
@@ -122,6 +126,7 @@ describe("getChartOptions", () => {
       devicePixelRatio: mockDevicePixelRatio,
       gridColor: mockGridColor,
       tickColor: mockTickColor,
+      titleColor: mockTitleColor,
     });
 
     expect(options.plugins?.decimation?.enabled).toBe(false);

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.test.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.test.ts
@@ -36,6 +36,19 @@ describe("useChartScalesAndBounds", () => {
     expect(result.current.xScale).toEqual({
       type: "linear",
       border: { display: false },
+      title: { display: false, text: undefined },
+    });
+  });
+
+  it("should return xScale with title when xAxisLabel is set", () => {
+    const customConfig = { ...config, xAxisLabel: "Time (s)" };
+    const { result } = renderHook(() =>
+      useChartScalesAndBounds(undefined, undefined, undefined, customConfig),
+    );
+    expect(result.current.xScale).toEqual({
+      type: "linear",
+      border: { display: false },
+      title: { display: true, text: "Time (s)" },
     });
   });
 

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.ts
@@ -43,8 +43,12 @@ const useChartScalesAndBounds = (
       border: {
         display: false,
       },
+      title: {
+        display: (config.xAxisLabel ?? "").length > 0,
+        text: config.xAxisLabel,
+      },
     };
-  }, []);
+  }, [config.xAxisLabel]);
 
   // Compute the fixed bounds (either via min/max x-axis config or end time since start).
   //

--- a/packages/suite-base/src/panels/StateTransitions/hooks/usePanelSettings.test.tsx
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/usePanelSettings.test.tsx
@@ -295,7 +295,7 @@ describe("buildSettingsTree", () => {
   });
 
   it("should include xAxisLabel field with provided value", () => {
-    const label = "My Custom Label";
+    const label = BasicBuilder.string();
     const { paths, config } = setup({ config: { xAxisLabel: label } });
 
     const { xAxis } = buildSettingsTree(

--- a/packages/suite-base/src/panels/StateTransitions/hooks/usePanelSettings.test.tsx
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/usePanelSettings.test.tsx
@@ -228,6 +228,7 @@ describe("buildSettingsTree", () => {
       xAxisMaxValue: BasicBuilder.number({ min: 50, max: 100 }),
       xAxisMinValue: BasicBuilder.number({ min: 0, max: 49 }),
       xAxisRange: BasicBuilder.number(),
+      xAxisLabel: BasicBuilder.string(),
       ...config,
     };
 
@@ -262,6 +263,11 @@ describe("buildSettingsTree", () => {
     // X axis settings
     expect(xAxis).toBeDefined();
     expect(xAxis!.label).toEqual("xAxis");
+    expect(xAxis!.fields!.xAxisLabel).toEqual({
+      label: "labels.axisLabel",
+      input: "string",
+      value: config.xAxisLabel,
+    });
     expect(xAxis!.fields!.xAxisMaxValue!.label).toEqual("max");
     expect(xAxis!.fields!.xAxisMaxValue!.value).toEqual(config.xAxisMaxValue);
     expect(xAxis!.fields!.xAxisMinValue!.label).toEqual("min");
@@ -286,6 +292,39 @@ describe("buildSettingsTree", () => {
     );
 
     expect(xAxis!.fields!.xAxisMaxValue!.error).toEqual("maxXError");
+  });
+
+  it("should include xAxisLabel field with provided value", () => {
+    const label = "My Custom Label";
+    const { paths, config } = setup({ config: { xAxisLabel: label } });
+
+    const { xAxis } = buildSettingsTree(
+      config as StateTransitionConfig,
+      paths,
+      t as unknown as TFunction<"stateTransitions">,
+    );
+
+    expect(xAxis!.fields!.xAxisLabel).toEqual({
+      label: "labels.axisLabel",
+      input: "string",
+      value: label,
+    });
+  });
+
+  it("should include xAxisLabel field with undefined value when not set", () => {
+    const { paths, config } = setup({ config: { xAxisLabel: undefined } });
+
+    const { xAxis } = buildSettingsTree(
+      config as StateTransitionConfig,
+      paths,
+      t as unknown as TFunction<"stateTransitions">,
+    );
+
+    expect(xAxis!.fields!.xAxisLabel).toEqual({
+      label: "labels.axisLabel",
+      input: "string",
+      value: undefined,
+    });
   });
 });
 

--- a/packages/suite-base/src/panels/StateTransitions/hooks/usePanelSettings.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/usePanelSettings.ts
@@ -148,7 +148,14 @@ export const makeRootSeriesNode = memoizeWeak(
 );
 
 export function buildSettingsTree(
-  { isSynced, xAxisMaxValue, xAxisMinValue, xAxisRange, showPoints }: StateTransitionConfig,
+  {
+    isSynced,
+    xAxisMaxValue,
+    xAxisMinValue,
+    xAxisRange,
+    xAxisLabel,
+    showPoints,
+  }: StateTransitionConfig,
   paths: PathState[],
   t: TFunction<"stateTransitions">,
 ): SettingsTreeNodes {
@@ -183,6 +190,11 @@ export function buildSettingsTree(
     xAxis: {
       label: t("xAxis"),
       fields: {
+        xAxisLabel: {
+          label: t("labels.axisLabel"),
+          input: "string",
+          value: xAxisLabel,
+        },
         xAxisMaxValue: setAxis({ label: t("max"), value: xAxisMaxValue, error: maxXError }),
         xAxisMinValue: setAxis({ label: t("min"), value: xAxisMinValue }),
         xAxisRange: setAxis({ label: t("secondsRange"), value: xAxisRange }),

--- a/packages/suite-base/src/panels/StateTransitions/types.ts
+++ b/packages/suite-base/src/panels/StateTransitions/types.ts
@@ -25,6 +25,7 @@ export type StateTransitionConfig = {
   xAxisMaxValue?: number;
   xAxisMinValue?: number;
   xAxisRange?: number;
+  xAxisLabel?: string;
   showPoints?: boolean;
 };
 


### PR DESCRIPTION
## User-Facing Changes

Add axis labels to both plot and state transition panels, enhancing the clarity of data representation.

## Description

This update introduces axis labels for plots and state transitions, improving user experience by providing clearer context for the displayed data.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

