### PR TITLE
feature: Implement session-based mcap resolution

### DIFF
--- a/packages/suite-base/src/Workspace.test.tsx
+++ b/packages/suite-base/src/Workspace.test.tsx
@@ -439,7 +439,10 @@ describe("Workspace - session-based MCAP resolution", () => {
 
   it("should not fetch session when sessionId is not present", () => {
     // Given
-    (parseAppURLState as jest.Mock).mockReturnValue({ ds: "remote-file", dsParams: { url: "https://example.com/file.mcap" } });
+    (parseAppURLState as jest.Mock).mockReturnValue({
+      ds: "remote-file",
+      dsParams: { url: "https://example.com/file.mcap" },
+    });
 
     // When
     render(<Workspace deepLinks={["https://app.example.com/?ds=remote-file"]} />);

--- a/packages/suite-base/src/Workspace.test.tsx
+++ b/packages/suite-base/src/Workspace.test.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import "@testing-library/jest-dom";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 
 import {
   useMessagePipeline,
@@ -25,6 +25,7 @@ import { useAppConfigurationValue } from "@lichtblick/suite-base/hooks";
 import useAlertCount from "@lichtblick/suite-base/hooks/useAlertCount";
 import { useHandleFiles } from "@lichtblick/suite-base/hooks/useHandleFiles";
 import { PlayerPresence } from "@lichtblick/suite-base/players/types";
+import { parseAppURLState } from "@lichtblick/suite-base/util/appURLState";
 
 import Workspace from "./Workspace";
 
@@ -41,7 +42,19 @@ jest.mock("react-i18next", () => ({
 }));
 jest.mock("@lichtblick/log", () => ({
   __esModule: true,
-  default: { getLogger: () => ({ debug: jest.fn() }) },
+  default: { getLogger: () => ({ debug: jest.fn(), error: jest.fn() }) },
+}));
+
+const mockEnqueueSnackbar = jest.fn();
+jest.mock("notistack", () => ({
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueueSnackbar }),
+}));
+
+// ── api ───────────────────────────────────────────────────────────────────────
+const mockGetSession = jest.fn();
+jest.mock("@lichtblick/suite-base/api/session/SessionAPI", () => ({
+  __esModule: true,
+  default: { getSession: (...args: unknown[]) => mockGetSession(...args) },
 }));
 
 // ── components (rendered as null — Sidebars is the exception below) ────────────
@@ -336,5 +349,102 @@ describe("Workspace - alerts badge in leftSidebarItems", () => {
     // Then
     const leftItems = MockedSidebars.mock.lastCall?.[0]?.leftItems as Map<string, SidebarItem>;
     expect(leftItems.get("alerts")?.badge?.count).toBe(5);
+  });
+});
+
+describe("Workspace - session-based MCAP resolution", () => {
+  const mockSelectSource = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useMessagePipeline as jest.Mock).mockImplementation(
+      (selector: (ctx: typeof mockPipelineContext) => unknown) => selector(mockPipelineContext),
+    );
+    (useMessagePipelineGetter as jest.Mock).mockReturnValue(() => mockPipelineContext);
+    (useWorkspaceStore as jest.Mock).mockImplementation(
+      (selector: (store: typeof mockWorkspaceStore) => unknown) => selector(mockWorkspaceStore),
+    );
+    (useWorkspaceActions as jest.Mock).mockReturnValue(mockWorkspaceActions);
+    (usePlayerSelection as jest.Mock).mockReturnValue({
+      availableSources: [],
+      selectSource: mockSelectSource,
+    });
+    (useAlertCount as jest.Mock).mockReturnValue({
+      playerAlerts: [],
+      sessionAlerts: [],
+      alertCount: 0,
+    });
+    (useHandleFiles as jest.Mock).mockReturnValue({ handleFiles: jest.fn() });
+    (useAppConfigurationValue as jest.Mock).mockReturnValue([false]);
+    (useCurrentUser as jest.Mock).mockReturnValue({ currentUser: undefined, signIn: undefined });
+    (useCurrentUserType as jest.Mock).mockReturnValue("unauthenticated");
+    (useEvents as jest.Mock).mockImplementation(
+      (selector: (store: { eventsSupported: boolean; selectEvent: jest.Mock }) => unknown) =>
+        selector({ eventsSupported: false, selectEvent: jest.fn() }),
+    );
+    (useAppContext as jest.Mock).mockReturnValue({
+      PerformanceSidebarComponent: undefined,
+      sidebarItems: [],
+      layoutBrowser: undefined,
+      workspaceStoreCreator: undefined,
+    });
+  });
+
+  it("should fetch session and call selectSource with resolved URLs and metadata", async () => {
+    // Given
+    const sessionId = "test-session-123";
+    const mockMcaps = [
+      { url: "https://example.com/file1.mcap", metadata: { robot: "r1" } },
+      { url: "https://example.com/file2.mcap", metadata: { robot: "r2" } },
+    ];
+    mockGetSession.mockResolvedValue(mockMcaps);
+    (parseAppURLState as jest.Mock).mockReturnValue({ sessionId });
+
+    // When
+    render(<Workspace deepLinks={["https://app.example.com/?sessionid=test-session-123"]} />);
+
+    // Then
+    await waitFor(() => {
+      expect(mockGetSession).toHaveBeenCalledWith(sessionId);
+    });
+    await waitFor(() => {
+      expect(mockSelectSource).toHaveBeenCalledWith("remote-file", {
+        type: "connection",
+        params: { url: "https://example.com/file1.mcap,https://example.com/file2.mcap" },
+        sourceMetadata: [{ robot: "r1" }, { robot: "r2" }],
+      });
+    });
+  });
+
+  it("should show error snackbar when session fetch fails", async () => {
+    // Given
+    const sessionId = "failing-session";
+    mockGetSession.mockRejectedValue(new Error("Network error"));
+    (parseAppURLState as jest.Mock).mockReturnValue({ sessionId });
+
+    // When
+    render(<Workspace deepLinks={["https://app.example.com/?sessionid=failing-session"]} />);
+
+    // Then
+    await waitFor(() => {
+      expect(mockGetSession).toHaveBeenCalledWith(sessionId);
+    });
+    await waitFor(() => {
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith("Failed to load session data sources", {
+        variant: "error",
+      });
+    });
+  });
+
+  it("should not fetch session when sessionId is not present", () => {
+    // Given
+    (parseAppURLState as jest.Mock).mockReturnValue({ ds: "remote-file", dsParams: { url: "https://example.com/file.mcap" } });
+
+    // When
+    render(<Workspace deepLinks={["https://app.example.com/?ds=remote-file"]} />);
+
+    // Then
+    expect(mockGetSession).not.toHaveBeenCalled();
   });
 });

