### PR TITLE
docs: focus CodeRabbit and agents on performance review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,6 +5,13 @@ language: "en-US"
 
 reviews:
   profile: "chill"
+  tone_instructions: |
+    Pay special attention to performance in hot paths — players, MessagePipeline, 3D and Plot
+    rendering, Web Workers, and frequently re-rendering React components. Flag allocations in
+    render/tick loops, lost reference stability or missing memoization, main-thread work that
+    belongs in a Worker, and buffer copies that should be zero-copy transfers. Follow "measure
+    before you optimize": raise performance concerns only with concrete, high-confidence impact and
+    avoid speculative micro-optimizations.
   request_changes_workflow: false
   high_level_summary: true
   high_level_summary_placeholder: "@coderabbitai summary"
@@ -61,6 +68,47 @@ reviews:
       instructions: |
         Type definition files. Check for accurate and comprehensive type definitions.
         Ensure no `any` types are used without justification.
+
+    - path: "packages/suite-base/src/players/**"
+      instructions: |
+        Performance-critical player and data-source code. Flag allocations inside tick loops or
+        per-message hot paths, missing message batching, and subscriptions that iterate topics no
+        panel requested. Verify message-cache/memory budgets are respected and that large buffers
+        are released behind the read head. Flag concrete regressions only — do not restate the
+        generic rules already in .github/instructions/performance.instructions.md.
+
+    - path: "packages/suite-base/src/components/MessagePipeline/**"
+      instructions: |
+        Hot render-state path. Verify renderState fields keep stable references when their data is
+        unchanged (reference equality drives panel re-renders), zustand selectors stay
+        fine-grained, and subscription merging is preserved. Flag changes that would make all
+        panels re-render every frame.
+
+    - path: "packages/suite-base/src/panels/ThreeDeeRender/**"
+      instructions: |
+        GPU/render hot path. Flag per-frame allocations (new THREE objects, arrays, or closures
+        created inside render/update loops), GPU buffers recreated per frame instead of reused or
+        grown, unbounded draw-call growth, and bypassed object pools. Verify temp objects are
+        reused for frequently created/destroyed values.
+
+    - path: "packages/suite-base/src/panels/Plot/**"
+      instructions: |
+        Chart rendering hot path. Verify heavy dataset work stays off the main thread (Workers or
+        OffscreenCanvas), the per-series point cap is respected, and updates are incremental rather
+        than full rebuilds. Flag main-thread processing of large datasets.
+
+    - path: "**/*.worker.ts"
+      instructions: |
+        Web Worker boundary. Verify large ArrayBuffer/TypedArray payloads use zero-copy
+        Comlink.transfer instead of structured-clone copies, and that worker proxies are disposed
+        to avoid leaks. Flag large buffers copied across the worker boundary.
+
+    - path: "**/*.tsx"
+      instructions: |
+        React render path. Raise only clear, high-impact render-performance issues: inline
+        object/array/function literals passed to memoized children, expensive work run directly in
+        render instead of useMemo, or setState called unconditionally inside useEffect. Do not
+        nitpick low-traffic components — respect the project's "measure before you optimize" rule.
 
   auto_review:
     enabled: true

--- a/.github/agents/lb-deserialization.agent.md
+++ b/.github/agents/lb-deserialization.agent.md
@@ -68,3 +68,4 @@ This is the single function that resolves any channel's schema into a deserializ
 ## Skills Reference
 - MCAP format, chunk structure, and indexed reading: `read_file(".github/skills/mcap-format/SKILL.md")`
 - Worker/Comlink patterns (offloading decode to SharedWorker): `read_file(".github/skills/web-workers/SKILL.md")`
+- Decode throughput profiling or allocation reduction: `read_file(".github/skills/performance/SKILL.md")`

--- a/.github/agents/lb-message-pipeline.agent.md
+++ b/.github/agents/lb-message-pipeline.agent.md
@@ -90,3 +90,4 @@ Key fields panels can access:
 
 ## Skills Reference
 - Deep MessagePipeline internals, subscription merging, or renderState building: `read_file(".github/skills/message-pipeline/SKILL.md")`
+- Render-state reference stability or subscription performance: `read_file(".github/skills/performance/SKILL.md")`

--- a/.github/agents/lb-panel-image.agent.md
+++ b/.github/agents/lb-panel-image.agent.md
@@ -130,3 +130,4 @@ Overlaid on the image plane:
 - Image panel architecture, camera models, or VideoDecoder pipeline: `read_file(".github/skills/panel-image/SKILL.md")`
 - THREE.js fundamentals or ImageMode rendering internals: `read_file(".github/skills/3d-rendering/SKILL.md")`
 - Worker/Comlink patterns for image decode offloading: `read_file(".github/skills/web-workers/SKILL.md")`
+- Image decode and render performance profiling: `read_file(".github/skills/performance/SKILL.md")`

