### PR TITLE
fix(AppBar): use palette color instead of hardcode white

### DIFF
--- a/packages/suite-base/src/components/AppBar/AppBarContainer.tsx
+++ b/packages/suite-base/src/components/AppBar/AppBarContainer.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles()((theme) => {
       boxShadow: "none",
       backgroundColor: theme.palette.appBar.main,
       borderBottom: "none",
-      color: theme.palette.common.white,
+      color: theme.palette.appBar.text,
       height: APP_BAR_HEIGHT,
 
       paddingRight: "calc(100% - env(titlebar-area-x) - env(titlebar-area-width))",

--- a/packages/suite-base/src/components/AppBar/AppBarDropdownButton.tsx
+++ b/packages/suite-base/src/components/AppBar/AppBarDropdownButton.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles()((theme) => ({
     borderRadius: 0,
 
     ":hover": {
-      backgroundColor: tinycolor2(theme.palette.common.white).setAlpha(0.08).toString(),
+      backgroundColor: tinycolor2(theme.palette.appBar.text).setAlpha(0.08).toString(),
     },
     "&.Mui-selected": {
       backgroundColor: theme.palette.appBar.primary,

--- a/packages/suite-base/src/components/AppBar/AppBarIconButton.tsx
+++ b/packages/suite-base/src/components/AppBar/AppBarIconButton.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles()((theme) => ({
       fontSize: "1em",
     },
     "&:hover": {
-      backgroundColor: tinycolor(theme.palette.common.white).setAlpha(0.08).toRgbString(),
+      backgroundColor: tinycolor(theme.palette.appBar.text).setAlpha(0.08).toRgbString(),
     },
     "&.Mui-selected": {
       backgroundColor: theme.palette.appBar.primary,

--- a/packages/suite-base/src/components/AppBar/index.tsx
+++ b/packages/suite-base/src/components/AppBar/index.tsx
@@ -69,11 +69,11 @@ const useStyles = makeStyles<{ debugDragRegion?: boolean }, "avatar">()(
           fontSize: "1em",
         },
         "&:hover": {
-          backgroundColor: tc(theme.palette.common.white).setAlpha(0.08).toRgbString(),
+          backgroundColor: tc(theme.palette.appBar.text).setAlpha(0.08).toRgbString(),
         },
         "&.Mui-selected": {
           backgroundColor: theme.palette.appBar.primary,
-          color: theme.palette.common.white,
+          color: theme.palette.appBar.text,
         },
         "&.Mui-disabled": {
           color: "currentColor",
@@ -114,7 +114,7 @@ const useStyles = makeStyles<{ debugDragRegion?: boolean }, "avatar">()(
       },
       keyEquivalent: {
         fontFamily: customTypography.fontMonospace,
-        background: tc(theme.palette.common.white).darken(45).toString(),
+        background: tc(theme.palette.appBar.text).darken(45).toString(),
         padding: theme.spacing(0, 0.5),
         aspectRatio: 1,
         borderRadius: theme.shape.borderRadius,
@@ -124,7 +124,7 @@ const useStyles = makeStyles<{ debugDragRegion?: boolean }, "avatar">()(
         marginTop: `${theme.spacing(0.5)} !important`,
       },
       avatar: {
-        color: theme.palette.common.white,
+        color: theme.palette.appBar.text,
         backgroundColor: tc(theme.palette.appBar.main).lighten().toString(),
         height: theme.spacing(3.5),
         width: theme.spacing(3.5),
@@ -134,7 +134,7 @@ const useStyles = makeStyles<{ debugDragRegion?: boolean }, "avatar">()(
         borderRadius: 0,
 
         "&:hover": {
-          backgroundColor: tc(theme.palette.common.white).setAlpha(0.08).toString(),
+          backgroundColor: tc(theme.palette.appBar.text).setAlpha(0.08).toString(),
 
           [`.${classes.avatar}`]: {
             backgroundColor: tc(theme.palette.appBar.main).lighten(20).toString(),
@@ -220,7 +220,7 @@ export function AppBar(props: AppBarProps): React.JSX.Element {
                 <LichtblickLogo fontSize="inherit" color="inherit" />
                 <ChevronDown12Regular
                   className={classes.dropDownIcon}
-                  primaryFill={theme.palette.common.white}
+                  primaryFill={theme.palette.appBar.text}
                 />
               </IconButton>
               <AppMenu


### PR DESCRIPTION
## User-Facing Changes

Here there is just small changes on the color usage to use the palette rather than fixed values

## Description
This PR is there to prepare the integration of this issue : https://github.com/lichtblick-suite/lichtblick/issues/1046

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated AppBar visuals to use the `appBar.text` theme color consistently across the header, including the AppBar background, logo hover/selected states, dropdown button hover, icon button hover animation, avatar text, key-equivalent (keyboard shortcut) background, and chevron icon coloring for improved visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->