### PR TITLE
Code improvement - Create POM models to comply with ADR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ test-results/*
 .sonar_lock
 .scannerwork
 eslint-report.json
-blob-report/*
+blob-report/

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ test-results/*
 .sonar_lock
 .scannerwork
 eslint-report.json
+blob-report/*

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -96,17 +96,26 @@ install-multiple-extensions.web.spec.ts;
   │   │   ├── extension/             # Tests for extension
   │   │   ├── panel/                 # Tests for panels
   │   │   ├── utils/                 # Shared functions
-  │   │   ├── desktop-setup.ts       # Pré script to setup desktop tests
-  │   │   ├── desktop-teardown.ts    # Pré script to cleanup desktop tests
+  │   │   ├── desktop-setup.ts       # Pre-script to setup desktop tests
+  │   │   ├── desktop-teardown.ts    # Pre-script to cleanup desktop tests
   │   │   └── playwright.config.ts   # Desktop Playwright configuration
   │   └── web/                       # Web e2e tests
   │       ├── open-files/            # Tests for open files via URL
   │       │   ├── open-mcap-via-url.web.spec.ts
   │       │   └── ...web.spec.ts
   │       ├── utils/                 # Shared functions
-  │       ├── web-setup.ts           # Pré script to setup web tests
-  │       ├── web-teardown.ts        # Pré script to cleanup web tests
+  │       ├── web-setup.ts           # Pre-script to setup web tests
+  │       ├── web-teardown.ts        # Pre-script to cleanup web tests
   │       └── playwright.config.ts   # Web Playwright configuration
+  ├── page-objects/                   # Page Object Models for UI abstraction
+  │   ├── data-source-dialog.ts      # DataSourceDialog interactions
+  │   ├── sidebar.ts                 # Left/right sidebar navigation
+  │   ├── player-controls.ts         # Playback controls (play, pause, seek)
+  │   ├── layout-manager.ts          # Layout creation and management
+  │   ├── extension-manager.ts       # Extension install/uninstall workflows
+  │   ├── app-menu.ts                # Application menu (File, View)
+  │   ├── panels.ts                  # Panel add/configure operations
+  │   └── index.ts                   # Barrel export
   ├── fixtures/                      # Fixtures for testing (e.g. data mocks)
   ├── helpers/                       # Generic functions useful for testing
   ├── reports/                       # Automatically generated test reports
@@ -116,4 +125,4 @@ install-multiple-extensions.web.spec.ts;
 
 ---
 
-> For questions or improvements, contact the QA team or refer to the [Playwright docs](https://playwright.dev/docs/intro).
+> For questions or improvements, contact the Lichtblick team or refer to the [Playwright docs](https://playwright.dev/docs/intro).

--- a/e2e/page-objects/app-menu.ts
+++ b/e2e/page-objects/app-menu.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { Locator, Page } from "playwright";
+
+export class AppMenu {
+  public constructor(private readonly page: Page) {}
+
+  public async openFileMenu(): Promise<void> {
+    await this.page.getByTestId("AppMenuButton").click();
+    await this.page.getByTestId("app-menu-file").click();
+  }
+
+  public async openViewMenu(): Promise<void> {
+    await this.page.getByTestId("AppMenuButton").click();
+    await this.page.getByTestId("app-menu-view").click();
+  }
+
+  public async openFile(): Promise<void> {
+    await this.openFileMenu();
+    await this.page.getByTestId("menu-item-open").click();
+  }
+
+  public async importLayoutFromMenu(): Promise<void> {
+    await this.openViewMenu();
+    await this.page.getByText("Import layout from file…").click();
+  }
+
+  public async openDataSource(): Promise<void> {
+    await this.openFileMenu();
+    await this.page.getByText("Open data source").click();
+  }
+
+  public async openConnection(): Promise<void> {
+    await this.openFileMenu();
+    await this.page.getByText("Open connection").click();
+  }
+
+  public getMenuButton(): Locator {
+    return this.page.getByTestId("AppMenuButton");
+  }
+}

--- a/e2e/page-objects/data-source-dialog.ts
+++ b/e2e/page-objects/data-source-dialog.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { Locator, Page } from "playwright";
+
+export class DataSourceDialog {
+  private readonly dialog: Locator;
+
+  public constructor(private readonly page: Page) {
+    this.dialog = page.getByTestId("DataSourceDialog");
+  }
+
+  public async close(): Promise<void> {
+    await this.dialog.getByTestId("CloseIcon").click();
+  }
+
+  public async isVisible(): Promise<boolean> {
+    return await this.dialog.isVisible();
+  }
+
+  public async openConnection(): Promise<void> {
+    await this.dialog.getByText("Open connection").click();
+  }
+
+  public getLocator(): Locator {
+    return this.dialog;
+  }
+}

--- a/e2e/page-objects/extension-manager.ts
+++ b/e2e/page-objects/extension-manager.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { Locator, Page } from "playwright";
+
+export class ExtensionManager {
+  public constructor(private readonly page: Page) {}
+
+  public async open(): Promise<void> {
+    await this.page.getByTestId("PersonIcon").click();
+    await this.page.getByRole("menuitem", { name: "Extensions" }).click();
+  }
+
+  public async search(query: string): Promise<void> {
+    await this.page.getByPlaceholder("Search Extensions...").fill(query);
+  }
+
+  public findExtension(name: string, version?: string): Locator {
+    let entry = this.page
+      .locator('[data-testid="extension-list-entry"]')
+      .filter({ hasText: name });
+
+    if (version) {
+      entry = entry.filter({ hasText: version });
+    }
+
+    return entry;
+  }
+
+  public async selectExtension(name: string, version?: string): Promise<void> {
+    await this.findExtension(name, version).click();
+  }
+
+  public async uninstall(): Promise<void> {
+    await this.page.getByText("Uninstall").click();
+  }
+
+  public getSearchBar(): Locator {
+    return this.page.getByPlaceholder("Search Extensions...");
+  }
+}

--- a/e2e/page-objects/extension-manager.ts
+++ b/e2e/page-objects/extension-manager.ts
@@ -16,9 +16,7 @@ export class ExtensionManager {
   }
 
   public findExtension(name: string, version?: string): Locator {
-    let entry = this.page
-      .locator('[data-testid="extension-list-entry"]')
-      .filter({ hasText: name });
+    let entry = this.page.locator('[data-testid="extension-list-entry"]').filter({ hasText: name });
 
     if (version) {
       entry = entry.filter({ hasText: version });

--- a/e2e/page-objects/index.ts
+++ b/e2e/page-objects/index.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+export { AppMenu } from "./app-menu";
+export { DataSourceDialog } from "./data-source-dialog";
+export { ExtensionManager } from "./extension-manager";
+export { LayoutManager } from "./layout-manager";
+export { Panels } from "./panels";
+export { PlayerControls } from "./player-controls";
+export { Sidebar } from "./sidebar";

--- a/e2e/page-objects/layout-manager.ts
+++ b/e2e/page-objects/layout-manager.ts
@@ -7,10 +7,7 @@ export class LayoutManager {
   public constructor(private readonly page: Page) {}
 
   public async openDefaultLayout(): Promise<void> {
-    await this.page
-      .getByTestId("layout-list-item")
-      .getByText("Default", { exact: true })
-      .click();
+    await this.page.getByTestId("layout-list-item").getByText("Default", { exact: true }).click();
   }
 
   public async createNewLayout(): Promise<void> {
@@ -18,10 +15,7 @@ export class LayoutManager {
   }
 
   public async selectLayout(name: string): Promise<void> {
-    await this.page
-      .getByTestId("layout-list-item")
-      .getByText(name, { exact: true })
-      .click();
+    await this.page.getByTestId("layout-list-item").getByText(name, { exact: true }).click();
   }
 
   public async selectPanel(panelName: string): Promise<void> {

--- a/e2e/page-objects/layout-manager.ts
+++ b/e2e/page-objects/layout-manager.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { Locator, Page } from "playwright";
+
+export class LayoutManager {
+  public constructor(private readonly page: Page) {}
+
+  public async openDefaultLayout(): Promise<void> {
+    await this.page
+      .getByTestId("layout-list-item")
+      .getByText("Default", { exact: true })
+      .click();
+  }
+
+  public async createNewLayout(): Promise<void> {
+    await this.page.getByText("Create new layout").click();
+  }
+
+  public async selectLayout(name: string): Promise<void> {
+    await this.page
+      .getByTestId("layout-list-item")
+      .getByText(name, { exact: true })
+      .click();
+  }
+
+  public async selectPanel(panelName: string): Promise<void> {
+    await this.page.getByTestId(`panel-grid-card ${panelName}`).click();
+  }
+
+  public async importLayout(): Promise<void> {
+    await this.page.getByRole("button", { name: "Import from file…" }).click();
+  }
+
+  public async revertLayout(): Promise<void> {
+    await this.page.getByTestId("unsaved-changes-icon").click();
+    await this.page.getByRole("menuitem", { name: "Revert" }).click();
+  }
+
+  public async addTab(): Promise<void> {
+    await this.page.getByTestId("add-tab").click();
+  }
+
+  public getLayoutListItem(): Locator {
+    return this.page.getByTestId("layout-list-item");
+  }
+
+  public getCreateNewLayoutButton(): Locator {
+    return this.page.getByTestId("create-new-layout");
+  }
+}

--- a/e2e/page-objects/panels.ts
+++ b/e2e/page-objects/panels.ts
@@ -11,12 +11,6 @@ export class Panels {
     await this.page.getByTestId(`panel-menu-item ${panelName}`).click();
   }
 
-  public async addPanelFromSearch(panelName: string): Promise<void> {
-    await this.page.getByTestId("AddPanelButton").click();
-    await this.page.getByTestId("panel-list-textfield").locator("input").fill(panelName);
-    await this.page.getByTestId(`panel-menu-item ${panelName}`).click();
-  }
-
   public async setTopicPath(path: string): Promise<void> {
     await this.page.getByPlaceholder("/some/topic.msgs[0].field").fill(path);
   }

--- a/e2e/page-objects/panels.ts
+++ b/e2e/page-objects/panels.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { Locator, Page } from "playwright";
+
+export class Panels {
+  public constructor(private readonly page: Page) {}
+
+  public async addPanel(panelName: string): Promise<void> {
+    await this.page.getByTestId("AddPanelButton").click();
+    await this.page.getByTestId(`panel-menu-item ${panelName}`).click();
+  }
+
+  public async addPanelFromSearch(panelName: string): Promise<void> {
+    await this.page.getByTestId("AddPanelButton").click();
+    await this.page.getByTestId("panel-list-textfield").locator("input").fill(panelName);
+    await this.page.getByTestId(`panel-menu-item ${panelName}`).click();
+  }
+
+  public async setTopicPath(path: string): Promise<void> {
+    await this.page.getByPlaceholder("/some/topic.msgs[0].field").fill(path);
+  }
+
+  public async openPanelMenu(): Promise<void> {
+    await this.page.getByTestId("panel-menu").click();
+  }
+
+  public async splitPanelDown(): Promise<void> {
+    await this.openPanelMenu();
+    await this.page.getByRole("menuitem", { name: "Split down" }).click();
+  }
+
+  public getAddPanelButton(): Locator {
+    return this.page.getByTestId("AddPanelButton");
+  }
+
+  public getWorkspacePanels(): Locator {
+    return this.page.getByTestId("workspace-panels");
+  }
+
+  public getLogPanelRoot(): Locator {
+    return this.page.getByTestId("log-panel-root");
+  }
+
+  public getScrollToBottomButton(): Locator {
+    return this.page.getByTestId("scroll-to-bottom-button");
+  }
+}

--- a/e2e/page-objects/player-controls.ts
+++ b/e2e/page-objects/player-controls.ts
@@ -1,17 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-import { expect, Locator, Page } from "@playwright/test";
+import { Locator, Page } from "playwright";
 
 export class PlayerControls {
   public constructor(private readonly page: Page) {}
 
   public async play(): Promise<void> {
-    await this.getPlayButton().click();
+    await this.page.getByTestId("play-button").and(this.page.getByTitle("Play")).click();
   }
 
   public async pause(): Promise<void> {
-    await this.getPlayButton().click();
+    await this.page.getByTestId("play-button").and(this.page.getByTitle("Pause")).click();
   }
 
   public async togglePlayback(): Promise<void> {
@@ -28,7 +28,9 @@ export class PlayerControls {
 
   public async setSpeed(speed: string): Promise<void> {
     await this.page.getByTestId("PlaybackSpeedControls-Dropdown").click();
-    await this.page.getByRole("menuitem", { name: speed, exact: true }).click();
+    const menuItem = this.page.getByRole("menuitem", { name: speed, exact: true });
+    await menuItem.click();
+    await menuItem.waitFor({ state: "hidden" });
   }
 
   public async switchToEpochFormat(initialTimestamp: string): Promise<void> {
@@ -38,7 +40,7 @@ export class PlayerControls {
     await timestampDropdown.click();
     const newTimestampOption = this.page.getByTestId("playback-time-display-option-SEC");
     await newTimestampOption.click();
-    await expect(newTimestampOption).toHaveCount(0);
+    await newTimestampOption.waitFor({ state: "hidden" });
   }
 
   public async getTimestampValue(): Promise<number> {

--- a/e2e/page-objects/player-controls.ts
+++ b/e2e/page-objects/player-controls.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { expect, Locator, Page } from "@playwright/test";
+
+export class PlayerControls {
+  public constructor(private readonly page: Page) {}
+
+  public async play(): Promise<void> {
+    await this.getPlayButton().click();
+  }
+
+  public async pause(): Promise<void> {
+    await this.getPlayButton().click();
+  }
+
+  public async togglePlayback(): Promise<void> {
+    await this.page.keyboard.press("Space");
+  }
+
+  public async seekForward(): Promise<void> {
+    await this.page.getByTestId("seek-forward-button").click();
+  }
+
+  public async seekBackward(): Promise<void> {
+    await this.page.getByTestId("seek-backward-button").click();
+  }
+
+  public async setSpeed(speed: string): Promise<void> {
+    await this.page.getByTestId("PlaybackSpeedControls-Dropdown").click();
+    await this.page.getByRole("menuitem", { name: speed, exact: true }).click();
+  }
+
+  public async switchToEpochFormat(initialTimestamp: string): Promise<void> {
+    const playerStartingTime = this.page.locator(`input[value="${initialTimestamp}"]`);
+    await playerStartingTime.hover();
+    const timestampDropdown = this.page.getByTestId("playback-time-display-toggle-button");
+    await timestampDropdown.click();
+    const newTimestampOption = this.page.getByTestId("playback-time-display-option-SEC");
+    await newTimestampOption.click();
+    await expect(newTimestampOption).toHaveCount(0);
+  }
+
+  public async getTimestampValue(): Promise<number> {
+    return Number(await this.getTimestampInput().inputValue());
+  }
+
+  public async getTimestampText(): Promise<string> {
+    return await this.getTimestampInput().inputValue();
+  }
+
+  public getPlayButton(): Locator {
+    return this.page.getByTestId("play-button");
+  }
+
+  public getTimestampInput(): Locator {
+    return this.page.getByTestId("PlaybackTime-text").locator("input");
+  }
+
+  public getSlider(): Locator {
+    return this.page.getByTestId("playback-slider");
+  }
+
+  public getProgressPlot(): Locator {
+    return this.page.getByTestId("progress-plot");
+  }
+}

--- a/e2e/page-objects/sidebar.ts
+++ b/e2e/page-objects/sidebar.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { Locator, Page } from "playwright";
+
+export class Sidebar {
+  public constructor(private readonly page: Page) {}
+
+  public async toggleLeftSidebar(): Promise<void> {
+    await this.page.getByTestId("left-sidebar-button").click();
+  }
+
+  public async toggleRightSidebar(): Promise<void> {
+    await this.page.getByTestId("right-sidebar-button").click();
+  }
+
+  public async openLayoutsTab(): Promise<void> {
+    await this.page.getByTestId("layouts-left").click();
+  }
+
+  public async openTopicsTab(): Promise<void> {
+    await this.page.getByTestId("topics-left").click();
+  }
+
+  public async openPanelSettingsTab(): Promise<void> {
+    await this.page.getByTestId("panel-settings-left").click();
+  }
+
+  public async openAlertsTab(): Promise<void> {
+    await this.page.getByTestId("alerts-left").click();
+  }
+
+  public async openVariablesTab(): Promise<void> {
+    await this.page.getByTestId("variables-right").click();
+  }
+
+  public getLeftSidebar(): Locator {
+    return this.page.getByTestId("sidebar-left");
+  }
+
+  public getLayoutsTab(): Locator {
+    return this.page.getByTestId("layouts-left");
+  }
+
+  public getTopicsTab(): Locator {
+    return this.page.getByTestId("topics-left");
+  }
+
+  public getPanelSettingsTab(): Locator {
+    return this.page.getByTestId("panel-settings-left");
+  }
+
+  public getAlertsTab(): Locator {
+    return this.page.getByTestId("alerts-left");
+  }
+
+  public getVariablesTab(): Locator {
+    return this.page.getByTestId("variables-right");
+  }
+}

--- a/e2e/page-objects/sidebar.ts
+++ b/e2e/page-objects/sidebar.ts
@@ -38,6 +38,10 @@ export class Sidebar {
     return this.page.getByTestId("sidebar-left");
   }
 
+  public getRightSidebar(): Locator {
+    return this.page.getByTestId("sidebar-right");
+  }
+
   public getLayoutsTab(): Locator {
     return this.page.getByTestId("layouts-left");
   }

--- a/e2e/tests/desktop/extension/custom-camera-model.desktop.spec.ts
+++ b/e2e/tests/desktop/extension/custom-camera-model.desktop.spec.ts
@@ -3,6 +3,7 @@
 
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { DataSourceDialog, PlayerControls, Sidebar } from "../../../page-objects";
 
 /**
  * Given the Data Source dialog is closed
@@ -24,7 +25,11 @@ import { loadFiles } from "../../../fixtures/load-files";
  * Then no error icons should appear on the sidebar
  */
 test("custom camera model", async ({ mainWindow }) => {
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+  const player = new PlayerControls(mainWindow);
+
+  await dialog.close();
   /**
    * MCAP structure:
    * /image/compressed - Topic with compressed image
@@ -41,7 +46,7 @@ test("custom camera model", async ({ mainWindow }) => {
 
   // WHEN
   await mainWindow.getByTestId("SettingsIcon").nth(1).click();
-  const sidebarLeft = mainWindow.getByTestId("sidebar-left");
+  const sidebarLeft = sidebar.getLeftSidebar();
   await sidebarLeft.getByText("None", { exact: true }).nth(0).click();
   await mainWindow.getByRole("option", { name: "/camera_calibration", exact: true }).click();
 
@@ -69,7 +74,7 @@ test("custom camera model", async ({ mainWindow }) => {
     mainWindow,
     filenames: foxeFile,
   });
-  await mainWindow.getByTestId("play-button").click();
+  await player.play();
 
   // THEN
   await mainWindow.waitForTimeout(100); // await for the sidebar to update

--- a/e2e/tests/desktop/extension/install-extension-on-source-folder.spec.ts
+++ b/e2e/tests/desktop/extension/install-extension-on-source-folder.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { test, expect } from "../../../fixtures/electron";
+import { DataSourceDialog, ExtensionManager } from "../../../page-objects";
 
 const extensionSourceFolder = "lichtblick.suite-extension-turtlesim-0.0.1";
 
@@ -16,17 +17,15 @@ test.use({
 });
 
 test("should install an extension (user folder)", async ({ mainWindow }) => {
-  // When
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+  const dialog = new DataSourceDialog(mainWindow);
+  const extensions = new ExtensionManager(mainWindow);
 
-  await mainWindow.getByTestId("user-button").click();
-  await mainWindow.getByRole("menuitem", { name: "Extensions" }).click();
-  const searchBar = mainWindow.getByPlaceholder("Search Extensions...");
-  await searchBar.fill("turtlesim");
-  const turtlesimExtension = mainWindow
-    .locator('[data-testid="extension-list-entry"]')
-    .filter({ hasText: "turtlesim" })
-    .filter({ hasText: "0.0.1" });
+  // When
+  await dialog.close();
+
+  await extensions.open();
+  await extensions.search("turtlesim");
+  const turtlesimExtension = extensions.findExtension("turtlesim", "0.0.1");
 
   // Then
   await expect(turtlesimExtension).toBeVisible();

--- a/e2e/tests/desktop/extension/open-extension-panel.desktop.spec.ts
+++ b/e2e/tests/desktop/extension/open-extension-panel.desktop.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { DataSourceDialog } from "../../../page-objects";
 
 /**
  * GIVEN the "turtlesim" extension file is loaded
@@ -17,7 +18,7 @@ test("open extension panel", async ({ mainWindow }) => {
   });
 
   // When
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+  await new DataSourceDialog(mainWindow).close();
   await mainWindow.getByLabel("Add panel button").click();
   await mainWindow.getByText("Turtle [local]").click();
 

--- a/e2e/tests/desktop/extension/uninstall-extension.desktop.spec.ts
+++ b/e2e/tests/desktop/extension/uninstall-extension.desktop.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { DataSourceDialog, ExtensionManager } from "../../../page-objects";
 
 /**
  * GIVEN the "turtlesim" extension file is loaded
@@ -11,24 +12,21 @@ import { loadFiles } from "../../../fixtures/load-files";
  * THEN a toast indicating "Uninstalling..." should appear
  */
 test("should uninstall an extension", async ({ mainWindow }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const extensions = new ExtensionManager(mainWindow);
+
   // Given
   const filename = "lichtblick.suite-extension-turtlesim-0.0.1.foxe";
   await loadFiles({
     mainWindow,
     filenames: filename,
   });
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+  await dialog.close();
 
   // When
-  await mainWindow.getByTestId("PersonIcon").click();
-  await mainWindow.getByRole("menuitem", { name: "Extensions" }).click();
-  const searchBar = mainWindow.getByPlaceholder("Search Extensions...");
-  await searchBar.fill("turtlesim");
-  const extensionListItem = mainWindow
-    .locator('[data-testid="extension-list-entry"]')
-    .filter({ hasText: "turtlesim" })
-    .filter({ hasText: "0.0.1" });
-  await extensionListItem.click();
+  await extensions.open();
+  await extensions.search("turtlesim");
+  await extensions.selectExtension("turtlesim", "0.0.1");
   const uninstallButton = mainWindow.getByText("Uninstall");
 
   // Then

--- a/e2e/tests/desktop/extension/uninstall-extension.desktop.spec.ts
+++ b/e2e/tests/desktop/extension/uninstall-extension.desktop.spec.ts
@@ -33,7 +33,7 @@ test("should uninstall an extension", async ({ mainWindow }) => {
   await expect(uninstallButton).toBeEnabled();
 
   // When
-  await uninstallButton.click();
+  await extensions.uninstall();
   const uninstallingToast = mainWindow.getByText("Uninstalling...");
 
   // Then

--- a/e2e/tests/desktop/layout/add-tab-to-layout.spec.ts
+++ b/e2e/tests/desktop/layout/add-tab-to-layout.spec.ts
@@ -3,6 +3,7 @@
 
 import { test, expect } from "../../../fixtures/electron";
 import { loadFromFilePicker } from "../../../fixtures/load-from-file-picker";
+import { DataSourceDialog, LayoutManager, Sidebar } from "../../../page-objects";
 
 const LAYOUT_FILE = "tab-layout.json";
 
@@ -18,11 +19,15 @@ const LAYOUT_FILE = "tab-layout.json";
  */
 test("create a new layout and add a tab", async ({ mainWindow }) => {
   test.setTimeout(45_000);
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+  const layout = new LayoutManager(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
-  await mainWindow.getByTestId("layouts-left").click();
+  await dialog.close();
+  await sidebar.openLayoutsTab();
   await loadFromFilePicker(mainWindow, LAYOUT_FILE);
-  await mainWindow.getByRole("button", { name: "Import from file…" }).click();
+  await layout.importLayout();
 
   //Then
   await expect(mainWindow.getByTestId("toolbar-tab")).toHaveCount(1);

--- a/e2e/tests/desktop/layout/create-new-layout.desktop.spec.ts
+++ b/e2e/tests/desktop/layout/create-new-layout.desktop.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
+import { DataSourceDialog, LayoutManager, Sidebar } from "../../../page-objects";
 
 /**
  * GIVEN the user is on the layouts tab
@@ -8,14 +9,18 @@ import { test, expect } from "../../../fixtures/electron";
  * THEN the new layout should appear with the name "Unnamed layout"
  */
 test("create a new layout by accessing Layouts > Create new layout", async ({ mainWindow }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+  const layout = new LayoutManager(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
-  await mainWindow.getByTestId("layouts-left").click();
+  await dialog.close();
+  await sidebar.openLayoutsTab();
 
   // When
-  await mainWindow.getByTestId("layout-list-item").getByText("Default", { exact: true }).click();
-  await mainWindow.getByText("Create new layout").click();
-  await mainWindow.getByTestId("panel-grid-card Diagnostics – Detail (ROS)").click();
+  await layout.openDefaultLayout();
+  await layout.createNewLayout();
+  await layout.selectPanel("Diagnostics – Detail (ROS)");
 
   // Then
   await expect(mainWindow.getByText("Unnamed layout").nth(0).innerText()).resolves.toContain(

--- a/e2e/tests/desktop/layout/import-layout.spec.ts
+++ b/e2e/tests/desktop/layout/import-layout.spec.ts
@@ -2,37 +2,45 @@
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
 import { loadFromFilePicker } from "../../../fixtures/load-from-file-picker";
+import { AppMenu, DataSourceDialog, LayoutManager, Sidebar } from "../../../page-objects";
 
 const LAYOUT_FILE = "imported-layout.json";
 
 test("Import a layout via layout tab > import layout", async ({ mainWindow }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+  const layout = new LayoutManager(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
-  await mainWindow.getByTestId("layouts-left").click();
+  await dialog.close();
+  await sidebar.openLayoutsTab();
   await loadFromFilePicker(mainWindow, LAYOUT_FILE);
 
   // When
-  await mainWindow.getByRole("button", { name: "Import from file…" }).click();
+  await layout.importLayout();
 
   // Then
   await expect(
-    mainWindow.getByTestId("layout-list-item").getByText("imported-layout", { exact: true }),
+    layout.getLayoutListItem().getByText("imported-layout", { exact: true }),
   ).toBeVisible();
 });
 
 test("Import a layout via menu > view > import layout", async ({ mainWindow }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+  const layout = new LayoutManager(mainWindow);
+  const appMenu = new AppMenu(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
-  await mainWindow.getByTestId("layouts-left").click();
+  await dialog.close();
+  await sidebar.openLayoutsTab();
   await loadFromFilePicker(mainWindow, LAYOUT_FILE);
 
   // When
-  await mainWindow.getByTestId("AppMenuButton").click();
-  await mainWindow.getByTestId("app-menu-view").click();
-  await mainWindow.getByText("Import layout from file…").click();
+  await appMenu.importLayoutFromMenu();
 
   // Then
   await expect(
-    mainWindow.getByTestId("layout-list-item").getByText("imported-layout", { exact: true }),
+    layout.getLayoutListItem().getByText("imported-layout", { exact: true }),
   ).toBeVisible();
 });

--- a/e2e/tests/desktop/layout/open-3d-panel-via-default-layout.desktop.spec.ts
+++ b/e2e/tests/desktop/layout/open-3d-panel-via-default-layout.desktop.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
+import { DataSourceDialog, LayoutManager, Sidebar } from "../../../page-objects";
 
 /**
  * GIVEN the default layout is open
@@ -8,13 +9,17 @@ import { test, expect } from "../../../fixtures/electron";
  * THEN the 3D panel settings should be displayed
  */
 test("open 3D panel when clicking on Layouts > layout", async ({ mainWindow }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+  const layout = new LayoutManager(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
-  await mainWindow.getByTestId("layouts-left").click();
-  await mainWindow.getByTestId("layout-list-item").getByText("Default", { exact: true }).click();
+  await dialog.close();
+  await sidebar.openLayoutsTab();
+  await layout.openDefaultLayout();
 
   // When
-  await mainWindow.getByTestId("panel-settings-left").click();
+  await sidebar.openPanelSettingsTab();
   await mainWindow.getByText("3D").nth(0).click();
 
   // Then

--- a/e2e/tests/desktop/layout/open-image-panel-via-default-layout.desktop.spec.ts
+++ b/e2e/tests/desktop/layout/open-image-panel-via-default-layout.desktop.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
+import { DataSourceDialog, LayoutManager, Sidebar } from "../../../page-objects";
 
 /**
  * GIVEN the default layout is open
@@ -8,13 +9,17 @@ import { test, expect } from "../../../fixtures/electron";
  * THEN the Images panel settings should be displayed
  */
 test("open Image panel when clicking on Layouts > layout", async ({ mainWindow }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+  const layout = new LayoutManager(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
-  await mainWindow.getByTestId("layouts-left").click();
-  await mainWindow.getByTestId("layout-list-item").getByText("Default", { exact: true }).click();
+  await dialog.close();
+  await sidebar.openLayoutsTab();
+  await layout.openDefaultLayout();
 
   // When
-  await mainWindow.getByTestId("panel-settings-left").click();
+  await sidebar.openPanelSettingsTab();
   await mainWindow.getByText("Image").nth(0).click();
 
   // Then

--- a/e2e/tests/desktop/layout/open-layout.spec.ts
+++ b/e2e/tests/desktop/layout/open-layout.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { DataSourceDialog, Sidebar } from "../../../page-objects";
 
 const LAYOUT_FILENAME = "imported-layout.json";
 /**
@@ -17,8 +18,8 @@ test("open layout via drag and drop", async ({ mainWindow }) => {
   });
 
   // When
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
-  await mainWindow.getByTestId("layouts-left").click();
+  await new DataSourceDialog(mainWindow).close();
+  await new Sidebar(mainWindow).openLayoutsTab();
 
   // Then
   await expect(mainWindow.getByText("imported-layout", { exact: true })).toHaveCount(1);

--- a/e2e/tests/desktop/layout/open-plot-panel-via-new-layout.spec.ts
+++ b/e2e/tests/desktop/layout/open-plot-panel-via-new-layout.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { Sidebar } from "../../../page-objects";
 
 /**
  * GIVEN a file is loaded and a new layout is created
@@ -16,12 +17,14 @@ test("open Plot panel when clicking on Layouts > layout", async ({ mainWindow })
     filenames: filename,
   });
 
-  await mainWindow.getByTestId("layouts-left").click();
+  const sidebar = new Sidebar(mainWindow);
+
+  await sidebar.openLayoutsTab();
   await mainWindow.getByTestId("create-new-layout").click();
 
   // When
   // the user opens a Plot panel and adds a series with "mouse.clientX"
-  await mainWindow.getByTestId("panel-settings-left").click();
+  await sidebar.openPanelSettingsTab();
   await mainWindow.getByText("Plot").nth(0).click();
 
   await mainWindow.getByTestId("add-series").click();

--- a/e2e/tests/desktop/layout/open-raw-messages-via-default-layout.desktop.spec.ts
+++ b/e2e/tests/desktop/layout/open-raw-messages-via-default-layout.desktop.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
+import { DataSourceDialog, LayoutManager, Sidebar } from "../../../page-objects";
 
 /**
  * GIVEN the default layout is open
@@ -8,13 +9,17 @@ import { test, expect } from "../../../fixtures/electron";
  * THEN the Raw Messages panel settings should be displayed
  */
 test("open Raw Messages panel when clicking on Layouts > layout", async ({ mainWindow }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+  const layout = new LayoutManager(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
-  await mainWindow.getByTestId("layouts-left").click();
-  await mainWindow.getByTestId("layout-list-item").getByText("Default", { exact: true }).click();
+  await dialog.close();
+  await sidebar.openLayoutsTab();
+  await layout.openDefaultLayout();
 
   // When
-  await mainWindow.getByTestId("panel-settings-left").click();
+  await sidebar.openPanelSettingsTab();
   await mainWindow.getByText("No topic selected").nth(0).click();
 
   // Then

--- a/e2e/tests/desktop/layout/revert-layout-changes.spec.ts
+++ b/e2e/tests/desktop/layout/revert-layout-changes.spec.ts
@@ -5,6 +5,7 @@ import { Page } from "playwright";
 
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { DataSourceDialog, Sidebar } from "../../../page-objects";
 
 const LAYOUT_FILE = "imported-layout.json";
 
@@ -32,8 +33,8 @@ test("makes changes to layout and then reverts them", async ({ mainWindow }) => 
   });
 
   // When
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
-  await mainWindow.getByTestId("layouts-left").click();
+  await new DataSourceDialog(mainWindow).close();
+  await new Sidebar(mainWindow).openLayoutsTab();
 
   // Then
   const importedLayout = mainWindow.getByRole("button", { name: "imported-layout" });

--- a/e2e/tests/desktop/layout/show-hide-side-bars-via-click.desktop.spec.ts
+++ b/e2e/tests/desktop/layout/show-hide-side-bars-via-click.desktop.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
+import { DataSourceDialog, Sidebar } from "../../../page-objects";
 
 /**
  * Given the Data Source dialog is closed
@@ -10,26 +11,29 @@ import { test, expect } from "../../../fixtures/electron";
  * Then the left‐sidebar tabs are all visible
  */
 test("show/hide left side bar via click", async ({ mainWindow }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+  await dialog.close();
 
   // When
-  await mainWindow.getByTestId("left-sidebar-button").click();
+  await sidebar.toggleLeftSidebar();
 
   // Then
-  await expect(mainWindow.getByTestId("panel-settings-left")).not.toBeVisible();
-  await expect(mainWindow.getByTestId("topics-left")).not.toBeVisible();
-  await expect(mainWindow.getByTestId("alerts-left")).not.toBeVisible();
-  await expect(mainWindow.getByTestId("layouts-left")).not.toBeVisible();
+  await expect(sidebar.getPanelSettingsTab()).not.toBeVisible();
+  await expect(sidebar.getTopicsTab()).not.toBeVisible();
+  await expect(sidebar.getAlertsTab()).not.toBeVisible();
+  await expect(sidebar.getLayoutsTab()).not.toBeVisible();
 
   // When
-  await mainWindow.getByTestId("left-sidebar-button").click();
+  await sidebar.toggleLeftSidebar();
 
   // Then
-  await expect(mainWindow.getByTestId("panel-settings-left")).toBeVisible();
-  await expect(mainWindow.getByTestId("topics-left")).toBeVisible();
-  await expect(mainWindow.getByTestId("alerts-left")).toBeVisible();
-  await expect(mainWindow.getByTestId("layouts-left")).toBeVisible();
+  await expect(sidebar.getPanelSettingsTab()).toBeVisible();
+  await expect(sidebar.getTopicsTab()).toBeVisible();
+  await expect(sidebar.getAlertsTab()).toBeVisible();
+  await expect(sidebar.getLayoutsTab()).toBeVisible();
 });
 
 /**
@@ -40,18 +44,21 @@ test("show/hide left side bar via click", async ({ mainWindow }) => {
  * Then the right‐sidebar tabs are all visible
  */
 test("hide/show right side bar via click", async ({ mainWindow }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+  await dialog.close();
 
   // When
-  await mainWindow.getByTestId("right-sidebar-button").click();
+  await sidebar.toggleRightSidebar();
 
   // Then
-  await expect(mainWindow.getByTestId("variables-right")).toBeVisible();
+  await expect(sidebar.getVariablesTab()).toBeVisible();
 
   // When
-  await mainWindow.getByTestId("right-sidebar-button").click();
+  await sidebar.toggleRightSidebar();
 
   // Then
-  await expect(mainWindow.getByTestId("variables-right")).not.toBeVisible();
+  await expect(sidebar.getVariablesTab()).not.toBeVisible();
 });

--- a/e2e/tests/desktop/layout/show-hide-side-bars-via-shortcut.desktop.spec.ts
+++ b/e2e/tests/desktop/layout/show-hide-side-bars-via-shortcut.desktop.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
+import { DataSourceDialog, Sidebar } from "../../../page-objects";
 
 /**
  * Given the Data Source dialog is closed
@@ -10,26 +11,29 @@ import { test, expect } from "../../../fixtures/electron";
  * Then the left‐sidebar tabs are all visible
  */
 test("show/hide left side bar via shortcut", async ({ mainWindow }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+  await dialog.close();
 
   // When
   await mainWindow.keyboard.press("[");
 
   // Then
-  await expect(mainWindow.getByTestId("panel-settings-left")).not.toBeVisible();
-  await expect(mainWindow.getByTestId("topics-left")).not.toBeVisible();
-  await expect(mainWindow.getByTestId("alerts-left")).not.toBeVisible();
-  await expect(mainWindow.getByTestId("layouts-left")).not.toBeVisible();
+  await expect(sidebar.getPanelSettingsTab()).not.toBeVisible();
+  await expect(sidebar.getTopicsTab()).not.toBeVisible();
+  await expect(sidebar.getAlertsTab()).not.toBeVisible();
+  await expect(sidebar.getLayoutsTab()).not.toBeVisible();
 
   // When
   await mainWindow.keyboard.press("[");
 
   // Then
-  await expect(mainWindow.getByTestId("panel-settings-left")).toBeVisible();
-  await expect(mainWindow.getByTestId("topics-left")).toBeVisible();
-  await expect(mainWindow.getByTestId("alerts-left")).toBeVisible();
-  await expect(mainWindow.getByTestId("layouts-left")).toBeVisible();
+  await expect(sidebar.getPanelSettingsTab()).toBeVisible();
+  await expect(sidebar.getTopicsTab()).toBeVisible();
+  await expect(sidebar.getAlertsTab()).toBeVisible();
+  await expect(sidebar.getLayoutsTab()).toBeVisible();
 });
 
 /**
@@ -40,18 +44,21 @@ test("show/hide left side bar via shortcut", async ({ mainWindow }) => {
  * Then the right‐sidebar panels are all hidden
  */
 test("hide/show right side bar via shortcut", async ({ mainWindow }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+  await dialog.close();
 
   // When
   await mainWindow.keyboard.press("]");
 
   // Then
-  await expect(mainWindow.getByTestId("variables-right")).toBeVisible();
+  await expect(sidebar.getVariablesTab()).toBeVisible();
 
   // When
   await mainWindow.keyboard.press("]");
 
   // Then
-  await expect(mainWindow.getByTestId("variables-right")).not.toBeVisible();
+  await expect(sidebar.getVariablesTab()).not.toBeVisible();
 });

--- a/e2e/tests/desktop/menu/open-data-source-dialog-via-menu.desktop.spec.ts
+++ b/e2e/tests/desktop/menu/open-data-source-dialog-via-menu.desktop.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
+import { AppMenu, DataSourceDialog } from "../../../page-objects";
 
 /**
  * GIVEN the app is on the initial screen
@@ -8,14 +9,15 @@ import { test, expect } from "../../../fixtures/electron";
  * THEN the Data Source dialog should appear
  */
 test("Display the data source dialog when clicking File > Open...", async ({ mainWindow }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const appMenu = new AppMenu(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+  await dialog.close();
 
   // When
-  await mainWindow.getByTestId("AppMenuButton").click();
-  await mainWindow.getByTestId("app-menu-file").click();
-  await mainWindow.getByTestId("menu-item-open").click();
+  await appMenu.openFile();
 
   // Then
-  await expect(mainWindow.getByTestId("DataSourceDialog").isVisible()).resolves.toBe(true);
+  await expect(dialog.isVisible()).resolves.toBe(true);
 });

--- a/e2e/tests/desktop/menu/open-open-connection-screen-via-menu.desktop.spec.ts
+++ b/e2e/tests/desktop/menu/open-open-connection-screen-via-menu.desktop.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
+import { AppMenu, DataSourceDialog } from "../../../page-objects";
 
 /**
  * GIVEN the app is on the initial screen
@@ -11,13 +12,14 @@ import { test, expect } from "../../../fixtures/electron";
 test("Display the open a new connection dialog when clicking File > Open... > Open connection", async ({
   mainWindow,
 }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const appMenu = new AppMenu(mainWindow);
+
   // Given
-  await mainWindow.getByTestId("DataSourceDialog").getByTestId("CloseIcon").click();
+  await dialog.close();
 
   // When
-  await mainWindow.getByTestId("AppMenuButton").click();
-  await mainWindow.getByTestId("app-menu-file").click();
-  await mainWindow.getByTestId("menu-item-open").click();
+  await appMenu.openFile();
   await mainWindow.getByText("Open connection").nth(0).click();
 
   // Then

--- a/e2e/tests/desktop/menu/open-open-connection-screen-via-menu.desktop.spec.ts
+++ b/e2e/tests/desktop/menu/open-open-connection-screen-via-menu.desktop.spec.ts
@@ -19,8 +19,7 @@ test("Display the open a new connection dialog when clicking File > Open... > Op
   await dialog.close();
 
   // When
-  await appMenu.openFile();
-  await mainWindow.getByText("Open connection").nth(0).click();
+  await appMenu.openConnection();
 
   // Then
   await expect(mainWindow.getByText("Open a new connection", { exact: true })).toBeVisible();

--- a/e2e/tests/desktop/panel/Log/check-scroll-bottom-button.desktop.spec.ts
+++ b/e2e/tests/desktop/panel/Log/check-scroll-bottom-button.desktop.spec.ts
@@ -4,6 +4,7 @@
 import { changeToEpochFormat } from "../../../../fixtures/change-to-epoch-format";
 import { test, expect } from "../../../../fixtures/electron";
 import { loadFiles } from "../../../../fixtures/load-files";
+import { Panels, PlayerControls } from "../../../../page-objects";
 
 const MCAP_FILENAME = "example_logs.mcap";
 
@@ -14,6 +15,8 @@ const MCAP_FILENAME = "example_logs.mcap";
  * THEN the "Log panel" settings should be visible
  */
 test("open log panel after loading an mcap file", async ({ mainWindow }) => {
+  const panels = new Panels(mainWindow);
+
   /// Given
   await loadFiles({
     mainWindow,
@@ -21,9 +24,8 @@ test("open log panel after loading an mcap file", async ({ mainWindow }) => {
   });
 
   // When
-  await mainWindow.getByTestId("AddPanelButton").click();
-  await mainWindow.getByRole("button", { name: "Log" }).click();
-  await mainWindow.getByTestId("log-panel-root").getByRole("button", { name: "Settings" }).click();
+  await panels.addPanel("Log");
+  await panels.getLogPanelRoot().getByRole("button", { name: "Settings" }).click();
 
   // Then
   await expect(mainWindow.getByText("Log panel", { exact: true }).count()).resolves.toBe(1);
@@ -41,6 +43,9 @@ test('should show "scroll to bottom" button when there is a scroll up in the log
 }) => {
   // This test usually takes slightly longer than the default 30s timeout
   test.setTimeout(60_000);
+  const panels = new Panels(mainWindow);
+  const player = new PlayerControls(mainWindow);
+
   /// Given
   await loadFiles({
     mainWindow,
@@ -48,19 +53,17 @@ test('should show "scroll to bottom" button when there is a scroll up in the log
   });
 
   // When
-  await mainWindow.getByTestId("AddPanelButton").click();
-  await mainWindow.getByRole("button", { name: "Log" }).click();
+  await panels.addPanel("Log");
 
-  const playButton = mainWindow.getByTestId("play-button");
   // Change to epoch time format to make calculations easier
   await changeToEpochFormat(mainWindow);
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
+  const timestamp = player.getTimestampInput();
 
   const initialValue: string = await timestamp.inputValue();
   const initialTimestamp: number = Number(initialValue);
 
-  await expect(playButton).toHaveAttribute("title", "Play");
-  await playButton.click();
+  await expect(player.getPlayButton()).toHaveAttribute("title", "Play");
+  await player.play();
 
   // Verify timestamp actually moves.
   await expect(async () => {
@@ -72,10 +75,10 @@ test('should show "scroll to bottom" button when there is a scroll up in the log
     timeout: 5000,
     intervals: [100],
   });
-  await expect(playButton).toHaveAttribute("title", "Pause", { timeout: 5_000 });
+  await expect(player.getPlayButton()).toHaveAttribute("title", "Pause", { timeout: 5_000 });
 
-  const logPanel = mainWindow.getByTestId("log-panel-root");
-  const scrollToBottomBtn = mainWindow.getByTestId("scroll-to-bottom-button");
+  const logPanel = panels.getLogPanelRoot();
+  const scrollToBottomBtn = panels.getScrollToBottomButton();
 
   await logPanel.hover();
   // Scroll up until the button shows up. More resiliant than a single scroll which can be flaky.

--- a/e2e/tests/desktop/panel/Map/open-map-panel.desktop.spec.ts
+++ b/e2e/tests/desktop/panel/Map/open-map-panel.desktop.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../../fixtures/electron";
 import { loadFiles } from "../../../../fixtures/load-files";
+import { Panels, Sidebar } from "../../../../page-objects";
 
 /**
  * GIVEN a .bag file is loaded
@@ -10,6 +11,9 @@ import { loadFiles } from "../../../../fixtures/load-files";
  * THEN the "Map panel" settings should be visible
  */
 test("open map panel after loading a bag file", async ({ mainWindow }) => {
+  const panels = new Panels(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+
   /// Given
   const filename = "example.bag";
   await loadFiles({
@@ -18,9 +22,8 @@ test("open map panel after loading a bag file", async ({ mainWindow }) => {
   });
 
   // When
-  await mainWindow.getByTestId("AddPanelButton").click();
-  await mainWindow.getByTestId("panel-menu-item Map").click();
-  await mainWindow.getByTestId("panel-settings-left").click();
+  await panels.addPanel("Map");
+  await sidebar.openPanelSettingsTab();
   await mainWindow.getByText("Waiting for first GPS point...").nth(0).click();
 
   // Then

--- a/e2e/tests/desktop/panel/ThreeDee/open-three-dee-panel.desktop.spec.ts
+++ b/e2e/tests/desktop/panel/ThreeDee/open-three-dee-panel.desktop.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../../fixtures/electron";
 import { loadFiles } from "../../../../fixtures/load-files";
+import { Panels, Sidebar } from "../../../../page-objects";
 
 const MCAP_FILE = "example-converter.mcap";
 const EXTENSION_FILE = "lichtblickteamctw.message-converter-extension-0.0.2.foxe";
@@ -14,6 +15,9 @@ const EXTENSION_FILE = "lichtblickteamctw.message-converter-extension-0.0.2.foxe
  * THEN the topics should be visible on the settings tree
  */
 test("open 3D panel after loading a mcap file", async ({ mainWindow }) => {
+  const panels = new Panels(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+
   /// Given
   await loadFiles({
     mainWindow,
@@ -26,9 +30,8 @@ test("open 3D panel after loading a mcap file", async ({ mainWindow }) => {
   });
 
   // When
-  await mainWindow.getByTestId("AddPanelButton").click();
-  await mainWindow.getByTestId("panel-menu-item 3D").click();
-  await mainWindow.getByTestId("panel-settings-left").click();
+  await panels.addPanel("3D");
+  await sidebar.openPanelSettingsTab();
   await mainWindow.getByText("3D").nth(0).click();
 
   // Then

--- a/e2e/tests/desktop/panel/raw-messages/drag-and-drop-topic-on-raw-messages.spec.ts
+++ b/e2e/tests/desktop/panel/raw-messages/drag-and-drop-topic-on-raw-messages.spec.ts
@@ -3,6 +3,7 @@
 
 import { expect, test } from "../../../../fixtures/electron";
 import { loadFiles } from "../../../../fixtures/load-files";
+import { Panels, Sidebar } from "../../../../page-objects";
 
 /**
  * GIVEN a file is loaded and a new layout is created with a Raw Messages panel
@@ -10,6 +11,9 @@ import { loadFiles } from "../../../../fixtures/load-files";
  * THEN the topic message data is displayed in the Raw Messages panel
  */
 test("open Raw Messages panel when clicking on Layouts > layout", async ({ mainWindow }) => {
+  const sidebar = new Sidebar(mainWindow);
+  const panels = new Panels(mainWindow);
+
   // GIVEN a file is loaded and a new layout is created with a Raw Messages panel
   const filename = "example-2.mcap";
   await loadFiles({
@@ -17,13 +21,13 @@ test("open Raw Messages panel when clicking on Layouts > layout", async ({ mainW
     filenames: filename,
   });
 
-  await mainWindow.getByTestId("layouts-left").click();
+  await sidebar.openLayoutsTab();
   await mainWindow.getByTestId("create-new-layout").click();
   await mainWindow.getByText("Raw Messages").nth(0).click();
 
   // WHEN the user opens the Topics sidebar and drags a topic onto the panel
-  await mainWindow.getByTestId("topics-left").click();
-  await mainWindow.getByTestId("topic-row").dragTo(mainWindow.getByTestId("workspace-panels"));
+  await sidebar.openTopicsTab();
+  await mainWindow.getByTestId("topic-row").dragTo(panels.getWorkspacePanels());
 
   // THEN the topic message data is displayed in the Raw Messages panel
   const topicMessageClientX = mainWindow.getByText("clientX");

--- a/e2e/tests/desktop/panel/raw-messages/select-topic-on-raw-messages.spec.ts
+++ b/e2e/tests/desktop/panel/raw-messages/select-topic-on-raw-messages.spec.ts
@@ -3,6 +3,7 @@
 
 import { test, expect } from "../../../../fixtures/electron";
 import { loadFiles } from "../../../../fixtures/load-files";
+import { LayoutManager, Sidebar } from "../../../../page-objects";
 
 const MCAP_FILENAME = "example_logs.mcap";
 
@@ -19,16 +20,19 @@ const MCAP_FILENAME = "example_logs.mcap";
 test("create a new layout with raw messages panel, select a topic and change the font size", async ({
   mainWindow,
 }) => {
+  const sidebar = new Sidebar(mainWindow);
+  const layout = new LayoutManager(mainWindow);
+
   // Given
   await loadFiles({
     mainWindow,
     filenames: MCAP_FILENAME,
   });
-  await mainWindow.getByTestId("layouts-left").click();
+  await sidebar.openLayoutsTab();
 
   // When
-  await mainWindow.getByTestId("layout-list-item").getByText("Default", { exact: true }).click();
-  await mainWindow.getByText("Create new layout").click();
+  await layout.openDefaultLayout();
+  await layout.createNewLayout();
 
   const panelSearch = mainWindow.getByTestId("panel-list-textfield").locator("input");
   await panelSearch.fill("Raw Messages");
@@ -50,7 +54,7 @@ test("create a new layout with raw messages panel, select a topic and change the
   await expect(topicMessage).toHaveCSS("font-size", "12px");
 
   // When
-  await mainWindow.getByTestId("panel-settings-left").click();
+  await sidebar.openPanelSettingsTab();
   await mainWindow.getByTestId("FieldEditor-Select").click();
   await mainWindow.getByText("30 px").click();
 

--- a/e2e/tests/desktop/player/pause-play.desktop.spec.ts
+++ b/e2e/tests/desktop/player/pause-play.desktop.spec.ts
@@ -1,20 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-import { Locator, Page } from "playwright";
-
 import { changeToEpochFormat } from "../../../fixtures/change-to-epoch-format";
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { PlayerControls } from "../../../page-objects";
 
 const MCAP_FILENAME = "example.mcap";
-
-function getPlaybackElements(mainWindow: Page): { button: Locator; timestamp: Locator } {
-  const button = mainWindow.getByTestId("play-button");
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
-
-  return { button, timestamp };
-}
 
 /**
  * GIVEN a .mcap file is loaded
@@ -25,20 +17,21 @@ function getPlaybackElements(mainWindow: Page): { button: Locator; timestamp: Lo
  */
 
 test("should start playing when clicking on Play button", async ({ mainWindow }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
 
-  const { button, timestamp } = getPlaybackElements(mainWindow);
-  const startTime = Number(await timestamp.inputValue());
+  const startTime = await player.getTimestampValue();
 
   // When
-  await expect(button).toHaveAttribute("title", "Play");
-  await button.click(); // start playback
+  await expect(player.getPlayButton()).toHaveAttribute("title", "Play");
+  await player.play();
 
   // Then
-  await expect(button).toHaveAttribute("title", "Pause");
-  const elapsedTimestamp = Number(await timestamp.inputValue());
+  await expect(player.getPlayButton()).toHaveAttribute("title", "Pause");
+  const elapsedTimestamp = await player.getTimestampValue();
   expect(elapsedTimestamp).toBeGreaterThan(startTime);
 });
 
@@ -50,19 +43,20 @@ test("should start playing when clicking on Play button", async ({ mainWindow })
  */
 
 test("should start playing when clicking on Spacebar key", async ({ mainWindow }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
-  const { button, timestamp } = getPlaybackElements(mainWindow);
-  const startTime = Number(await timestamp.inputValue());
+  const startTime = await player.getTimestampValue();
 
   // When
-  await expect(button).toHaveAttribute("title", "Play");
-  await mainWindow.keyboard.press("Space"); // start playback
+  await expect(player.getPlayButton()).toHaveAttribute("title", "Play");
+  await player.togglePlayback();
 
   // Then
-  await expect(button).toHaveAttribute("title", "Pause");
-  const elapsedTimestamp = Number(await timestamp.inputValue());
+  await expect(player.getPlayButton()).toHaveAttribute("title", "Pause");
+  const elapsedTimestamp = await player.getTimestampValue();
   expect(elapsedTimestamp).toBeGreaterThan(startTime);
 });
 
@@ -75,23 +69,24 @@ test("should start playing when clicking on Spacebar key", async ({ mainWindow }
  */
 
 test("should stop playing when clicking on Play button", async ({ mainWindow }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
-  const { button, timestamp } = getPlaybackElements(mainWindow);
 
-  await button.click(); // start playback
+  await player.play();
 
   // When
-  await expect(button).toHaveAttribute("title", "Pause");
-  await button.click(); // stop playback
+  await expect(player.getPlayButton()).toHaveAttribute("title", "Pause");
+  await player.pause();
 
   // Then
-  await expect(button).toHaveAttribute("title", "Play"); // check if icon has changed first
-  const startTime = Number(await timestamp.inputValue());
+  await expect(player.getPlayButton()).toHaveAttribute("title", "Play");
+  const startTime = await player.getTimestampValue();
 
-  await mainWindow.waitForTimeout(1000); // wait to check if value is still the same
-  const elapsedTimestamp = Number(await timestamp.inputValue());
+  await mainWindow.waitForTimeout(1000);
+  const elapsedTimestamp = await player.getTimestampValue();
   expect(elapsedTimestamp).toEqual(startTime);
 });
 
@@ -104,22 +99,23 @@ test("should stop playing when clicking on Play button", async ({ mainWindow }) 
  */
 
 test("should stop playing when clicking on Spacebar key", async ({ mainWindow }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
-  const { button, timestamp } = getPlaybackElements(mainWindow);
 
-  await mainWindow.keyboard.press("Space"); // start playback
+  await player.togglePlayback();
 
   // When
-  await expect(button).toHaveAttribute("title", "Pause");
-  await mainWindow.keyboard.press("Space"); // stop playback
+  await expect(player.getPlayButton()).toHaveAttribute("title", "Pause");
+  await player.togglePlayback();
 
   // Then
-  await expect(button).toHaveAttribute("title", "Play"); // check if icon has changed first
-  const startTime = Number(await timestamp.inputValue());
+  await expect(player.getPlayButton()).toHaveAttribute("title", "Play");
+  const startTime = await player.getTimestampValue();
 
-  await mainWindow.waitForTimeout(1000); // wait to check if value is still the same
-  const elapsedTimestamp = Number(await timestamp.inputValue());
+  await mainWindow.waitForTimeout(1000);
+  const elapsedTimestamp = await player.getTimestampValue();
   expect(elapsedTimestamp).toEqual(startTime);
 });

--- a/e2e/tests/desktop/player/playback-seek.desktop.spec.ts
+++ b/e2e/tests/desktop/player/playback-seek.desktop.spec.ts
@@ -10,7 +10,7 @@ import { PlayerControls } from "../../../page-objects";
 
 const MCAP_FILENAME = "example.mcap";
 
-async function clickPlayblackSlider(
+async function clickPlaybackSlider(
   player: PlayerControls,
   mainWindow: Page,
   fraction: number,
@@ -156,7 +156,7 @@ test("should regress timestamp 100ms when seek forward backward is clicked", asy
   await changeToEpochFormat(mainWindow);
 
   // When
-  await clickPlayblackSlider(player, mainWindow, 0.5); // move slider to middle
+  await clickPlaybackSlider(player, mainWindow, 0.5); // move slider to middle
 
   const startTime = await player.getTimestampValue();
 
@@ -185,7 +185,7 @@ test("should regress timestamp 100ms when left arrow key is pressed", async ({ m
   await changeToEpochFormat(mainWindow);
 
   // When
-  await clickPlayblackSlider(player, mainWindow, 0.5); // move slider to middle
+  await clickPlaybackSlider(player, mainWindow, 0.5); // move slider to middle
 
   const startTime = await player.getTimestampValue();
 
@@ -216,7 +216,7 @@ test("should regress timestamp 500ms when alt + left arrow key is pressed", asyn
   await changeToEpochFormat(mainWindow);
 
   // When
-  await clickPlayblackSlider(player, mainWindow, 0.5); // move slider to middle
+  await clickPlaybackSlider(player, mainWindow, 0.5); // move slider to middle
 
   const startTime = await player.getTimestampValue();
 
@@ -248,10 +248,10 @@ test("should foward timestamp to end of slider when alt + right arrow key is pre
   await changeToEpochFormat(mainWindow);
 
   // When
-  await clickPlayblackSlider(player, mainWindow, 1); // move slider to end
+  await clickPlaybackSlider(player, mainWindow, 1); // move slider to end
   const startTime = await player.getTimestampValue();
 
-  await clickPlayblackSlider(player, mainWindow, 0.9); // move slider close to end
+  await clickPlaybackSlider(player, mainWindow, 0.9); // move slider close to end
 
   await mainWindow.keyboard.down("Alt");
   await mainWindow.keyboard.press("ArrowRight");
@@ -281,10 +281,10 @@ test("should regress timestamp to start of slider alt + left arrow key is presse
   await changeToEpochFormat(mainWindow);
 
   // When
-  await clickPlayblackSlider(player, mainWindow, 0); // move slider to start
+  await clickPlaybackSlider(player, mainWindow, 0); // move slider to start
   const startTime = await player.getTimestampValue();
 
-  await clickPlayblackSlider(player, mainWindow, 0.1); // move slider close to start
+  await clickPlaybackSlider(player, mainWindow, 0.1); // move slider close to start
 
   await mainWindow.keyboard.down("Alt");
   await mainWindow.keyboard.press("ArrowLeft");

--- a/e2e/tests/desktop/player/playback-seek.desktop.spec.ts
+++ b/e2e/tests/desktop/player/playback-seek.desktop.spec.ts
@@ -6,13 +6,16 @@ import { Locator, Page } from "playwright";
 import { changeToEpochFormat } from "../../../fixtures/change-to-epoch-format";
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { PlayerControls } from "../../../page-objects";
 
 const MCAP_FILENAME = "example.mcap";
 
-async function clickPlayblackSlider(mainWindow: Page, fraction: number) {
-  const slider = mainWindow.getByTestId("playback-slider");
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
-  const box = await slider.boundingBox();
+async function clickPlayblackSlider(
+  player: PlayerControls,
+  mainWindow: Page,
+  fraction: number,
+) {
+  const box = await player.getSlider().boundingBox();
   if (!box) {
     throw new Error("Slider bounding box not found");
   }
@@ -31,7 +34,7 @@ async function clickPlayblackSlider(mainWindow: Page, fraction: number) {
   const y = box.y + box.height / 2;
 
   await mainWindow.mouse.click(x, y);
-  await waitTimestamp(timestamp);
+  await waitTimestamp(player.getTimestampInput());
 }
 
 async function waitTimestamp(timestamp: Locator): Promise<void> {
@@ -61,20 +64,20 @@ async function waitTimestamp(timestamp: Locator): Promise<void> {
 test("should advance timestamp 100ms when seek forward button is clicked", async ({
   mainWindow,
 }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
 
-  const button = mainWindow.getByTestId("seek-forward-button");
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
-  const startTime = Number(await timestamp.inputValue());
+  const startTime = await player.getTimestampValue();
 
   // When
-  await button.click(); // seek forwards
+  await player.seekForward();
+  await waitTimestamp(player.getTimestampInput());
 
-  await waitTimestamp(timestamp);
   // Then
-  const elapsedTimestamp = Number(await timestamp.inputValue());
+  const elapsedTimestamp = await player.getTimestampValue();
 
   const diff = Math.abs(elapsedTimestamp - startTime); // 100ms
   expect(diff).toBeLessThanOrEqual(0.11); // 100ms + 10% tolerance
@@ -88,19 +91,20 @@ test("should advance timestamp 100ms when seek forward button is clicked", async
  */
 
 test("should advance timestamp 100ms when right arrow key is pressed", async ({ mainWindow }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
 
   // When
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
-  const startTime = Number(await timestamp.inputValue());
+  const startTime = await player.getTimestampValue();
 
   await mainWindow.keyboard.press("ArrowRight"); // seek forwards
-  await waitTimestamp(timestamp);
+  await waitTimestamp(player.getTimestampInput());
 
   // Then
-  const elapsedTimestamp = Number(await timestamp.inputValue());
+  const elapsedTimestamp = await player.getTimestampValue();
 
   const diff = Math.abs(elapsedTimestamp - startTime);
   expect(diff).toBeLessThanOrEqual(0.11); // 100ms + 10% tolerance
@@ -115,20 +119,21 @@ test("should advance timestamp 100ms when right arrow key is pressed", async ({ 
 test("should advance timestamp 500ms when alt + right arrow key is pressed", async ({
   mainWindow,
 }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
 
   // When
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
-  const startTime = Number(await timestamp.inputValue());
+  const startTime = await player.getTimestampValue();
 
   await mainWindow.keyboard.down("Alt");
   await mainWindow.keyboard.press("ArrowRight");
-  await waitTimestamp(timestamp);
+  await waitTimestamp(player.getTimestampInput());
 
   // Then
-  const elapsedTimestamp = Number(await timestamp.inputValue());
+  const elapsedTimestamp = await player.getTimestampValue();
 
   const diff = Math.abs(elapsedTimestamp - startTime);
   expect(diff).toBeLessThanOrEqual(0.55); // 500ms + 10% tolerance
@@ -144,22 +149,22 @@ test("should advance timestamp 500ms when alt + right arrow key is pressed", asy
 test("should regress timestamp 100ms when seek forward backward is clicked", async ({
   mainWindow,
 }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
-  const button = mainWindow.getByTestId("seek-backward-button");
 
   // When
-  await clickPlayblackSlider(mainWindow, 0.5); // move slider to middle
+  await clickPlayblackSlider(player, mainWindow, 0.5); // move slider to middle
 
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
-  const startTime = Number(await timestamp.inputValue());
+  const startTime = await player.getTimestampValue();
 
-  await button.click();
-  await waitTimestamp(timestamp);
+  await player.seekBackward();
+  await waitTimestamp(player.getTimestampInput());
 
   // Then
-  const elapsedTimestamp = Number(await timestamp.inputValue());
+  const elapsedTimestamp = await player.getTimestampValue();
 
   const diff = Math.abs(elapsedTimestamp - startTime);
   expect(diff).toBeLessThanOrEqual(0.11); // 100ms + 10% tolerance
@@ -173,21 +178,22 @@ test("should regress timestamp 100ms when seek forward backward is clicked", asy
  */
 
 test("should regress timestamp 100ms when left arrow key is pressed", async ({ mainWindow }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
 
   // When
-  await clickPlayblackSlider(mainWindow, 0.5); // move slider to middle
+  await clickPlayblackSlider(player, mainWindow, 0.5); // move slider to middle
 
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
-  const startTime = Number(await timestamp.inputValue());
+  const startTime = await player.getTimestampValue();
 
   await mainWindow.keyboard.press("ArrowLeft"); // seek backwards
-  await waitTimestamp(timestamp);
+  await waitTimestamp(player.getTimestampInput());
 
   // Then
-  const elapsedTimestamp = Number(await timestamp.inputValue());
+  const elapsedTimestamp = await player.getTimestampValue();
 
   const diff = Math.abs(elapsedTimestamp - startTime);
   expect(diff).toBeLessThanOrEqual(0.11); // 100ms + 10% tolerance
@@ -203,22 +209,23 @@ test("should regress timestamp 100ms when left arrow key is pressed", async ({ m
 test("should regress timestamp 500ms when alt + left arrow key is pressed", async ({
   mainWindow,
 }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
 
   // When
-  await clickPlayblackSlider(mainWindow, 0.5); // move slider to middle
+  await clickPlayblackSlider(player, mainWindow, 0.5); // move slider to middle
 
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
-  const startTime = Number(await timestamp.inputValue());
+  const startTime = await player.getTimestampValue();
 
   await mainWindow.keyboard.down("Alt");
   await mainWindow.keyboard.press("ArrowLeft");
 
   // Then
-  await waitTimestamp(timestamp);
-  const elapsedTimestamp = Number(await timestamp.inputValue());
+  await waitTimestamp(player.getTimestampInput());
+  const elapsedTimestamp = await player.getTimestampValue();
 
   const diff = Math.abs(elapsedTimestamp - startTime);
   expect(diff).toBeLessThanOrEqual(0.55); // 500ms + 10% tolerance
@@ -234,23 +241,24 @@ test("should regress timestamp 500ms when alt + left arrow key is pressed", asyn
 test("should foward timestamp to end of slider when alt + right arrow key is pressed less than 500ms from the end", async ({
   mainWindow,
 }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
 
   // When
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
-  await clickPlayblackSlider(mainWindow, 1); // move slider to end
-  const startTime = Number(await timestamp.inputValue());
+  await clickPlayblackSlider(player, mainWindow, 1); // move slider to end
+  const startTime = await player.getTimestampValue();
 
-  await clickPlayblackSlider(mainWindow, 0.9); // move slider close to end
+  await clickPlayblackSlider(player, mainWindow, 0.9); // move slider close to end
 
   await mainWindow.keyboard.down("Alt");
   await mainWindow.keyboard.press("ArrowRight");
-  await waitTimestamp(timestamp);
+  await waitTimestamp(player.getTimestampInput());
 
   // Then
-  const elapsedTimestamp = Number(await timestamp.inputValue());
+  const elapsedTimestamp = await player.getTimestampValue();
 
   const diff = Math.abs(elapsedTimestamp - startTime);
   expect(diff).toBeLessThanOrEqual(0.01);
@@ -266,23 +274,24 @@ test("should foward timestamp to end of slider when alt + right arrow key is pre
 test("should regress timestamp to start of slider alt + left arrow key is pressed less than 500ms from the start", async ({
   mainWindow,
 }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
 
   // When
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
-  await clickPlayblackSlider(mainWindow, 0); // move slider to start
-  const startTime = Number(await timestamp.inputValue());
+  await clickPlayblackSlider(player, mainWindow, 0); // move slider to start
+  const startTime = await player.getTimestampValue();
 
-  await clickPlayblackSlider(mainWindow, 0.1); // move slider close to start
+  await clickPlayblackSlider(player, mainWindow, 0.1); // move slider close to start
 
   await mainWindow.keyboard.down("Alt");
   await mainWindow.keyboard.press("ArrowLeft");
 
   // Then
-  await waitTimestamp(timestamp);
-  const elapsedTimestamp = Number(await timestamp.inputValue());
+  await waitTimestamp(player.getTimestampInput());
+  const elapsedTimestamp = await player.getTimestampValue();
 
   const diff = Math.abs(elapsedTimestamp - startTime);
   expect(diff).toBeLessThanOrEqual(0.01);

--- a/e2e/tests/desktop/player/playback-seek.desktop.spec.ts
+++ b/e2e/tests/desktop/player/playback-seek.desktop.spec.ts
@@ -10,11 +10,7 @@ import { PlayerControls } from "../../../page-objects";
 
 const MCAP_FILENAME = "example.mcap";
 
-async function clickPlaybackSlider(
-  player: PlayerControls,
-  mainWindow: Page,
-  fraction: number,
-) {
+async function clickPlaybackSlider(player: PlayerControls, mainWindow: Page, fraction: number) {
   const box = await player.getSlider().boundingBox();
   if (!box) {
     throw new Error("Slider bounding box not found");

--- a/e2e/tests/desktop/player/player-speed.desktop.spec.ts
+++ b/e2e/tests/desktop/player/player-speed.desktop.spec.ts
@@ -4,6 +4,7 @@
 import { changeToEpochFormat } from "../../../fixtures/change-to-epoch-format";
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { PlayerControls } from "../../../page-objects";
 
 const MCAP_FILENAME = "example.mcap";
 
@@ -14,37 +15,30 @@ const MCAP_FILENAME = "example.mcap";
  */
 
 test("should double playback speed after choosing 2x", async ({ mainWindow }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
 
   const expectedRatio = 2;
   const expectedDuration = 500; // ms
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
-  const dropDownButton = mainWindow.getByTestId("PlaybackSpeedControls-Dropdown");
 
-  await dropDownButton.click();
-  const regularSpeed = mainWindow.getByRole("menuitem", { name: "1×", exact: true }); // make sure we're on 1x speed
-  await regularSpeed.click();
-  await expect(regularSpeed).toHaveCount(0);
+  await player.setSpeed("1×"); // make sure we're on 1x speed
 
-  const getTimestamp = async () => Number(await timestamp.inputValue());
   const measureProgress = async (durationMs: number): Promise<number> => {
-    const start = await getTimestamp();
-    await mainWindow.keyboard.press("Space"); // start playback
+    const start = await player.getTimestampValue();
+    await player.togglePlayback(); // start playback
     await mainWindow.waitForTimeout(durationMs);
-    await mainWindow.keyboard.press("Space"); // stop playback
-    const end = await getTimestamp();
+    await player.togglePlayback(); // stop playback
+    const end = await player.getTimestampValue();
     return end - start;
   };
 
   // When
   const normalProgress = await measureProgress(expectedDuration);
 
-  await dropDownButton.click();
-  const speedOption = mainWindow.getByRole("menuitem", { name: "2×", exact: true }); // change to 2x speed
-  await speedOption.click();
-  await expect(speedOption).toHaveCount(0);
+  await player.setSpeed("2×"); // change to 2x speed
 
   // Then
   const newProgress = await measureProgress(expectedDuration);
@@ -64,37 +58,30 @@ test("should double playback speed after choosing 2x", async ({ mainWindow }) =>
  */
 
 test("should playback at one-tenth speed after choosing 0.1x", async ({ mainWindow }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   await loadFiles({ mainWindow, filenames: MCAP_FILENAME });
   await changeToEpochFormat(mainWindow);
 
   const expectedRatio = 0.1;
   const expectedDuration = 500; // ms
-  const timestamp = mainWindow.getByTestId("PlaybackTime-text").locator("input");
-  const dropDownButton = mainWindow.getByTestId("PlaybackSpeedControls-Dropdown");
 
-  await dropDownButton.click();
-  const regularSpeed = mainWindow.getByRole("menuitem", { name: "1×", exact: true }); // make sure we're on 1x speed
-  await regularSpeed.click();
-  await expect(regularSpeed).toHaveCount(0);
+  await player.setSpeed("1×"); // make sure we're on 1x speed
 
-  const getTimestamp = async () => Number(await timestamp.inputValue());
   const measureProgress = async (durationMs: number): Promise<number> => {
-    const start = await getTimestamp();
-    await mainWindow.keyboard.press("Space"); // start playback
+    const start = await player.getTimestampValue();
+    await player.togglePlayback(); // start playback
     await mainWindow.waitForTimeout(durationMs);
-    await mainWindow.keyboard.press("Space"); // stop playback
-    const end = await getTimestamp();
+    await player.togglePlayback(); // stop playback
+    const end = await player.getTimestampValue();
     return end - start;
   };
 
   // When
   const normalProgress = await measureProgress(expectedDuration);
 
-  await dropDownButton.click();
-  const speedOption = mainWindow.getByRole("menuitem", { name: "0.1×", exact: true }); // change to 0.1x speed
-  await speedOption.click();
-  await expect(speedOption).toHaveCount(0);
+  await player.setSpeed("0.1×"); // change to 0.1x speed
 
   // Then
   const newProgress = await measureProgress(expectedDuration);

--- a/e2e/tests/desktop/player/timestamp-type-switch.desktop.spec.ts
+++ b/e2e/tests/desktop/player/timestamp-type-switch.desktop.spec.ts
@@ -3,6 +3,7 @@
 
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { PlayerControls } from "../../../page-objects";
 
 /**
  * GIVEN a .mcap file is loaded
@@ -12,6 +13,8 @@ import { loadFiles } from "../../../fixtures/load-files";
  * THEN the player time displayed should change to 1740566235.547000000 (epoch format)
  */
 test("should switch playback time to epoch format next to the player", async ({ mainWindow }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   const initialTimeInUTC = "2025-02-26 10:37:15.547 AM WET";
   const intialTimeInEpoch = "1740566235.547000000";
@@ -23,15 +26,7 @@ test("should switch playback time to epoch format next to the player", async ({ 
   });
 
   // When
-  const playerStartingTime = mainWindow.locator(`input[value="${initialTimeInUTC}"]`);
-  // Playback time display needs to be hovered first so clicking on it is possible
-  await playerStartingTime.hover();
-
-  const timestampDropdown = mainWindow.getByTestId("playback-time-display-toggle-button");
-  await timestampDropdown.click();
-
-  const newTimestampOption = mainWindow.getByTestId("playback-time-display-option-SEC");
-  await newTimestampOption.click();
+  await player.switchToEpochFormat(initialTimeInUTC);
 
   // Then
   const playerStartingTimeInEpoch = mainWindow.locator(`input[value="${intialTimeInEpoch}"]`);

--- a/e2e/tests/desktop/remote-data/open-websocket-connection.desktop.spec.ts
+++ b/e2e/tests/desktop/remote-data/open-websocket-connection.desktop.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
 import { launchWebsocket } from "../../../fixtures/launch-websocket";
+import { DataSourceDialog, Panels, Sidebar } from "../../../page-objects";
 
 /**
  * GIVEN there is a WebSocket server is running
@@ -15,21 +16,24 @@ import { launchWebsocket } from "../../../fixtures/launch-websocket";
 test("show correctly open a web socket connection showing correct attibutes on raw messages panel", async ({
   mainWindow,
 }) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+  const panels = new Panels(mainWindow);
+
   // Given
   const websocketServer = launchWebsocket();
 
   // When
-  await mainWindow.getByText("Open connection").click();
+  await dialog.openConnection();
   await mainWindow.getByText("Open", { exact: true }).click();
 
   // Then
   await expect(mainWindow.getByText("ws://localhost:8765").innerHTML()).resolves.toBeDefined();
 
   // When
-  await mainWindow.getByText("Topics", { exact: true }).click();
+  await sidebar.openTopicsTab();
   await expect(mainWindow.getByText("/websocket_test").innerHTML()).resolves.toBeDefined();
-  await mainWindow.getByTestId("AddPanelButton").click();
-  await mainWindow.getByText("Raw Messages", { exact: true }).click();
+  await panels.addPanel("Raw Messages");
   await mainWindow.getByPlaceholder("/some/topic.msgs[0].field").nth(0).click();
   await mainWindow.getByTestId("autocomplete-item").click();
 

--- a/e2e/tests/desktop/settings/customize-step-size.desktop.spec.ts
+++ b/e2e/tests/desktop/settings/customize-step-size.desktop.spec.ts
@@ -3,6 +3,7 @@
 
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { PlayerControls } from "../../../page-objects";
 
 /**
  * GIVEN example.mcap file is loaded
@@ -18,6 +19,8 @@ import { loadFiles } from "../../../fixtures/load-files";
 test("Should update the step size value via settings and verify that change being applied on the player by moving forward and backward", async ({
   mainWindow,
 }) => {
+  const player = new PlayerControls(mainWindow);
+
   // Given
   const initialTime = "2025-02-26 10:37:15.547 AM WET";
   const forwardedTime = "2025-02-26 10:37:15.947 AM WET";
@@ -38,14 +41,14 @@ test("Should update the step size value via settings and verify that change bein
 
   await mainWindow.locator("#stepSizeInput").fill("400");
   await mainWindow.getByText("Done").click();
-  await mainWindow.getByTitle("Seek forward").click();
+  await player.seekForward();
 
   // Then
   const playerForwardedTime = mainWindow.locator(`input[value="${forwardedTime}"]`);
   expect(await playerForwardedTime.inputValue()).toBe(forwardedTime);
 
   // When
-  await mainWindow.getByTitle("Seek backward").click();
+  await player.seekBackward();
 
   // Then
   expect(await playerStartingTime.inputValue()).toBe(initialTime);

--- a/e2e/tests/desktop/topics/toggle-topic-visibility.desktop.spec.ts
+++ b/e2e/tests/desktop/topics/toggle-topic-visibility.desktop.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { Sidebar } from "../../../page-objects";
 
 /**
  * GIVEN a file with multiple topics is loaded
@@ -9,6 +10,8 @@ import { loadFiles } from "../../../fixtures/load-files";
  * THEN the filters "List all", "List visible", and "List invisible" should work as expected
  */
 test("toggle topics visibility", async ({ mainWindow }) => {
+  const sidebar = new Sidebar(mainWindow);
+
   // Given
   const filename = "demo-shuffled.bag";
   await loadFiles({
@@ -17,7 +20,7 @@ test("toggle topics visibility", async ({ mainWindow }) => {
   });
 
   // When
-  await mainWindow.getByTestId("panel-settings-left").click();
+  await sidebar.openPanelSettingsTab();
   await mainWindow.getByText("3D").first().click();
   const visibilityButtons = mainWindow.getByTitle("Toggle visibility");
   await visibilityButtons.first().click();

--- a/e2e/tests/desktop/variables/create-and-use-global-variable.desktop.spec.ts
+++ b/e2e/tests/desktop/variables/create-and-use-global-variable.desktop.spec.ts
@@ -3,6 +3,7 @@
 
 import { test, expect } from "../../../fixtures/electron";
 import { loadFiles } from "../../../fixtures/load-files";
+import { PlayerControls, Sidebar } from "../../../page-objects";
 
 /**
  * Given the file example.bag is loaded
@@ -14,6 +15,9 @@ import { loadFiles } from "../../../fixtures/load-files";
  * Then a message with `child_frame_id` equal to "turtle1" should be visible
  */
 test("Create global variable and use it on Raw Messages Panel", async ({ mainWindow }) => {
+  const player = new PlayerControls(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+
   // Given
   const filename = "example.bag";
   await loadFiles({
@@ -22,7 +26,7 @@ test("Create global variable and use it on Raw Messages Panel", async ({ mainWin
   });
 
   // When
-  await mainWindow.getByTestId("right-sidebar-button").click();
+  await sidebar.toggleRightSidebar();
   await mainWindow.getByTestId("add-variable-button").click();
 
   const newVariableNameInput = mainWindow.getByPlaceholder("variable_name");
@@ -34,7 +38,7 @@ test("Create global variable and use it on Raw Messages Panel", async ({ mainWin
   await newVariableValueInput.press("Backspace");
   await newVariableValueInput.fill('"turtle1"');
 
-  await mainWindow.getByRole("button", { name: "Play", exact: true }).click();
+  await player.play();
 
   // Then
   await expect(mainWindow.getByText("No topic selected")).toBeVisible();

--- a/e2e/tests/web/edit-timestamp.web.spec.ts
+++ b/e2e/tests/web/edit-timestamp.web.spec.ts
@@ -4,6 +4,7 @@
 import { test, expect } from "@playwright/test";
 
 import { loadFiles } from "../../fixtures/load-files";
+import { PlayerControls } from "../../page-objects";
 
 const MCAP_FILENAME = "example.mcap";
 
@@ -16,6 +17,8 @@ const MCAP_FILENAME = "example.mcap";
  */
 
 test("is able to manually edit the timestamp display on the player", async ({ page }) => {
+  const player = new PlayerControls(page);
+
   // Given
   const getTimeParam = () => new URL(page.url()).searchParams.get("time");
 
@@ -35,7 +38,7 @@ test("is able to manually edit the timestamp display on the player", async ({ pa
   expect(getTimeParam()).toBe(urlInitialTimestamp);
 
   // When
-  const timestampInput = page.getByTestId("PlaybackTime-text").locator("input");
+  const timestampInput = player.getTimestampInput();
   const newTimestamp = "2025-02-26 10:37:18.499 AM WET";
   await timestampInput.click();
   await timestampInput.fill(newTimestamp);
@@ -60,6 +63,8 @@ test("is able to manually edit the timestamp display on the player", async ({ pa
 test("is able to manually edit the timestamp display (epoch format) on the player", async ({
   page,
 }) => {
+  const player = new PlayerControls(page);
+
   // Given
   const getTimeParam = () => new URL(page.url()).searchParams.get("time");
 
@@ -86,7 +91,7 @@ test("is able to manually edit the timestamp display (epoch format) on the playe
   expect(getTimeParam()).toBe(urlInitialTimestamp);
 
   // When
-  const timestampInput = page.getByTestId("PlaybackTime-text").locator("input");
+  const timestampInput = player.getTimestampInput();
   const newEpochTimestamp = "1740566238.499000000";
   await timestampInput.click();
   await timestampInput.fill(newEpochTimestamp);

--- a/e2e/tests/web/open-files/open-mcap-via-url.web.spec.ts
+++ b/e2e/tests/web/open-files/open-mcap-via-url.web.spec.ts
@@ -4,8 +4,11 @@
 import { test, expect } from "@playwright/test";
 
 import { TEST_MCAP_URL } from "../../../fixtures/urls";
+import { PlayerControls } from "../../../page-objects";
 
 test("should open an MCAP file via URL", async ({ page }) => {
+  const player = new PlayerControls(page);
+
   // Given
   await page.goto(`/?ds=remote-file&ds.url=${TEST_MCAP_URL}`);
 
@@ -19,7 +22,7 @@ test("should open an MCAP file via URL", async ({ page }) => {
   await expect(playButton).toBeEnabled();
 
   // When
-  await page.getByTestId("progress-plot").waitFor({ state: "hidden" });
+  await player.getProgressPlot().waitFor({ state: "hidden" });
   await playButton.click();
 
   // Then


### PR DESCRIPTION
## User-Facing Changes

None. This is an internal test infrastructure improvement with no impact on application behavior.

## Description

Introduces a **Page Object Model (POM)** layer for the Playwright e2e test suite, complying with the project's ADR for test architecture.

### What was done

**New page objects** (`e2e/page-objects/`):
- `AppMenu` — File/View menu interactions
- `DataSourceDialog` — Data source dialog open/close/navigation
- `ExtensionManager` — Extension install/uninstall/search workflows
- `LayoutManager` — Layout creation, selection, import, and revert
- `Panels` — Panel add/configure/split operations
- `PlayerControls` — Playback controls (play, pause, seek, speed, timestamp)
- `Sidebar` — Left/right sidebar toggle and tab navigation

**Test refactoring:**
- 30+ test files updated to use page objects instead of raw `getByTestId()` calls
- Eliminated duplicated selector logic scattered across tests
- Removed local helper functions replaced by POM methods (e.g., `getPlaybackElements()`)

**Housekeeping:**
- Added `blob-report/` to `.gitignore`
- Fixed "Pré script" typos → "Pre-script" in README
- Updated contact reference from "QA team" to "Lichtblick team"
- Fixed `clickPlayblackSlider` typo → `clickPlaybackSlider`
- Removed unused `addPanelFromSearch()` method

### Benefits
- **Single point of change**: UI selector updates only need to happen in one POM file instead of dozens of tests
- **Readability**: `player.play()` is immediately clear vs. `mainWindow.getByTestId("play-button").click()`
- **Reduced flakiness**: State-aware interactions and explicit waits for UI transitions

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated