### PR TITLE
Fix duplicate Default layout creation

### DIFF
--- a/packages/suite-base/src/IdbLayoutStorage.test.ts
+++ b/packages/suite-base/src/IdbLayoutStorage.test.ts
@@ -1,0 +1,85 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { IDBFactory } from "fake-indexeddb";
+
+import { IdbLayoutStorage } from "@lichtblick/suite-base/IdbLayoutStorage";
+import { LayoutID } from "@lichtblick/suite-base/context/CurrentLayoutContext";
+import {
+  ISO8601Timestamp,
+  Layout,
+  LayoutBaseline,
+} from "@lichtblick/suite-base/services/ILayoutStorage";
+
+function makeLayout(id: string, name: string): Layout {
+  const baseline: LayoutBaseline = {
+    data: {
+      configById: {},
+      globalVariables: {},
+      userNodes: {},
+      playbackConfig: { speed: 1 },
+    },
+    savedAt: new Date(10).toISOString() as ISO8601Timestamp,
+  };
+  return {
+    id: id as LayoutID,
+    name,
+    permission: "CREATOR_WRITE",
+    baseline,
+    working: undefined,
+    syncInfo: undefined,
+  };
+}
+
+describe("IdbLayoutStorage", () => {
+  beforeEach(() => {
+    // Reset the shared fake IndexedDB between tests so namespaces don't leak across cases.
+    globalThis.indexedDB = new IDBFactory();
+  });
+
+  describe("importLayouts", () => {
+    it("moves layouts whose names are absent in the target namespace", async () => {
+      // Given a "Default" layout in the local namespace and an empty target namespace
+      const storage = new IdbLayoutStorage();
+      await storage.put("local", makeLayout("local-default", "Default"));
+
+      // When importing local layouts into the remote namespace
+      await storage.importLayouts({
+        fromNamespace: "local",
+        toNamespace: "remote-default-layouts",
+      });
+
+      // Then the layout is moved and the source namespace is emptied
+      const target = await storage.list("remote-default-layouts");
+      const source = await storage.list("local");
+      expect(target.map((l) => l.name)).toEqual(["Default"]);
+      expect(source).toHaveLength(0);
+    });
+
+    it("does not duplicate a layout whose name already exists in the target namespace", async () => {
+      // Given a "Default" in both the local and the remote namespace (the workspace-removed repro)
+      const storage = new IdbLayoutStorage();
+      await storage.put("local", makeLayout("local-default", "Default"));
+      await storage.put("remote-default-layouts", makeLayout("remote-default", "Default"));
+
+      // When importing local layouts into the remote namespace
+      await storage.importLayouts({
+        fromNamespace: "local",
+        toNamespace: "remote-default-layouts",
+      });
+
+      // Then the remote namespace still has exactly one "Default" and the source is emptied
+      const target = await storage.list("remote-default-layouts");
+      const source = await storage.list("local");
+      expect(target.filter((l) => l.name === "Default")).toHaveLength(1);
+      expect(target.map((l) => l.id)).toEqual(["remote-default"]);
+      expect(source).toHaveLength(0);
+    });
+  });
+});

