### PR TITLE
fix: update VSCode eslint.options 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,11 @@
   // enable intellisense in custom snippets (see snippets.code-snippets)
   "editor.suggest.snippetsPreventQuickSuggestions": false,
   "eslint.options": {
-    "reportUnusedDisableDirectives": "error"
+    "overrideConfig": {
+      "linterOptions": {
+        "reportUnusedDisableDirectives": "error"
+      }
+    }
   },
   "files.eol": "\n",
   "files.insertFinalNewline": true,


### PR DESCRIPTION
## User-Facing Changes
N/A

## Description
Updated the `eslint.options` to use the new `overrideConfig` structure for compatibility with ESLint 9. This was causing eslint server to fail locally (in VSCode).

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated