### PR TITLE
Fix 2 bugs on sonar workflow

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -62,7 +62,7 @@ jobs:
   external-fork-scan:
     name: External fork scan
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.pull_request.labels.name == 'quality-check' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     permissions:
       actions: read
       checks: write
@@ -149,6 +149,19 @@ jobs:
     needs: [internal-scan, external-fork-scan]
     steps:
       - run: |
-          if [[ "${{ needs.internal-scan.result }}" == "failure" || "${{ needs.external-fork-scan.result }}" == "failure" ]]; then
+          INTERNAL="${{ needs.internal-scan.result }}"
+          EXTERNAL="${{ needs.external-fork-scan.result }}"
+
+          # Fail if any scan failed
+          if [[ "$INTERNAL" == "failure" || "$EXTERNAL" == "failure" ]]; then
+            echo "::error::A Sonar scan failed (internal=$INTERNAL, external=$EXTERNAL)"
             exit 1
           fi
+
+          # Fail if both were skipped (no scan ran at all)
+          if [[ "$INTERNAL" == "skipped" && "$EXTERNAL" == "skipped" ]]; then
+            echo "::error::No Sonar scan ran (both jobs skipped)"
+            exit 1
+          fi
+
+          echo "Sonar scan completed (internal=$INTERNAL, external=$EXTERNAL)"


### PR DESCRIPTION
## User-Facing Changes

N/A

## Description

- Removed the broken label check on `github.event.pull_request`, so that condition always failed. 

- Result check now fails when both scans are skipped, previously "skipped" wasn't treated as a problem, so the check passed vacuously on fork PRs where neither scan actually ran.

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