--- a/packages/suite-base/src/IdbLayoutStorage.ts
+++ b/packages/suite-base/src/IdbLayoutStorage.ts
@@ -81,13 +81,23 @@ export class IdbLayoutStorage implements ILayoutStorage {
     fromNamespace: string;
     toNamespace: string;
   }): Promise<void> {
-    const tx = (await this.#db).transaction("layouts", "readwrite");
-    const store = tx.objectStore("layouts");
+    const db = await this.#db;
 
     try {
-      for await (const cursor of store.index("namespace").iterate(fromNamespace)) {
-        await store.put({ namespace: toNamespace, layout: cursor.value.layout });
-        await cursor.delete();
+      // Read up front: separate cursor passes in one readwrite tx would auto-commit and throw.
+      const targetRecords = await db.getAllFromIndex(OBJECT_STORE_NAME, "namespace", toNamespace);
+      const existingNames = new Set(targetRecords.map(({ layout }) => layout.name));
+      const sourceRecords = await db.getAllFromIndex(OBJECT_STORE_NAME, "namespace", fromNamespace);
+
+      const tx = db.transaction(OBJECT_STORE_NAME, "readwrite");
+      const store = tx.objectStore(OBJECT_STORE_NAME);
+      for (const { layout } of sourceRecords) {
+        // Skip layouts whose name already exists in the target namespace to avoid duplicates.
+        if (!existingNames.has(layout.name)) {
+          await store.put({ namespace: toNamespace, layout });
+          existingNames.add(layout.name);
+        }
+        await store.delete([fromNamespace, layout.id]);
       }
       await tx.done;
     } catch (error) {

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/cleanupDuplicateDefaultLayouts.test.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/cleanupDuplicateDefaultLayouts.test.ts
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { cleanupDuplicateDefaultLayouts } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/cleanupDuplicateDefaultLayouts";
+import { DEFAULT_LAYOUT } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/constants";
+import MockLayoutManager from "@lichtblick/suite-base/services/LayoutManager/MockLayoutManager";
+import LayoutBuilder from "@lichtblick/suite-base/testing/builders/LayoutBuilder";
+import { BasicBuilder } from "@lichtblick/test-builders";
+
+describe("cleanupDuplicateDefaultLayouts", () => {
+  const layoutManager = new MockLayoutManager();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does nothing when there are no Default layouts", async () => {
+    // Given a list without any "Default" layout
+    const layouts = [
+      LayoutBuilder.layout({ name: BasicBuilder.string() }),
+      LayoutBuilder.layout({ name: BasicBuilder.string() }),
+    ];
+
+    // When cleaning up
+    await cleanupDuplicateDefaultLayouts(layouts, layoutManager);
+
+    // Then nothing is deleted
+    expect(layoutManager.deleteLayout).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there is a single default layout", async () => {
+    // Given exactly one candidate "Default" layout
+    const layouts = [
+      LayoutBuilder.layout({
+        name: DEFAULT_LAYOUT.name,
+        permission: DEFAULT_LAYOUT.permission,
+      }),
+      LayoutBuilder.layout({ name: BasicBuilder.string() }),
+    ];
+
+    // When cleaning up
+    await cleanupDuplicateDefaultLayouts(layouts, layoutManager);
+
+    // Then nothing is deleted
+    expect(layoutManager.deleteLayout).not.toHaveBeenCalled();
+  });
+
+  it("keeps the first default layout and deletes the duplicates", async () => {
+    // Given two candidate "Default" layouts
+    const first = LayoutBuilder.layout({
+      id: LayoutBuilder.layoutId("first"),
+      name: DEFAULT_LAYOUT.name,
+      permission: DEFAULT_LAYOUT.permission,
+    });
+    const second = LayoutBuilder.layout({
+      id: LayoutBuilder.layoutId("second"),
+      name: DEFAULT_LAYOUT.name,
+      permission: DEFAULT_LAYOUT.permission,
+    });
+
+    // When cleaning up
+    await cleanupDuplicateDefaultLayouts([first, second], layoutManager);
+
+    // Then the first one is kept and the rest deleted
+    expect(layoutManager.deleteLayout).toHaveBeenCalledTimes(1);
+    expect(layoutManager.deleteLayout).toHaveBeenCalledWith({ id: second.id });
+  });
+
+  it("ignores default-named layouts that do not have the default permission", async () => {
+    // Given one candidate Default layout and one Default-named layout with another permission
+    const layoutToKeep = LayoutBuilder.layout({
+      id: LayoutBuilder.layoutId("keep"),
+      name: DEFAULT_LAYOUT.name,
+      permission: DEFAULT_LAYOUT.permission,
+    });
+    const orgLayout = LayoutBuilder.layout({
+      id: LayoutBuilder.layoutId("org"),
+      name: DEFAULT_LAYOUT.name,
+      permission: "ORG_READ",
+    });
+
+    // When cleaning up
+    await cleanupDuplicateDefaultLayouts([layoutToKeep, orgLayout], layoutManager);
+
+    // Then nothing is deleted because only one candidate matches the permission filter
+    expect(layoutManager.deleteLayout).not.toHaveBeenCalled();
+  });
+
+  it("only considers layouts named Default with the default permission", async () => {
+    // Given duplicate Default candidates plus an unrelated layout
+    const keep = LayoutBuilder.layout({
+      id: LayoutBuilder.layoutId("keep"),
+      name: DEFAULT_LAYOUT.name,
+      permission: DEFAULT_LAYOUT.permission,
+    });
+    const toDelete = LayoutBuilder.layout({
+      id: LayoutBuilder.layoutId("delete"),
+      name: DEFAULT_LAYOUT.name,
+      permission: DEFAULT_LAYOUT.permission,
+    });
+    const unrelated = LayoutBuilder.layout({ name: BasicBuilder.string() });
+
+    // When cleaning up
+    await cleanupDuplicateDefaultLayouts([keep, toDelete, unrelated], layoutManager);
+
+    // Then only the duplicate Default is deleted, never the unrelated layout
+    expect(layoutManager.deleteLayout).toHaveBeenCalledTimes(1);
+    expect(layoutManager.deleteLayout).toHaveBeenCalledWith({ id: toDelete.id });
+  });
+});

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/cleanupDuplicateDefaultLayouts.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/cleanupDuplicateDefaultLayouts.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { DEFAULT_LAYOUT } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/constants";
+import { ILayoutManager } from "@lichtblick/suite-base/services/ILayoutManager";
+import { Layout } from "@lichtblick/suite-base/services/ILayoutStorage";
+
+export async function cleanupDuplicateDefaultLayouts(
+  layouts: readonly Layout[],
+  layoutManager: ILayoutManager,
+): Promise<void> {
+  const defaultLayouts = layouts.filter((layout) => layout.name === DEFAULT_LAYOUT.name && layout.permission === DEFAULT_LAYOUT.permission);
+  if (defaultLayouts.length <= 1) {
+    return;
+  }
+
+  const layoutToKeep =
+    defaultLayouts.find((layout) => layout.permission === DEFAULT_LAYOUT.permission) ?? defaultLayouts[0];
+
+  for (const layout of defaultLayouts) {
+    if (layout.id !== layoutToKeep?.id) {
+      await layoutManager.deleteLayout({ id: layout.id });
+    }
+  }
+}

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/constants.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/constants.ts
@@ -1,7 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
+import { defaultLayout } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/defaultLayout";
+import { SaveNewLayout } from "@lichtblick/suite-base/services/LayoutManager/LayoutManager";
+
 export const MAX_SUPPORTED_LAYOUT_VERSION = 1;
+
 export const ORG_PERMISSION_PREFIX = "ORG_";
+
 export const BUSY_POLLING_INTERVAL_MS = 100;
+
 export const BUSY_POLLING_TIMEOUT_MS = 5000;
+
+export const DEFAULT_LAYOUT: SaveNewLayout = {
+  name: "Default",
+  data: defaultLayout,
+  permission: `CREATOR_WRITE`,
+};

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/defaultLayout.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/defaultLayout.ts
@@ -40,7 +40,7 @@ export const defaultLayout: LayoutData =
           },
         },
       },
-      "RawMessages!os6rgs": {},
+      "RawMessagesVirtual!os6rgs": {},
       "Image!3mnp456": {},
     },
     globalVariables: {},
@@ -50,7 +50,7 @@ export const defaultLayout: LayoutData =
       first: "3D!18i6zy7",
       second: {
         first: "Image!3mnp456",
-        second: "RawMessages!os6rgs",
+        second: "RawMessagesVirtual!os6rgs",
         direction: "column",
         splitPercentage: 30,
       },

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -574,4 +574,29 @@ describe("CurrentLayoutProvider", () => {
       expect(mockLayoutManager.getLayouts).toHaveBeenCalled();
     });
   });
+
+  describe("Fallback Default layout creation", () => {
+    it("creates a personal Default layout when no layouts exist", async () => {
+      // Given a layout manager with no existing layouts and a user profile without a selection
+      const localOnlyManager = makeMockLayoutManager();
+      localOnlyManager.getLayouts.mockResolvedValue([]);
+      localOnlyManager.saveNewLayout.mockResolvedValue({
+        id: "new-default",
+        name: "Default",
+        baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
+      });
+      mockUserProfile.getUserProfile.mockResolvedValue({ currentLayoutId: undefined });
+
+      // When the provider initializes
+      const { result } = renderTest({ mockLayoutManager: localOnlyManager, mockUserProfile });
+      await act(async () => {
+        await result.current.childMounted;
+      });
+
+      // Then a personal Default layout is created
+      expect(localOnlyManager.saveNewLayout).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "Default", permission: "CREATOR_WRITE" }),
+      );
+    });
+  });
 });

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -40,13 +40,14 @@ import {
 } from "@lichtblick/suite-base/context/CurrentLayoutContext/actions";
 import { useLayoutManager } from "@lichtblick/suite-base/context/LayoutManagerContext";
 import { useUserProfileStorage } from "@lichtblick/suite-base/context/UserProfileStorageContext";
+import { cleanupDuplicateDefaultLayouts } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/cleanupDuplicateDefaultLayouts";
 import {
   BUSY_POLLING_INTERVAL_MS,
   BUSY_POLLING_TIMEOUT_MS,
+  DEFAULT_LAYOUT,
   MAX_SUPPORTED_LAYOUT_VERSION,
   ORG_PERMISSION_PREFIX,
 } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/constants";
-import { defaultLayout } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/defaultLayout";
 import useUpdateSharedPanelState from "@lichtblick/suite-base/providers/CurrentLayoutProvider/hooks/useUpdateSharedPanelState";
 import { loadDefaultLayouts } from "@lichtblick/suite-base/providers/CurrentLayoutProvider/loadDefaultLayouts";
 import panelsReducer from "@lichtblick/suite-base/providers/CurrentLayoutProvider/reducers";
@@ -342,6 +343,7 @@ export default function CurrentLayoutProvider({
       : undefined;
 
     if (layout) {
+      await cleanupDuplicateDefaultLayouts(layouts, layoutManager);
       await setSelectedLayoutId(currentLayoutId, { saveToProfile: false });
       return;
     }
@@ -354,12 +356,8 @@ export default function CurrentLayoutProvider({
       return;
     }
 
-    const newLayout = await layoutManager.saveNewLayout({
-      name: "Default",
-      data: defaultLayout,
-      permission: "CREATOR_WRITE",
-    });
-    await setSelectedLayoutId(newLayout.id);
+    const defaultLayout = await layoutManager.saveNewLayout(DEFAULT_LAYOUT);
+    await setSelectedLayoutId(defaultLayout.id);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getUserProfile, layoutManager, setSelectedLayoutId, enqueueSnackbar]);

--- a/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/suite-base/src/services/LayoutManager/LayoutManager.ts
@@ -42,6 +42,13 @@ import { emitBusyStatus } from "./utils/emitBusyStatus.decorator";
 
 const log = Logger.getLogger(__filename);
 
+export type SaveNewLayout = {
+    name: string;
+    data: LayoutData;
+    permission: LayoutPermission;
+    from?: string;
+  };
+
 export default class LayoutManager implements ILayoutManager {
   public static readonly LOCAL_STORAGE_NAMESPACE = "local";
   public static readonly REMOTE_STORAGE_NAMESPACE_PREFIX = "remote-";
@@ -176,12 +183,7 @@ export default class LayoutManager implements ILayoutManager {
     data: unmigratedData,
     permission,
     from,
-  }: {
-    name: string;
-    data: LayoutData;
-    permission: LayoutPermission;
-    from?: string;
-  }): Promise<Layout> {
+  }: SaveNewLayout): Promise<Layout> {
     const data = migratePanelsState(unmigratedData);
     if (layoutPermissionIsShared(permission)) {
       if (!this.remote) {


### PR DESCRIPTION
## Summary

Fixes duplicate "Default" layouts appearing after a workspace is removed and local layouts are imported into a remote namespace.

The root cause was in `IdbLayoutStorage.importLayouts`: it moved every layout from the source namespace into the target namespace without checking for name collisions, so a locally-created `Default` layout would duplicate an existing remote `Default`. The move also used two sequential cursor passes inside a single `readwrite` transaction, which could auto-commit and throw.

## Changes

- **`IdbLayoutStorage.importLayouts`** — read all source/target records up front, then skip importing any layout whose name already exists in the target namespace (dedup by name). Reworked to avoid the transaction auto-commit bug.
- **`cleanupDuplicateDefaultLayouts`** — new helper (own file) that defensively removes duplicate `Default` layouts on startup, keeping a single `CREATOR_WRITE` copy. Wired into `CurrentLayoutProvider`.
- **`DEFAULT_LAYOUT`** — extracted the default-layout descriptor into a shared constant in `constants.ts`; `CurrentLayoutProvider` now saves it via `layoutManager.saveNewLayout(DEFAULT_LAYOUT)`.
- **`SaveNewLayout`** — exported the `saveNewLayout` parameter type from `LayoutManager` for reuse.
- **`defaultLayout`** — switched the default layout to use `RawMessagesVirtual` instead of `RawMessages`.

## Tests

- New `IdbLayoutStorage.test.ts` — covers move + name-dedup behavior in `importLayouts`.
- New `cleanupDuplicateDefaultLayouts.test.ts` — 5 GWT cases.
- Updated `CurrentLayoutProvider/index.test.tsx` — added fallback Default-layout creation test.

All new/updated tests pass with no type or lint errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default layouts are now created with the correct personal access level when no layout exists.
  * Duplicate “Default” layouts are cleaned up automatically.

* **Bug Fixes**
  * Importing layouts now avoids creating duplicate names in the target location.
  * Existing layouts are preserved when duplicates are found, while source layouts are still moved/cleared as expected.

* **Tests**
  * Added coverage for layout import behavior, duplicate default cleanup, and fallback default layout creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->