### PR TITLE
separating audit ci

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,12 +4,18 @@ on:
   push:
     branches: [develop, main]
   pull_request:
+  schedule:
+    - cron: "0 8 * * 1-5" # Mon–Fri at 08:00 UTC (GMT)
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   test:
+    # Push/PR check: behaves exactly as before. Skipped on the scheduled and
+    # manual runs, which are handled by the audit-report job below.
+    if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
 
     # Run each command in parallel with the same setup steps.
@@ -46,3 +52,70 @@ jobs:
       - run: yarn install --immutable
 
       - run: ${{ matrix.config.command }}
+
+  audit-report:
+    # Scheduled (and manually dispatched) run: produce an HTML report, email it,
+    # then fail the job if any vulnerabilities were found.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    name: audit report
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - run: corepack enable yarn
+
+      - name: Restore cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            .yarn/cache
+            **/node_modules
+          key: v5-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: v5-${{ runner.os }}-yarn-
+
+      - run: yarn install --immutable
+
+      - name: Run npm audit (capture JSON, do not fail yet)
+        id: audit
+        run: |
+          set +e
+          yarn npm audit --all --recursive --json > audit.json
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Generate HTML report
+        run: yarn audit:report
+
+      - name: Upload audit artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: audit-report
+          path: |
+            audit.json
+            audit-report.html
+          retention-days: 30
+
+      - name: Send report email
+        if: always()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{ secrets.MAIL_SERVER }}
+          server_port: ${{ secrets.MAIL_PORT }}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          from: ${{ secrets.MAIL_FROM }}
+          to: ${{ secrets.MAIL_TO }}
+          subject: "Dependency Audit Report — ${{ github.repository }} (${{ github.run_id }})"
+          html_body: file://audit-report.html
+          attachments: audit-report.html
+
+      - name: Fail if vulnerabilities were found
+        if: ${{ steps.audit.outputs.exit_code != '0' }}
+        run: |
+          echo "npm audit reported vulnerabilities (exit code ${{ steps.audit.outputs.exit_code }})."
+          exit 1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    # Run each command in parallel with the same setup steps.
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        config:
+          # Specify names so that the GitHub branch protection settings for
+          # required checks don't need to change if we ever change the commands used.
+          - name: npm audit
+            command: yarn npm audit --all --recursive --severity moderate

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Audit
 
 on:
   push:
@@ -23,3 +23,26 @@ jobs:
           # required checks don't need to change if we ever change the commands used.
           - name: npm audit
             command: yarn npm audit --all --recursive --severity moderate
