### PR TITLE
fix(multi-mcap): add minimum cache floor per source to prevent crash

### DIFF
--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
@@ -9,10 +9,27 @@ import { BasicBuilder } from "@lichtblick/test-builders";
 import { MultiIterableSource } from "./MultiIterableSource";
 import { IIterableSource, Initialization } from "../IIterableSource";
 
+// Capture log.warn so individual tests can assert on it.
+// Variables whose names start with "mock" are hoisted by babel-jest alongside jest.mock(),
+// so mockLogWarn is guaranteed to be defined before the factory executes.
+const mockLogWarn = jest.fn();
+jest.mock("@lichtblick/log", () => ({
+  getLogger: jest.fn(() => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    // Wrap in an arrow function so mockLogWarn is only read when log.warn() is actually
+    // invoked during a test (after the `const mockLogWarn = jest.fn()` line has executed),
+    // not at module-import time when jest.mock factories are evaluated.
+    warn: (...args: unknown[]) => mockLogWarn(...args),
+    error: jest.fn(),
+  })),
+}));
+
 describe("MultiIterableSource", () => {
   let mockSourceConstructor: jest.Mock;
   let dataSource: MultiSource;
   beforeEach(() => {
+    mockLogWarn.mockClear();
     mockSourceConstructor = jest.fn().mockImplementation(
       () =>
         ({
@@ -78,6 +95,82 @@ describe("MultiIterableSource", () => {
         cacheSizeInBytes: expect.any(Number),
       });
       expect(initializations).toHaveLength(2);
+    });
+    it("should allocate equal cache split when few sources do not trigger the minimum floor", async () => {
+      // GIVEN: 2 URL sources with the default 500 MiB total cache budget.
+      // floor(500 MiB / 2) = 250 MiB, which is well above the 10 MiB minimum floor,
+      // so the linear split is used as-is and no warning should be emitted.
+      const url1 = BasicBuilder.string();
+      const url2 = BasicBuilder.string();
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls: [url1, url2],
+          // totalCacheSizeInBytes defaults to 500 MiB, minCachePerSourceBytes defaults to 10 MiB
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: each source receives exactly 250 MiB (floor(500 / 2)),
+      // and log.warn is not called because the budget is not exceeded
+      const expected250Mib = 1024 * 1024 * 250;
+      expect(mockSourceConstructor.mock.calls[0]![0].cacheSizeInBytes).toBe(expected250Mib);
+      expect(mockSourceConstructor.mock.calls[1]![0].cacheSizeInBytes).toBe(expected250Mib);
+      expect(mockLogWarn).not.toHaveBeenCalled();
+    });
+    it("should apply minimum floor cache per source when many sources would produce a sub-floor split", async () => {
+      // GIVEN: 100 URL sources with an explicit 500 MiB total cache budget.
+      // A pure linear split would give floor(500 MiB / 100) = 5 MiB per source,
+      // which is below the 10 MiB minimum floor, so the floor must be applied instead.
+      const urls = Array.from({ length: 100 }, () => BasicBuilder.string());
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+          totalCacheSizeInBytes: 1024 * 1024 * 500, // 500 MiB
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: every source gets the 10 MiB minimum, not the 5 MiB linear value
+      const min10Mib = 1024 * 1024 * 10;
+      expect(mockSourceConstructor.mock.calls[0]![0].cacheSizeInBytes).toBe(min10Mib);
+      expect(mockSourceConstructor.mock.calls[99]![0].cacheSizeInBytes).toBe(min10Mib);
+    });
+    it("should respect custom minCachePerSourceBytes and warn when the total budget is exceeded", async () => {
+      // GIVEN: 3 URL sources, totalCacheSizeInBytes = 6 MiB, minCachePerSourceBytes = 4 MiB.
+      // A pure linear split gives floor(6 MiB / 3) = 2 MiB, which is below the 4 MiB custom
+      // floor, so each source is allocated 4 MiB.  Because 4 MiB × 3 = 12 MiB > 6 MiB total,
+      // the implementation must emit exactly one log.warn to signal the budget overrun.
+      const url1 = BasicBuilder.string();
+      const url2 = BasicBuilder.string();
+      const url3 = BasicBuilder.string();
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls: [url1, url2, url3],
+          totalCacheSizeInBytes: 1024 * 1024 * 6, // 6 MiB
+          minCachePerSourceBytes: 1024 * 1024 * 4, // 4 MiB custom floor
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: each source gets 4 MiB (custom floor applied, not the 2 MiB linear split),
+      // and exactly one log.warn is emitted because the total allocation exceeds the budget
+      const expected4Mib = 1024 * 1024 * 4;
+      expect(mockSourceConstructor.mock.calls[0]![0].cacheSizeInBytes).toBe(expected4Mib);
+      expect(mockSourceConstructor.mock.calls[1]![0].cacheSizeInBytes).toBe(expected4Mib);
+      expect(mockSourceConstructor.mock.calls[2]![0].cacheSizeInBytes).toBe(expected4Mib);
+      expect(mockLogWarn).toHaveBeenCalledTimes(1);
     });
     it("should call initialize method for each iterable source", async () => {
       const multiSource = new MultiIterableSource(dataSource, mockSourceConstructor);

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
+import Logger from "@lichtblick/log";
 import { compare } from "@lichtblick/rostime";
 import {
   IterableSourceConstructor,
@@ -33,6 +34,14 @@ import {
   ISerializedIterableSource,
 } from "../IIterableSource";
 
+const log = Logger.getLogger(__filename);
+
+// Minimum cache allocated per remote source to prevent crashes when reading MCAP metadata.
+// The MCAP summary section (chunk indexes, schema records, etc.) can be several MiB in size.
+// Without a floor, a linear split across 300+ files produces cache slices smaller than a
+// single metadata read, causing CachedFilelike to throw "Requested more data than cache size".
+const MIN_CACHE_PER_SOURCE_BYTES = 1024 * 1024 * 10; // 10 MiB
+
 export class MultiIterableSource<T extends ISerializedIterableSource, P>
   implements ISerializedIterableSource
 {
@@ -54,10 +63,22 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
         (file) => new this.SourceConstructor({ type: "file", file } as P),
       );
     } else {
-      // Distribute total cache budget evenly across remote sources.
-      // Default total budget: 500MiB (same as single-file default).
+      // Distribute total cache budget across remote sources with a minimum floor per source.
+      // A pure linear split (totalCache / n) can produce a per-source budget smaller than a
+      // single MCAP metadata read when n > ~300, causing a crash in CachedFilelike.
       const totalCache = this.dataSource.totalCacheSizeInBytes ?? 1024 * 1024 * 500;
-      const perSourceCache = Math.floor(totalCache / this.dataSource.urls.length);
+      const minPerSource = this.dataSource.minCachePerSourceBytes ?? MIN_CACHE_PER_SOURCE_BYTES;
+      const numSources = this.dataSource.urls.length;
+      const perSourceCache = Math.max(minPerSource, Math.floor(totalCache / numSources));
+
+      if (perSourceCache * numSources > totalCache) {
+        log.warn(
+          `Cache budget (${totalCache} bytes) is less than minimum per-source cache ` +
+            `(${minPerSource} bytes) × ${numSources} sources. ` +
+            `Each source will use ${perSourceCache} bytes; total may exceed budget.`,
+        );
+      }
+
       sources = this.dataSource.urls.map(
         (url) =>
           new this.SourceConstructor({

--- a/packages/suite-base/src/players/IterablePlayer/shared/types.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/types.ts
@@ -10,7 +10,12 @@ import {
 
 export type MultiSource =
   | { type: "files"; files: Blob[] }
-  | { type: "urls"; urls: string[]; totalCacheSizeInBytes?: number };
+  | {
+      type: "urls";
+      urls: string[];
+      totalCacheSizeInBytes?: number;
+      minCachePerSourceBytes?: number;
+    };
 
 export type IterableSourceConstructor<T extends IIterableSource, P> = new (args: P) => T;
 


### PR DESCRIPTION
When opening 300+ remote MCAP files, the linear cache split (500 MiB / n) produced per-source budgets smaller than a single MCAP metadata read (summary section, chunk indexes), causing CachedFilelike to throw: "Requested more data than cache size"

Fix: apply a 10 MiB minimum floor via Math.max(MIN_CACHE_PER_SOURCE_BYTES, floor(total / n)) so every source always has enough cache for metadata reads. When the floor causes the effective total to exceed the budget, a log.warn is emitted. Also exposes minCachePerSourceBytes on the MultiSource "urls" type for callers that need a different floor.

## User-Facing Changes

<!-- will be used as a changelog entry -->

## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `minCachePerSourceBytes` configuration parameter for remote sources.

* **Bug Fixes**
  * Implemented minimum per-source cache floor to prevent crashes when reading large MCAP metadata.
  * Added warning when total cache budget would be exceeded.

* **Tests**
  * Added test coverage for cache allocation and budget distribution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->