### PR TITLE
feat(layouts): allow sync of local layouts with remote layout storage

### DIFF
--- a/packages/suite-base/jest.config.json
+++ b/packages/suite-base/jest.config.json
@@ -13,7 +13,8 @@
     "ReactNull": null,
     "LICHTBLICK_SUITE_VERSION": "TEST",
     "API_URL": "/",
-    "DEV_WORKSPACE": ""
+    "DEV_WORKSPACE": "",
+    "SYNC_LOCAL_LAYOUTS": false
   },
   "setupFiles": ["<rootDir>/src/test/setup.ts", "jest-canvas-mock", "fake-indexeddb/auto"],
   "setupFilesAfterEnv": ["<rootDir>/src/test/setupTestFramework.ts"],

--- a/packages/suite-base/src/constants/config.test.ts
+++ b/packages/suite-base/src/constants/config.test.ts
@@ -92,12 +92,13 @@ describe("APP_CONFIG", () => {
     (globalThis as any).API_URL = "";
     (globalThis as any).LICHTBLICK_SUITE_VERSION = "";
     (globalThis as any).DEV_WORKSPACE = "";
-    (globalThis as any).SYNC_LOCAL_LAYOUTS = "";
+    // This setting is statically typed as boolean, keep it undefined to test the fallback branch.
+    (globalThis as any).SYNC_LOCAL_LAYOUTS = undefined;
     const { APP_CONFIG } = await import("./config");
 
     expect(APP_CONFIG.apiUrl).toBe(""); // Empty string, not default
     expect(APP_CONFIG.version).toBe(""); // Empty string, not default
     expect(APP_CONFIG.devWorkspace).toBe(""); // Empty string, not default
-    expect(APP_CONFIG.syncLocalLayouts).toBe(""); // Empty string, not default
+    expect(APP_CONFIG.syncLocalLayouts).toBe(false); // Falls back when undefined
   });
 });