+
+    name: ${{ matrix.config.name }} (${{ matrix.os }})
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - run: corepack enable yarn
+
+      - name: Restore cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            .yarn/cache
+            **/node_modules
+          key: v5-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: v5-${{ runner.os }}-yarn-
+
+      - run: yarn install --immutable
+
+      - run: ${{ matrix.config.command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
         config:
           # Specify names so that the GitHub branch protection settings for
           # required checks don't need to change if we ever change the commands used.
-          - name: npm audit
-            command: yarn npm audit --all --recursive --severity moderate
           - name: lint
             command: |
               # lint steps

--- a/ci/audit-report-template.ts
+++ b/ci/audit-report-template.ts
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export const SEVERITY_ORDER = ["critical", "high", "moderate", "low", "info"] as const;
+export type Severity = (typeof SEVERITY_ORDER)[number];
+
+export type Advisory = {
+  module: string;
+  severity: Severity;
+  id: string;
+  issue: string;
+  vulnerableVersions?: string;
+  dependents?: string[];
+};
+
+const SEVERITY_COLORS: Record<Severity, string> = {
+  critical: "#b71c1c",
+  high: "#e53935",
+  moderate: "#fb8c00",
+  low: "#fdd835",
+  info: "#1e88e5",
+};
+
+export function countBySeverity(advisories: Advisory[]): Record<Severity, number> {
+  const counts: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    moderate: 0,
+    low: 0,
+    info: 0,
+  };
+  for (const advisory of advisories) {
+    counts[advisory.severity] += 1;
+  }
+  return counts;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function renderHtml(advisories: Advisory[]): string {
+  const counts = countBySeverity(advisories);
+  const total = advisories.length;
+  const generatedAt = new Date().toISOString();
+  const repository = process.env.GITHUB_REPOSITORY ?? "local";
+
+  const summaryCells = SEVERITY_ORDER.map(
+    (severity) => `
+        <td style="text-align:center;padding:8px 16px;">
+          <div style="font-size:24px;font-weight:700;color:${SEVERITY_COLORS[severity]};">${counts[severity]}</div>
+          <div style="font-size:12px;text-transform:uppercase;color:#555;">${severity}</div>
+        </td>`,
+  ).join("");
+
+  const sorted = [...advisories].sort(
+    (a, b) => SEVERITY_ORDER.indexOf(a.severity) - SEVERITY_ORDER.indexOf(b.severity),
+  );
+
+  const rows =
+    sorted.length === 0
+      ? `<tr><td colspan="4" style="padding:16px;text-align:center;color:#2e7d32;">No vulnerabilities found. 🎉</td></tr>`
+      : sorted
+          .map((advisory) => {
+            const dependents =
+              advisory.dependents && advisory.dependents.length > 0
+                ? advisory.dependents.map((dep) => escapeHtml(dep)).join("<br />")
+                : "—";
+            return `
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #eee;white-space:nowrap;">
+            <span style="display:inline-block;padding:2px 8px;border-radius:10px;color:#fff;font-size:12px;background:${SEVERITY_COLORS[advisory.severity]};">${advisory.severity}</span>
+          </td>
+          <td style="padding:8px 12px;border-bottom:1px solid #eee;font-family:monospace;">${escapeHtml(advisory.module)}</td>
+          <td style="padding:8px 12px;border-bottom:1px solid #eee;">${escapeHtml(advisory.issue)}<div style="font-size:12px;color:#777;">${escapeHtml(advisory.id)}${advisory.vulnerableVersions ? ` • ${escapeHtml(advisory.vulnerableVersions)}` : ""}</div></td>
+          <td style="padding:8px 12px;border-bottom:1px solid #eee;font-family:monospace;font-size:12px;">${dependents}</td>
+        </tr>`;
+          })
+          .join("");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dependency Audit Report</title>
+</head>
+<body style="margin:0;padding:24px;background:#f4f5f7;font-family:Arial,Helvetica,sans-serif;color:#222;">
+  <div style="max-width:880px;margin:0 auto;background:#fff;border-radius:8px;overflow:hidden;box-shadow:0 1px 4px rgba(0,0,0,0.1);">
+    <div style="background:#0d1b2a;color:#fff;padding:20px 24px;">
+      <h1 style="margin:0;font-size:20px;">Dependency Audit Report</h1>
+      <div style="font-size:13px;opacity:0.8;margin-top:4px;">${escapeHtml(repository)} • ${escapeHtml(generatedAt)}</div>
+    </div>
+    <div style="padding:24px;">
+      <table style="width:100%;border-collapse:collapse;margin-bottom:24px;background:#fafafa;border-radius:6px;">
+        <tr>
+          <td style="text-align:center;padding:8px 16px;">
+            <div style="font-size:24px;font-weight:700;">${total}</div>
+            <div style="font-size:12px;text-transform:uppercase;color:#555;">total</div>
+          </td>
+          ${summaryCells}
+        </tr>
+      </table>
+      <table style="width:100%;border-collapse:collapse;font-size:14px;">
+        <thead>
+          <tr style="text-align:left;background:#f0f0f0;">
+            <th style="padding:8px 12px;">Severity</th>
+            <th style="padding:8px 12px;">Package</th>
+            <th style="padding:8px 12px;">Advisory</th>
+            <th style="padding:8px 12px;">Dependents</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+    <div style="padding:16px 24px;background:#f0f0f0;font-size:12px;color:#777;">
+      Generated by <code>yarn npm audit</code> • This is an automated report.
+    </div>
+  </div>
+</body>
+</html>
+`;
+}

--- a/ci/generate-audit-report.ts
+++ b/ci/generate-audit-report.ts
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import fs from "fs";
+import path from "path";
+
+import {
+  Advisory,
+  Severity,
+  SEVERITY_ORDER,
+  countBySeverity,
+  renderHtml,
+} from "./audit-report-template";
+
+const INPUT_PATH = process.env.AUDIT_JSON ?? "audit.json";
+const OUTPUT_PATH = process.env.AUDIT_HTML ?? "audit-report.html";
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Yarn Berry's `yarn npm audit --json` emits newline-delimited JSON (NDJSON) with one record
+ * per line of the shape `{ value: "<module>", children: { ID, Issue, Severity, ... } }`. Older
+ * npm-style output uses a single `{ advisories: { [id]: advisory } }` object. This parser
+ * handles both shapes and normalizes them into a flat list of advisories.
+ */
+function parseAuditFile(raw: string): Advisory[] {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return [];
+  }
+
+  const advisories: Advisory[] = [];
+
+  const ingestYarnRecord = (moduleName: string, children: unknown): void => {
+    if (typeof children !== "object" || children == undefined) {
+      return;
+    }
+    const value = children as Record<string, unknown>;
+    const dependents = Array.isArray(value.Dependents)
+      ? value.Dependents.filter((dep): dep is string => typeof dep === "string")
+      : undefined;
+    advisories.push({
+      module: moduleName,
+      severity: normalizeSeverity(value.Severity),
+      id: asString(value.ID) ?? moduleName,
+      issue: asString(value.Issue) ?? "Unknown advisory",
+      vulnerableVersions: asString(value["Vulnerable Versions"]),
+      dependents,
+    });
+  };
+
+  const ingestNpmAdvisory = (key: string, record: unknown): void => {
+    if (typeof record !== "object" || record == undefined) {
+      return;
+    }
+    const value = record as Record<string, unknown>;
+    advisories.push({
+      module: asString(value.module_name) ?? key,
+      severity: normalizeSeverity(value.severity),
+      id: asString(value.url) ?? key,
+      issue: asString(value.title) ?? "Unknown advisory",
+      vulnerableVersions: asString(value.vulnerable_versions),
+      dependents: undefined,
+    });
+  };
+
+  const ingestObject = (parsed: unknown): void => {
+    if (typeof parsed !== "object" || parsed == undefined) {
+      return;
+    }
+    const obj = parsed as Record<string, unknown>;
+
+    // NPM-style summary object: { advisories: { [id]: advisory } }
+    if (typeof obj.advisories === "object" && obj.advisories != undefined) {
+      for (const [key, advisory] of Object.entries(obj.advisories as Record<string, unknown>)) {
+        ingestNpmAdvisory(key, advisory);
+      }
+      return;
+    }
+
+    // Yarn NDJSON-style line: { value: "<module>", children: { ... } }
+    if (typeof obj.value === "string" && typeof obj.children === "object") {
+      ingestYarnRecord(obj.value, obj.children);
+    }
+  };
+
+  // Try a single JSON document first; fall back to NDJSON line-by-line.
+  try {
+    ingestObject(JSON.parse(trimmed));
+  } catch {
+    for (const line of trimmed.split("\n")) {
+      const lineText = line.trim();
+      if (lineText.length === 0) {
+        continue;
+      }
+      try {
+        ingestObject(JSON.parse(lineText));
+      } catch {
+        // Ignore malformed lines.
+      }
+    }
+  }
+
+  return advisories;
+}
+
+function normalizeSeverity(value: unknown): Severity {
+  const text = typeof value === "string" ? value.toLowerCase() : "";
+  return (SEVERITY_ORDER as readonly string[]).includes(text) ? (text as Severity) : "info";
+}
+
+function main(): void {
+  const inputPath = path.resolve(INPUT_PATH);
+  let raw = "";
+  try {
+    raw = fs.readFileSync(inputPath, "utf8");
+  } catch (err) {
+    console.error(`Failed to read audit JSON at ${inputPath}:`, err);
+    process.exit(1);
+  }
+
+  const advisories = parseAuditFile(raw);
+  const html = renderHtml(advisories);
+  fs.writeFileSync(path.resolve(OUTPUT_PATH), html, "utf8");
+
+  const counts = countBySeverity(advisories);
+  console.info(
+    `Audit report written to ${OUTPUT_PATH} — ${advisories.length} advisories ` +
+      `(critical: ${counts.critical}, high: ${counts.high}, moderate: ${counts.moderate}, ` +
+      `low: ${counts.low}, info: ${counts.info}).`,
+  );
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "benchmark:serve": "webpack serve --mode development --progress --config benchmark/webpack.config.ts",
     "benchmark:build:prod": "webpack --mode production --progress --config benchmark/webpack.config.ts",
     "license-check": "ts-node ci/license-check.ts",
+    "audit:report": "ts-node ci/generate-audit-report.ts",
     "lint": "TIMING=1 eslint --report-unused-disable-directives --cache --fix .",
     "lint:ci": "TIMING=1 eslint --report-unused-disable-directives --cache --max-warnings 0 --config eslint.config.ci.mjs .",
     "lint:ci:report": "yarn lint:ci -f json -o eslint-report.json --quiet",


### PR DESCRIPTION
## User-Facing Changes

<!-- will be used as a changelog entry -->

## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Audit” CI workflow with checks on pushes, pull requests, and scheduled runs, plus manual triggering.
  * Introduced automatic generation and publishing of an HTML audit report (with severity summaries) and email delivery for scheduled/manual runs.
  * Added an `audit:report` script to generate the report locally/within CI.
* **Bug Fixes**
  * Removed the audit step from the main CI test job to keep the primary pipeline focused on existing lint/build/test steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->