### PR TITLE
Fixing cursor not moving in State Transition panel

### DIFF
--- a/packages/suite-base/src/panels/StateTransitions/hooks/useStateTransitionsTime.test.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useStateTransitionsTime.test.ts
@@ -6,7 +6,10 @@
 import { renderHook } from "@testing-library/react";
 
 import { Time, toSec } from "@lichtblick/rostime";
-import { useMessagePipelineGetter } from "@lichtblick/suite-base/components/MessagePipeline";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@lichtblick/suite-base/components/MessagePipeline";
 import { subtractTimes } from "@lichtblick/suite-base/players/UserScriptPlayer/transformerWorker/typescript/userUtils/time";
 
 import useStateTransitionsTime from "./useStateTransitionsTime";
@@ -18,9 +21,18 @@ jest.mock(
 );
 
 describe("useStateTransitionsTime", () => {
-  const mockUseMessagePipelineGetter = useMessagePipelineGetter as jest.Mock;
+  const mockUseMessagePipeline = useMessagePipeline as jest.Mock;
   const mockToSec = toSec as jest.Mock;
   const mockSubtractTimes = subtractTimes as jest.Mock;
+  type ActiveData = MessagePipelineContext["playerState"]["activeData"];
+  type MockActiveData = Partial<NonNullable<ActiveData>> | undefined;
+
+  const mockActiveData = (activeData: MockActiveData) => {
+    const mockContext = {
+      playerState: { activeData: activeData as ActiveData },
+    } as MessagePipelineContext;
+    mockUseMessagePipeline.mockImplementation((selector) => selector(mockContext));
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -28,10 +40,8 @@ describe("useStateTransitionsTime", () => {
 
   it.each([{}, undefined])(
     "should return undefined values when there is no active data or it is undefined. (testing with %s)",
-    () => {
-      mockUseMessagePipelineGetter.mockReturnValue((activeDataValue: string | object) => ({
-        playerState: { activeData: activeDataValue },
-      }));
+    (activeDataValue) => {
+      mockActiveData(activeDataValue as MockActiveData);
 
       const { result } = renderHook(() => useStateTransitionsTime());
 
@@ -45,9 +55,7 @@ describe("useStateTransitionsTime", () => {
     const startTime: Time = { sec: 1, nsec: 0 };
     const currentTime: Time = { sec: 3, nsec: 0 };
 
-    mockUseMessagePipelineGetter.mockReturnValue(() => ({
-      playerState: { activeData: { startTime, currentTime } },
-    }));
+    mockActiveData({ startTime, currentTime });
 
     mockSubtractTimes.mockReturnValue({ sec: 2, nsec: 0 });
     mockToSec.mockReturnValue(2);
@@ -63,9 +71,7 @@ describe("useStateTransitionsTime", () => {
     const startTime: Time = { sec: 1, nsec: 0 };
     const endTime: Time = { sec: 5, nsec: 0 };
 
-    mockUseMessagePipelineGetter.mockReturnValue(() => ({
-      playerState: { activeData: { startTime, endTime } },
-    }));
+    mockActiveData({ startTime, endTime });
 
     mockSubtractTimes.mockReturnValue({ sec: 4, nsec: 0 });
 
@@ -83,9 +89,7 @@ describe("useStateTransitionsTime", () => {
     const currentTime: Time = { sec: 3, nsec: 0 };
     const endTime: Time = { sec: 5, nsec: 0 };
 
-    mockUseMessagePipelineGetter.mockReturnValue(() => ({
-      playerState: { activeData: { startTime, currentTime, endTime } },
-    }));
+    mockActiveData({ startTime, currentTime, endTime });
 
     mockSubtractTimes
       .mockReturnValueOnce({ sec: 2, nsec: 0 })

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useStateTransitionsTime.test.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useStateTransitionsTime.test.ts
@@ -11,6 +11,7 @@ import {
   useMessagePipeline,
 } from "@lichtblick/suite-base/components/MessagePipeline";
 import { subtractTimes } from "@lichtblick/suite-base/players/UserScriptPlayer/transformerWorker/typescript/userUtils/time";
+import { PlayerStateActiveData } from "@lichtblick/suite-base/players/types";
 
 import useStateTransitionsTime from "./useStateTransitionsTime";
 
@@ -24,13 +25,12 @@ describe("useStateTransitionsTime", () => {
   const mockUseMessagePipeline = useMessagePipeline as jest.Mock;
   const mockToSec = toSec as jest.Mock;
   const mockSubtractTimes = subtractTimes as jest.Mock;
-  type ActiveData = MessagePipelineContext["playerState"]["activeData"];
-  type MockActiveData = Partial<NonNullable<ActiveData>> | undefined;
+  const activeDataCases: Array<Partial<PlayerStateActiveData> | undefined> = [{}, undefined];
 
-  const mockActiveData = (activeData: MockActiveData) => {
+  const mockActiveData = (activeData: Partial<PlayerStateActiveData> | undefined) => {
     const mockContext = {
-      playerState: { activeData: activeData as ActiveData },
-    } as MessagePipelineContext;
+      playerState: { activeData: activeData as PlayerStateActiveData },
+    } as unknown as MessagePipelineContext;
     mockUseMessagePipeline.mockImplementation((selector) => selector(mockContext));
   };
 
@@ -38,10 +38,10 @@ describe("useStateTransitionsTime", () => {
     jest.clearAllMocks();
   });
 
-  it.each([{}, undefined])(
+  it.each(activeDataCases)(
     "should return undefined values when there is no active data or it is undefined. (testing with %s)",
-    (activeDataValue) => {
-      mockActiveData(activeDataValue as MockActiveData);
+    (activeDataValue: Partial<PlayerStateActiveData> | undefined) => {
+      mockActiveData(activeDataValue);
 
       const { result } = renderHook(() => useStateTransitionsTime());
 

--- a/packages/suite-base/src/panels/StateTransitions/hooks/useStateTransitionsTime.ts
+++ b/packages/suite-base/src/panels/StateTransitions/hooks/useStateTransitionsTime.ts
@@ -4,7 +4,10 @@
 import { useMemo } from "react";
 
 import { Time, toSec } from "@lichtblick/rostime";
-import { useMessagePipelineGetter } from "@lichtblick/suite-base/components/MessagePipeline";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@lichtblick/suite-base/components/MessagePipeline";
 import { subtractTimes } from "@lichtblick/suite-base/players/UserScriptPlayer/transformerWorker/typescript/userUtils/time";
 
 type UseStateTransitionsTime = {
@@ -13,12 +16,14 @@ type UseStateTransitionsTime = {
   endTimeSinceStart: number | undefined;
 };
 
-const useStateTransitionsTime = (): UseStateTransitionsTime => {
-  const getMessagePipelineState = useMessagePipelineGetter();
+const selectStartTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.startTime;
+const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
+const selectEndTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.endTime;
 
-  const {
-    playerState: { activeData: { startTime, currentTime, endTime } = {} },
-  } = getMessagePipelineState();
+const useStateTransitionsTime = (): UseStateTransitionsTime => {
+  const startTime = useMessagePipeline(selectStartTime);
+  const currentTime = useMessagePipeline(selectCurrentTime);
+  const endTime = useMessagePipeline(selectEndTime);
 
   const currentTimeSinceStart = useMemo(
     () => (currentTime && startTime ? toSec(subtractTimes(currentTime, startTime)) : undefined),


### PR DESCRIPTION
## User-Facing Changes

State Transitions should show again the playback position and follow it along the playback

## Description


Using pipeline selectors inside hook `useStateTransitionsTime.ts` now because:

- It keeps the hook reactive to playback updates rendering them "live" with the playback

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Tests**
  * Refactored the `useStateTransitionsTime` test setup to use selector-based message pipeline mocking and a shared helper for consistent typed context.

* **Refactor**
  * Updated the state transitions timing hook to retrieve `start`, `current`, and `end` timestamps via selector-based pipeline access, keeping the same computed timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->