--- a/packages/suite-base/src/constants/config.test.ts
+++ b/packages/suite-base/src/constants/config.test.ts
@@ -16,6 +16,7 @@ describe("APP_CONFIG", () => {
     delete (globalThis as any).API_URL;
     delete (globalThis as any).LICHTBLICK_SUITE_VERSION;
     delete (globalThis as any).DEV_WORKSPACE;
+    delete (globalThis as any).SYNC_LOCAL_LAYOUTS;
 
     // Clear module cache to ensure fresh imports
     jest.resetModules();
@@ -31,12 +32,13 @@ describe("APP_CONFIG", () => {
     (globalThis as any).API_URL = undefined;
     (globalThis as any).LICHTBLICK_SUITE_VERSION = undefined;
     (globalThis as any).DEV_WORKSPACE = undefined;
-
+    (globalThis as any).SYNC_LOCAL_LAYOUTS = undefined;
     const { APP_CONFIG } = await import("./config");
 
     expect(APP_CONFIG.apiUrl).toBe(undefined);
     expect(APP_CONFIG.version).toBe("unknown");
     expect(APP_CONFIG.devWorkspace).toBe("");
+    expect(APP_CONFIG.syncLocalLayouts).toBe(false);
   });
 
   it("should use global variables when they are defined", async () => {
@@ -44,12 +46,13 @@ describe("APP_CONFIG", () => {
     (globalThis as any).API_URL = "https://api.example.com";
     (globalThis as any).LICHTBLICK_SUITE_VERSION = "1.2.3";
     (globalThis as any).DEV_WORKSPACE = "test-workspace";
-
+    (globalThis as any).SYNC_LOCAL_LAYOUTS = true;
     const { APP_CONFIG } = await import("./config");
 
     expect(APP_CONFIG.apiUrl).toBe("https://api.example.com");
     expect(APP_CONFIG.version).toBe("1.2.3");
     expect(APP_CONFIG.devWorkspace).toBe("test-workspace");
+    expect(APP_CONFIG.syncLocalLayouts).toBe(true);
   });
 
   it("should handle partial global variables", async () => {
@@ -57,12 +60,14 @@ describe("APP_CONFIG", () => {
     (globalThis as any).API_URL = "https://partial.example.com";
     (globalThis as any).LICHTBLICK_SUITE_VERSION = undefined;
     (globalThis as any).DEV_WORKSPACE = "partial-workspace";
+    (globalThis as any).SYNC_LOCAL_LAYOUTS = false;
 
     const { APP_CONFIG } = await import("./config");
 
     expect(APP_CONFIG.apiUrl).toBe("https://partial.example.com");
     expect(APP_CONFIG.version).toBe("unknown");
     expect(APP_CONFIG.devWorkspace).toBe("partial-workspace");
+    expect(APP_CONFIG.syncLocalLayouts).toBe(false);
   });
 
   it("should handle null values in global variables", async () => {
@@ -70,12 +75,14 @@ describe("APP_CONFIG", () => {
     (globalThis as any).API_URL = undefined;
     (globalThis as any).LICHTBLICK_SUITE_VERSION = undefined;
     (globalThis as any).DEV_WORKSPACE = undefined;
+    (globalThis as any).SYNC_LOCAL_LAYOUTS = undefined;
 
     const { APP_CONFIG } = await import("./config");
 
     expect(APP_CONFIG.apiUrl).toBe(undefined);
     expect(APP_CONFIG.version).toBe("unknown");
     expect(APP_CONFIG.devWorkspace).toBe("");
+    expect(APP_CONFIG.syncLocalLayouts).toBe(false);
   });
 
   it("should handle empty string values in global variables", async () => {
@@ -85,11 +92,12 @@ describe("APP_CONFIG", () => {
     (globalThis as any).API_URL = "";
     (globalThis as any).LICHTBLICK_SUITE_VERSION = "";
     (globalThis as any).DEV_WORKSPACE = "";
-
+    (globalThis as any).SYNC_LOCAL_LAYOUTS = "";
     const { APP_CONFIG } = await import("./config");
 
     expect(APP_CONFIG.apiUrl).toBe(""); // Empty string, not default
     expect(APP_CONFIG.version).toBe(""); // Empty string, not default
     expect(APP_CONFIG.devWorkspace).toBe(""); // Empty string, not default
+    expect(APP_CONFIG.syncLocalLayouts).toBe(""); // Empty string, not default
   });
 });

--- a/packages/suite-base/src/constants/config.ts
+++ b/packages/suite-base/src/constants/config.ts
@@ -10,6 +10,7 @@
 declare const API_URL: string | undefined;
 declare const LICHTBLICK_SUITE_VERSION: string | undefined;
 declare const DEV_WORKSPACE: string | undefined;
+declare const SYNC_LOCAL_LAYOUTS: boolean | undefined;
 
 export const APP_CONFIG = {
   /**
@@ -26,4 +27,9 @@ export const APP_CONFIG = {
    * Development workspace prefix (for local storage keys)
    */
   devWorkspace: DEV_WORKSPACE ?? "",
+
+  /**
+   * Whether to sync local layouts with remote storage
+   */
+  syncLocalLayouts: SYNC_LOCAL_LAYOUTS ?? false,
 } as const;

--- a/packages/suite-base/src/services/ILayoutStorage.ts
+++ b/packages/suite-base/src/services/ILayoutStorage.ts
@@ -5,9 +5,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { APP_CONFIG } from "@lichtblick/suite-base/constants/config";
 import { LayoutID } from "@lichtblick/suite-base/context/CurrentLayoutContext";
 import { LayoutData } from "@lichtblick/suite-base/context/CurrentLayoutContext/actions";
-import { APP_CONFIG } from "@lichtblick/suite-base/constants/config";
 
 // We use "brand" tags to prevent confusion between string types with distinct meanings
 // https://github.com/microsoft/TypeScript/issues/4895

--- a/packages/suite-base/src/services/ILayoutStorage.ts
+++ b/packages/suite-base/src/services/ILayoutStorage.ts
@@ -7,6 +7,7 @@
 
 import { LayoutID } from "@lichtblick/suite-base/context/CurrentLayoutContext";
 import { LayoutData } from "@lichtblick/suite-base/context/CurrentLayoutContext/actions";
+import { APP_CONFIG } from "@lichtblick/suite-base/constants/config";
 
 // We use "brand" tags to prevent confusion between string types with distinct meanings
 // https://github.com/microsoft/TypeScript/issues/4895
@@ -83,6 +84,18 @@ export function layoutIsShared(
   layout: Layout,
 ): layout is Layout & { permission: Exclude<LayoutPermission, "CREATOR_WRITE"> } {
   return layoutPermissionIsShared(layout.permission);
+}
+
+export function shouldSyncPersonalLayouts(): boolean {
+  return APP_CONFIG.syncLocalLayouts;
+}
+
+export function shouldSyncLayoutPermission(permission: LayoutPermission): boolean {
+  return shouldSyncPersonalLayouts() || layoutPermissionIsShared(permission);
+}
+
+export function shouldSyncLayout(layout: Layout): boolean {
+  return shouldSyncPersonalLayouts() || layoutIsShared(layout);
 }
 
 export function layoutAppearsDeleted(layout: Layout): boolean {

--- a/packages/suite-base/src/services/ILayoutStorage.ts
+++ b/packages/suite-base/src/services/ILayoutStorage.ts
@@ -34,7 +34,7 @@ export type LayoutSyncInfo = {
 
 export type Layout = {
   id: LayoutID;
-  externalId?: string; // Only for remote
+  externalId?: string; // Only for remote layouts or for local layouts that have been synced to remote storage when syncLocalLayouts is enabled.
   name: string;
   from?: string;
   permission: LayoutPermission;
@@ -86,16 +86,25 @@ export function layoutIsShared(
   return layoutPermissionIsShared(layout.permission);
 }
 
+/**
+ * Global switch to sync personal (CREATOR_WRITE) layouts in addition to shared layouts.
+ */
 export function shouldSyncPersonalLayouts(): boolean {
   return APP_CONFIG.syncLocalLayouts;
 }
 
+/**
+ * Returns whether a layout with the given permission should be synchronized remotely regarding the syncLocalLayouts setting.
+ */
 export function shouldSyncLayoutPermission(permission: LayoutPermission): boolean {
   return shouldSyncPersonalLayouts() || layoutPermissionIsShared(permission);
 }
 
+/**
+ * Returns whether this specific layout should be synchronized remotely regarding the syncLocalLayouts setting.
+ */
 export function shouldSyncLayout(layout: Layout): boolean {
-  return shouldSyncPersonalLayouts() || layoutIsShared(layout);
+  return layoutIsShared(layout) || (shouldSyncPersonalLayouts() && layout.externalId != undefined);
 }
 
 export function layoutAppearsDeleted(layout: Layout): boolean {

--- a/packages/suite-base/src/services/LayoutManager/LayoutManager.test.ts
+++ b/packages/suite-base/src/services/LayoutManager/LayoutManager.test.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-import { LayoutID } from "@lichtblick/suite-base/context/CurrentLayoutContext";
 import { APP_CONFIG } from "@lichtblick/suite-base/constants/config";
+import { LayoutID } from "@lichtblick/suite-base/context/CurrentLayoutContext";
 import {
   ILayoutStorage,
   ISO8601Timestamp,

--- a/packages/suite-base/src/services/LayoutManager/LayoutManager.test.ts
+++ b/packages/suite-base/src/services/LayoutManager/LayoutManager.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { LayoutID } from "@lichtblick/suite-base/context/CurrentLayoutContext";
+import { APP_CONFIG } from "@lichtblick/suite-base/constants/config";
 import {
   ILayoutStorage,
   ISO8601Timestamp,
@@ -15,9 +16,15 @@ import { BasicBuilder } from "@lichtblick/test-builders";
 describe("LayoutManager", () => {
   let mockLocalStorage: jest.Mocked<ILayoutStorage>;
   let mockRemoteStorage: jest.Mocked<IRemoteLayoutStorage>;
+  const originalSyncLocalLayouts = APP_CONFIG.syncLocalLayouts;
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    Object.defineProperty(APP_CONFIG, "syncLocalLayouts", {
+      value: originalSyncLocalLayouts,
+      configurable: true,
+    });
 
     mockLocalStorage = {
       list: jest.fn().mockResolvedValue([]),
@@ -36,6 +43,13 @@ describe("LayoutManager", () => {
       updateLayout: jest.fn(),
       deleteLayout: jest.fn().mockResolvedValue(true),
     };
+  });
+
+  afterAll(() => {
+    Object.defineProperty(APP_CONFIG, "syncLocalLayouts", {
+      value: originalSyncLocalLayouts,
+      configurable: true,
+    });
   });
 
   describe("constructor", () => {
@@ -1108,6 +1122,248 @@ describe("LayoutManager", () => {
 
       // Then
       expect(mockListener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("with syncLocalLayouts enabled", () => {
+    beforeEach(() => {
+      Object.defineProperty(APP_CONFIG, "syncLocalLayouts", {
+        value: true,
+        configurable: true,
+      });
+    });
+
+    it("should save CREATOR_WRITE layouts to remote storage", async () => {
+      const layoutManager = new LayoutManager({
+        local: mockLocalStorage,
+        remote: mockRemoteStorage,
+      });
+      layoutManager.setOnline({ online: true });
+
+      const layoutName = BasicBuilder.string();
+      const layoutData = LayoutBuilder.data();
+      const savedRemoteLayout = LayoutBuilder.remoteLayout({
+        name: layoutName,
+        permission: "CREATOR_WRITE",
+      });
+
+      mockRemoteStorage.saveNewLayout.mockResolvedValue(savedRemoteLayout);
+      jest.spyOn(mockLocalStorage, "put").mockResolvedValue(
+        LayoutBuilder.layout({
+          id: savedRemoteLayout.id,
+          name: savedRemoteLayout.name,
+          permission: savedRemoteLayout.permission,
+        }),
+      );
+
+      await layoutManager.saveNewLayout({
+        name: layoutName,
+        data: layoutData,
+        permission: "CREATOR_WRITE",
+      });
+
+      expect(mockRemoteStorage.saveNewLayout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: layoutName,
+          permission: "CREATOR_WRITE",
+        }),
+      );
+    });
+
+    it("should update CREATOR_WRITE layout remotely when renaming", async () => {
+      const layoutId = LayoutBuilder.layoutId();
+      const newName = BasicBuilder.string();
+      const localLayout = LayoutBuilder.layout({
+        id: layoutId,
+        permission: "CREATOR_WRITE",
+      });
+      localLayout.externalId = BasicBuilder.string();
+
+      mockLocalStorage.list.mockResolvedValue([localLayout]);
+      mockRemoteStorage.updateLayout.mockResolvedValue({
+        status: "success",
+        newLayout: LayoutBuilder.remoteLayout({
+          id: layoutId,
+          externalId: localLayout.externalId,
+          name: newName,
+          permission: "CREATOR_WRITE",
+        }),
+      });
+
+      const layoutManager = new LayoutManager({
+        local: mockLocalStorage,
+        remote: mockRemoteStorage,
+      });
+      layoutManager.setOnline({ online: true });
+
+      await layoutManager.updateLayout({
+        id: layoutId,
+        name: newName,
+        data: undefined,
+      });
+
+      expect(mockRemoteStorage.updateLayout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: layoutId,
+          name: newName,
+        }),
+      );
+    });
+
+    it("should delete CREATOR_WRITE layout remotely", async () => {
+      const layoutId = LayoutBuilder.layoutId();
+      const localLayout = LayoutBuilder.layout({
+        id: layoutId,
+        permission: "CREATOR_WRITE",
+      });
+      localLayout.externalId = BasicBuilder.string();
+
+      mockLocalStorage.list.mockResolvedValue([localLayout]);
+
+      const layoutManager = new LayoutManager({
+        local: mockLocalStorage,
+        remote: mockRemoteStorage,
+      });
+      layoutManager.setOnline({ online: true });
+
+      await layoutManager.deleteLayout({ id: layoutId });
+
+      expect(mockRemoteStorage.deleteLayout).toHaveBeenCalledWith(localLayout.externalId);
+      expect(jest.spyOn(mockLocalStorage, "delete")).toHaveBeenCalledWith(
+        expect.any(String),
+        layoutId,
+      );
+    });
+
+    it("should overwrite CREATOR_WRITE layout remotely", async () => {
+      const layoutId = LayoutBuilder.layoutId();
+      const localLayout = LayoutBuilder.layout({
+        id: layoutId,
+        permission: "CREATOR_WRITE",
+        working: {
+          data: LayoutBuilder.data(),
+          savedAt: "2023-01-01T00:00:00Z" as ISO8601Timestamp,
+        },
+      });
+      localLayout.externalId = BasicBuilder.string();
+
+      mockLocalStorage.list.mockResolvedValue([localLayout]);
+      mockRemoteStorage.updateLayout.mockResolvedValue({
+        status: "success",
+        newLayout: LayoutBuilder.remoteLayout({
+          id: layoutId,
+          externalId: localLayout.externalId,
+          permission: "CREATOR_WRITE",
+          data: localLayout.working!.data,
+        }),
+      });
+
+      const layoutManager = new LayoutManager({
+        local: mockLocalStorage,
+        remote: mockRemoteStorage,
+      });
+      layoutManager.setOnline({ online: true });
+
+      await layoutManager.overwriteLayout({ id: layoutId });
+
+      expect(mockRemoteStorage.updateLayout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: layoutId,
+          data: localLayout.working!.data,
+        }),
+      );
+    });
+
+    it("should overwrite shared layout when online", async () => {
+      // Given
+      const layoutId = LayoutBuilder.layoutId();
+      const sharedLayout = LayoutBuilder.layout({
+        id: layoutId,
+        permission: "ORG_WRITE",
+        working: {
+          data: LayoutBuilder.data(),
+          savedAt: "2023-01-01T00:00:00Z" as ISO8601Timestamp,
+        },
+      });
+      const remoteLayout = LayoutBuilder.remoteLayout({
+        id: layoutId,
+        permission: "ORG_WRITE",
+        data: sharedLayout.working!.data,
+      });
+
+      // Include the shared layout in the list results for the cache
+      mockLocalStorage.list.mockResolvedValue([sharedLayout]);
+      mockRemoteStorage.updateLayout.mockResolvedValue({
+        status: "success",
+        newLayout: remoteLayout,
+      });
+
+      const layoutManager = new LayoutManager({
+        local: mockLocalStorage,
+        remote: mockRemoteStorage,
+      });
+      layoutManager.setOnline({ online: true });
+
+      // When
+      const result = await layoutManager.overwriteLayout({ id: layoutId });
+
+      // Then
+      expect(mockRemoteStorage.updateLayout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: layoutId,
+          data: sharedLayout.working!.data,
+        }),
+      );
+      expect(result.working).toBe(undefined);
+      expect(result.baseline.data).toEqual(remoteLayout.data);
+      expect(result.syncInfo?.status).toBe("tracked");
+    });
+
+    it("should sync makePersonalCopy to remote storage", async () => {
+      // Given
+      const originalLayout = LayoutBuilder.layout({
+        name: "Original Shared Layout",
+        permission: "ORG_WRITE",
+      });
+      originalLayout.externalId = BasicBuilder.string();
+
+      const copyName = "My Personal Copy";
+      const remotePersonalLayout = LayoutBuilder.remoteLayout({
+        name: copyName,
+        permission: "CREATOR_WRITE",
+        data: originalLayout.baseline.data,
+      });
+
+      mockLocalStorage.list.mockResolvedValue([originalLayout]);
+      mockRemoteStorage.saveNewLayout.mockResolvedValue(remotePersonalLayout);
+      jest.spyOn(mockLocalStorage, "put").mockResolvedValue(
+        LayoutBuilder.layout({
+          id: remotePersonalLayout.id,
+          name: copyName,
+          permission: "CREATOR_WRITE",
+        }),
+      );
+
+      const layoutManager = new LayoutManager({
+        local: mockLocalStorage,
+        remote: mockRemoteStorage,
+      });
+      layoutManager.setOnline({ online: true });
+
+      // When
+      await layoutManager.makePersonalCopy({
+        id: originalLayout.id,
+        name: copyName,
+      });
+
+      // Then
+      expect(mockRemoteStorage.saveNewLayout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: copyName,
+          permission: "CREATOR_WRITE",
+          data: originalLayout.working?.data ?? originalLayout.baseline.data,
+        }),
+      );
     });
   });
 });

--- a/packages/suite-base/src/services/LayoutManager/LayoutManager.test.ts
+++ b/packages/suite-base/src/services/LayoutManager/LayoutManager.test.ts
@@ -1215,6 +1215,10 @@ describe("LayoutManager", () => {
       const localLayout = LayoutBuilder.layout({
         id: layoutId,
         permission: "CREATOR_WRITE",
+        syncInfo: {
+          status: "tracked",
+          lastRemoteSavedAt: "2023-01-01T00:00:00Z" as ISO8601Timestamp,
+        },
       });
       localLayout.externalId = BasicBuilder.string();
 

--- a/packages/suite-base/src/services/LayoutManager/LayoutManager.test.ts
+++ b/packages/suite-base/src/services/LayoutManager/LayoutManager.test.ts
@@ -820,7 +820,7 @@ describe("LayoutManager", () => {
           data: sharedLayout.working!.data,
         }),
       );
-      expect(result.working).toBe(undefined);
+      expect(result.working).toBeUndefined();
       expect(result.baseline.data).toEqual(remoteLayout.data);
       expect(result.syncInfo?.status).toBe("tracked");
     });

--- a/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
@@ -25,8 +25,9 @@ import {
   Layout,
   LayoutPermission,
   layoutAppearsDeleted,
-  layoutIsShared,
-  layoutPermissionIsShared,
+  shouldSyncPersonalLayouts,
+  shouldSyncLayout,
+  shouldSyncLayoutPermission,
 } from "@lichtblick/suite-base/services/ILayoutStorage";
 import { IRemoteLayoutStorage } from "@lichtblick/suite-base/services/IRemoteLayoutStorage";
 import computeLayoutSyncOperations, {
@@ -170,7 +171,7 @@ export default class LayoutManager implements ILayoutManager {
         permission: remoteLayout.permission,
         baseline: { data: remoteLayout.data, savedAt: remoteLayout.savedAt },
         working: undefined,
-        syncInfo: layoutPermissionIsShared(remoteLayout.permission)
+        syncInfo: shouldSyncLayoutPermission(remoteLayout.permission)
           ? { status: "tracked", lastRemoteSavedAt: remoteLayout.savedAt }
           : undefined,
       });
@@ -185,7 +186,7 @@ export default class LayoutManager implements ILayoutManager {
     from,
   }: SaveNewLayout): Promise<Layout> {
     const data = migratePanelsState(unmigratedData);
-    if (layoutPermissionIsShared(permission)) {
+    if (shouldSyncLayoutPermission(permission)) {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
@@ -257,7 +258,7 @@ export default class LayoutManager implements ILayoutManager {
           : { data, savedAt: now };
 
     // Renames of shared layouts go directly to the server
-    if (name != undefined && layoutIsShared(localLayout)) {
+    if (name != undefined && shouldSyncLayout(localLayout)) {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
@@ -291,7 +292,7 @@ export default class LayoutManager implements ILayoutManager {
       const isRename =
         this.remote != undefined &&
         name != undefined &&
-        layoutIsShared(localLayout) &&
+        shouldSyncLayout(localLayout) &&
         localLayout.syncInfo != undefined &&
         localLayout.syncInfo.status !== "new";
 
@@ -304,7 +305,7 @@ export default class LayoutManager implements ILayoutManager {
 
             // If the name is being changed, we will need to upload to the server with a new savedAt
             baseline: isRename ? { ...localLayout.baseline, savedAt: now } : localLayout.baseline,
-            syncInfo: layoutIsShared(localLayout)
+            syncInfo: shouldSyncLayout(localLayout)
               ? isRename
                 ? { status: "updated", lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt }
                 : localLayout.syncInfo
@@ -323,7 +324,7 @@ export default class LayoutManager implements ILayoutManager {
       throw new Error(`Cannot delete layout ${id} because it does not exist`);
     }
 
-    if (layoutIsShared(localLayout)) {
+    if (shouldSyncLayout(localLayout)) {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
@@ -338,7 +339,7 @@ export default class LayoutManager implements ILayoutManager {
       }
     }
     await this.local.runExclusive(async (local) => {
-      if (this.remote && !layoutIsShared(localLayout)) {
+      if (this.remote && !shouldSyncLayout(localLayout)) {
         await local.put({
           ...localLayout,
           working: {
@@ -364,7 +365,7 @@ export default class LayoutManager implements ILayoutManager {
       throw new Error(`Cannot overwrite layout ${id} because it does not exist`);
     }
     const now = new Date().toISOString() as ISO8601Timestamp;
-    if (layoutIsShared(localLayout)) {
+    if (shouldSyncLayout(localLayout)) {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
@@ -427,21 +428,57 @@ export default class LayoutManager implements ILayoutManager {
 
   @emitBusyStatus
   public async makePersonalCopy({ id, name }: { id: LayoutID; name: string }): Promise<Layout> {
+    const localLayout = await this.local.runExclusive(async (local) => await local.get(id));
+    if (!localLayout) {
+      throw new Error(`Cannot make a personal copy of layout id ${id} because it does not exist`);
+    }
+
     const now = new Date().toISOString() as ISO8601Timestamp;
-    const result = await this.local.runExclusive(async (local) => {
-      const layout = await local.get(id);
-      if (!layout) {
-        throw new Error(`Cannot make a personal copy of layout id ${id} because it does not exist`);
+    if (shouldSyncPersonalLayouts()) {
+      if (!this.remote) {
+        throw new Error("Shared layouts are not supported without remote layout storage");
       }
+      if (!this.isOnline) {
+        throw new Error("Cannot save a shared layout while offline");
+      }
+      if (!localLayout.externalId) {
+        throw new Error("Local layout does not have externalId");
+      }
+
+      const newLayout = await this.remote.saveNewLayout({
+        id: uuidv4() as LayoutID,
+        name,
+        data: localLayout.working?.data ?? localLayout.baseline.data,
+        permission: "CREATOR_WRITE",
+      });
+
+      const localLayoutData = {
+        id: newLayout.id,
+        name: newLayout.name,
+        externalId: newLayout.externalId,
+        permission: newLayout.permission,
+        baseline: { data: newLayout.data, savedAt: newLayout.savedAt },
+        working: undefined,
+        syncInfo: { status: "tracked" as const, lastRemoteSavedAt: newLayout.savedAt },
+      };
+
+      const result = await this.local.runExclusive(
+        async (local) => await local.put(localLayoutData),
+      );
+
+      this.notifyChangeListeners({ type: "change", updatedLayout: result });
+      return result;
+    }
+    const result = await this.local.runExclusive(async (local) => {
       const newLayout = await local.put({
         id: uuidv4() as LayoutID,
         name,
         permission: "CREATOR_WRITE",
-        baseline: { data: layout.working?.data ?? layout.baseline.data, savedAt: now },
+        baseline: { data: localLayout.working?.data ?? localLayout.baseline.data, savedAt: now },
         working: undefined,
         syncInfo: { status: "new", lastRemoteSavedAt: now },
       });
-      await local.put({ ...layout, working: undefined });
+      await local.put({ ...localLayout, working: undefined });
       return newLayout;
     });
     this.notifyChangeListeners({ type: "change", updatedLayout: undefined });
@@ -542,7 +579,7 @@ export default class LayoutManager implements ILayoutManager {
               permission: remoteLayout.permission,
               baseline: { data: remoteLayout.data, savedAt: remoteLayout.savedAt },
               working: undefined,
-              syncInfo: layoutPermissionIsShared(remoteLayout.permission)
+              syncInfo: shouldSyncLayoutPermission(remoteLayout.permission)
                 ? { status: "tracked", lastRemoteSavedAt: remoteLayout.savedAt }
                 : undefined,
             });

--- a/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
@@ -434,15 +434,14 @@ export default class LayoutManager implements ILayoutManager {
     }
 
     const now = new Date().toISOString() as ISO8601Timestamp;
+
+    // if the APP_CONFIG.syncLocalLayouts is set to true, we will save the personal copy to remote storage as well
     if (shouldSyncPersonalLayouts()) {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
       if (!this.isOnline) {
         throw new Error("Cannot save a shared layout while offline");
-      }
-      if (!localLayout.externalId) {
-        throw new Error("Local layout does not have externalId");
       }
 
       const newLayout = await this.remote.saveNewLayout({
@@ -462,9 +461,11 @@ export default class LayoutManager implements ILayoutManager {
         syncInfo: { status: "tracked" as const, lastRemoteSavedAt: newLayout.savedAt },
       };
 
-      const result = await this.local.runExclusive(
-        async (local) => await local.put(localLayoutData),
-      );
+      const result = await this.local.runExclusive(async (local) => {
+        const newLayout = await local.put(localLayoutData);
+        await local.put({ ...localLayout, working: undefined });
+        return newLayout;
+      });
 
       this.notifyChangeListeners({ type: "change", updatedLayout: result });
       return result;

--- a/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
@@ -462,9 +462,9 @@ export default class LayoutManager implements ILayoutManager {
       };
 
       const result = await this.local.runExclusive(async (local) => {
-        const newLayout = await local.put(localLayoutData);
+        const newLocalLayout = await local.put(localLayoutData);
         await local.put({ ...localLayout, working: undefined });
-        return newLayout;
+        return newLocalLayout;
       });
 
       this.notifyChangeListeners({ type: "change", updatedLayout: result });

--- a/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
@@ -25,8 +25,9 @@ import {
   Layout,
   LayoutPermission,
   layoutAppearsDeleted,
-  layoutIsShared,
-  layoutPermissionIsShared,
+  shouldSyncPersonalLayouts,
+  shouldSyncLayout,
+  shouldSyncLayoutPermission,
 } from "@lichtblick/suite-base/services/ILayoutStorage";
 import { IRemoteLayoutStorage } from "@lichtblick/suite-base/services/IRemoteLayoutStorage";
 import computeLayoutSyncOperations, {
@@ -163,7 +164,7 @@ export default class LayoutManager implements ILayoutManager {
         permission: remoteLayout.permission,
         baseline: { data: remoteLayout.data, savedAt: remoteLayout.savedAt },
         working: undefined,
-        syncInfo: layoutPermissionIsShared(remoteLayout.permission)
+        syncInfo: shouldSyncLayoutPermission(remoteLayout.permission)
           ? { status: "tracked", lastRemoteSavedAt: remoteLayout.savedAt }
           : undefined,
       });
@@ -183,7 +184,7 @@ export default class LayoutManager implements ILayoutManager {
     from?: string;
   }): Promise<Layout> {
     const data = migratePanelsState(unmigratedData);
-    if (layoutPermissionIsShared(permission)) {
+    if (shouldSyncLayoutPermission(permission)) {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
@@ -255,7 +256,7 @@ export default class LayoutManager implements ILayoutManager {
           : { data, savedAt: now };
 
     // Renames of shared layouts go directly to the server
-    if (name != undefined && layoutIsShared(localLayout)) {
+    if (name != undefined && shouldSyncLayout(localLayout)) {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
@@ -289,7 +290,7 @@ export default class LayoutManager implements ILayoutManager {
       const isRename =
         this.remote != undefined &&
         name != undefined &&
-        layoutIsShared(localLayout) &&
+        shouldSyncLayout(localLayout) &&
         localLayout.syncInfo != undefined &&
         localLayout.syncInfo.status !== "new";
 
@@ -302,7 +303,7 @@ export default class LayoutManager implements ILayoutManager {
 
             // If the name is being changed, we will need to upload to the server with a new savedAt
             baseline: isRename ? { ...localLayout.baseline, savedAt: now } : localLayout.baseline,
-            syncInfo: layoutIsShared(localLayout)
+            syncInfo: shouldSyncLayout(localLayout)
               ? isRename
                 ? { status: "updated", lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt }
                 : localLayout.syncInfo
@@ -321,7 +322,7 @@ export default class LayoutManager implements ILayoutManager {
       throw new Error(`Cannot delete layout ${id} because it does not exist`);
     }
 
-    if (layoutIsShared(localLayout)) {
+    if (shouldSyncLayout(localLayout)) {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
@@ -336,7 +337,7 @@ export default class LayoutManager implements ILayoutManager {
       }
     }
     await this.local.runExclusive(async (local) => {
-      if (this.remote && !layoutIsShared(localLayout)) {
+      if (this.remote && !shouldSyncLayout(localLayout)) {
         await local.put({
           ...localLayout,
           working: {
@@ -362,7 +363,7 @@ export default class LayoutManager implements ILayoutManager {
       throw new Error(`Cannot overwrite layout ${id} because it does not exist`);
     }
     const now = new Date().toISOString() as ISO8601Timestamp;
-    if (layoutIsShared(localLayout)) {
+    if (shouldSyncLayout(localLayout)) {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
@@ -425,21 +426,57 @@ export default class LayoutManager implements ILayoutManager {
 
   @emitBusyStatus
   public async makePersonalCopy({ id, name }: { id: LayoutID; name: string }): Promise<Layout> {
+    const localLayout = await this.local.runExclusive(async (local) => await local.get(id));
+    if (!localLayout) {
+      throw new Error(`Cannot make a personal copy of layout id ${id} because it does not exist`);
+    }
+
     const now = new Date().toISOString() as ISO8601Timestamp;
-    const result = await this.local.runExclusive(async (local) => {
-      const layout = await local.get(id);
-      if (!layout) {
-        throw new Error(`Cannot make a personal copy of layout id ${id} because it does not exist`);
+    if (shouldSyncPersonalLayouts()) {
+      if (!this.remote) {
+        throw new Error("Shared layouts are not supported without remote layout storage");
       }
+      if (!this.isOnline) {
+        throw new Error("Cannot save a shared layout while offline");
+      }
+      if (!localLayout.externalId) {
+        throw new Error("Local layout does not have externalId");
+      }
+
+      const newLayout = await this.remote.saveNewLayout({
+        id: uuidv4() as LayoutID,
+        name,
+        data: localLayout.working?.data ?? localLayout.baseline.data,
+        permission: "CREATOR_WRITE",
+      });
+
+      const localLayoutData = {
+        id: newLayout.id,
+        name: newLayout.name,
+        externalId: newLayout.externalId,
+        permission: newLayout.permission,
+        baseline: { data: newLayout.data, savedAt: newLayout.savedAt },
+        working: undefined,
+        syncInfo: { status: "tracked" as const, lastRemoteSavedAt: newLayout.savedAt },
+      };
+
+      const result = await this.local.runExclusive(
+        async (local) => await local.put(localLayoutData),
+      );
+
+      this.notifyChangeListeners({ type: "change", updatedLayout: result });
+      return result;
+    }
+    const result = await this.local.runExclusive(async (local) => {
       const newLayout = await local.put({
         id: uuidv4() as LayoutID,
         name,
         permission: "CREATOR_WRITE",
-        baseline: { data: layout.working?.data ?? layout.baseline.data, savedAt: now },
+        baseline: { data: localLayout.working?.data ?? localLayout.baseline.data, savedAt: now },
         working: undefined,
         syncInfo: { status: "new", lastRemoteSavedAt: now },
       });
-      await local.put({ ...layout, working: undefined });
+      await local.put({ ...localLayout, working: undefined });
       return newLayout;
     });
     this.notifyChangeListeners({ type: "change", updatedLayout: undefined });
@@ -540,7 +577,7 @@ export default class LayoutManager implements ILayoutManager {
               permission: remoteLayout.permission,
               baseline: { data: remoteLayout.data, savedAt: remoteLayout.savedAt },
               working: undefined,
-              syncInfo: layoutPermissionIsShared(remoteLayout.permission)
+              syncInfo: shouldSyncLayoutPermission(remoteLayout.permission)
                 ? { status: "tracked", lastRemoteSavedAt: remoteLayout.savedAt }
                 : undefined,
             });

--- a/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
@@ -432,15 +432,14 @@ export default class LayoutManager implements ILayoutManager {
     }
 
     const now = new Date().toISOString() as ISO8601Timestamp;
+
+    // if the APP_CONFIG.syncLocalLayouts is set to true, we will save the personal copy to remote storage as well
     if (shouldSyncPersonalLayouts()) {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
       if (!this.isOnline) {
         throw new Error("Cannot save a shared layout while offline");
-      }
-      if (!localLayout.externalId) {
-        throw new Error("Local layout does not have externalId");
       }
 
       const newLayout = await this.remote.saveNewLayout({
@@ -460,9 +459,11 @@ export default class LayoutManager implements ILayoutManager {
         syncInfo: { status: "tracked" as const, lastRemoteSavedAt: newLayout.savedAt },
       };
 
-      const result = await this.local.runExclusive(
-        async (local) => await local.put(localLayoutData),
-      );
+      const result = await this.local.runExclusive(async (local) => {
+        const newLayout = await local.put(localLayoutData);
+        await local.put({ ...localLayout, working: undefined });
+        return newLayout;
+      });
 
       this.notifyChangeListeners({ type: "change", updatedLayout: result });
       return result;

--- a/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
@@ -460,9 +460,9 @@ export default class LayoutManager implements ILayoutManager {
       };
 
       const result = await this.local.runExclusive(async (local) => {
-        const newLayout = await local.put(localLayoutData);
+        const newLocalLayout = await local.put(localLayoutData);
         await local.put({ ...localLayout, working: undefined });
-        return newLayout;
+        return newLocalLayout;
       });
 
       this.notifyChangeListeners({ type: "change", updatedLayout: result });

--- a/packages/suite-base/src/typings/webpack-defines.d.ts
+++ b/packages/suite-base/src/typings/webpack-defines.d.ts
@@ -13,3 +13,5 @@ declare const API_URL: string | undefined;
 declare const LICHTBLICK_SUITE_VERSION: string | undefined;
 
 declare const DEV_WORKSPACE: string | undefined;
+
+declare const SYNC_LOCAL_LAYOUTS: boolean | undefined;

--- a/packages/suite-base/webpack.ts
+++ b/packages/suite-base/webpack.ts
@@ -283,6 +283,7 @@ export function makeConfig(
         LICHTBLICK_SUITE_VERSION: JSON.stringify(version),
         API_URL: JSON.stringify(process.env.API_URL),
         DEV_WORKSPACE: JSON.stringify(process.env.DEV_WORKSPACE),
+        SYNC_LOCAL_LAYOUTS: process.env.SYNC_LOCAL_LAYOUTS === "true",
         ...buildEnvVars(),
       }),
       // https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales

--- a/packages/suite-base/webpack.ts
+++ b/packages/suite-base/webpack.ts
@@ -246,6 +246,7 @@ export function makeConfig(
         LICHTBLICK_SUITE_VERSION: JSON.stringify(version),
         API_URL: JSON.stringify(process.env.API_URL),
         DEV_WORKSPACE: JSON.stringify(process.env.DEV_WORKSPACE),
+        SYNC_LOCAL_LAYOUTS: process.env.SYNC_LOCAL_LAYOUTS === "true",
         ...buildEnvVars(),
       }),
       // https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales

--- a/packages/suite-desktop/src/preload/ExtensionHandler.test.ts
+++ b/packages/suite-desktop/src/preload/ExtensionHandler.test.ts
@@ -370,7 +370,7 @@ describe("ExtensionsHandler", () => {
       expect(result).toMatchObject({
         id: extensionId,
         packageJson: mockPackageJson,
-        directory: `${rootDir}/${extensionName}`,
+        directory: join(rootDir, extensionName),
         readme: mockReadmeContent,
         changelog: mockChangelogContent,
       });
@@ -402,7 +402,7 @@ describe("ExtensionsHandler", () => {
       expect(result).toMatchObject({
         id: extensionId,
         packageJson: mockPackageJson,
-        directory: `${rootDir}/${extensionName}`,
+        directory: join(rootDir, extensionName),
         readme: "",
         changelog: "",
       });
@@ -478,14 +478,14 @@ describe("ExtensionsHandler", () => {
       expect(result[0]).toMatchObject({
         id: `${mockPackageJson.publisher}.${mockPackageJson.name}`,
         packageJson: mockPackageJson,
-        directory: `${rootDir}/extension1`,
+        directory: join(rootDir, "extension1"),
         readme: "",
         changelog: "",
       });
       expect(result[1]).toMatchObject({
         id: `${mockPackageJson.publisher}.${mockPackageJson.name}`,
         packageJson: mockPackageJson,
-        directory: `${rootDir}/extension2`,
+        directory: join(rootDir, "extension2"),
         readme: "",
         changelog: "",
       });
@@ -529,7 +529,7 @@ describe("ExtensionsHandler", () => {
       expect(result[0]).toMatchObject({
         id: `${mockPackageJson.publisher}.${mockPackageJson.name}`,
         packageJson: mockPackageJson,
-        directory: `${rootDir}/extension2`,
+        directory: join(rootDir, "extension2"),
         readme: mockReadmeContent,
         changelog: mockChangelogContent,
       });

--- a/packages/suite-desktop/src/webpackCommonConfig.test.ts
+++ b/packages/suite-desktop/src/webpackCommonConfig.test.ts
@@ -113,10 +113,11 @@ describe("createCommonWebpackConfig", () => {
     expect(hasForkTs).toBe(true);
   });
 
-  it("should propagate API_URL and DEV_WORKSPACE from environment if set", () => {
+  it("should propagate API_URL, DEV_WORKSPACE and SYNC_LOCAL_LAYOUTS from environment if set", () => {
     // Given
     process.env.API_URL = "https://api.example.com";
     (process.env as any).DEV_WORKSPACE = "workspace-1";
+    (process.env as any).SYNC_LOCAL_LAYOUTS = true;
     const params = createTestParams();
 
     // When
@@ -126,12 +127,14 @@ describe("createCommonWebpackConfig", () => {
     // Then
     expect(definePlugin.definitions.API_URL).toBe(JSON.stringify("https://api.example.com"));
     expect(definePlugin.definitions.DEV_WORKSPACE).toBe(JSON.stringify("workspace-1"));
+    expect(definePlugin.definitions.SYNC_LOCAL_LAYOUTS).toBe(true);
   });
 
-  it("should leave API_URL and DEV_WORKSPACE undefined if not set", () => {
+  it("should leave API_URL, DEV_WORKSPACE and SYNC_LOCAL_LAYOUTS undefined if not set", () => {
     // Given
     delete process.env.API_URL;
     delete (process.env as any).DEV_WORKSPACE;
+    delete (process.env as any).SYNC_LOCAL_LAYOUTS;
     const params = createTestParams();
 
     // When
@@ -141,5 +144,6 @@ describe("createCommonWebpackConfig", () => {
     // Then
     expect(definePlugin.definitions.API_URL).toBeUndefined();
     expect(definePlugin.definitions.DEV_WORKSPACE).toBeUndefined();
+    expect(definePlugin.definitions.SYNC_LOCAL_LAYOUTS).toBeUndefined();
   });
 });

--- a/packages/suite-desktop/src/webpackCommonConfig.ts
+++ b/packages/suite-desktop/src/webpackCommonConfig.ts
@@ -59,6 +59,9 @@ export function createCommonWebpackConfig(
         DEV_WORKSPACE: process.env.DEV_WORKSPACE
           ? JSON.stringify(process.env.DEV_WORKSPACE)
           : undefined,
+        SYNC_LOCAL_LAYOUTS: process.env.SYNC_LOCAL_LAYOUTS
+          ? process.env.SYNC_LOCAL_LAYOUTS === "true"
+          : undefined,
       }),
       new ForkTsCheckerWebpackPlugin(),
     ],


### PR DESCRIPTION
## User-Facing Changes

Setting the new environment variable `SYNC_LOCAL_LAYOUTS=true` will also synchronize local layouts with the remote layout storage (if configured).

## Description

This PR addresses the topic of local layouts to be synced with remote storage as discussed in [#1044 ](https://github.com/lichtblick-suite/lichtblick/issues/1044)

## Checklist

- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `SYNC_LOCAL_LAYOUTS` toggle to control whether local personal layout changes sync to remote storage, with refined eligibility based on layout type/permission. Defaults to off; when enabled, remote save/rename/delete/overwrite and personal-copy results participate.
* **Tests**
  * Expanded coverage for `SYNC_LOCAL_LAYOUTS`, including Jest global/config handling, webpack define propagation, and LayoutManager remote-sync behavior.
* **Documentation**
  * Updated comments to describe the new `syncLocalLayouts` behavior and how layouts are marked for remote syncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->