### PR TITLE
feat: render data source gaps

### DIFF
--- a/packages/suite-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/suite-base/src/components/Chart/worker/ChartJSManager.ts
@@ -43,6 +43,7 @@ import {
 import { maybeCast } from "@lichtblick/suite-base/util/maybeCast";
 import { fontMonospace } from "@lichtblick/theme";
 
+import { hasGapMarkerBetweenSelectionAndCursor } from "./lastX";
 import { lineSegmentLabelColor } from "./lineSegments";
 import { proxyTyped } from "./proxy";
 
@@ -91,15 +92,28 @@ const lastX: InteractionModeFunction = (chart, event, _options, useFinalPosition
   const position = getRelativePosition(event, chart);
 
   // Create a sparse array to track the last datum for each dataset
-  const datasetIndexToLastItem: InteractionItem[] = [];
+  const datasetIndexToLastItem: Array<InteractionItem | undefined> = [];
   Interaction.evaluateInteractionItems(chart, "x", position, (element, datasetIndex, index) => {
     const center = element.getCenterPoint(useFinalPosition);
     if (center.x <= position.x) {
       datasetIndexToLastItem[datasetIndex] = { element, datasetIndex, index };
     }
   });
-  // Filter unused entries from the sparse array
-  return datasetIndexToLastItem.filter(Boolean);
+
+  const cursorXValue = chart.scales.x?.getValueForPixel(position.x);
+
+  const items = datasetIndexToLastItem.filter((item): item is InteractionItem => item != undefined);
+
+  if (typeof cursorXValue !== "number" || !Number.isFinite(cursorXValue)) {
+    return items;
+  }
+
+  return items.filter((item) => {
+    const dataset = chart.data.datasets[item.datasetIndex];
+    const datasetData = Array.isArray(dataset?.data) ? dataset.data : undefined;
+
+    return !hasGapMarkerBetweenSelectionAndCursor(datasetData, item.index, cursorXValue);
+  });
 };
 
 Interaction.modes.lastX = lastX;

--- a/packages/suite-base/src/components/Chart/worker/lastX.test.ts
+++ b/packages/suite-base/src/components/Chart/worker/lastX.test.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { hasGapMarkerBetweenSelectionAndCursor } from "./lastX";
+
+describe("hasGapMarkerBetweenSelectionAndCursor", () => {
+  it("returns true when a NaN gap marker exists between selected point and cursor", () => {
+    const datasetData = [
+      { x: 0, value: true },
+      { x: 0.999999, value: true },
+      { x: 1, value: Number.NaN },
+    ];
+
+    expect(hasGapMarkerBetweenSelectionAndCursor(datasetData, 1, 1)).toBe(true);
+    expect(hasGapMarkerBetweenSelectionAndCursor(datasetData, 0, 1.5)).toBe(true);
+  });
+
+  it("returns false when cursor is before the gap marker", () => {
+    const datasetData = [
+      { x: 0, value: true },
+      { x: 1, value: Number.NaN },
+      { x: 2, value: false },
+    ];
+
+    expect(hasGapMarkerBetweenSelectionAndCursor(datasetData, 0, 0.5)).toBe(false);
+  });
+
+  it("returns false when selected point is after the gap marker", () => {
+    const datasetData = [
+      { x: 0, value: true },
+      { x: 1, value: Number.NaN },
+      { x: 2, value: false },
+    ];
+
+    expect(hasGapMarkerBetweenSelectionAndCursor(datasetData, 2, 2.5)).toBe(false);
+  });
+
+  const datasetData = [
+    { x: 0, value: true },
+    { x: 1, value: Number.NaN },
+  ];
+
+  it.each([
+    ["undefined dataset", undefined, 0, 1],
+    ["empty dataset", [], 0, 1],
+    ["non-object dataset", [1, 2, 3], 0, 1],
+    ["selected index out of bounds (negative)", datasetData, -1, 1],
+    ["selected index out of bounds (too large)", datasetData, 9, 1],
+    ["NaN cursor x", datasetData, 0, Number.NaN],
+  ])(
+    "returns false for empty or invalid inputs: %s",
+    (_description, data, selectedIndex, cursorX) => {
+      expect(hasGapMarkerBetweenSelectionAndCursor(data, selectedIndex, cursorX)).toBe(false);
+    },
+  );
+});

--- a/packages/suite-base/src/components/Chart/worker/lastX.ts
+++ b/packages/suite-base/src/components/Chart/worker/lastX.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+type DatumLike = {
+  x: number;
+  value: unknown;
+};
+
+function isDatumLike(value: unknown): value is DatumLike {
+  return (
+    value != undefined &&
+    typeof value === "object" &&
+    "x" in value &&
+    typeof value.x === "number" &&
+    "value" in value
+  );
+}
+
+function isGapValue(value: unknown): boolean {
+  return typeof value === "number" && Number.isNaN(value);
+}
+
+// Returns true when a NaN gap marker exists between the selected point and hovered X.
+export function hasGapMarkerBetweenSelectionAndCursor(
+  datasetData: unknown[] | undefined,
+  selectedIndex: number,
+  cursorX: number,
+): boolean {
+  if (datasetData == undefined) {
+    return false;
+  }
+
+  if (selectedIndex < 0 || selectedIndex >= datasetData.length) {
+    return false;
+  }
+
+  if (!Number.isFinite(cursorX)) {
+    return false;
+  }
+
+  for (let index = selectedIndex + 1; index < datasetData.length; index++) {
+    const datum = datasetData[index];
+    if (!isDatumLike(datum)) {
+      continue;
+    }
+
+    if (datum.x > cursorX) {
+      break;
+    }
+
+    if (isGapValue(datum.value)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/suite-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
+++ b/packages/suite-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
@@ -614,6 +614,66 @@ describe("useCachedGetMessagePathDataItems", () => {
         ],
       ]);
     });
+
+    it("captures null/undefined values when they are at the end of a path", () => {
+      const messages: MessageEvent[] = [
+        {
+          topic: "/some/topic",
+          receiveTime: { sec: 0, nsec: 0 },
+          message: { payload: null },
+          schemaName: "datatype",
+          sizeInBytes: 0,
+        },
+        {
+          topic: "/some/topic",
+          receiveTime: { sec: 0, nsec: 0 },
+          message: { payload: undefined },
+          schemaName: "datatype",
+          sizeInBytes: 0,
+        },
+        {
+          topic: "/some/topic",
+          receiveTime: { sec: 0, nsec: 0 },
+          message: { payload: { x: 10 } },
+          schemaName: "datatype",
+          sizeInBytes: 0,
+        },
+      ];
+      const topics: Topic[] = [{ name: "/some/topic", schemaName: "some_datatype" }];
+      const datatypes: RosDatatypes = new Map(
+        Object.entries({
+          some_datatype: {
+            definitions: [{ name: "payload", type: "some_other_datatype", isComplex: true }],
+          },
+          some_other_datatype: {
+            definitions: [{ name: "x", type: "uint32" }],
+          },
+        }),
+      );
+
+      expect(addValuesWithPathsToItems(messages, "/some/topic.payload", topics, datatypes)).toEqual(
+        [
+          [
+            {
+              value: null,
+              path: "/some/topic.payload",
+            },
+          ],
+          [
+            {
+              value: undefined,
+              path: "/some/topic.payload",
+            },
+          ],
+          [
+            {
+              value: { x: 10 },
+              path: "/some/topic.payload",
+            },
+          ],
+        ],
+      );
+    });
   });
 });
 

