### PR TITLE
feat: add VS Code workspace and improve worktree setup prompt

### DIFF
--- a/.github/prompts/setup-worktree.prompt.md
+++ b/.github/prompts/setup-worktree.prompt.md
@@ -9,9 +9,10 @@ Use this workflow to set up a new worktree so you can work on a task in parallel
 
 Ask the user for the following before proceeding:
 
-1. **Task type** — `feature`, `bugfix`, or `hotfix` (determines branch prefix)
+1. **Task type** — `feature`, `bugfix`, or `hotfix` (determines branch prefix). Not required when setting up a worktree to review an existing PR.
 2. **Branch short name** — e.g., `improve-plot-rendering` (without prefix)
 3. **Base branch** — default `origin/develop`; ask if different
+4. **PR number** (optional) — when creating a worktree to **review a pull request**, provide its number (e.g. `1170`). The worktree folder is named `pr-{id}` instead of `{short-name}`, and the PR's head branch is checked out from an existing branch.
 
 ## Branch Naming
 
@@ -38,11 +39,13 @@ git fetch upstream
 
 ## Create the worktree
 
-Use the path convention `../{repository-name}-worktree/{short-name}/`. The `{short-name}` subfolder is intentional: it lets multiple worktrees (e.g. parallel SDD subagent tasks) live side by side under one parent folder.
+Use the path convention `../{repository-name}.worktree/{short-name}/`. The `{short-name}` subfolder is intentional: it lets multiple worktrees (e.g. parallel SDD subagent tasks) live side by side under one parent folder.
+
+When the worktree is for **reviewing a PR**, use `pr-{id}` as the folder name (e.g. `../lichtblick.worktree/pr-1170/`) so review worktrees are easy to identify and clean up.
 
 ```bash
 git worktree add -b {type}/{short-name} \
-  ../lichtblick-worktree/{short-name} \
+  ../lichtblick.worktree/{short-name} \
   {base-branch}
 ```
 
@@ -53,13 +56,20 @@ git worktree add -b {type}/{short-name} \
 To create a worktree from an **existing** branch instead (e.g. to resume work), omit `-b`:
 
 ```bash
-git worktree add ../lichtblick-worktree/{short-name} {existing-branch}
+git worktree add ../lichtblick.worktree/{short-name} {existing-branch}
+```
+
+To create a worktree for **reviewing a PR**, fetch the PR's head branch and check it out into a `pr-{id}` folder:
+
+```bash
+gh pr checkout {id} --detach 2>/dev/null || git fetch origin pull/{id}/head:pr-{id}
+git worktree add ../lichtblick.worktree/pr-{id} pr-{id}
 ```
 
 ## Install dependencies
 
 ```bash
-cd ../lichtblick-worktree/{short-name}
+cd ../lichtblick.worktree/{short-name}
 yarn install
 ```
 
@@ -71,13 +81,13 @@ Git worktrees only include git-tracked files. Untracked local state (e.g. a giti
 
 ```bash
 # Only if you have a local .env or similar untracked config
-cp .env ../lichtblick-worktree/{short-name}/.env
+cp .env ../lichtblick.worktree/{short-name}/.env
 ```
 
 ## Open in VS Code
 
 ```bash
-code ../lichtblick-worktree/{short-name}
+code ../lichtblick.worktree/{short-name}
 ```
 
 Or guide the user to **File → Open Folder** if they prefer the UI.
@@ -92,6 +102,6 @@ When the task is complete and the branch is merged, clean up with:
 
 ```bash
 # From the main repo (not inside the worktree)
-git worktree remove ../lichtblick-worktree/{short-name}
+git worktree remove ../lichtblick.worktree/{short-name}
 git worktree prune
 ```

--- a/.github/prompts/setup-worktree.prompt.md
+++ b/.github/prompts/setup-worktree.prompt.md
@@ -59,10 +59,10 @@ To create a worktree from an **existing** branch instead (e.g. to resume work), 
 git worktree add ../lichtblick.worktree/{short-name} {existing-branch}
 ```
 
-To create a worktree for **reviewing a PR**, fetch the PR's head branch and check it out into a `pr-{id}` folder:
+To create a worktree for **reviewing a PR**, fetch the PR's head branch into a local `pr-{id}` ref first, then add a worktree that checks out that ref. Fetching before `git worktree add` guarantees the `pr-{id}` ref exists (unlike `gh pr checkout --detach`, which leaves HEAD detached in the current worktree without creating the ref):
 
 ```bash
-gh pr checkout {id} --detach 2>/dev/null || git fetch origin pull/{id}/head:pr-{id}
+git fetch origin pull/{id}/head:pr-{id}
 git worktree add ../lichtblick.worktree/pr-{id} pr-{id}
 ```
 

--- a/lichtblick.code-workspace
+++ b/lichtblick.code-workspace
@@ -1,0 +1,17 @@
+{
+  "folders": [
+    {
+      "name": "Root",
+      "path": ".",
+    },
+    {
+      "name": "Worktree",
+      "path": "../lichtblick.worktree",
+    },
+  ],
+  "settings": {
+    "files.exclude": {
+      "**/.DS_Store": true,
+    },
+  },
+}


### PR DESCRIPTION
## Summary

Aligns the documented worktree path with a shareable VS Code workspace and makes it easy to spin up dedicated worktrees for reviewing pull requests.
Adds local developer tooling for the Lichtblick repo:

- **`lichtblick.code-workspace`** — a VS Code multi-root workspace that exposes the main repo (`Root`) alongside a `Worktree` folder at `../lichtblick.worktree`, and hides `.DS_Store` files.
- **`.github/prompts/setup-worktree.prompt.md`** — updates the worktree setup convention:
  - Default worktree path changed from `../lichtblick-worktree/` to `../lichtblick.worktree/` (matches the workspace folder above).
  - Adds support for **PR-review worktrees**: an optional PR number input, `pr-{id}` folder naming, and a command to fetch/check out a PR's head branch into its own worktree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated worktree setup instructions to use a new, consistent directory layout.
  * Improved pull request review setup steps, including clearer naming and fallback checkout behavior.
  * Aligned local environment and editor setup examples with the new worktree path.

* **Chores**
  * Added/updated a VS Code workspace configuration to open both the main project and the worktree together.
  * Hid macOS `.DS_Store` files from the file explorer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->