### PR TITLE
Add bypass to new actions/checkout safety rule

### DIFF
--- a/.github/workflows/sonarqube-fork.yml
+++ b/.github/workflows/sonarqube-fork.yml
@@ -68,6 +68,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: refs/pull/${{ steps.metadata.outputs.number }}/head
+          # Allows this workflow to checkout the PR head ref even though it is from a fork.
+          # This is safe because this workflow does not execute any code from the fork, only downloads artifacts and runs the scanner.
+          # https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target#opting-out-of-built-in-protections
+          allow-unsafe-pr-checkout: true
 
       - name: Download ESLint report artifact
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## User-Facing Changes

SonarCloud analysis now runs and reports results on pull requests opened from forks again.

## Description

Fork PRs are scanned by a two-workflow chain: `Sonar Fork Reports` (runs on the fork
PR, builds lint/coverage artifacts, no secrets) hands off to `SonarCloud Fork`
(runs via `workflow_run` with `SONAR_TOKEN`, downloads the artifacts, checks out the
PR head, and runs the scanner).

A recent `actions/checkout` release added a hard guard that refuses to check out fork
PR code inside a `workflow_run` context unless explicitly opted in:

> Refusing to check out fork pull request code from a 'workflow_run' workflow...
> set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

As a result the PR-head checkout step failed (~15s), the scanner step never executed,
and the only thing surfaced on the PR was the placeholder "SonarCloud Analysis" check
flipping to failure. See PR #1158 and `SonarCloud Fork` runs #298–#304.

This change sets `allow-unsafe-pr-checkout: true` on the PR-head checkout step in
`.github/workflows/sonarqube-fork.yml`. This is safe here because the steps after the
checkout never execute fork code — they only download pre-built artifacts and run the
trusted Sonar scanner (no `yarn install`, build, or fork scripts run in the trusted
context). The workflow's existing "pwn request" safeguards are therefore preserved.

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI handling for forked pull requests to make scans run more reliably and safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->