### PR TITLE
bump webpack-dev-server version

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -20,6 +20,6 @@
     "react": "18.3.1",
     "react-dom": "18.2.0",
     "webpack": "5.106.2",
-    "webpack-dev-server": "5.2.3"
+    "webpack-dev-server": "5.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "typescript": "5.9.3",
     "webpack": "5.106.2",
     "webpack-cli": "7.0.2",
-    "webpack-dev-server": "5.2.3",
+    "webpack-dev-server": "5.2.4",
     "webpack-hot-middleware": "2.26.0"
   },
   "dependencies": {

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -53,6 +53,6 @@
     "tss-react": "4.9.19",
     "utif": "3.1.0",
     "webpack": "5.106.2",
-    "webpack-dev-server": "5.2.3"
+    "webpack-dev-server": "5.2.4"
   }
 }

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -21,6 +21,6 @@
     "react-dom": "18.3.1",
     "tss-react": "4.9.19",
     "webpack": "5.106.2",
-    "webpack-dev-server": "5.2.3"
+    "webpack-dev-server": "5.2.4"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,6 @@
     "playwright": "1.55.1",
     "serve-handler": "6.1.7",
     "webpack": "5.106.2",
-    "webpack-dev-server": "5.2.3"
+    "webpack-dev-server": "5.2.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3670,7 +3670,7 @@ __metadata:
     tss-react: 4.9.19
     utif: 3.1.0
     webpack: 5.106.2
-    webpack-dev-server: 5.2.3
+    webpack-dev-server: 5.2.4
   languageName: unknown
   linkType: soft
 
@@ -3693,7 +3693,7 @@ __metadata:
     react-dom: 18.3.1
     tss-react: 4.9.19
     webpack: 5.106.2
-    webpack-dev-server: 5.2.3
+    webpack-dev-server: 5.2.4
   languageName: unknown
   linkType: soft
 
@@ -8048,7 +8048,7 @@ __metadata:
     react: 18.3.1
     react-dom: 18.2.0
     webpack: 5.106.2
-    webpack-dev-server: 5.2.3
+    webpack-dev-server: 5.2.4
   languageName: unknown
   linkType: soft
 
@@ -15092,7 +15092,7 @@ __metadata:
     vm-browserify: 1.1.2
     webpack: 5.106.2
     webpack-cli: 7.0.2
-    webpack-dev-server: 5.2.3
+    webpack-dev-server: 5.2.4
     webpack-hot-middleware: 2.26.0
   languageName: unknown
   linkType: soft
@@ -21471,7 +21471,7 @@ __metadata:
     playwright: 1.55.1
     serve-handler: 6.1.7
     webpack: 5.106.2
-    webpack-dev-server: 5.2.3
+    webpack-dev-server: 5.2.4
   languageName: unknown
   linkType: soft
 
@@ -21561,9 +21561,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:5.2.3":
-  version: 5.2.3
-  resolution: "webpack-dev-server@npm:5.2.3"
+"webpack-dev-server@npm:5.2.4":
+  version: 5.2.4
+  resolution: "webpack-dev-server@npm:5.2.4"
   dependencies:
     "@types/bonjour": ^3.5.13
     "@types/connect-history-api-fallback": ^1.5.4
@@ -21602,7 +21602,7 @@ __metadata:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 2b7f2096529945f578e86966d9a0994b0a87b82e3bb3a7cd1ccea2fb81aa95724473a88c9b2033ae3d2f799d13330342948ea77638029d10c8c0c746aac545f7
+  checksum: 4e1b13dc170b9964e579e5703dd56e97c2fbb6b101586cfda56f58f1ea0327ea9fcb9e4f36ff6264ee02ab69298697df87bd9617716d9c8379d2a6dc22bb103f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## User-Facing Changes


bump webpack-dev-server version to fix vulnerability

## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
