### PR TITLE
fix(layouts): use updatedAt timestamp for layout version tracking

### DIFF
--- a/packages/suite-base/src/api/layouts/LayoutsAPI.test.ts
+++ b/packages/suite-base/src/api/layouts/LayoutsAPI.test.ts
@@ -49,7 +49,7 @@ describe("LayoutsAPI", () => {
             userNodes: {},
           },
           permission: "CREATOR_WRITE" as any,
-          updatedBy: "2023-01-01T00:00:00.000Z",
+          updatedAt: "2023-01-01T00:00:00.000Z",
         },
       ];
 
@@ -105,8 +105,8 @@ describe("LayoutsAPI", () => {
         permission: mockSaveRequest.permission,
         from: BasicBuilder.string(),
         workspace: mockWorkspace,
-        createdBy: "2023-01-01T00:00:00.000Z",
-        updatedBy: "2023-01-01T00:00:00.000Z",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        updatedAt: "2023-01-01T00:00:00.000Z",
       };
 
       const mockApiResponse: WorkspaceLayoutResponse = {
@@ -154,7 +154,7 @@ describe("LayoutsAPI", () => {
         name: "Updated Layout",
         data: mockUpdateRequest.data,
         permission: "ORG_READ" as any,
-        updatedBy: "2023-01-01T00:00:00.000Z",
+        updatedAt: "2023-01-01T00:00:00.000Z",
       };
 
       const mockHttpService = jest.mocked(HttpService);

--- a/packages/suite-base/src/api/layouts/LayoutsAPI.ts
+++ b/packages/suite-base/src/api/layouts/LayoutsAPI.ts
@@ -37,7 +37,7 @@ export class LayoutsAPI implements IRemoteLayoutStorage {
       name: layout.name,
       data: layout.data,
       permission: layout.permission,
-      savedAt: layout.updatedBy as ISO8601Timestamp | undefined,
+      savedAt: layout.updatedAt as ISO8601Timestamp | undefined,
     }));
   }
 
@@ -66,7 +66,7 @@ export class LayoutsAPI implements IRemoteLayoutStorage {
       name: layoutData.name,
       data: layoutData.data,
       permission: layoutData.permission,
-      savedAt: layoutData.updatedBy as ISO8601Timestamp | undefined,
+      savedAt: layoutData.updatedAt as ISO8601Timestamp | undefined,
     };
 
     return transformedLayout;
@@ -91,7 +91,7 @@ export class LayoutsAPI implements IRemoteLayoutStorage {
       name: layoutData.name,
       data: layoutData.data,
       permission: layoutData.permission,
-      savedAt: layoutData.updatedBy as ISO8601Timestamp | undefined,
+      savedAt: layoutData.updatedAt as ISO8601Timestamp | undefined,
     };
 
     return { status: "success", newLayout };

--- a/packages/suite-base/src/api/layouts/LayoutsAPI.ts
+++ b/packages/suite-base/src/api/layouts/LayoutsAPI.ts
@@ -37,7 +37,7 @@ export class LayoutsAPI implements IRemoteLayoutStorage {
       name: layout.name,
       data: layout.data,
       permission: layout.permission,
-      savedAt: layout.updatedAt as ISO8601Timestamp | undefined,
+      savedAt: layout.updatedAt as ISO8601Timestamp,
     }));
   }
 
@@ -66,7 +66,7 @@ export class LayoutsAPI implements IRemoteLayoutStorage {
       name: layoutData.name,
       data: layoutData.data,
       permission: layoutData.permission,
-      savedAt: layoutData.updatedAt as ISO8601Timestamp | undefined,
+      savedAt: layoutData.updatedAt as ISO8601Timestamp,
     };
 
     return transformedLayout;
@@ -91,7 +91,7 @@ export class LayoutsAPI implements IRemoteLayoutStorage {
       name: layoutData.name,
       data: layoutData.data,
       permission: layoutData.permission,
-      savedAt: layoutData.updatedAt as ISO8601Timestamp | undefined,
+      savedAt: layoutData.updatedAt as ISO8601Timestamp,
     };
 
     return { status: "success", newLayout };

--- a/packages/suite-base/src/api/layouts/types.ts
+++ b/packages/suite-base/src/api/layouts/types.ts
@@ -31,10 +31,10 @@ export interface LayoutApiData {
   permission: LayoutPermission;
   /** Source or origin information */
   from: string;
-  /** User who created the layout */
-  createdBy: string;
-  /** User who last updated the layout */
-  updatedBy: string;
+  /** Timestamp when the layout was created */
+  createdAt: string;
+  /** Timestamp when the layout was last updated */
+  updatedAt: string;
 }
 
 // =============================================================================


### PR DESCRIPTION
## User-Facing Changes

Fix organizational layouts being duplicated and showing stale data after updates.

## Description

This fix maps `savedAt` to `updatedAt` timestamp field so version comparisons work as intended.

## Checklist

- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Layout metadata now provides explicit createdAt and updatedAt timestamps for more accurate layout timing.
* **Tests**
  * Test fixtures and suites updated to reflect the new timestamp fields so saved and retrieved layouts show correct created/updated times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->