--- a/packages/suite-base/src/Workspace.test.tsx
+++ b/packages/suite-base/src/Workspace.test.tsx
@@ -406,7 +406,7 @@ describe("Workspace - session-based MCAP resolution", () => {
 
     // Then
     await waitFor(() => {
-      expect(mockGetSession).toHaveBeenCalledWith(sessionId);
+      expect(mockGetSession).toHaveBeenCalledWith(sessionId, expect.any(AbortSignal));
     });
     await waitFor(() => {
       expect(mockSelectSource).toHaveBeenCalledWith("remote-file", {
@@ -428,7 +428,7 @@ describe("Workspace - session-based MCAP resolution", () => {
 
     // Then
     await waitFor(() => {
-      expect(mockGetSession).toHaveBeenCalledWith(sessionId);
+      expect(mockGetSession).toHaveBeenCalledWith(sessionId, expect.any(AbortSignal));
     });
     await waitFor(() => {
       expect(mockEnqueueSnackbar).toHaveBeenCalledWith("Failed to load session data sources", {

--- a/packages/suite-base/src/Workspace.tsx
+++ b/packages/suite-base/src/Workspace.tsx
@@ -15,12 +15,14 @@
 
 import { Link, Typography } from "@mui/material";
 import { t } from "i18next";
+import { useSnackbar } from "notistack";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 
 import Logger from "@lichtblick/log";
 import { AppSetting } from "@lichtblick/suite-base/AppSetting";
 import { useStyles } from "@lichtblick/suite-base/Workspace.style";
+import SessionAPI from "@lichtblick/suite-base/api/session/SessionAPI";
 import AccountSettings from "@lichtblick/suite-base/components/AccountSettingsSidebar/AccountSettings";
 import { AlertsList } from "@lichtblick/suite-base/components/AlertsList";
 import { AppBar } from "@lichtblick/suite-base/components/AppBar";
@@ -158,6 +160,7 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
     [getMessagePipeline],
   );
 
+  const { enqueueSnackbar } = useSnackbar();
   const { dialogActions, sidebarActions } = useWorkspaceActions();
   const { handleFiles } = useHandleFiles({
     availableSources,
@@ -488,9 +491,40 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
     return deepLinks[0] ? parseAppURLState(new URL(deepLinks[0])) : undefined;
   }, [props.deepLinks]);
 
-  const [unappliedSourceArgs, setUnappliedSourceArgs] = useState(
-    targetUrlState ? { ds: targetUrlState.ds, dsParams: targetUrlState.dsParams } : undefined,
+  const [unappliedSourceArgs, setUnappliedSourceArgs] = useState<
+    | {
+        ds: string | undefined;
+        dsParams: Record<string, string> | undefined;
+        sourceMetadata?: Record<string, unknown>[];
+      }
+    | undefined
+  >(
+    targetUrlState && !targetUrlState.sessionId
+      ? { ds: targetUrlState.ds, dsParams: targetUrlState.dsParams }
+      : undefined,
   );
+
+  // Resolve session-based MCAP URLs when sessionId is present.
+  useEffect(() => {
+    if (!targetUrlState?.sessionId) {
+      return;
+    }
+
+    void (async () => {
+      try {
+        const mcaps = await SessionAPI.getSession(targetUrlState.sessionId!);
+        const urls = mcaps.map((mcap) => mcap.url);
+        setUnappliedSourceArgs({
+          ds: "remote-file",
+          dsParams: { url: urls.join(",") },
+          sourceMetadata: mcaps.map((mcap) => mcap.metadata),
+        });
+      } catch (error) {
+        log.error("Failed to fetch session MCAP URLs:", error);
+        enqueueSnackbar("Failed to load session data sources", { variant: "error" });
+      }
+    })();
+  }, [targetUrlState?.sessionId, enqueueSnackbar]);
 
   const selectEvent = useEvents(selectSelectEvent);
   // Load data source from URL.
@@ -505,6 +539,7 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
       selectSource(unappliedSourceArgs.ds, {
         type: "connection",
         params: unappliedSourceArgs.dsParams,
+        sourceMetadata: unappliedSourceArgs.sourceMetadata,
       });
       selectEvent(unappliedSourceArgs.dsParams?.eventId);
       setUnappliedSourceArgs({ ds: undefined, dsParams: undefined });

--- a/packages/suite-base/src/Workspace.tsx
+++ b/packages/suite-base/src/Workspace.tsx
@@ -506,13 +506,14 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
 
   // Resolve session-based MCAP URLs when sessionId is present.
   useEffect(() => {
-    if (!targetUrlState?.sessionId) {
+    const sessionId = targetUrlState?.sessionId;
+    if (!sessionId) {
       return;
     }
 
     void (async () => {
       try {
-        const mcaps = await SessionAPI.getSession(targetUrlState.sessionId!);
+        const mcaps = await SessionAPI.getSession(sessionId);
         const urls = mcaps.map((mcap) => mcap.url);
         setUnappliedSourceArgs({
           ds: "remote-file",

--- a/packages/suite-base/src/Workspace.tsx
+++ b/packages/suite-base/src/Workspace.tsx
@@ -511,9 +511,17 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
       return;
     }
 
+    const controller = new AbortController();
+    const { signal } = controller;
+
     void (async () => {
       try {
-        const mcaps = await SessionAPI.getSession(sessionId);
+        const mcaps = await SessionAPI.getSession(sessionId, signal);
+        if (mcaps.length === 0) {
+          enqueueSnackbar("Session contains no data sources", { variant: "error" });
+          return;
+        }
+
         const urls = mcaps.map((mcap) => mcap.url);
         setUnappliedSourceArgs({
           ds: "remote-file",
@@ -521,10 +529,17 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
           sourceMetadata: mcaps.map((mcap) => mcap.metadata),
         });
       } catch (error) {
+        if (signal.aborted) {
+          return;
+        }
         log.error("Failed to fetch session MCAP URLs:", error);
         enqueueSnackbar("Failed to load session data sources", { variant: "error" });
       }
     })();
+
+    return () => {
+      controller.abort();
+    };
   }, [targetUrlState?.sessionId, enqueueSnackbar]);
 
   const selectEvent = useEvents(selectSelectEvent);

--- a/packages/suite-base/src/api/session/SessionAPI.test.ts
+++ b/packages/suite-base/src/api/session/SessionAPI.test.ts
@@ -36,7 +36,7 @@ describe("SessionAPI", () => {
 
       const result = await sessionApi.getSession(sessionId);
 
-      expect(mockGet).toHaveBeenCalledWith(`session/${sessionId}`);
+      expect(mockGet).toHaveBeenCalledWith(`session/${sessionId}`, {}, { signal: undefined });
       expect(result).toEqual(mockMcaps);
     });
 

--- a/packages/suite-base/src/api/session/SessionAPI.test.ts
+++ b/packages/suite-base/src/api/session/SessionAPI.test.ts
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import HttpService from "@lichtblick/suite-base/services/http/HttpService";
+import { BasicBuilder } from "@lichtblick/test-builders";
+
+import { SessionAPI } from "./SessionAPI";
+
+jest.mock("@lichtblick/suite-base/services/http/HttpService");
+
+describe("SessionAPI", () => {
+  let sessionApi: SessionAPI;
+
+  const createMockHttpResponse = <T>(data: T) => ({
+    data,
+    timestamp: new Date().toISOString(),
+    path: "/test",
+  });
+
+  beforeEach(() => {
+    sessionApi = new SessionAPI();
+    jest.clearAllMocks();
+  });
+
+  describe("getSession", () => {
+    it("should fetch and return session mcap URLs", async () => {
+      const sessionId = BasicBuilder.string();
+      const mockMcaps = [
+        { url: `https://${BasicBuilder.string()}.com/file1.mcap`, metadata: {} },
+        { url: `https://${BasicBuilder.string()}.com/file2.mcap`, metadata: { size: 1024 } },
+      ];
+
+      const mockHttpService = jest.mocked(HttpService);
+      const mockGet = jest.fn().mockResolvedValue(createMockHttpResponse({ mcaps: mockMcaps }));
+      mockHttpService.get = mockGet;
+
+      const result = await sessionApi.getSession(sessionId);
+
+      expect(mockGet).toHaveBeenCalledWith(`session/${sessionId}`);
+      expect(result).toEqual(mockMcaps);
+    });
+
+    it("should handle empty mcaps list", async () => {
+      const sessionId = BasicBuilder.string();
+
+      const mockHttpService = jest.mocked(HttpService);
+      const mockGet = jest.fn().mockResolvedValue(createMockHttpResponse({ mcaps: [] }));
+      mockHttpService.get = mockGet;
+
+      const result = await sessionApi.getSession(sessionId);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should propagate HTTP errors", async () => {
+      const sessionId = BasicBuilder.string();
+      const mockError = new Error("HTTP Error: 404 Not Found");
+
+      const mockHttpService = jest.mocked(HttpService);
+      const mockGet = jest.fn().mockRejectedValue(mockError);
+      mockHttpService.get = mockGet;
+
+      await expect(sessionApi.getSession(sessionId)).rejects.toThrow("HTTP Error: 404 Not Found");
+    });
+  });
+});

--- a/packages/suite-base/src/api/session/SessionAPI.ts
+++ b/packages/suite-base/src/api/session/SessionAPI.ts
@@ -7,8 +7,10 @@ import { SessionMcap, SessionResponse } from "./types";
 
 export class SessionAPI {
   public readonly sessionPath = "session";
-  public async getSession(sessionId: string): Promise<SessionMcap[]> {
-    const { data } = await HttpService.get<SessionResponse>(`${this.sessionPath}/${sessionId}`);
+  public async getSession(sessionId: string, signal?: AbortSignal): Promise<SessionMcap[]> {
+    const { data } = await HttpService.get<SessionResponse>(`${this.sessionPath}/${sessionId}`, {}, {
+      signal,
+    });
     return data.mcaps;
   }
 }

--- a/packages/suite-base/src/api/session/SessionAPI.ts
+++ b/packages/suite-base/src/api/session/SessionAPI.ts
@@ -8,9 +8,13 @@ import { SessionMcap, SessionResponse } from "./types";
 export class SessionAPI {
   public readonly sessionPath = "session";
   public async getSession(sessionId: string, signal?: AbortSignal): Promise<SessionMcap[]> {
-    const { data } = await HttpService.get<SessionResponse>(`${this.sessionPath}/${sessionId}`, {}, {
-      signal,
-    });
+    const { data } = await HttpService.get<SessionResponse>(
+      `${this.sessionPath}/${sessionId}`,
+      {},
+      {
+        signal,
+      },
+    );
     return data.mcaps;
   }
 }

--- a/packages/suite-base/src/api/session/SessionAPI.ts
+++ b/packages/suite-base/src/api/session/SessionAPI.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import HttpService from "@lichtblick/suite-base/services/http/HttpService";
+
+import { SessionMcap, SessionResponse } from "./types";
+
+export class SessionAPI {
+  public readonly sessionPath = "session";
+  public async getSession(sessionId: string): Promise<SessionMcap[]> {
+    const { data } = await HttpService.get<SessionResponse>(`${this.sessionPath}/${sessionId}`);
+    return data.mcaps;
+  }
+}
+
+export default new SessionAPI();

--- a/packages/suite-base/src/api/session/types.ts
+++ b/packages/suite-base/src/api/session/types.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+export type SessionMcap = {
+  url: string;
+  metadata: Record<string, unknown>;
+};
+
+export type SessionResponse = {
+  mcaps: SessionMcap[];
+};

--- a/packages/suite-base/src/components/PlayerManager.tsx
+++ b/packages/suite-base/src/components/PlayerManager.tsx
@@ -201,6 +201,7 @@ export default function PlayerManager(
             const newPlayer = foundSource.initialize({
               metricsCollector,
               params: args.params,
+              sourceMetadata: args.sourceMetadata,
             });
             setBasePlayer(newPlayer);
 

--- a/packages/suite-base/src/context/PlayerSelectionContext.ts
+++ b/packages/suite-base/src/context/PlayerSelectionContext.ts
@@ -16,6 +16,7 @@ export type DataSourceFactoryInitializeArgs = {
   file?: File;
   files?: File[];
   params?: Record<string, string | undefined>;
+  sourceMetadata?: Record<string, unknown>[];
 };
 
 export type DataSourceFactoryType = "file" | "connection" | "sample";
@@ -91,6 +92,7 @@ type FileDataSourceArgs = {
 type ConnectionDataSourceArgs = {
   type: "connection";
   params?: Record<string, string | undefined>;
+  sourceMetadata?: Record<string, unknown>[];
 };
 
 export type DataSourceArgs = FileDataSourceArgs | ConnectionDataSourceArgs;

--- a/packages/suite-base/src/hooks/useStateToURLSynchronization.test.tsx
+++ b/packages/suite-base/src/hooks/useStateToURLSynchronization.test.tsx
@@ -82,4 +82,41 @@ describe("useStateToURLSynchronization", () => {
       "http://localhost/?ds=test-source2&ds.b=two&ds.c=three&time=1970-01-01T00:00:01.000000001Z",
     );
   });
+
+  it("suppresses ds param writeback when sessionid is present in the URL", () => {
+    const spy = jest.spyOn(window.history, "replaceState");
+
+    // Set the URL to include sessionid
+    Object.defineProperty(window, "location", {
+      value: new URL("http://localhost/?sessionid=test-session-123"),
+      writable: true,
+    });
+
+    (useMessagePipeline as jest.Mock).mockImplementation((selector) =>
+      selector({
+        playerState: {
+          activeData: {
+            currentTime: { sec: 5, nsec: 0 },
+          },
+          capabilities: ["playbackControl"],
+          urlState: {
+            sourceId: "remote-file",
+            parameters: { url: "http://example.com/file.mcap" },
+          },
+        },
+      }),
+    );
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <EventsProvider>{children}</EventsProvider>
+    );
+
+    renderHook(useStateToURLSynchronization, { wrapper });
+
+    // Should only write time, not ds params
+    const calls = spy.mock.calls;
+    const lastCallUrl = calls[calls.length - 1]?.[2] as string | undefined;
+    expect(lastCallUrl).not.toContain("ds=remote-file");
+    expect(lastCallUrl).not.toContain("ds.url=");
+  });
 });

--- a/packages/suite-base/src/hooks/useStateToURLSynchronization.test.tsx
+++ b/packages/suite-base/src/hooks/useStateToURLSynchronization.test.tsx
@@ -87,10 +87,7 @@ describe("useStateToURLSynchronization", () => {
     const spy = jest.spyOn(window.history, "replaceState");
 
     // Set the URL to include sessionid
-    Object.defineProperty(window, "location", {
-      value: new URL("http://localhost/?sessionid=test-session-123"),
-      writable: true,
-    });
+    window.history.pushState({}, "", "http://localhost/?sessionid=test-session-123");
 
     (useMessagePipeline as jest.Mock).mockImplementation((selector) =>
       selector({

--- a/packages/suite-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/suite-base/src/hooks/useStateToURLSynchronization.ts
@@ -48,8 +48,14 @@ export function useStateToURLSynchronization(): void {
   }, [canSeek, debouncedCurrentTime]);
 
   // Sync player state with the url.
+  // When a sessionid is present, skip writing ds/dsParams to avoid URL length issues.
   useEffect(() => {
     if (stablePlayerUrlState == undefined) {
+      return;
+    }
+
+    const currentUrl = new URL(window.location.href);
+    if (currentUrl.searchParams.has("sessionid")) {
       return;
     }
 

--- a/packages/suite-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/suite-base/src/hooks/useStateToURLSynchronization.ts
@@ -54,7 +54,7 @@ export function useStateToURLSynchronization(): void {
       return;
     }
 
-    const currentUrl = new URL(window.location.href);
+    const currentUrl = new URL(globalThis.location.href);
     if (currentUrl.searchParams.has("sessionid")) {
       return;
     }

--- a/packages/suite-base/src/util/appURLState.test.ts
+++ b/packages/suite-base/src/util/appURLState.test.ts
@@ -129,6 +129,42 @@ describe("app state url parser", () => {
         dsParams: { url: dataSourceUrl.href },
       });
     });
+
+    it("parses sessionid query parameter", () => {
+      const url = urlBuilder();
+      const sessionId = BasicBuilder.string();
+      url.searchParams.append("sessionid", sessionId);
+
+      const parsed = parseAppURLState(url);
+
+      expect(parsed).toMatchObject({
+        sessionId,
+      });
+    });
+
+    it("parses sessionid alongside time and other params", () => {
+      const url = urlBuilder();
+      const sessionId = BasicBuilder.string();
+      url.searchParams.append("sessionid", sessionId);
+      url.searchParams.append("time", "2025-07-01T14:05:09.331293771Z");
+
+      const parsed = parseAppURLState(url);
+
+      expect(parsed).toMatchObject({
+        sessionId,
+        time: { sec: 1751378709, nsec: 331293771 },
+      });
+    });
+
+    it("returns undefined sessionId when not present", () => {
+      const url = urlBuilder();
+      url.searchParams.append("ds", "remote-file");
+      url.searchParams.append("ds.url", `http://${BasicBuilder.string()}.com/file.mcap`);
+
+      const parsed = parseAppURLState(url);
+
+      expect(parsed?.sessionId).toBeUndefined();
+    });
   });
 });
 

--- a/packages/suite-base/src/util/appURLState.ts
+++ b/packages/suite-base/src/util/appURLState.ts
@@ -18,6 +18,7 @@ export type AppURLState = {
   dsParams?: Record<string, string>;
   dsParamsArray?: Record<string, string[]>;
   layoutId?: LayoutID;
+  sessionId?: string;
   time?: Time;
 };
 
@@ -78,6 +79,7 @@ export function updateAppURLState(url: URL, urlState: AppURLState): URL {
  */
 export function parseAppURLState(url: URL): AppURLState | undefined {
   const ds = url.searchParams.get("ds") ?? undefined;
+  const sessionId = url.searchParams.get("sessionid") ?? undefined;
   const timeString = url.searchParams.get("time");
   const time = parseTimeUrlString(timeString ?? undefined);
   const dsParams: Record<string, string> = {};
@@ -98,6 +100,7 @@ export function parseAppURLState(url: URL): AppURLState | undefined {
     {
       time,
       ds,
+      sessionId,
       dsParams: _.isEmpty(dsParams) ? undefined : dsParams,
     },
     _.isEmpty,


### PR DESCRIPTION
## User-Facing Changes
Implement session-based MCAP resolution.

## Description
Introduce session management for MCAP resolution, allowing multiple MCAPs to be fetched based on a session ID. 

There are several purposes for this:
 - Allow the resolution of multiple mcaps without crowding the url (eventual limit)
 - Enable server-side session management
 - Prepare metadata processing server side (not yet implemented).
 - Maintain backward compatibility — the existing `ds/dsParams` URL-based flow continues to work unchanged; `sessionid` is an additive path

## How to Test
Start local-mcap-server: (https://github.com/luluiz/local-mcap-server)

```
// server.js
const http = require("http");

const PORT = process.env.PORT || 3000;
const headers = {
  "Content-Type": "application/json",
  "Access-Control-Allow-Origin": "*",
  "Access-Control-Allow-Methods": "GET, OPTIONS",
  "Access-Control-Allow-Headers": "Content-Type, Api-Version",
};

http
  .createServer((req, res) => {
    const match = req.url && req.url.match(/^\/api\/session\/([^/?#]+)\/?(?:\?.*)?$/);
    if (req.method === "OPTIONS") {
      res.writeHead(204, headers);
      return res.end();
    }
    if (req.method !== "GET" || !match) {
      res.writeHead(match ? 405 : 404, headers);
      return res.end(JSON.stringify({ error: match ? "Method not allowed" : "Not found" }));
    }
    res.writeHead(200, headers);
    return res.end(
      JSON.stringify({
        data: {
          // change the urls based on what the local-mcap-server provides you with
          mcaps: [{ url: "http://mymcapdata1.com" }, { url: "http://mymcapdata2.com" }],
        },
      }),
    );
  })
  .listen(PORT, () => console.log(`Server listening on http://localhost:${PORT}`));
```
Start API with
```
node server.js
```
Change the mcaps url code based on the url given by local-mcap-server


## Checklist
- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


