### PR TITLE
fix: State Transition Panel detects settings

### DIFF
--- a/packages/suite-base/src/panels/StateTransitions/hooks/constants.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/constants.ts
@@ -3,3 +3,4 @@
 
 export const ROW_SPACING = 9;
 export const ROW_MARGIN = ROW_SPACING / 4;
+export const DEFAULT_X_END_TIME = 1;

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.test.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.test.ts
@@ -71,11 +71,14 @@ describe("useChartScalesAndBounds", () => {
     });
   });
 
-  it("should return undefined databounds when endTimeSinceStart is undefined", () => {
+  it("should default to safe databounds when endTimeSinceStart is undefined", () => {
     const { result } = renderHook(() =>
       useChartScalesAndBounds(undefined, undefined, undefined, config),
     );
-    expect(result.current.databounds).toBeUndefined();
+    expect(result.current.databounds).toEqual({
+      x: { min: 0, max: 1 },
+      y: { min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+    });
   });
 
   it("should return correct width and sizeRef", () => {

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.test.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.test.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { renderHook } from "@testing-library/react";
+
 import { DEFAULT_X_END_TIME } from "@lichtblick/suite-base/panels/StateTransitions/hooks/constants";
 import { StateTransitionConfig } from "@lichtblick/suite-base/panels/StateTransitions/types";
 

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.test.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.test.ts
@@ -8,6 +8,7 @@ import { renderHook } from "@testing-library/react";
 import { StateTransitionConfig } from "@lichtblick/suite-base/panels/StateTransitions/types";
 
 import useChartScalesAndBounds from "./useChartScalesAndBounds";
+import { DEFAULT_X_END_TIME } from "@lichtblick/suite-base/panels/StateTransitions/hooks/constants";
 
 describe("useChartScalesAndBounds", () => {
   const config: StateTransitionConfig = {
@@ -76,7 +77,7 @@ describe("useChartScalesAndBounds", () => {
       useChartScalesAndBounds(undefined, undefined, undefined, config),
     );
     expect(result.current.databounds).toEqual({
-      x: { min: 0, max: 1 },
+      x: { min: 0, max: DEFAULT_X_END_TIME },
       y: { min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
     });
   });

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.test.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.test.ts
@@ -4,11 +4,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { renderHook } from "@testing-library/react";
-
+import { DEFAULT_X_END_TIME } from "@lichtblick/suite-base/panels/StateTransitions/hooks/constants";
 import { StateTransitionConfig } from "@lichtblick/suite-base/panels/StateTransitions/types";
 
 import useChartScalesAndBounds from "./useChartScalesAndBounds";
-import { DEFAULT_X_END_TIME } from "@lichtblick/suite-base/panels/StateTransitions/hooks/constants";
 
 describe("useChartScalesAndBounds", () => {
   const config: StateTransitionConfig = {

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.test.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.test.ts
@@ -62,6 +62,28 @@ describe("useChartScalesAndBounds", () => {
     });
   });
 
+  it("should return correct databounds when only xAxisMinValue is defined", () => {
+    const customConfig = { ...config, xAxisMinValue: 50 };
+    const { result } = renderHook(() =>
+      useChartScalesAndBounds(undefined, undefined, 1000, customConfig),
+    );
+    expect(result.current.databounds).toEqual({
+      x: { min: 50, max: 1000 },
+      y: { min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+    });
+  });
+
+  it("should return correct databounds when only xAxisMaxValue is defined", () => {
+    const customConfig = { ...config, xAxisMaxValue: 500 };
+    const { result } = renderHook(() =>
+      useChartScalesAndBounds(undefined, undefined, 1000, customConfig),
+    );
+    expect(result.current.databounds).toEqual({
+      x: { min: 0, max: 500 },
+      y: { min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+    });
+  });
+
   it("should return correct databounds when endTimeSinceStart is defined", () => {
     const { result } = renderHook(() =>
       useChartScalesAndBounds(undefined, undefined, 1000, config),

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.ts
@@ -56,15 +56,13 @@ const useChartScalesAndBounds = (
   // below, otherwise playing through a recording will update the currentTimeSince start and return
   // a new fixedBounds reference which causes expensive downstream rendering.
   const fixedBounds = useMemo(() => {
-    if (endTimeSinceStart == undefined) {
-      return undefined;
-    }
+    const defaultMax = endTimeSinceStart ?? 1;
 
     if (config.xAxisMinValue != undefined || config.xAxisMaxValue != undefined) {
       return {
         x: {
           min: config.xAxisMinValue ?? 0,
-          max: config.xAxisMaxValue ?? endTimeSinceStart,
+          max: config.xAxisMaxValue ?? defaultMax,
         },
         y: { min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
       };
@@ -75,7 +73,7 @@ const useChartScalesAndBounds = (
     // than constantly adjusting the end time to the latest loaded state transition while data
     // is loading.
     return {
-      x: { min: 0, max: endTimeSinceStart },
+      x: { min: 0, max: defaultMax },
       y: { min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
     };
   }, [config.xAxisMaxValue, config.xAxisMinValue, endTimeSinceStart]);

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.ts
@@ -5,9 +5,9 @@ import { ScaleOptions } from "chart.js";
 import { RefCallback, useEffect, useMemo } from "react";
 import { useResizeDetector } from "react-resize-detector";
 
+import { DEFAULT_X_END_TIME } from "@lichtblick/suite-base/panels/StateTransitions/hooks/constants";
 import { StateTransitionConfig } from "@lichtblick/suite-base/panels/StateTransitions/types";
 import { Bounds } from "@lichtblick/suite-base/types/Bounds";
-import { DEFAULT_X_END_TIME } from "@lichtblick/suite-base/panels/StateTransitions/hooks/constants";
 
 type UseChartScalesAndBounds = {
   yScale: ScaleOptions<"linear">;

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useChartScalesAndBounds.ts
@@ -7,6 +7,7 @@ import { useResizeDetector } from "react-resize-detector";
 
 import { StateTransitionConfig } from "@lichtblick/suite-base/panels/StateTransitions/types";
 import { Bounds } from "@lichtblick/suite-base/types/Bounds";
+import { DEFAULT_X_END_TIME } from "@lichtblick/suite-base/panels/StateTransitions/hooks/constants";
 
 type UseChartScalesAndBounds = {
   yScale: ScaleOptions<"linear">;
@@ -56,13 +57,13 @@ const useChartScalesAndBounds = (
   // below, otherwise playing through a recording will update the currentTimeSince start and return
   // a new fixedBounds reference which causes expensive downstream rendering.
   const fixedBounds = useMemo(() => {
-    const defaultMax = endTimeSinceStart ?? 1;
+    const xDefaultMax = endTimeSinceStart ?? DEFAULT_X_END_TIME;
 
     if (config.xAxisMinValue != undefined || config.xAxisMaxValue != undefined) {
       return {
         x: {
           min: config.xAxisMinValue ?? 0,
-          max: config.xAxisMaxValue ?? defaultMax,
+          max: config.xAxisMaxValue ?? xDefaultMax,
         },
         y: { min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
       };
@@ -73,7 +74,7 @@ const useChartScalesAndBounds = (
     // than constantly adjusting the end time to the latest loaded state transition while data
     // is loading.
     return {
-      x: { min: 0, max: defaultMax },
+      x: { min: 0, max: xDefaultMax },
       y: { min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
     };
   }, [config.xAxisMaxValue, config.xAxisMinValue, endTimeSinceStart]);


### PR DESCRIPTION
## User-Facing Changes
State Transition Panel X Axis changes now trigger a re-render even when there's no data source.

## Description
This update stabilizes the `fixedBounds` while introducing a `defaultMax` value to ensure rendering is possible even when `endTimeSinceStart` is undefined. Unit tests have been adjusted accordingly.

## Checklist

- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated