### PR TITLE
Make layout section collapsable

### DIFF
--- a/packages/suite-base/src/components/LayoutBrowser/LayoutSection.style.ts
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutSection.style.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { makeStyles } from "tss-react/mui";
+
+export const useLayoutSectionStyles = makeStyles()((theme) => ({
+  sectionHeader: {
+    display: "flex",
+    alignItems: "center",
+    width: "100%",
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(2),
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(0.5),
+    justifyContent: "flex-start",
+    gap: theme.spacing(0.5),
+    "&:hover": {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+  arrow: {
+    fontSize: "1.25rem",
+    color: theme.palette.text.secondary,
+    transition: theme.transitions.create("transform", {
+      duration: theme.transitions.duration.shortest,
+    }),
+  },
+}));

--- a/packages/suite-base/src/components/LayoutBrowser/LayoutSection.style.ts
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutSection.style.ts
@@ -25,4 +25,7 @@ export const useLayoutSectionStyles = makeStyles()((theme) => ({
       duration: theme.transitions.duration.shortest,
     }),
   },
+  arrowCollapsed: {
+    transform: "rotate(-90deg)",
+  },
 }));

--- a/packages/suite-base/src/components/LayoutBrowser/LayoutSection.test.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutSection.test.tsx
@@ -3,7 +3,8 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
 import { LayoutID } from "@lichtblick/suite-base/context/CurrentLayoutContext";
@@ -125,5 +126,48 @@ describe("LayoutSection", () => {
     expect(screen.getByTestId("layout-row-1").dataset.selected).toBe("false");
     expect(screen.getByTestId("layout-row-2").dataset.selected).toBe("false");
     expect(screen.getByTestId("layout-row-3").dataset.selected).toBe("false");
+  });
+
+  it("collapses the list when the section header is clicked", async () => {
+    // GIVEN
+    const title = BasicBuilder.string();
+    const user = userEvent.setup();
+    render(<LayoutSection {...defaultProps} title={title} />);
+
+    // WHEN
+    await user.click(screen.getByTestId(`layout-section-header-${title}`));
+
+    // THEN
+    await waitFor(() => {
+      expect(screen.queryByTestId("layout-row-1")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("layout-row-2")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("layout-row-3")).not.toBeInTheDocument();
+  });
+
+  it("expands the list when the collapsed section header is clicked again", async () => {
+    // GIVEN
+    const title = BasicBuilder.string();
+    const user = userEvent.setup();
+    render(<LayoutSection {...defaultProps} title={title} />);
+
+    // WHEN - collapse then expand
+    await user.click(screen.getByTestId(`layout-section-header-${title}`));
+    await user.click(screen.getByTestId(`layout-section-header-${title}`));
+
+    // THEN
+    expect(screen.getByTestId("layout-row-1")).toBeInTheDocument();
+    expect(screen.getByTestId("layout-row-2")).toBeInTheDocument();
+    expect(screen.getByTestId("layout-row-3")).toBeInTheDocument();
+  });
+
+  it("always shows items when title is undefined (not collapsible)", () => {
+    // WHEN
+    render(<LayoutSection {...defaultProps} title={undefined} />);
+
+    // THEN
+    expect(screen.getByTestId("layout-row-1")).toBeInTheDocument();
+    expect(screen.getByTestId("layout-row-2")).toBeInTheDocument();
+    expect(screen.getByTestId("layout-row-3")).toBeInTheDocument();
   });
 });

--- a/packages/suite-base/src/components/LayoutBrowser/LayoutSection.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutSection.tsx
@@ -50,7 +50,7 @@ export default function LayoutSection({
   onRevert: (item: Layout) => void;
   onMakePersonalCopy: (item: Layout) => void;
 }>): React.JSX.Element {
-  const { classes } = useLayoutSectionStyles();
+  const { classes, cx } = useLayoutSectionStyles();
   const [expanded, setExpanded] = useState(true);
 
   const toggleExpanded = useCallback(() => {
@@ -69,8 +69,7 @@ export default function LayoutSection({
           data-testid={`layout-section-header-${title}`}
         >
           <ArrowDropDownIcon
-            className={classes.arrow}
-            style={{ transform: expanded ? undefined : "rotate(-90deg)" }}
+            className={cx(classes.arrow, { [classes.arrowCollapsed]: !expanded })}
           />
           <Typography variant="overline" color="text.secondary">
             {title}

--- a/packages/suite-base/src/components/LayoutBrowser/LayoutSection.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/LayoutSection.tsx
@@ -5,13 +5,15 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Typography, List } from "@mui/material";
-import { MouseEvent } from "react";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import { ButtonBase, Collapse, Typography, List } from "@mui/material";
+import { MouseEvent, useCallback, useState } from "react";
 
 import Stack from "@lichtblick/suite-base/components/Stack";
 import { Layout } from "@lichtblick/suite-base/services/ILayoutStorage";
 
 import LayoutRow from "./LayoutRow";
+import { useLayoutSectionStyles } from "./LayoutSection.style";
 
 export default function LayoutSection({
   title,
@@ -48,42 +50,62 @@ export default function LayoutSection({
   onRevert: (item: Layout) => void;
   onMakePersonalCopy: (item: Layout) => void;
 }>): React.JSX.Element {
+  const { classes } = useLayoutSectionStyles();
+  const [expanded, setExpanded] = useState(true);
+
+  const toggleExpanded = useCallback(() => {
+    setExpanded((prev) => !prev);
+  }, []);
+
+  const isCollapsible = title != undefined;
+
   return (
     <Stack>
       {title != undefined && (
-        <Stack paddingX={2} paddingY={disablePadding ? 1 : 0}>
+        <ButtonBase
+          className={classes.sectionHeader}
+          onClick={toggleExpanded}
+          disableRipple
+          data-testid={`layout-section-header-${title}`}
+        >
+          <ArrowDropDownIcon
+            className={classes.arrow}
+            style={{ transform: expanded ? undefined : "rotate(-90deg)" }}
+          />
           <Typography variant="overline" color="text.secondary">
             {title}
           </Typography>
-        </Stack>
+        </ButtonBase>
       )}
-      <List disablePadding={disablePadding}>
-        {items?.length === 0 && (
-          <Stack paddingX={2}>
-            <Typography variant="body2" color="text.secondary">
-              {emptyText}
-            </Typography>
-          </Stack>
-        )}
-        {items?.map((layout) => (
-          <LayoutRow
-            key={layout.id}
-            layout={layout}
-            anySelectedModifiedLayouts={anySelectedModifiedLayouts}
-            multiSelectedIds={multiSelectedIds}
-            selected={selectedId === layout.id}
-            onSelect={onSelect}
-            onRename={onRename}
-            onDuplicate={onDuplicate}
-            onDelete={onDelete}
-            onShare={onShare}
-            onExport={onExport}
-            onOverwrite={onOverwrite}
-            onRevert={onRevert}
-            onMakePersonalCopy={onMakePersonalCopy}
-          />
-        ))}
-      </List>
+      <Collapse in={!isCollapsible || expanded} unmountOnExit>
+        <List disablePadding={disablePadding}>
+          {items?.length === 0 && (
+            <Stack paddingX={2}>
+              <Typography variant="body2" color="text.secondary">
+                {emptyText}
+              </Typography>
+            </Stack>
+          )}
+          {items?.map((layout) => (
+            <LayoutRow
+              key={layout.id}
+              layout={layout}
+              anySelectedModifiedLayouts={anySelectedModifiedLayouts}
+              multiSelectedIds={multiSelectedIds}
+              selected={selectedId === layout.id}
+              onSelect={onSelect}
+              onRename={onRename}
+              onDuplicate={onDuplicate}
+              onDelete={onDelete}
+              onShare={onShare}
+              onExport={onExport}
+              onOverwrite={onOverwrite}
+              onRevert={onRevert}
+              onMakePersonalCopy={onMakePersonalCopy}
+            />
+          ))}
+        </List>
+      </Collapse>
     </Stack>
   );
 }


### PR DESCRIPTION
## User-Facing Changes

Add expand/collapse functionality to Personal and Organization layout sections in the Layouts sidebar.

## Description

The Layout Browser sidebar now allows users to collapse and expand the "Personal" and "Organization" sections by clicking their headers. Each section header displays a rotating arrow indicator to show the current state.

**Changes:**
- `LayoutSection.tsx` — Added collapsible behavior with `useState`, clickable `ButtonBase` header with `ArrowDropDownIcon`, and MUI `<Collapse>` wrapper around the list content
- `LayoutSection.style.ts` *(new)* — Styles for the section header button and arrow transition animation
- `LayoutSection.test.tsx` — Added tests for collapse, expand, and always-visible (no-title) behavior

Sections without a title (e.g., when sharing is not supported) remain always expanded.

## Checklist

- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Section headers in the layout browser can now be expanded and collapsed when a title is present.
  * The header becomes clickable, with a rotating arrow indicator, and collapsed sections hide their contents.
* **Bug Fixes**
  * Sections without a title remain non-collapsible and always render their items consistently.
* **Tests**
  * Added interaction tests to verify collapse/expand behavior and non-collapsible rendering when no title is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->