--- a/.github/agents/lb-panel-log.agent.md
+++ b/.github/agents/lb-panel-log.agent.md
@@ -112,3 +112,4 @@ function filterMessages(
 
 ## Skills Reference
 - Log panel architecture, filtering logic, or virtualized list patterns: `read_file(".github/skills/panel-log/SKILL.md")`
+- Virtualized list rendering and scroll performance: `read_file(".github/skills/performance/SKILL.md")`

--- a/.github/agents/lb-panel-map.agent.md
+++ b/.github/agents/lb-panel-map.agent.md
@@ -91,3 +91,4 @@ On zoom change → grid recalculated
 
 ## Skills Reference
 - Map panel internals, Leaflet integration, or GeoJSON/GPS data handling: `read_file(".github/skills/panel-map/SKILL.md")`
+- Marker rendering and point-density performance: `read_file(".github/skills/performance/SKILL.md")`

--- a/.github/agents/lb-panel-plot.agent.md
+++ b/.github/agents/lb-panel-plot.agent.md
@@ -183,3 +183,4 @@ await renderer.updateDatasets(ds); // Push new data
 - Deep plot builder internals, downsampling, or dataset accumulation: `read_file(".github/skills/plot-internals/SKILL.md")`
 - Message-path syntax and topic data extraction: `read_file(".github/skills/message-path/SKILL.md")`
 - Worker/Comlink patterns (OffscreenCanvas, datasetsWorker): `read_file(".github/skills/web-workers/SKILL.md")`
+- Chart rendering throughput and dataset-size profiling: `read_file(".github/skills/performance/SKILL.md")`

--- a/.github/agents/lb-panel-state-transitions.agent.md
+++ b/.github/agents/lb-panel-state-transitions.agent.md
@@ -92,3 +92,4 @@ Shared chart component (also used by other panels):
 ## Skills Reference
 - StateTransitions panel internals, discrete state rendering, or TimeBasedChart: `read_file(".github/skills/panel-state-transitions/SKILL.md")`
 - Message-path syntax and topic data extraction: `read_file(".github/skills/message-path/SKILL.md")`
+- Dataset building and large-range rendering performance: `read_file(".github/skills/performance/SKILL.md")`

--- a/.github/agents/lb-panels-general.agent.md
+++ b/.github/agents/lb-panels-general.agent.md
@@ -175,3 +175,4 @@ Access and update panel configuration by panel ID.
 ## Skills Reference
 - PanelExtensionAdapter lifecycle, renderState building, or panel API contracts: `read_file(".github/skills/panel-extension-api/SKILL.md")`
 - Message-path syntax and panel data extraction: `read_file(".github/skills/message-path/SKILL.md")`
+- Panel render profiling and memoization strategy: `read_file(".github/skills/performance/SKILL.md")`

--- a/.github/agents/lb-player.agent.md
+++ b/.github/agents/lb-player.agent.md
@@ -308,3 +308,4 @@ type IteratorResult =
 - MCAP format, chunk structure, or indexed reading: `read_file(".github/skills/mcap-format/SKILL.md")`
 - Worker/Comlink patterns used by iterators: `read_file(".github/skills/web-workers/SKILL.md")`
 - Block caching, memory budgets, or BufferedIterableSource: `read_file(".github/skills/caching-internals/SKILL.md")`
+- Playback throughput, tick-loop cost, or memory-budget profiling: `read_file(".github/skills/performance/SKILL.md")`

--- a/.github/agents/lb-preload.agent.md
+++ b/.github/agents/lb-preload.agent.md
@@ -206,3 +206,4 @@ const unsubscribe = context.unstable_subscribeMessageRange({
 - MCAP chunk-level format and indexed reads: `read_file(".github/skills/mcap-format/SKILL.md")`
 - Worker-based source patterns and Comlink: `read_file(".github/skills/web-workers/SKILL.md")`
 - Player state machine and tick loop context: `read_file(".github/skills/player-internals/SKILL.md")`
+- Cache budgets, eviction, or read-ahead performance tuning: `read_file(".github/skills/performance/SKILL.md")`

--- a/.github/agents/lb-remote-connection.agent.md
+++ b/.github/agents/lb-remote-connection.agent.md
@@ -319,3 +319,4 @@ WorkerSerializedIterableSource       McapIterableSourceWorker.worker.ts
 - MCAP format structure and indexed reading: `read_file(".github/skills/mcap-format/SKILL.md")`
 - Worker/Comlink patterns: `read_file(".github/skills/web-workers/SKILL.md")`
 - BufferedIterableSource or BlockLoader details: `read_file(".github/skills/caching-internals/SKILL.md")`
+- Network/read latency profiling and buffering performance: `read_file(".github/skills/performance/SKILL.md")`

--- a/.github/agents/lb-websocket-connection.agent.md
+++ b/.github/agents/lb-websocket-connection.agent.md
@@ -95,3 +95,4 @@ MessagePipeline → Panels
 ## Skills Reference
 - Foxglove WebSocket protocol, message framing, or server capabilities: `read_file(".github/skills/websocket-connection/SKILL.md")`
 - Worker/Comlink patterns for WebSocket processing: `read_file(".github/skills/web-workers/SKILL.md")`
+- Live-message throughput or emission-batching performance: `read_file(".github/skills/performance/SKILL.md")`

--- a/.github/instructions/performance.instructions.md
+++ b/.github/instructions/performance.instructions.md
@@ -11,6 +11,7 @@ These rules apply to ALL TypeScript and TSX code in the Lichtblick monorepo. Vio
 - Never allocate inside render loops, `requestAnimationFrame`, or `tick()` callbacks
 - Reuse typed arrays and buffers — prefer `.set()` over creating new instances
 - Prefer `for` loops over `.map()` / `.filter()` / `.reduce()` in hot paths (avoids intermediate allocations)
+- Avoid lodash chains and per-element iteratees (`_.chain`, `_.map`, `_.filter`, `_.cloneDeep`) in hot paths — native loops avoid the extra function-call and allocation overhead; reserve lodash for non-critical code (e.g., `memoize` for settings).
 - Use object pools for frequently created/destroyed objects (e.g., `THREE.Vector3`)
 
 ## React Performance

--- a/.github/prompts/review-pr.prompt.md
+++ b/.github/prompts/review-pr.prompt.md
@@ -34,7 +34,18 @@ To request a fresh CodeRabbit pass on an existing PR, comment:
 
 1. Correctness and regressions
 2. API and behavior compatibility
-3. Performance risks
+3. Performance risks — pay special attention here. Check hot paths against
+   `.github/instructions/performance.instructions.md`, and load
+   `.github/skills/performance/SKILL.md` for deep analysis. Focus on:
+   - Allocations inside render loops, `requestAnimationFrame`, or player `tick()` paths
+   - Lost reference stability or missing memoization causing avoidable re-renders
+   - Main-thread work >16ms that should move to a Web Worker
+   - Large buffers copied instead of zero-copy `Comlink.transfer`
+   - Cache/memory budgets exceeded (player message cache, block caps)
+
+   CodeRabbit now applies per-path performance checks (see `.coderabbit.yaml`); use its
+   findings as the baseline and focus manual review on non-obvious regressions. Apply
+   "measure before you optimize" — raise concerns only with concrete impact.
 4. Security risks
 5. Test coverage gaps
 6. Acceptance criteria coverage (cross-check against linked GitHub issue)


### PR DESCRIPTION
## User-Facing Changes

None — internal AI review/development tooling only (CodeRabbit config, review prompt, and agent/instruction docs).

## Description

Strengthens performance attention across the AI review/dev tooling **without duplicating** the canonical rules already in `.github/instructions/performance.instructions.md` and `.github/skills/performance/SKILL.md`.

- **`.coderabbit.yaml`** — adds a global performance `tone_instructions` nudge plus per-path review checks for the highest-impact hot paths: `players/**`, `components/MessagePipeline/**`, `panels/ThreeDeeRender/**`, `panels/Plot/**`, `**/*.worker.ts`, `**/*.tsx`. Checks are phrased as review flag/verify items (not restatements of the dev-time rules) and follow the "measure before you optimize" guardrail to limit false positives.
- **`.github/prompts/review-pr.prompt.md`** — expands the "Performance risks" review dimension with a concise hot-path checklist that references (does not restate) the canonical instructions/skill and points to the new CodeRabbit per-path checks.
- **`.github/instructions/performance.instructions.md`** — adds a hot-path guideline to avoid lodash chains and per-element iteratees (`_.chain`, `_.map`, `_.cloneDeep`) in performance-critical code, preferring native loops; lodash remains fine for non-critical code.
- **12 domain agents** — add a one-line `Skills Reference` pointer to `.github/skills/performance/SKILL.md` on perf-relevant agents that lacked it (lb-player, lb-message-pipeline, lb-preload, lb-deserialization, lb-remote-connection, lb-websocket-connection, lb-panels-general, lb-panel-plot, lb-panel-log, lb-panel-map, lb-panel-state-transitions, lb-panel-image).

Docs/config only — no runtime code changes. `.github/**/*.md` is prettier-ignored, so the doc edits are single-line and surgical. `.coderabbit.yaml` was validated as valid YAML.

## Checklist

- [ ] The web version was tested and it is running ok — N/A (docs/config only)
- [ ] The desktop version was tested and it is running ok — N/A (docs/config only)
- [ ] This change is covered by unit tests — N/A (no runtime code)
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated — N/A (no such files changed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded review and performance guidance with more concrete checks for hot paths, rendering, playback, messaging, workers, and React update loops.
  * Added performance-focused references across several agent guides for easier access to profiling and optimization advice.
  * Clarified allocation guidance to discourage expensive utility chains in critical code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->