--- a/packages/suite-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/packages/suite-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -233,16 +233,14 @@ export function getMessagePathDataItems(
     path: string,
     structureItem: MessagePathStructureItem | undefined,
   ) {
-    if (value == undefined) {
-      return;
-    }
     const pathItem = filledInPath.messagePath[pathIndex];
     const nextPathItem = filledInPath.messagePath[pathIndex + 1];
     if (!pathItem) {
       // If we're at the end of the `messagePath`, we're done! Just store the point.
+      // Note: value can be undefined/null here, and we want to capture that as valid data
       let constantName: string | undefined;
       const prevPathItem = filledInPath.messagePath[pathIndex - 1];
-      if (prevPathItem?.type === "name") {
+      if (prevPathItem?.type === "name" && value != undefined) {
         const fieldName = prevPathItem.name;
         const enumMap = structureItem != undefined ? enumValues[structureItem.datatype] : undefined;
         constantName = enumMap?.[fieldName]?.[value];
@@ -253,12 +251,19 @@ export function getMessagePathDataItems(
       (structureItem == undefined || structureItem.structureType === "message")
     ) {
       // If the `pathItem` is a name, we're traversing down using that name.
-      const next = structureItem?.nextByName[pathItem.name];
-      traverse(value[pathItem.name], pathIndex + 1, `${path}.${pathItem.repr}`, next);
+      // Skip if value is undefined - we can't traverse into undefined
+      if (value != undefined) {
+        const next = structureItem?.nextByName[pathItem.name];
+        traverse(value[pathItem.name], pathIndex + 1, `${path}.${pathItem.repr}`, next);
+      }
     } else if (
       pathItem.type === "slice" &&
       (structureItem == undefined || structureItem.structureType === "array")
     ) {
+      // Skip if value is undefined - we can't slice an undefined array
+      if (value == undefined) {
+        return;
+      }
       const { start, end } = pathItem;
       if (typeof start === "object" || typeof end === "object") {
         throw new Error(
@@ -308,7 +313,7 @@ export function getMessagePathDataItems(
         traverse(arrayElement, pathIndex + 1, newPath, structureItem?.next);
       }
     } else if (pathItem.type === "filter") {
-      if (filterMatches(pathItem, value)) {
+      if (value != undefined && filterMatches(pathItem, value)) {
         traverse(value, pathIndex + 1, `${path}{${pathItem.repr}}`, structureItem);
       }
     } else {

--- a/packages/suite-base/src/components/TimeBasedChart/Downsampler.test.ts
+++ b/packages/suite-base/src/components/TimeBasedChart/Downsampler.test.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Downsampler } from "./Downsampler";
+import { ChartDatasets, PlotViewport } from "./types";
+
+describe("Downsampler", () => {
+  it("should keep a NaN gap marker when downsampling state transition data", () => {
+    // Given
+    const dataset: ChartDatasets = [
+      {
+        label: "cars",
+        data: [
+          { x: 0, y: 0, label: "cars (3)", value: 3 },
+          { x: 10, y: Number.NaN, value: Number.NaN },
+          { x: 20, y: 0, label: "cars (4)", value: 4 },
+        ],
+      },
+    ];
+    const viewport: PlotViewport = {
+      width: 100,
+      height: 40,
+      bounds: {
+        x: { min: 0, max: 20 },
+        y: { min: -1, max: 1 },
+      },
+    };
+
+    const downsampler = new Downsampler();
+    downsampler.update({
+      datasets: dataset,
+      datasetBounds: viewport,
+      scales: {
+        x: { min: 0, max: 20, pixelMin: 0, pixelMax: 100 },
+        y: { min: -1, max: 1, pixelMin: 0, pixelMax: 40 },
+      },
+    });
+
+    // When
+    const result = downsampler.downsample();
+
+    // Then
+    const points = result?.[0]?.data ?? [];
+    const hasNaNGap = points.some((point) => point != undefined && Number.isNaN(point.y));
+    const values = points
+      .map((point) => (point == undefined ? undefined : point.value))
+      .filter((value): value is number => typeof value === "number" && !Number.isNaN(value));
+
+    expect(hasNaNGap).toBe(true);
+    expect(values).toEqual(expect.arrayContaining([3, 4]));
+  });
+
+  it("should keep the gap ordered between the surrounding states after downsampling", () => {
+    // Given
+    const dataset: ChartDatasets = [
+      {
+        label: "cars",
+        data: [
+          { x: 0, y: 0, label: "cars (3)", value: 3 },
+          { x: 10, y: Number.NaN, value: Number.NaN },
+          { x: 20, y: 0, label: "cars (4)", value: 4 },
+        ],
+      },
+    ];
+    const viewport: PlotViewport = {
+      width: 100,
+      height: 40,
+      bounds: {
+        x: { min: 0, max: 20 },
+        y: { min: -1, max: 1 },
+      },
+    };
+
+    const downsampler = new Downsampler();
+    downsampler.update({
+      datasets: dataset,
+      datasetBounds: viewport,
+      scales: {
+        x: { min: 0, max: 20, pixelMin: 0, pixelMax: 100 },
+        y: { min: -1, max: 1, pixelMin: 0, pixelMax: 40 },
+      },
+    });
+
+    // When
+    const result = downsampler.downsample();
+
+    // Then
+    // The gap (NaN) must sit *between* the two valid states, otherwise the line
+    // reconnects across the gap and no break is rendered.
+    const points = result?.[0]?.data ?? [];
+    const gapIndex = points.findIndex((point) => point != undefined && Number.isNaN(point.y));
+    const firstValueIndex = points.findIndex((point) => point?.value === 3);
+    const secondValueIndex = points.findIndex((point) => point?.value === 4);
+
+    expect(firstValueIndex).toBeGreaterThanOrEqual(0);
+    expect(gapIndex).toBeGreaterThan(firstValueIndex);
+    expect(secondValueIndex).toBeGreaterThan(gapIndex);
+  });
+});

--- a/packages/suite-base/src/components/TimeBasedChart/downsampleStates.test.ts
+++ b/packages/suite-base/src/components/TimeBasedChart/downsampleStates.test.ts
@@ -96,4 +96,27 @@ describe("downsampleStates", () => {
       { x: 100, index: 4 },
     ]);
   });
+
+  it("keeps a gap point ordered between the surrounding states", () => {
+    // Given
+    // A gap marker (no label, e.g. a NaN datum) sits between two distinct
+    // states. It must remain between them after downsampling so the rendered
+    // line breaks instead of reconnecting across the gap.
+    // in:  A--|-#-|--B   (# = gap)
+    const data: Datum[] = [
+      { x: 0, y: 0, label: A },
+      { x: 50, y: Number.NaN },
+      { x: 100, y: 0, label: B },
+    ];
+
+    // When
+    const result = downsampleStates(iterateObjects(data), bounds, numPoints);
+
+    // Then
+    expect(result).toEqual([
+      { x: 0, index: 0 },
+      { x: 50, index: 1 },
+      { x: 100, index: 2 },
+    ]);
+  });
 });

--- a/packages/suite-base/src/components/TimeBasedChart/downsampleStates.ts
+++ b/packages/suite-base/src/components/TimeBasedChart/downsampleStates.ts
@@ -163,9 +163,17 @@ export function downsampleStates(
       continue;
     }
 
-    // This only seems to occur when we've inserted a dummy final point, which
-    // we need to add
+    // A point without a label is either the dummy final point or a gap marker
+    // (e.g. a NaN datum inserted by the state transitions panel to break the
+    // line). We must finish and reset the current interval first so the gap
+    // point keeps its position between the surrounding states. Otherwise the
+    // still-open interval would be flushed by the next labeled point and end up
+    // ordered *after* the gap, reconnecting the line across the gap.
     if (label == undefined) {
+      if (interval != undefined) {
+        finishInterval();
+        interval = undefined;
+      }
       indices.push({
         x,
         index,

--- a/packages/suite-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/suite-base/src/components/TimeBasedChart/index.tsx
@@ -355,6 +355,11 @@ export default function TimeBasedChart(props: Props): React.JSX.Element {
       }
 
       const { value, constantName, states } = datum;
+      const isGapValue = typeof value === "number" && Number.isNaN(value);
+      if (isGapValue) {
+        continue;
+      }
+
       if (value == undefined && states == undefined) {
         continue;
       }

--- a/packages/suite-base/src/panels/Plot/builders/IndexDatasetsBuilder.test.ts
+++ b/packages/suite-base/src/panels/Plot/builders/IndexDatasetsBuilder.test.ts
@@ -110,6 +110,46 @@ describe("IndexDatasetsBuilder", () => {
     });
   });
 
+  it("should create a gap (NaN) for null values inside an array so the line breaks", async () => {
+    // Given
+    const builder = new IndexDatasetsBuilder();
+
+    builder.setSeries(
+      buildSeriesItems([{ enabled: true, timestampMethod: "receiveTime", value: "/bar.val[:]" }]),
+    );
+
+    // When
+    builder.handlePlayerState(
+      buildPlayerState({
+        messages: [
+          {
+            topic: "/bar",
+            schemaName: "foo",
+            receiveTime: { sec: 0, nsec: 0 },
+            sizeInBytes: 0,
+            message: {
+              val: [1, ReactNull, 3],
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then
+    await expect(builder.getViewportDatasets()).resolves.toEqual({
+      pathsWithMismatchedDataLengths: new Set(),
+      datasetsByConfigIndex: [
+        expect.objectContaining({
+          data: [
+            { x: 0, y: 1, value: 1, receiveTime: { sec: 0, nsec: 0 } },
+            { x: 1, y: NaN, value: NaN, receiveTime: { sec: 0, nsec: 0 } },
+            { x: 2, y: 3, value: 3, receiveTime: { sec: 0, nsec: 0 } },
+          ],
+        }),
+      ],
+    });
+  });
+
   it("should return the existing dataset range when no input messages", async () => {
     const builder = new IndexDatasetsBuilder();
 

--- a/packages/suite-base/src/panels/Plot/builders/IndexDatasetsBuilder.ts
+++ b/packages/suite-base/src/panels/Plot/builders/IndexDatasetsBuilder.ts
@@ -61,6 +61,18 @@ export class IndexDatasetsBuilder implements IDatasetsBuilder {
 
       const items = simpleGetMessagePathDataItems(msgEvent, series.parsed);
       const pathItems = filterMap(items, (item, idx) => {
+        // A null/undefined value means there is no value at this index. Emit a gap (NaN) so the
+        // line breaks here instead of interpolating across the missing value, while preserving
+        // the x index of the surrounding points.
+        if (item == undefined) {
+          return {
+            x: idx,
+            y: Number.NaN,
+            receiveTime: msgEvent.receiveTime,
+            value: Number.NaN,
+          };
+        }
+
         if (!isChartValue(item)) {
           return;
         }

--- a/packages/suite-base/src/panels/Plot/builders/TimestampDatasetsBuilder.test.ts
+++ b/packages/suite-base/src/panels/Plot/builders/TimestampDatasetsBuilder.test.ts
@@ -236,6 +236,63 @@ describe("TimestampDatasetsBuilder", () => {
     });
   });
 
+  it("should create a gap (NaN) for null values so the line breaks", async () => {
+    // Given
+    const builder = new TimestampDatasetsBuilder();
+
+    builder.setSeries(
+      buildSeriesItems([{ enabled: true, timestampMethod: "receiveTime", value: "/foo.val" }]),
+    );
+
+    // When
+    builder.handlePlayerState(
+      buildPlayerState({
+        messages: [
+          {
+            topic: "/foo",
+            schemaName: "foo",
+            receiveTime: { sec: 0, nsec: 0 },
+            sizeInBytes: 0,
+            message: { val: 1 },
+          },
+          {
+            topic: "/foo",
+            schemaName: "foo",
+            receiveTime: { sec: 1, nsec: 0 },
+            sizeInBytes: 0,
+            message: { val: ReactNull },
+          },
+          {
+            topic: "/foo",
+            schemaName: "foo",
+            receiveTime: { sec: 2, nsec: 0 },
+            sizeInBytes: 0,
+            message: { val: 2 },
+          },
+        ],
+      }),
+    );
+
+    // Then
+    await expect(
+      builder.getViewportDatasets({
+        size: { width: 1_000, height: 1_000 },
+        bounds: {},
+      }),
+    ).resolves.toEqual({
+      pathsWithMismatchedDataLengths: new Set(),
+      datasetsByConfigIndex: [
+        expect.objectContaining({
+          data: [
+            { x: 0, y: 1, value: 1 },
+            { x: 1, y: NaN, value: NaN },
+            { x: 2, y: 2, value: 2 },
+          ],
+        }),
+      ],
+    });
+  });
+
   it("should reset full data when isReset is true", async () => {
     const builder = new TimestampDatasetsBuilder();
 

--- a/packages/suite-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
+++ b/packages/suite-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
@@ -178,6 +178,29 @@ function readMessagePathItems(
 
     const items = simpleGetMessagePathDataItems(event, path);
     for (const item of items) {
+      const headerStamp = getTimestampForMessage(event.message);
+      const timestamp = timestampMethod === "receiveTime" ? event.receiveTime : headerStamp;
+      if (!timestamp) {
+        continue;
+      }
+
+      const xValue = toSec(subtractTime(timestamp, startTime));
+
+      // A null/undefined value means the series has no value at this timestamp. Emit a gap
+      // (NaN) so the line breaks at this point instead of interpolating across the missing
+      // value. NaN values survive the downsampling pipeline and create a discontinuity in
+      // the rendered chart.
+      if (item == undefined) {
+        out.push({
+          x: xValue,
+          y: Number.NaN,
+          receiveTime: event.receiveTime,
+          headerStamp,
+          value: Number.NaN,
+        });
+        continue;
+      }
+
       if (!isChartValue(item)) {
         continue;
       }
@@ -186,13 +209,6 @@ function readMessagePathItems(
         continue;
       }
 
-      const headerStamp = getTimestampForMessage(event.message);
-      const timestamp = timestampMethod === "receiveTime" ? event.receiveTime : headerStamp;
-      if (!timestamp) {
-        continue;
-      }
-
-      const xValue = toSec(subtractTime(timestamp, startTime));
       const mathModified = mathFunction ? mathFunction(chartValue) : chartValue;
       out.push({
         x: xValue,

--- a/packages/suite-base/src/panels/StateTransitions/messagesToDataset.test.ts
+++ b/packages/suite-base/src/panels/StateTransitions/messagesToDataset.test.ts
@@ -496,4 +496,123 @@ describe("messagesToDataset", () => {
 
     expect(result.data.length).toBe(2);
   });
+
+  it("should add a gap (NaN point) when null/undefined value is encountered after valid data", () => {
+    const validMessageData = {
+      messageEvent,
+      queriedData: [{ value: queriedDataValue, path: queriedDataPath }],
+    };
+
+    const nullMessageData = {
+      messageEvent: { ...messageEvent, receiveTime: { sec: 2, nsec: 0 } },
+      queriedData: [{ value: undefined, path: queriedDataPath }],
+    };
+
+    const anotherValidMessageData = {
+      messageEvent: { ...messageEvent, receiveTime: { sec: 3, nsec: 0 } },
+      queriedData: [{ value: queriedDataValue, path: queriedDataPath }],
+    };
+
+    const blocks = [[validMessageData, nullMessageData, anotherValidMessageData]];
+
+    const result = messagesToDataset({
+      ...args,
+      blocks,
+      path: { ...args.path, timestampMethod: "receiveTime" },
+    });
+
+    // Should have: valid point, gap (NaN), valid point
+    expect(result.data.length).toBe(3);
+    expect(result.data[0]).toEqual(expect.objectContaining({ value: queriedDataValue }));
+    expect(result.data[1]).toEqual(
+      expect.objectContaining({
+        x: expect.any(Number),
+        y: Number.NaN,
+        value: Number.NaN,
+      }),
+    );
+    expect(result.data[2]).toEqual(expect.objectContaining({ value: queriedDataValue }));
+  });
+
+  it("should create one gap for consecutive nulls and resume with a new state", () => {
+    const firstValidValue = 3;
+    const resumedValidValue = 4;
+
+    const firstValidMessage = {
+      messageEvent,
+      queriedData: [{ value: firstValidValue, path: queriedDataPath }],
+    };
+
+    const nullMessageA = {
+      messageEvent: { ...messageEvent, receiveTime: { sec: 2, nsec: 0 } },
+      queriedData: [{ value: null, path: queriedDataPath }],
+    };
+
+    const nullMessageB = {
+      messageEvent: { ...messageEvent, receiveTime: { sec: 3, nsec: 0 } },
+      queriedData: [{ value: null, path: queriedDataPath }],
+    };
+
+    const resumedValidMessage = {
+      messageEvent: { ...messageEvent, receiveTime: { sec: 4, nsec: 0 } },
+      queriedData: [{ value: resumedValidValue, path: queriedDataPath }],
+    };
+
+    const blocks = [[firstValidMessage, nullMessageA, nullMessageB, resumedValidMessage]];
+
+    const result = messagesToDataset({
+      ...args,
+      blocks,
+      path: { ...args.path, timestampMethod: "receiveTime" },
+    });
+
+    expect(result.data.length).toBe(3);
+    expect(result.data[0]).toEqual(expect.objectContaining({ value: firstValidValue }));
+    expect(result.data[1]).toEqual(
+      expect.objectContaining({
+        x: expect.any(Number),
+        y: Number.NaN,
+        value: Number.NaN,
+      }),
+    );
+    expect(result.data[2]).toEqual(
+      expect.objectContaining({
+        value: resumedValidValue,
+        label: expect.stringContaining(String(resumedValidValue)),
+      }),
+    );
+  });
+
+  it("should preserve a full-duration segment before a null gap", () => {
+    const startTime = { sec: 1_539_869_067, nsec: 0 };
+
+    const activeMessageA = {
+      messageEvent: { ...messageEvent, receiveTime: { sec: 1_539_869_067, nsec: 0 } },
+      queriedData: [{ value: true, path: queriedDataPath }],
+    };
+
+    const activeMessageB = {
+      messageEvent: { ...messageEvent, receiveTime: { sec: 1_539_869_067, nsec: 999_999_000 } },
+      queriedData: [{ value: true, path: queriedDataPath }],
+    };
+
+    const nullMessage = {
+      messageEvent: { ...messageEvent, receiveTime: { sec: 1_539_869_068, nsec: 0 } },
+      queriedData: [{ value: null, path: queriedDataPath }],
+    };
+
+    const result = messagesToDataset({
+      ...args,
+      startTime,
+      blocks: [[activeMessageA, activeMessageB, nullMessage]],
+      path: { ...args.path, timestampMethod: "receiveTime" },
+      showPoints: false,
+    });
+
+    expect(result.data).toHaveLength(3);
+    expect(result.data[0]).toEqual(expect.objectContaining({ x: 0, value: true }));
+    expect(result.data[1]).toEqual(expect.objectContaining({ value: true }));
+    expect(result.data[1]?.x).toBeCloseTo(0.999999, 6);
+    expect(result.data[2]).toEqual(expect.objectContaining({ x: 1, value: Number.NaN }));
+  });
 });

--- a/packages/suite-base/src/panels/StateTransitions/messagesToDataset.ts
+++ b/packages/suite-base/src/panels/StateTransitions/messagesToDataset.ts
@@ -43,6 +43,7 @@ export function messagesToDataset(args: MessageDatasetArgs): ChartDataset {
 
   let lastValue: string | number | bigint | boolean | undefined = undefined;
   let lastDatum: ChartDataset["data"][0] | undefined = undefined;
+  let lastValidDataAdded = false;
 
   for (const messages of blocks) {
     if (!messages) {
@@ -63,6 +64,21 @@ export function messagesToDataset(args: MessageDatasetArgs): ChartDataset {
       const { constantName, value } = queriedData;
 
       if (!isValidValue(value)) {
+        // Add a gap point if we previously added valid data. Use NaN instead of
+        // undefined so the gap survives the downsampling pipeline.
+        if (lastValidDataAdded && lastValue != undefined) {
+          // Flush a pending repeated-value endpoint before the gap so the
+          // previous state segment keeps its full duration up to this timestamp.
+          if (lastDatum != undefined) {
+            dataset.data.push(lastDatum);
+          }
+
+          const x = toSec(subtractTimes(timestamp, startTime));
+          dataset.data.push({ x, y: Number.NaN, value: Number.NaN });
+          lastValue = undefined;
+          lastDatum = undefined;
+          lastValidDataAdded = false;
+        }
         continue;
       }
 
@@ -84,6 +100,7 @@ export function messagesToDataset(args: MessageDatasetArgs): ChartDataset {
 
       if (isNewSegment || showPoints) {
         dataset.data.push(lastDatum);
+        lastValidDataAdded = true;
 
         // after we add a datum we clear the last datum so we don't try to add it again at the end
         lastDatum = undefined;

--- a/packages/suite-base/src/panels/Table/Table.test.tsx
+++ b/packages/suite-base/src/panels/Table/Table.test.tsx
@@ -1,0 +1,64 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2020-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import "@testing-library/jest-dom";
+
+import Table from "./Table";
+
+describe("Table", () => {
+  it("should render values for simple keys", () => {
+    // Given
+    const value = [{ fieldName: "visible-value" }];
+
+    // When
+    render(<Table value={value} accessorPath="" />);
+
+    // Then
+    expect(screen.getByTestId("column-header-fieldName")).toBeVisible();
+    expect(screen.getByText("visible-value")).toBeVisible();
+  });
+
+  it("should render values for top-level keys that contain dots", () => {
+    // Given
+    const value = [{ "field.with.dot": "visible-value" }];
+
+    // When
+    render(<Table value={value} accessorPath="" />);
+
+    // Then
+    expect(screen.getByTestId("column-header-field-with-dot")).toBeVisible();
+    expect(screen.getByText("visible-value")).toBeVisible();
+  });
+
+  it("should render values for nested keys that contain dots after expanding", async () => {
+    // Given
+    const value = [{ outer: { "inner.with.dot": "nested-visible-value" } }];
+
+    // When
+    const user = userEvent.setup();
+    render(<Table value={value} accessorPath="" />);
+    await user.click(screen.getByTestId("expand-cell-outer-0"));
+
+    // Then
+    expect(screen.getByTestId("column-header-inner-with-dot")).toBeVisible();
+    expect(screen.getByText("nested-visible-value")).toBeVisible();
+  });
+});

--- a/packages/suite-base/src/panels/Table/Table.tsx
+++ b/packages/suite-base/src/panels/Table/Table.tsx
@@ -189,7 +189,7 @@ function getColumnsFromObject(val: CellValue, accessorPath: string) {
   }
   const columns: MergedColumnsType = Object.keys(val).map((accessor) => {
     const id = accessorPath.length !== 0 ? `${accessorPath}.${accessor}` : accessor;
-    return columnHelper.accessor(accessor, {
+    return columnHelper.accessor((row) => row[accessor], {
       header: accessor,
       id,
       cell: memoizedCellRenderer(accessorPath, id),


### PR DESCRIPTION
## User-Facing Changes

Data sources that contain message gap values, indicated by explicit `null` payload, will be rendered sowing these gaps in state transition, table or plot panels.

## Description
This is a follow up of PR #1156 
Message with with a the data containing a key and explicit value `null` will be considered as valid values. This will make e.g. plot grap lines or state transition bars contain to a visible gap.

Example:

<img width="3216" height="576" alt="image" src="https://github.com/user-attachments/assets/a228569a-e897-44e7-a24e-6da7cdda6eb9" />


## Checklist

- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  - Charts now preserve gaps/missing values end-to-end: dataset building, downsampling, and line rendering no longer interpolate across `null`/`undefined` or `NaN` markers
  - Tooltips skip gap points so placeholders aren’t shown
  - Chart cursor/interaction behavior now respects gap markers when resolving “last” data
  - Message path resolution now retains terminal `null`/`undefined` values with the correct resolved path
  - Table columns continue to support field names containing special characters
<!-- end of auto-generated comment: release notes by coderabbit.ai -->