### PR TITLE
feat(multi-mcap): lazy-load remote MCAP sources to avoid full up-front download

### DIFF
--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
@@ -225,22 +225,28 @@ describe("McapIterableSource", () => {
       return tempBuffer.get();
     }
 
-    it("should create RemoteFileReadable with url and cacheSizeInBytes", async () => {
+    it("should create RemoteFileReadable with url, cacheSizeInBytes, and readAheadEnabled", async () => {
       // Given an indexed MCAP served via URL with a custom cache size
       const mcapData = await buildIndexedMcap([{ logTime: 1_000_000_000n }]);
       mockRemoteFileReadableWith(mcapData);
       const cacheSizeInBytes = 1024 * 1024 * 100;
+      const readAheadEnabled = false;
 
       // When initializing a McapIterableSource with URL type
       const source = new McapIterableSource({
         type: "url",
         url: urlIndexedMcap,
         cacheSizeInBytes,
+        readAheadEnabled,
       });
       await source.initialize();
 
-      // Then RemoteFileReadable should be constructed with the url and cache size
-      expect(MockRemoteFileReadable).toHaveBeenCalledWith(urlIndexedMcap, cacheSizeInBytes);
+      // Then RemoteFileReadable should be constructed with the URL options
+      expect(MockRemoteFileReadable).toHaveBeenCalledWith(
+        urlIndexedMcap,
+        cacheSizeInBytes,
+        readAheadEnabled,
+      );
     });
 
     it("should delegate getStart and getEnd to the underlying indexed source", async () => {

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
@@ -242,11 +242,10 @@ describe("McapIterableSource", () => {
       await source.initialize();
 
       // Then RemoteFileReadable should be constructed with the URL options
-      expect(MockRemoteFileReadable).toHaveBeenCalledWith(
-        urlIndexedMcap,
+      expect(MockRemoteFileReadable).toHaveBeenCalledWith(urlIndexedMcap, {
         cacheSizeInBytes,
         readAheadEnabled,
-      );
+      });
     });
 
     it("should delegate getStart and getEnd to the underlying indexed source", async () => {

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -90,11 +90,10 @@ export class McapIterableSource implements ISerializedIterableSource {
         break;
       }
       case "url": {
-        const readable = new RemoteFileReadable(
-          source.url,
-          source.cacheSizeInBytes,
-          source.readAheadEnabled,
-        );
+        const readable = new RemoteFileReadable(source.url, {
+          cacheSizeInBytes: source.cacheSizeInBytes,
+          readAheadEnabled: source.readAheadEnabled,
+        });
         await readable.open();
         const reader = await tryCreateIndexedReader(readable, decompressHandlers);
         if (reader) {

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -28,7 +28,7 @@ const log = Log.getLogger(__filename);
 
 type McapSource =
   | { type: "file"; file: Blob }
-  | { type: "url"; url: string; cacheSizeInBytes?: number };
+  | { type: "url"; url: string; cacheSizeInBytes?: number; readAheadEnabled?: boolean };
 
 /**
  * Create a McapIndexedReader if it will be possible to do an indexed read. If the file is not
@@ -90,7 +90,11 @@ export class McapIterableSource implements ISerializedIterableSource {
         break;
       }
       case "url": {
-        const readable = new RemoteFileReadable(source.url, source.cacheSizeInBytes);
+        const readable = new RemoteFileReadable(
+          source.url,
+          source.cacheSizeInBytes,
+          source.readAheadEnabled,
+        );
         await readable.open();
         const reader = await tryCreateIndexedReader(readable, decompressHandlers);
         if (reader) {

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.test.ts
@@ -47,7 +47,7 @@ describe("RemoteFileReadable", () => {
       const customSize = 1024 * 1024 * 100; // 100MiB
 
       // When creating a RemoteFileReadable
-      new RemoteFileReadable(testUrl, customSize);
+      new RemoteFileReadable(testUrl, { cacheSizeInBytes: customSize });
 
       // Then CachedFilelike should be created with the custom size
       expect(CachedFilelike).toHaveBeenCalledWith(

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
@@ -13,11 +13,17 @@ const DEFAULT_CACHE_SIZE_BYTES = 1024 * 1024 * 500; // 500MiB
 export class RemoteFileReadable {
   #remoteReader: CachedFilelike;
 
-  public constructor(url: string, cacheSizeInBytes?: number) {
+  public constructor(
+    url: string,
+    cacheSizeInBytes?: number,
+    // eslint-disable-next-line @lichtblick/no-boolean-parameters
+    readAheadEnabled?: boolean,
+  ) {
     const fileReader = new BrowserHttpReader(url);
     this.#remoteReader = new CachedFilelike({
       fileReader,
       cacheSizeInBytes: cacheSizeInBytes ?? DEFAULT_CACHE_SIZE_BYTES,
+      readAheadEnabled,
     });
   }
 

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
@@ -10,20 +10,20 @@ import CachedFilelike from "@lichtblick/suite-base/util/CachedFilelike";
 
 const DEFAULT_CACHE_SIZE_BYTES = 1024 * 1024 * 500; // 500MiB
 
+type RemoteFileReadableOptions = {
+  cacheSizeInBytes?: number;
+  readAheadEnabled?: boolean;
+};
+
 export class RemoteFileReadable {
   #remoteReader: CachedFilelike;
 
-  public constructor(
-    url: string,
-    cacheSizeInBytes?: number,
-    // eslint-disable-next-line @lichtblick/no-boolean-parameters
-    readAheadEnabled?: boolean,
-  ) {
+  public constructor(url: string, options?: RemoteFileReadableOptions) {
     const fileReader = new BrowserHttpReader(url);
     this.#remoteReader = new CachedFilelike({
       fileReader,
-      cacheSizeInBytes: cacheSizeInBytes ?? DEFAULT_CACHE_SIZE_BYTES,
-      readAheadEnabled,
+      cacheSizeInBytes: options?.cacheSizeInBytes ?? DEFAULT_CACHE_SIZE_BYTES,
+      readAheadEnabled: options?.readAheadEnabled,
     });
   }
 

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
@@ -134,6 +134,44 @@ describe("MultiIterableSource", () => {
       // THEN: the constructed source keeps legacy read-ahead behavior.
       expect(mockSourceConstructor.mock.calls[0]![0].readAheadEnabled).toBe(true);
     });
+    it("should respect an explicit readAheadEnabled override for multi-url sources", async () => {
+      // GIVEN: a multi-url source that explicitly opts into read-ahead.
+      const urls = [BasicBuilder.string(), BasicBuilder.string(), BasicBuilder.string()];
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+          readAheadEnabled: true,
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: the explicit value overrides the multi-url default of false.
+      expect(mockSourceConstructor.mock.calls[0]![0].readAheadEnabled).toBe(true);
+      expect(mockSourceConstructor.mock.calls[1]![0].readAheadEnabled).toBe(true);
+      expect(mockSourceConstructor.mock.calls[2]![0].readAheadEnabled).toBe(true);
+    });
+    it("should respect an explicit readAheadEnabled override for a single-url source", async () => {
+      // GIVEN: a single-url source that explicitly opts out of read-ahead.
+      const urls = [BasicBuilder.string()];
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+          readAheadEnabled: false,
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: the explicit value overrides the single-url default of true.
+      expect(mockSourceConstructor.mock.calls[0]![0].readAheadEnabled).toBe(false);
+    });
     it("should allocate equal cache split when few sources do not trigger the minimum floor", async () => {
       // GIVEN: 2 URL sources with the default 500 MiB total cache budget.
       // floor(500 MiB / 2) = 250 MiB, which is well above the 10 MiB minimum floor,

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { MultiSource } from "@lichtblick/suite-base/players/IterablePlayer/shared/types";
+import { MessageEvent, TopicSelection } from "@lichtblick/suite-base/players/types";
 import InitilizationSourceBuilder from "@lichtblick/suite-base/testing/builders/InitilizationSourceBuilder";
 import RosTimeBuilder from "@lichtblick/suite-base/testing/builders/RosTimeBuilder";
 import { BasicBuilder } from "@lichtblick/test-builders";
@@ -346,6 +347,105 @@ describe("MultiIterableSource", () => {
       );
 
       expect(mockSourceConstructor).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("getBackfillMessages", () => {
+    const makeSource = (
+      startSec: number,
+      backfill: jest.Mock,
+    ): IIterableSource<Uint8Array> =>
+      ({
+        initialize: jest.fn(),
+        messageIterator: jest.fn(),
+        getBackfillMessages: backfill,
+        getStart: jest.fn().mockReturnValue({ sec: startSec, nsec: 0 }),
+        getEnd: jest.fn().mockReturnValue({ sec: startSec + 10, nsec: 0 }),
+      }) as unknown as IIterableSource<Uint8Array>;
+
+    const messageOnTopic = (topic: string): MessageEvent<Uint8Array> =>
+      ({
+        topic,
+        receiveTime: { sec: 0, nsec: 0 },
+        publishTime: { sec: 0, nsec: 0 },
+        message: new Uint8Array(),
+        sizeInBytes: 0,
+        schemaName: "",
+      }) as MessageEvent<Uint8Array>;
+
+    const topicSelection = (...topics: string[]): TopicSelection =>
+      new Map(topics.map((topic) => [topic, { topic }]));
+
+    it("should stop querying earlier sources once all requested topics are satisfied", async () => {
+      // GIVEN: three time-sequential sources; the nearest (latest start) already has every topic.
+      const farBackfill = jest.fn().mockResolvedValue([]);
+      const midBackfill = jest.fn().mockResolvedValue([]);
+      const nearBackfill = jest
+        .fn()
+        .mockResolvedValue([messageOnTopic("a"), messageOnTopic("b")]);
+
+      const multiSource = new MultiIterableSource(dataSource, mockSourceConstructor);
+      multiSource["sourceImpl"] = [
+        makeSource(0, farBackfill),
+        makeSource(10, midBackfill),
+        makeSource(20, nearBackfill),
+      ];
+
+      // WHEN: backfilling at a time covered by the nearest source.
+      const result = await multiSource.getBackfillMessages({
+        topics: topicSelection("a", "b"),
+        time: { sec: 25, nsec: 0 },
+      });
+
+      // THEN: only the nearest source is queried; the redundant earlier sources are skipped.
+      expect(nearBackfill).toHaveBeenCalledTimes(1);
+      expect(midBackfill).not.toHaveBeenCalled();
+      expect(farBackfill).not.toHaveBeenCalled();
+      expect(result.map((message) => message.topic).sort()).toEqual(["a", "b"]);
+    });
+
+    it("should fall back to earlier sources only for topics missing from nearer ones", async () => {
+      // GIVEN: the nearest source has only topic "a"; the middle source has "b".
+      const farBackfill = jest.fn().mockResolvedValue([]);
+      const midBackfill = jest.fn().mockResolvedValue([messageOnTopic("b")]);
+      const nearBackfill = jest.fn().mockResolvedValue([messageOnTopic("a")]);
+
+      const multiSource = new MultiIterableSource(dataSource, mockSourceConstructor);
+      multiSource["sourceImpl"] = [
+        makeSource(0, farBackfill),
+        makeSource(10, midBackfill),
+        makeSource(20, nearBackfill),
+      ];
+
+      // WHEN
+      const result = await multiSource.getBackfillMessages({
+        topics: topicSelection("a", "b"),
+        time: { sec: 25, nsec: 0 },
+      });
+
+      // THEN: the nearest source is asked for both topics, the middle source is asked only for the
+      // still-missing "b", and the farthest source is never reached.
+      expect([...nearBackfill.mock.calls[0]![0].topics.keys()].sort()).toEqual(["a", "b"]);
+      expect([...midBackfill.mock.calls[0]![0].topics.keys()]).toEqual(["b"]);
+      expect(farBackfill).not.toHaveBeenCalled();
+      expect(result.map((message) => message.topic).sort()).toEqual(["a", "b"]);
+    });
+
+    it("should not query any source when there are no topics to backfill", async () => {
+      // GIVEN: a source that would return messages if queried.
+      const backfill = jest.fn().mockResolvedValue([messageOnTopic("a")]);
+      const multiSource = new MultiIterableSource(dataSource, mockSourceConstructor);
+      multiSource["sourceImpl"] = [makeSource(0, backfill)];
+
+      // WHEN: backfilling with an empty topic selection.
+      const result = await multiSource.getBackfillMessages({
+        topics: topicSelection(),
+        time: { sec: 25, nsec: 0 },
+      });
+
+      // THEN: nothing is fetched.
+      expect(backfill).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
     });
   });
 

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
@@ -351,10 +351,7 @@ describe("MultiIterableSource", () => {
   });
 
   describe("getBackfillMessages", () => {
-    const makeSource = (
-      startSec: number,
-      backfill: jest.Mock,
-    ): IIterableSource<Uint8Array> =>
+    const makeSource = (startSec: number, backfill: jest.Mock): IIterableSource<Uint8Array> =>
       ({
         initialize: jest.fn(),
         messageIterator: jest.fn(),
@@ -380,9 +377,7 @@ describe("MultiIterableSource", () => {
       // GIVEN: three time-sequential sources; the nearest (latest start) already has every topic.
       const farBackfill = jest.fn().mockResolvedValue([]);
       const midBackfill = jest.fn().mockResolvedValue([]);
-      const nearBackfill = jest
-        .fn()
-        .mockResolvedValue([messageOnTopic("a"), messageOnTopic("b")]);
+      const nearBackfill = jest.fn().mockResolvedValue([messageOnTopic("a"), messageOnTopic("b")]);
 
       const multiSource = new MultiIterableSource(dataSource, mockSourceConstructor);
       multiSource["sourceImpl"] = [

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
@@ -4,6 +4,7 @@
 import { MultiSource } from "@lichtblick/suite-base/players/IterablePlayer/shared/types";
 import { MessageEvent, TopicSelection } from "@lichtblick/suite-base/players/types";
 import InitilizationSourceBuilder from "@lichtblick/suite-base/testing/builders/InitilizationSourceBuilder";
+import MessageEventBuilder from "@lichtblick/suite-base/testing/builders/MessageEventBuilder";
 import RosTimeBuilder from "@lichtblick/suite-base/testing/builders/RosTimeBuilder";
 import { BasicBuilder } from "@lichtblick/test-builders";
 
@@ -361,14 +362,7 @@ describe("MultiIterableSource", () => {
       }) as unknown as IIterableSource<Uint8Array>;
 
     const messageOnTopic = (topic: string): MessageEvent<Uint8Array> =>
-      ({
-        topic,
-        receiveTime: { sec: 0, nsec: 0 },
-        publishTime: { sec: 0, nsec: 0 },
-        message: new Uint8Array(),
-        sizeInBytes: 0,
-        schemaName: "",
-      }) as MessageEvent<Uint8Array>;
+      MessageEventBuilder.messageEvent<Uint8Array>({ topic, message: new Uint8Array() });
 
     const topicSelection = (...topics: string[]): TopicSelection =>
       new Map(topics.map((topic) => [topic, { topic }]));

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
@@ -88,13 +88,51 @@ describe("MultiIterableSource", () => {
         type: "url",
         url: url1,
         cacheSizeInBytes: expect.any(Number),
+        readAheadEnabled: false,
       });
       expect(mockSourceConstructor).toHaveBeenNthCalledWith(2, {
         type: "url",
         url: url2,
         cacheSizeInBytes: expect.any(Number),
+        readAheadEnabled: false,
       });
       expect(initializations).toHaveLength(2);
+    });
+    it("should disable read-ahead by default for multi-url sources", async () => {
+      // GIVEN: a multi-url source with three URLs.
+      const urls = [BasicBuilder.string(), BasicBuilder.string(), BasicBuilder.string()];
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: each constructed source opts out of speculative read-ahead.
+      expect(mockSourceConstructor.mock.calls[0]![0].readAheadEnabled).toBe(false);
+      expect(mockSourceConstructor.mock.calls[1]![0].readAheadEnabled).toBe(false);
+      expect(mockSourceConstructor.mock.calls[2]![0].readAheadEnabled).toBe(false);
+    });
+    it("should enable read-ahead by default for a single-url source", async () => {
+      // GIVEN: a single-url source.
+      const urls = [BasicBuilder.string()];
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: the constructed source keeps legacy read-ahead behavior.
+      expect(mockSourceConstructor.mock.calls[0]![0].readAheadEnabled).toBe(true);
     });
     it("should allocate equal cache split when few sources do not trigger the minimum floor", async () => {
       // GIVEN: 2 URL sources with the default 500 MiB total cache budget.

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
@@ -140,15 +140,42 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
   public async getBackfillMessages(
     args: GetBackfillMessagesArgs,
   ): Promise<MessageEvent<Uint8Array>[]> {
-    // Only query sources that could contain messages at or before the backfill time.
+    // Only consider sources that could contain messages at or before the backfill time.
     // This avoids triggering HTTP requests to MCAP files that start after the requested time.
     const relevantSources = filterSourcesForBackfill(this.sourceImpl, args.time);
 
-    const backfillMessages = await Promise.all(
-      relevantSources.map(async (source) => await source.getBackfillMessages(args)),
-    );
+    // Query sources nearest to the backfill time first and stop as soon as every requested topic
+    // has a value. `sourceImpl` (and therefore `relevantSources`) is sorted ascending by start
+    // time, so we iterate in reverse to begin with the source covering the seek target.
+    //
+    // Without this short-circuit, every preceding source would independently read its last chunk
+    // for the requested topics — a large redundant download. For example, a forward seek across
+    // many small remote MCAPs fetched ~one chunk per preceding file even though only the
+    // nearest source(s) hold the winning "latest message before time" values.
+    const backfillMessages: MessageEvent<Uint8Array>[] = [];
+    const missingTopics = new Map(args.topics);
 
-    return backfillMessages.flat();
+    for (let index = relevantSources.length - 1; index >= 0; index--) {
+      if (missingTopics.size === 0) {
+        break;
+      }
+
+      const source = relevantSources[index]!;
+      // Pass a snapshot of the still-missing topics so later mutation of `missingTopics` cannot
+      // alias the map handed to the source.
+      const topicsForSource = new Map(missingTopics);
+      const messages = await source.getBackfillMessages({ ...args, topics: topicsForSource });
+      if (messages.length === 0) {
+        continue;
+      }
+
+      backfillMessages.push(...messages);
+      for (const message of messages) {
+        missingTopics.delete(message.topic);
+      }
+    }
+
+    return backfillMessages;
   }
 
   private mergeInitializations(initializations: Initialization[]): Initialization {

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
@@ -84,12 +84,19 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
         );
       }
 
+      // Default to lazy loading for multi-file remote sessions: with many small MCAPs the
+      // speculative whole-file read-ahead would download every file up-front. A single-file
+      // session keeps the legacy read-ahead behaviour. Callers may override explicitly.
+      const readAheadEnabled: boolean =
+        this.dataSource.readAheadEnabled ?? this.dataSource.urls.length === 1;
+
       sources = this.dataSource.urls.map(
         (url) =>
           new this.SourceConstructor({
             type: "url",
             url,
             cacheSizeInBytes: perSourceCache,
+            readAheadEnabled,
           } as P),
       );
     }

--- a/packages/suite-base/src/players/IterablePlayer/shared/types.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/types.ts
@@ -15,6 +15,9 @@ export type MultiSource =
       urls: string[];
       totalCacheSizeInBytes?: number;
       minCachePerSourceBytes?: number;
+      // When false (default for multi-file), each remote source downloads lazily without
+      // speculative read-ahead. When true, legacy whole-file read-ahead is used.
+      readAheadEnabled?: boolean;
     };
 
 export type IterableSourceConstructor<T extends IIterableSource, P> = new (args: P) => T;

--- a/packages/suite-base/src/util/CachedFilelike.test.ts
+++ b/packages/suite-base/src/util/CachedFilelike.test.ts
@@ -101,6 +101,19 @@ describe("CachedFilelike", () => {
       expect(fetch).toHaveBeenCalledWith(0, 10);
     });
 
+    it("throws a clear error when a single read exceeds the cache size", () => {
+      // GIVEN: a source allocated a small cache (mirrors a many-file remote session where each
+      // source receives only the 10 MiB minimum floor) backed by a larger file.
+      const fileReader = new InMemoryFileReader(new Uint8Array(100));
+      const cachedFileReader = new CachedFilelike({ fileReader, cacheSizeInBytes: 10, log });
+
+      // WHEN/THEN: a chunk read larger than the cache fails fast with an explicit, actionable
+      // message instead of silently truncating or mis-reading.
+      expect(() => {
+        void cachedFileReader.read(0, 20);
+      }).toThrow("Requested more data than cache size: 20 > 10");
+    });
+
     it("returns an error in the callback if the FileReader keeps returning errors", async () => {
       const fileReader = new InMemoryFileReader(new Uint8Array([0, 1, 2, 3]));
       let interval: any;

--- a/packages/suite-base/src/util/CachedFilelike.test.ts
+++ b/packages/suite-base/src/util/CachedFilelike.test.ts
@@ -82,6 +82,25 @@ describe("CachedFilelike", () => {
       await expect(cachedFileReader.read(2, 2)).resolves.toEqual(new Uint8Array([2, 3]));
     });
 
+    it("requests only the exact range when read-ahead is disabled", async () => {
+      // GIVEN: a file that fits entirely in the cache.
+      const fileReader = new InMemoryFileReader(new Uint8Array(100));
+      const fetch = jest.spyOn(fileReader, "fetch");
+      const cachedFileReader = new CachedFilelike({
+        fileReader,
+        cacheSizeInBytes: 100,
+        readAheadEnabled: false,
+        log,
+      });
+
+      // WHEN: reading a small range.
+      await expect(cachedFileReader.read(0, 10)).resolves.toEqual(new Uint8Array(10));
+
+      // THEN: no speculative whole-file or look-ahead fetch is made.
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(0, 10);
+    });
+
     it("returns an error in the callback if the FileReader keeps returning errors", async () => {
       const fileReader = new InMemoryFileReader(new Uint8Array([0, 1, 2, 3]));
       let interval: any;

--- a/packages/suite-base/src/util/CachedFilelike.ts
+++ b/packages/suite-base/src/util/CachedFilelike.ts
@@ -77,6 +77,7 @@ interface ILogger {
 export default class CachedFilelike implements Filelike {
   #fileReader: FileReader;
   #cacheSizeInBytes: number = Infinity;
+  #readAheadEnabled: boolean = true;
   #fileSize?: number;
   #virtualBuffer: VirtualLRUBuffer;
   #log: ILogger;
@@ -105,12 +106,14 @@ export default class CachedFilelike implements Filelike {
   public constructor(options: {
     fileReader: FileReader;
     cacheSizeInBytes?: number;
+    readAheadEnabled?: boolean;
     log?: ILogger;
     // eslint-disable-next-line @lichtblick/no-boolean-parameters
     keepReconnectingCallback?: (reconnecting: boolean) => void;
   }) {
     this.#fileReader = options.fileReader;
     this.#cacheSizeInBytes = options.cacheSizeInBytes ?? this.#cacheSizeInBytes;
+    this.#readAheadEnabled = options.readAheadEnabled ?? this.#readAheadEnabled;
     this.#keepReconnectingCallback = options.keepReconnectingCallback;
     this.#log = options.log ?? log;
     this.#virtualBuffer = new VirtualLRUBuffer({ size: 0 });
@@ -214,6 +217,7 @@ export default class CachedFilelike implements Filelike {
       maxRequestSize: this.#cacheSizeInBytes,
       fileSize: size,
       continueDownloadingThreshold: CLOSE_ENOUGH_BYTES_TO_NOT_START_NEW_CONNECTION,
+      readAheadEnabled: this.#readAheadEnabled,
     });
     if (newConnection) {
       this.#setConnection(newConnection);

--- a/packages/suite-base/src/util/getNewConnection.test.ts
+++ b/packages/suite-base/src/util/getNewConnection.test.ts
@@ -315,6 +315,80 @@ describe("getNewConnection", () => {
     });
   });
 
+  describe("when read-ahead is disabled (readAheadEnabled: false)", () => {
+    it("returns only the exact requested range instead of the whole file when cache spans the file", () => {
+      // GIVEN: a read request on a file that fits in the cache.
+      // WHEN: read-ahead is disabled.
+      const result = getNewConnection({
+        currentRemainingRange: undefined,
+        readRequestRange: { start: 10, end: 20 },
+        downloadedRanges: [],
+        lastResolvedCallbackEnd: undefined,
+        maxRequestSize: 100, // >= fileSize -> would normally download whole file
+        fileSize: 100,
+        continueDownloadingThreshold: 5,
+        readAheadEnabled: false,
+      });
+
+      // THEN: only the requested range is downloaded.
+      expect(result).toEqual({ start: 10, end: 20 });
+    });
+
+    it("keeps legacy whole-file read-ahead when readAheadEnabled is true", () => {
+      // GIVEN: the same inputs as the lazy-loading case above.
+      // WHEN: read-ahead is enabled.
+      const result = getNewConnection({
+        currentRemainingRange: undefined,
+        readRequestRange: { start: 10, end: 20 },
+        downloadedRanges: [],
+        lastResolvedCallbackEnd: undefined,
+        maxRequestSize: 100, // >= fileSize -> download to the end of the file
+        fileSize: 100,
+        continueDownloadingThreshold: 5,
+        readAheadEnabled: true,
+      });
+
+      // THEN: the legacy whole-file read-ahead range is returned.
+      expect(result).toEqual({ start: 10, end: 100 });
+    });
+
+    it("does not extend the range by the 50 MiB read-ahead buffer when finishing at the request end", () => {
+      // GIVEN: a cache smaller than the file where read-ahead would normally extend the request.
+      // WHEN: read-ahead is disabled.
+      const result = getNewConnection({
+        currentRemainingRange: undefined,
+        readRequestRange: { start: 0, end: 10 },
+        downloadedRanges: [],
+        lastResolvedCallbackEnd: undefined,
+        maxRequestSize: 100 * 1024 * 1024, // < fileSize
+        fileSize: 200 * 1024 * 1024,
+        continueDownloadingThreshold: 5,
+        readAheadEnabled: false,
+      });
+
+      // THEN: the request is not extended.
+      expect(result).toEqual({ start: 0, end: 10 });
+    });
+
+    it("returns undefined when idle (no read request) and read-ahead is disabled", () => {
+      // GIVEN: no active read request or connection.
+      // WHEN: read-ahead is disabled.
+      const result = getNewConnection({
+        currentRemainingRange: undefined,
+        readRequestRange: undefined,
+        downloadedRanges: [],
+        lastResolvedCallbackEnd: 20,
+        maxRequestSize: 100,
+        fileSize: 100,
+        continueDownloadingThreshold: 5,
+        readAheadEnabled: false,
+      });
+
+      // THEN: no speculative connection is created.
+      expect(result).toBeUndefined();
+    });
+  });
+
   // Tests specific to READ_AHEAD_BUFFER_SIZE behavior
   describe("READ_AHEAD_BUFFER_SIZE constraints", () => {
     it("limits read-ahead to READ_AHEAD_BUFFER_SIZE even with large maxRequestSize", () => {

--- a/packages/suite-base/src/util/getNewConnection.ts
+++ b/packages/suite-base/src/util/getNewConnection.ts
@@ -29,15 +29,25 @@ export function getNewConnection(options: {
   maxRequestSize: number; // The cache size. If equal to or larger than `fileSize` we will attempt to download the whole file.
   fileSize: number; // Size of the file.
   continueDownloadingThreshold: number; // Amount we're willing to wait downloading before opening a new connection.
+  // When false, only the exact requested byte ranges are downloaded and no speculative
+  // read-ahead is performed. Used for many-small-file remote sessions to avoid fetching
+  // whole files up-front. Defaults to true (legacy behaviour).
+  readAheadEnabled?: boolean;
 }): Range | undefined {
-  const { readRequestRange, currentRemainingRange, ...otherOptions } = options;
+  const {
+    readRequestRange,
+    currentRemainingRange,
+    readAheadEnabled = true,
+    ...otherOptions
+  } = options;
   if (readRequestRange) {
     return getNewConnectionWithExistingReadRequest({
       readRequestRange,
       currentRemainingRange,
+      readAheadEnabled,
       ...otherOptions,
     });
-  } else if (!currentRemainingRange) {
+  } else if (!currentRemainingRange && readAheadEnabled) {
     return getNewConnectionWithoutExistingConnection(otherOptions);
   }
   return undefined;
@@ -50,6 +60,7 @@ function getNewConnectionWithExistingReadRequest({
   maxRequestSize,
   fileSize,
   continueDownloadingThreshold,
+  readAheadEnabled,
 }: {
   currentRemainingRange?: Range;
   readRequestRange: Range;
@@ -58,6 +69,7 @@ function getNewConnectionWithExistingReadRequest({
   maxRequestSize: number;
   fileSize: number;
   continueDownloadingThreshold: number;
+  readAheadEnabled: boolean;
 }): Range | undefined {
   // We have a requested range that we're trying to download.
   if (readRequestRange.end - readRequestRange.start > maxRequestSize) {
@@ -85,6 +97,12 @@ function getNewConnectionWithExistingReadRequest({
 
   if (!startNewConnection) {
     return;
+  }
+  // When read-ahead is disabled, only download exactly the missing portion of the requested
+  // range. This skips both the "download the whole file" path (maxRequestSize >= fileSize) and
+  // the 50 MiB look-ahead extension below, keeping multi-file remote sessions lazy.
+  if (!readAheadEnabled) {
+    return notDownloadedRanges[0];
   }
   if (maxRequestSize >= fileSize) {
     // If we're trying to download the whole file, read all the way up to the next range that we have already downloaded.


### PR DESCRIPTION
## User-Facing Changes

Opening a session with **many remote MCAP files** (e.g. 300 files / ~2.4 GB) no longer downloads **every file up-front**. Data is now fetched **lazily** — only the MCAP index/summary is read on load, and message chunks are downloaded on demand as playback/seek reaches them.

This dramatically reduces:
- **Startup time and bandwidth** (no ~2.4 GB burst before the session is usable)
- **Peak memory** at load
- **Concurrent HTTP requests** at startup (previously the browser's per-host connection pool was saturated by hundreds of full-file downloads)
- **Seek bandwidth** — a forward seek no longer re-reads the tail chunk of every preceding file (see _Seek — backfill short-circuit_ below)

## Background — why everything was being downloaded

This builds on top of #1146 (minimum cache floor per source). After that fix, each remote source gets at least **10 MiB** of cache. But each MCAP file is only **~6–9 MiB**, so:

```
cacheSizeInBytes (10 MiB)  >=  fileSize (~8 MiB)
```

`CachedFilelike` treats "cache ≥ file size" as a signal to **download the whole file**. Two code paths in `getNewConnection` trigger this:

1. **On an explicit read** (`getNewConnectionWithExistingReadRequest`): when `maxRequestSize >= fileSize`, it extends the fetch range all the way to `fileSize` instead of the requested bytes.
2. **When idle** (`getNewConnectionWithoutExistingConnection`): it speculatively reads ahead to the end of the file.

With 300 files, both paths fire for every file → **300 × ~8 MiB ≈ 2.4 GB downloaded at startup**. Seeking afterwards issued no new requests because everything was already cached.

## The Fix

Introduce an opt-out `readAheadEnabled` flag, threaded through the remote-read stack:

```
MultiIterableSource  →  McapIterableSource (type: "url")  →  RemoteFileReadable  →  CachedFilelike  →  getNewConnection
```

When `readAheadEnabled === false`:
- `getNewConnection` **skips the whole-file path** and the **50 MiB look-ahead extension**, returning only the exact missing sub-range of the requested read.
- The **idle speculative read** is disabled entirely (returns `undefined`).

`MultiIterableSource` sets the default per session:

```ts
const readAheadEnabled = this.dataSource.readAheadEnabled ?? this.dataSource.urls.length === 1;
```

- **Multi-file** remote session → `false` (lazy) — the target scenario.
- **Single-file** remote session → `true` (unchanged legacy behaviour).
- Callers may override explicitly via `readAheadEnabled` on `MultiSource`.

The flag defaults to `true` at every other layer, so **no existing caller changes behaviour**.

## Seek — backfill short-circuit

Lazy loading fixed startup, but profiling a **forward seek** to a never-visited time across the same 300-file session still transferred **~204 MB** (164 range requests over 76 files). HAR analysis showed the reads were almost all **tail chunks** of files _preceding_ the seek target.

Root cause: `MultiIterableSource.getBackfillMessages` queried **every** source with `start ≤ time` via `Promise.all`. Each preceding MCAP independently read its own last chunk to answer "latest message ≤ T per topic", even though only the **nearest** source(s) actually hold the winning values.

Fix: walk sources **nearest-first** (they're already sorted ascending by start), asking each only for the **still-missing** topics, and **stop** as soon as every requested topic has a value:

```ts
const missingTopics = new Map(args.topics);
for (let index = relevantSources.length - 1; index >= 0; index--) {
  if (missingTopics.size === 0) break;            // every topic satisfied → stop
  const found = await relevantSources[index].getBackfillMessages({
    ...args,
    topics: new Map(missingTopics),               // snapshot — only what's still missing
  });
  for (const msg of found) missingTopics.delete(msg.topic);
  backfillMessages.push(...found);
}
```

Correctness is preserved when a topic's latest value lives in an earlier file — the loop continues backwards **only for the topics still missing**. Sources that don't contain a missing topic do no data-chunk read (the chunk index is already in memory), so the redundant tail reads disappear.

## Why playback still feels smooth

Disabling **byte-level** read-ahead does **not** disable buffering. The player still preloads messages via `readAheadDuration: { sec: 10 }` (block loader, message-level). Those preloads become on-demand chunk reads — so you keep ~10 s of look-ahead without prefetching whole files.

## Scope / side-effects (what is and isn't affected)

| Workflow | Path | Affected? |
| --- | --- | --- |
| **MCAP multi-remote** | `MultiIterableSource` (urls) | ✅ Now lazy + short-circuited backfill (intended) |
| **MCAP single-remote** | `McapIterableSource({type:"url"})` directly | ❌ Unchanged (default `true`) |
| **BAG remote** | `BagIterableSource` builds `CachedFilelike` directly, never passes the flag | ❌ Unchanged (default `true`, 200 MiB) |
| **Local files** (MCAP/BAG) | `BlobReadable` / `BlobReader` — don't use `CachedFilelike` | ❌ Unchanged |
| **`getNewConnection`** (shared util) | optional param, default `true` | ❌ Backward compatible |

### ⚠️ Known caveats
- **Unindexed remote MCAPs are not lazy.** `McapIterableSource` falls back to `fetch(url)` and streams the **entire file**, bypassing `CachedFilelike`. Lazy loading only benefits **indexed** MCAPs (which the many-small-files scenario uses). Worth a follow-up if unindexed remote is a real use case.
- **Trade-off during active linear playback:** with byte-level read-ahead off, sequential chunk reads are no longer batched into a single 50 MiB fetch, so a file being actively played issues more, smaller HTTP requests. This is the intended trade-off for not downloading every file, and is mitigated by the player-level 10 s message buffer.
- **Backfill short-circuit assumes time-sequential files.** It relies on the same ordering assumption as the existing merged-iterator path (sources sorted by start). Overlapping/interleaved sources still get correct results because the loop keeps querying earlier sources for any topic not yet satisfied.

## Testing

- [x] **UT** `getNewConnection.test.ts` — new `readAheadEnabled: false` cases: exact-range return instead of whole-file, no 50 MiB extension, `undefined` when idle (plus a contrast case asserting legacy `true` still returns the whole-file range).
- [x] **UT** `CachedFilelike.test.ts` — asserts only the exact requested range is fetched when read-ahead is disabled; asserts a single read larger than the cache floor fails fast with a clear "Requested more data than cache size" error.
- [x] **UT** `MultiIterableSource.test.ts` — multi-URL sources receive `readAheadEnabled: false`; single-URL receives `true`; explicit overrides take precedence. New `getBackfillMessages` suite: stops at the nearest source once all topics are satisfied, falls back to earlier sources only for still-missing topics, and issues no query when topics is empty.
- [x] **UT** `McapIterableSource.test.ts` — `readAheadEnabled` is forwarded to `RemoteFileReadable`.
- [x] All targeted suites green: **4 suites / 74 tests**. ESLint + Prettier clean. `tsc --noEmit` passes.

## Follow-ups (out of scope)
- Optionally expose `readAheadEnabled` through `RemoteDataSourceFactory` so users can toggle per session.
- Consider lazy support for **unindexed** remote MCAPs.

## 📊 Benchmark — real-world measurement

Same session throughout: **300 remote MCAP files, ~8 MiB each (~2.4 GB total)**, indexed, opened in Lichtblick **web**. "Before" already includes the #1146 cache floor.

### Initial load

| Metric | Before (#1146 floor only) | After (lazy loading) | Reduction |
| --- | --- | --- | --- |
| **Transferred** | 1,834,428 kB (~1.8 GB) | 34,845 kB (~34 MB) | **~98.1%** (~52× less) |
| **Resources** | 2,578,119 kB (~2.58 GB) | 33,570 kB (~33 MB) | **~98.7%** |
| **Requests** | 1542 / 1571 | 1522 / 1580 | ~unchanged |

**Why bytes collapse but request count stays ~1500:** lazy loading cuts the **payload**, not the number of metadata round-trips. `initialize()` still has to touch **every** file to build the merged timeline — `open()` (header probe) + footer + summary + chunk index, ≈ 300 files × ~5 range requests ≈ ~1500 requests — but now those requests carry only **a few KB of index/metadata** instead of the full file body. Chunk bodies are fetched **on demand** during playback/seek.

### Forward seek (never-visited time)

| Metric | Before backfill short-circuit | Cause |
| --- | --- | --- |
| **Requests** | 164 range requests | one tail-chunk read per preceding file |
| **Transferred** | ~204 MB | 76 files each re-read their last chunk |

HAR showed 68/71 large reads landing in the **file tail** (last chunk), sweeping contiguously across preceding files — the backfill fan-out described above. The short-circuit limits backfill reads to the nearest source(s) that actually hold the latest-before-T values, eliminating the redundant tail reads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `readAheadEnabled` setting for remote MCAP URL loading to control speculative read-ahead behavior.

* **Performance Improvements**
  * Multi-URL remote sessions now default to lazy loading (`readAheadEnabled: false`) to reduce bulk downloads; single-URL sessions keep legacy behavior with read-ahead enabled.
  * You can override the behavior per session (including multi-URL inputs).
  * Backfill retrieval was improved to stop querying once all requested topics are satisfied, avoiding redundant reads.
  * Updated and expanded tests to validate defaults, overrides, and read-ahead behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
