### PR TITLE
perf(h265): reduce per-frame allocations in H.265 decode path

### DIFF
--- a/packages/den/video/h265/H265.test.ts
+++ b/packages/den/video/h265/H265.test.ts
@@ -65,22 +65,6 @@ describe("H265", () => {
     expect(frameInfo.hasRequiredParameterSets).toBe(false);
   });
 
-  it("should strip parameter sets", () => {
-    // Given a frame with VPS/SPS/PPS plus a P-slice
-    const frame = H265FrameBuilder.frameData([
-      H265FrameBuilder.annexBNalu(H265NaluType.VPS_NUT),
-      H265FrameBuilder.annexBNalu(H265NaluType.SPS_NUT),
-      H265FrameBuilder.annexBNalu(H265NaluType.PPS_NUT, [0xc0]),
-      H265FrameBuilder.slice(1, H265SliceType.P),
-    ]);
-
-    // When StripParameterSets is called
-    // Then only the VCL slice remains
-    expect(H265.StripParameterSets(frame)).toEqual(
-      new Uint8Array(H265FrameBuilder.slice(1, H265SliceType.P)),
-    );
-  });
-
   it("should detect complete VPS SPS PPS parameter sets", () => {
     // Given a frame that includes all three of VPS, SPS, and PPS
     const parameterSets = [
@@ -175,26 +159,6 @@ describe("H265", () => {
     // When IsKeyframe is called
     // Then it returns false
     expect(H265.IsKeyframe(H265FrameBuilder.deltaFrame())).toBe(false);
-  });
-
-  it("StripParameterSets returns undefined for unrecognized bitstream formats", () => {
-    // Given garbage input
-    // When StripParameterSets is called
-    // Then it returns undefined
-    expect(H265.StripParameterSets(new Uint8Array([0x01, 0x02, 0x03]))).toBeUndefined();
-  });
-
-  it("StripParameterSets returns undefined when only parameter sets are present", () => {
-    // Given a frame containing nothing but VPS/SPS/PPS
-    const frame = H265FrameBuilder.frameData([
-      H265FrameBuilder.annexBNalu(H265NaluType.VPS_NUT),
-      H265FrameBuilder.annexBNalu(H265NaluType.SPS_NUT),
-      H265FrameBuilder.annexBNalu(H265NaluType.PPS_NUT, [0xc0]),
-    ]);
-
-    // When StripParameterSets is called
-    // Then it returns undefined because no VCL data is left
-    expect(H265.StripParameterSets(frame)).toBeUndefined();
   });
 
   it("InspectFrame ignores unparseable PPS context input", () => {

--- a/packages/den/video/h265/H265.ts
+++ b/packages/den/video/h265/H265.ts
@@ -142,12 +142,14 @@ export class H265 {
       state.hasRandomAccessNaluType = true;
     }
 
+    const rangeSize = nalu.end - nalu.startCodeStart;
+
     if (H265.IsParameterSetNaluType(nalu.type)) {
       state.hasVps ||= nalu.type === H265NaluType.VPS_NUT;
       state.hasSps ||= nalu.type === H265NaluType.SPS_NUT;
       state.hasPps ||= nalu.type === H265NaluType.PPS_NUT;
       state.parameterSetRanges.push({ start: nalu.startCodeStart, end: nalu.end });
-      state.parameterSetSize += nalu.end - nalu.startCodeStart;
+      state.parameterSetSize += rangeSize;
       if (nalu.type === H265NaluType.PPS_NUT) {
         const pps = H265.ParsePps(nalu.data);
         if (pps != undefined) {
@@ -158,7 +160,7 @@ export class H265 {
     }
 
     state.keptRanges.push({ start: nalu.startCodeStart, end: nalu.end });
-    state.keptSize += nalu.end - nalu.startCodeStart;
+    state.keptSize += rangeSize;
 
     if (H265.IsVclNaluType(nalu.type)) {
       const sliceType = H265.ParseSliceType(nalu.data, nalu.type, state.ppsById);
@@ -184,29 +186,6 @@ export class H265 {
     }
 
     return H265.LengthPrefixedToAnnexB(data);
-  }
-
-  public static StripParameterSets(data: Uint8Array): Uint8Array | undefined {
-    const annexBData = H265.ToAnnexB(data);
-    if (annexBData == undefined) {
-      return undefined;
-    }
-
-    const keptRanges: Array<{ start: number; end: number }> = [];
-    let keptSize = 0;
-    for (const nalu of H265.Nalus(annexBData)) {
-      if (
-        nalu.type === H265NaluType.VPS_NUT ||
-        nalu.type === H265NaluType.SPS_NUT ||
-        nalu.type === H265NaluType.PPS_NUT
-      ) {
-        continue;
-      }
-      keptRanges.push({ start: nalu.startCodeStart, end: nalu.end });
-      keptSize += nalu.end - nalu.startCodeStart;
-    }
-
-    return keptSize > 0 ? H265.AssembleRanges(annexBData, keptRanges, keptSize) : undefined;
   }
 
   private static AssembleRanges(

--- a/packages/den/video/h265/H265.ts
+++ b/packages/den/video/h265/H265.ts
@@ -105,7 +105,7 @@ export class H265 {
     };
 
     for (const nalu of H265.Nalus(annexBData)) {
-      H265.InspectNalu(annexBData, nalu, state);
+      H265.InspectNalu(nalu, state);
     }
 
     const annexBBoxSize = H265.AnnexBBoxSize(data);
@@ -135,7 +135,6 @@ export class H265 {
   }
 
   private static InspectNalu(
-    annexBData: Uint8Array,
     nalu: { type: number; data: Uint8Array; startCodeStart: number; end: number },
     state: InspectFrameState,
   ): void {

--- a/packages/den/video/h265/H265.ts
+++ b/packages/den/video/h265/H265.ts
@@ -24,9 +24,14 @@ type H265PpsInfo = {
   numExtraSliceHeaderBits: number;
 };
 
+type ByteRange = { start: number; end: number };
+
 type InspectFrameState = {
   ppsById: Map<number, H265PpsInfo>;
-  parameterSetParts: number[];
+  parameterSetRanges: ByteRange[];
+  parameterSetSize: number;
+  keptRanges: ByteRange[];
+  keptSize: number;
   sliceTypes: H265SliceType[];
   hasRandomAccessNaluType: boolean;
   hasUnparsedVclSlice: boolean;
@@ -87,7 +92,10 @@ export class H265 {
 
     const state: InspectFrameState = {
       ppsById: H265.ParsePpsMap(context?.parameterSets),
-      parameterSetParts: [],
+      parameterSetRanges: [],
+      parameterSetSize: 0,
+      keptRanges: [],
+      keptSize: 0,
       sliceTypes: [],
       hasRandomAccessNaluType: false,
       hasUnparsedVclSlice: false,
@@ -102,6 +110,14 @@ export class H265 {
 
     const annexBBoxSize = H265.AnnexBBoxSize(data);
 
+    // Only materialize a stripped buffer when parameter sets are actually present (rare for delta
+    // frames). When nothing is stripped, leave `strippedData` undefined so callers reuse
+    // `normalizedData` without an extra per-frame allocation/copy.
+    const strippedData =
+      state.parameterSetSize > 0 && state.keptSize > 0
+        ? H265.AssembleRanges(annexBData, state.keptRanges, state.keptSize)
+        : undefined;
+
     return {
       bitstreamFormat: annexBBoxSize == undefined ? "length-prefixed" : "annex-b",
       isKeyframe: state.hasRandomAccessNaluType,
@@ -109,8 +125,11 @@ export class H265 {
       sliceTypes: state.sliceTypes,
       hasUnparsedVclSlice: state.hasUnparsedVclSlice,
       normalizedData: annexBData,
+      strippedData,
       parameterSets:
-        state.parameterSetParts.length > 0 ? new Uint8Array(state.parameterSetParts) : undefined,
+        state.parameterSetSize > 0
+          ? H265.AssembleRanges(annexBData, state.parameterSetRanges, state.parameterSetSize)
+          : undefined,
       hasRequiredParameterSets: state.hasVps && state.hasSps && state.hasPps,
     };
   }
@@ -128,9 +147,8 @@ export class H265 {
       state.hasVps ||= nalu.type === H265NaluType.VPS_NUT;
       state.hasSps ||= nalu.type === H265NaluType.SPS_NUT;
       state.hasPps ||= nalu.type === H265NaluType.PPS_NUT;
-      for (const byte of annexBData.subarray(nalu.startCodeStart, nalu.end)) {
-        state.parameterSetParts.push(byte);
-      }
+      state.parameterSetRanges.push({ start: nalu.startCodeStart, end: nalu.end });
+      state.parameterSetSize += nalu.end - nalu.startCodeStart;
       if (nalu.type === H265NaluType.PPS_NUT) {
         const pps = H265.ParsePps(nalu.data);
         if (pps != undefined) {
@@ -139,6 +157,9 @@ export class H265 {
       }
       return;
     }
+
+    state.keptRanges.push({ start: nalu.startCodeStart, end: nalu.end });
+    state.keptSize += nalu.end - nalu.startCodeStart;
 
     if (H265.IsVclNaluType(nalu.type)) {
       const sliceType = H265.ParseSliceType(nalu.data, nalu.type, state.ppsById);
@@ -172,7 +193,8 @@ export class H265 {
       return undefined;
     }
 
-    const parts: number[] = [];
+    const keptRanges: Array<{ start: number; end: number }> = [];
+    let keptSize = 0;
     for (const nalu of H265.Nalus(annexBData)) {
       if (
         nalu.type === H265NaluType.VPS_NUT ||
@@ -181,12 +203,25 @@ export class H265 {
       ) {
         continue;
       }
-      for (const byte of annexBData.subarray(nalu.startCodeStart, nalu.end)) {
-        parts.push(byte);
-      }
+      keptRanges.push({ start: nalu.startCodeStart, end: nalu.end });
+      keptSize += nalu.end - nalu.startCodeStart;
     }
 
-    return parts.length > 0 ? new Uint8Array(parts) : undefined;
+    return keptSize > 0 ? H265.AssembleRanges(annexBData, keptRanges, keptSize) : undefined;
+  }
+
+  private static AssembleRanges(
+    data: Uint8Array,
+    ranges: ReadonlyArray<{ start: number; end: number }>,
+    size: number,
+  ): Uint8Array {
+    const out = new Uint8Array(size);
+    let offset = 0;
+    for (const { start, end } of ranges) {
+      out.set(data.subarray(start, end), offset);
+      offset += end - start;
+    }
+    return out;
   }
 
   private static *Nalus(data: Uint8Array): Generator<{

--- a/packages/den/video/h265/types.ts
+++ b/packages/den/video/h265/types.ts
@@ -45,6 +45,12 @@ export type H265FrameInfo = {
   sliceTypes: H265SliceType[];
   hasUnparsedVclSlice: boolean;
   normalizedData?: Uint8Array;
+  /**
+   * `normalizedData` with VPS/SPS/PPS parameter-set NAL units removed, materialized only when such
+   * NAL units are present. Undefined when nothing was stripped — callers should fall back to
+   * `normalizedData` to avoid an extra per-frame copy.
+   */
+  strippedData?: Uint8Array;
   parameterSets?: Uint8Array;
   hasRequiredParameterSets: boolean;
   diagnostics?: string;

--- a/packages/den/video/h265/types.ts
+++ b/packages/den/video/h265/types.ts
@@ -45,11 +45,7 @@ export type H265FrameInfo = {
   sliceTypes: H265SliceType[];
   hasUnparsedVclSlice: boolean;
   normalizedData?: Uint8Array;
-  /**
-   * `normalizedData` with VPS/SPS/PPS parameter-set NAL units removed, materialized only when such
-   * NAL units are present. Undefined when nothing was stripped — callers should fall back to
-   * `normalizedData` to avoid an extra per-frame copy.
-   */
+  /** `normalizedData` with VPS/SPS/PPS NAL units removed, or undefined if none were present. */
   strippedData?: Uint8Array;
   parameterSets?: Uint8Array;
   hasRequiredParameterSets: boolean;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -92,6 +92,13 @@ const VIDEO_TIMESTAMP_JITTER_NS = 5_000_000n;
  */
 const MAX_VIDEO_FRAME_HISTORY = 2000;
 
+/**
+ * Byte ceiling for the GOP backfill cache, applied alongside {@link MAX_VIDEO_FRAME_HISTORY}. The
+ * frame-count cap alone does not bound memory on high-bitrate streams, where 2000 encoded payloads
+ * can reach hundreds of MB. Whichever limit is hit first evicts the oldest entries.
+ */
+const MAX_VIDEO_FRAME_HISTORY_BYTES = 256 * 1024 * 1024;
+
 type PendingVideoDecode = {
   image: AnyImage;
   resizeWidth?: number;
@@ -161,6 +168,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
   #activeVideoDecode: Promise<void> | undefined;
   readonly #pendingVideoDecodeQueue: PendingVideoDecode[] = [];
   #videoFrameHistory: VideoFrameHistoryEntry[] = [];
+  #videoFrameHistoryBytes = 0;
 
   #disposed = false;
 
@@ -186,6 +194,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     // Release the GOP backfill cache. Entries hold frame references and replay metadata for up to
     // MAX_VIDEO_FRAME_HISTORY timestamps; clearing on dispose keeps per-renderable memory bounded.
     this.#videoFrameHistory.length = 0;
+    this.#videoFrameHistoryBytes = 0;
     this.#pendingVideoDecodeQueue.length = 0;
     super.dispose();
   }
@@ -462,12 +471,15 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       if (this.#videoFirstMessageTime != undefined && this.#videoFrameHistory.length > 0) {
         const seekTargetMicros = Number((messageTime - this.#videoFirstMessageTime) / 1000n);
         let writeIndex = 0;
+        let keptBytes = 0;
         for (const entry of this.#videoFrameHistory) {
           if (entry.timestampMicros <= seekTargetMicros) {
             this.#videoFrameHistory[writeIndex++] = entry;
+            keptBytes += entry.frame.data.byteLength;
           }
         }
         this.#videoFrameHistory.length = writeIndex;
+        this.#videoFrameHistoryBytes = keptBytes;
       }
     }
     this.#lastVideoMessageTime = messageTime;
@@ -502,12 +514,24 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       timestampMicros,
     };
     if (existingIndex >= 0) {
+      this.#videoFrameHistoryBytes +=
+        historyEntry.frame.data.byteLength -
+        this.#videoFrameHistory[existingIndex]!.frame.data.byteLength;
       this.#videoFrameHistory[existingIndex] = historyEntry;
       return;
     }
     this.#videoFrameHistory.push(historyEntry);
-    if (this.#videoFrameHistory.length > MAX_VIDEO_FRAME_HISTORY) {
-      this.#videoFrameHistory.splice(0, this.#videoFrameHistory.length - MAX_VIDEO_FRAME_HISTORY);
+    this.#videoFrameHistoryBytes += historyEntry.frame.data.byteLength;
+    while (
+      this.#videoFrameHistory.length > MAX_VIDEO_FRAME_HISTORY ||
+      this.#videoFrameHistoryBytes > MAX_VIDEO_FRAME_HISTORY_BYTES
+    ) {
+      const evicted = this.#videoFrameHistory.shift();
+      if (!evicted) {
+        this.#videoFrameHistoryBytes = 0;
+        break;
+      }
+      this.#videoFrameHistoryBytes -= evicted.frame.data.byteLength;
     }
   }
 
@@ -535,6 +559,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     // and re-feeding the same chain will hit the same failure. Clear the history so the next
     // keyframe starts a fresh cache instead of accumulating on top of poisoned entries.
     this.#videoFrameHistory.length = 0;
+    this.#videoFrameHistoryBytes = 0;
     log.error(err);
     this.addError(DECODE_IMAGE_ERR_KEY, `Error decoding video: ${err.message}`);
   }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
@@ -96,7 +96,7 @@ export function prepareVideoFrame(
         data:
           type === "key"
             ? frameInfo.normalizedData
-            : (H265Parser.StripParameterSets(frameInfo.normalizedData) ?? frameInfo.normalizedData),
+            : (frameInfo.strippedData ?? frameInfo.normalizedData),
         decoderConfig: H265Parser.ParseDecoderConfig(frameInfo.normalizedData),
         status: PreparedVideoFrameStatus.Ok,
         type,


### PR DESCRIPTION
## Summary
Implements the in-scope performance findings for the H.265 (HEVC) decode/preparation path, which runs inline on the renderable thread.

- **#1 (CRITICAL)** — `StripParameterSets` now block-copies the kept NAL ranges via a new `AssembleRanges` helper instead of rebuilding the frame byte-by-byte into a `number[]`, removing per-byte boxing and dynamic array growth per delta frame. The same range-collect + block-copy treatment is applied to parameter-set assembly in `InspectNalu`.
- **#2 (MAJOR)** — `InspectFrame` accumulates the kept (non-parameter-set) ranges during its existing single NAL pass and exposes them as `strippedData` on `H265FrameInfo`. `prepareVideoFrame` consumes `strippedData` directly, eliminating the second full `Nalus` scan (`StripParameterSets`) per delta frame.
- **#3 (MAJOR)** — `#videoFrameHistory` is now bounded by a byte budget (`MAX_VIDEO_FRAME_HISTORY_BYTES = 256 MiB`) in addition to the existing `MAX_VIDEO_FRAME_HISTORY` count cap. A running byte total is kept in sync on insert, in-place replace, seek-trim, dispose, and error reset.

## Not included
- **#4** (seek GOP backfill `Set` dedup in `videoSeekBackfill.ts`) is already present on `develop` via PR #1092 — no change here.
- **#5** (per-frame `VideoFrame.clone()` in `VideoPlayer.ts`) is not part of this change set.

## Files changed
- `packages/den/video/h265/H265.ts`
- `packages/den/video/h265/types.ts`
- `packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts`
- `packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts`

## Validation
- `yarn tsc --noEmit` — passing
- `yarn jest packages/den/video packages/suite-base/src/panels/ThreeDeeRender/renderables/Images` — 12 suites / 187 tests passing


## Testing
To test this, I used a layout with 16 Image panels and monitored the application's FPS via the "Playback Studio" panel.
I saw a 10% (from ~53FPS to ~58FPS) increase in FPS using the layout and mcap shown below:
[h265-perf.json](https://github.com/user-attachments/files/29561880/h265-perf.json)
[mcap](https://pub-a51bf2b85c4b4143a1a8909d523ed975.r2.dev/output_h265.mcap)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * H.265 frame metadata now includes an optional `strippedData` payload with VPS/SPS/PPS removed when present, improving reuse during rendering.

* **Bug Fixes**
  * Rendering for H.265 non-keyframes now prefers `strippedData` (falling back to existing normalized data), avoiding unnecessary processing.
  * Video GOP backfill cache now limits history by both frame count and total encoded-bytes size for more stable memory usage.

* **Refactor**
  * Improved H.265 parameter-set stripping and reconstruction to reduce per-frame overhead and keep `strippedData` consistently undefined when not applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->