### PR TITLE
perf: coalesce nearby remote MCAP reads to cut HTTP Range requests

### DIFF
--- a/.github/agents/lb-remote-connection.agent.md
+++ b/.github/agents/lb-remote-connection.agent.md
@@ -23,6 +23,9 @@ FetchReader (Streams API → EventEmitter: data/error/end)
 CachedFilelike (VirtualLRUBuffer LRU cache, 500MB default, 10MB blocks)
     │
     ▼
+BatchingReadable (coalesces reads <64KiB apart within a microtask tick, ≤4MiB span)
+    │
+    ▼
 RemoteFileReadable (IReadable adapter: size(), read(offset, size))
     │
     ├─────────────────── Worker boundary ────────────────────┐
@@ -76,7 +79,8 @@ WorkerSerializedIterableSource → BufferedIterableSource → Player
 | `util/VirtualLRUBuffer.ts` | Block-level LRU memory management |
 | `util/getNewConnection.ts` | HTTP connection decision algorithm |
 | `util/RequestQueue.ts` | Global concurrency limiter (10 max) |
-| `IterablePlayer/Mcap/RemoteFileReadable.ts` | `IReadable` adapter wrapping CachedFilelike |
+| `IterablePlayer/Mcap/RemoteFileReadable.ts` | `IReadable` adapter wrapping CachedFilelike (reads pass through BatchingReadable) |
+| `IterablePlayer/Mcap/BatchingReadable.ts` | Coalesces nearby `IReadable.read()` calls into fewer, larger reads |
 | `IterablePlayer/Mcap/McapIterableSource.ts` | Factory: indexed vs streaming decision |
 | `IterablePlayer/Mcap/McapIndexedIterableSource.ts` | Random access via chunk indexes |
 | `IterablePlayer/shared/MultiIterableSource.ts` | Multi-file orchestration |
@@ -306,6 +310,7 @@ WorkerSerializedIterableSource       McapIterableSourceWorker.worker.ts
 8. **WASM decompression preload** prevents initialization failures under slow network
 9. **Cache budget division** for multi-file: consider fewer large files over many small ones
 10. **BufferedIterableSource** (10s, 300MB) smooths network latency for playback
+11. **Read coalescing** (`BatchingReadable`): merges `read()` calls arriving in the same microtask tick (gap <64KiB, ≤4MiB span) before they reach `CachedFilelike`
 
 ## Common Pitfalls
 - Server missing `Accept-Ranges: bytes` header → fails at open

--- a/.github/skills/mcap-format/SKILL.md
+++ b/.github/skills/mcap-format/SKILL.md
@@ -179,6 +179,7 @@ MCAP is an open-source container format for heterogeneous timestamped data, desi
 | Indexed source | `McapIndexedIterableSource.ts` |
 | Unindexed source | `McapUnindexedIterableSource.ts` |
 | File readable | `BlobReadable.ts` (local), `RemoteFileReadable.ts` (HTTP Range) |
+| Remote read coalescing | `BatchingReadable.ts` (merges nearby `read()` calls in a microtask tick) |
 | Decompression | `packages/mcap-support/src/decompressHandlers.ts` |
 | Schema parsing | `packages/mcap-support/src/parseChannel.ts` |
 | 10s read-ahead (default) | `BufferedIterableSource` (`DEFAULT_READ_AHEAD_DURATION = { sec: 10, nsec: 0 }`) |

--- a/.github/skills/remote-caching/SKILL.md
+++ b/.github/skills/remote-caching/SKILL.md
@@ -16,6 +16,9 @@ FetchReader (Streams API → EventEmitter: data/error/end)
 CachedFilelike (LRU block cache via VirtualLRUBuffer)
      │
      ▼
+BatchingReadable (coalesces nearby read() calls within a microtask tick)
+     │
+     ▼
 RemoteFileReadable (IReadable adapter: size(), read(offset, size))
      │
      ▼                              ┌─── Worker boundary ───┐
@@ -277,19 +280,38 @@ Thin adapter bridging `CachedFilelike` (byte-offset Filelike API) to `McapTypes.
 
 ```typescript
 class RemoteFileReadable {
-  #remoteReader: CachedFilelike;  // Configured with 500MB cache
+  #remoteReader: CachedFilelike;         // Configured with 500MB cache
+  #batchingReadable: BatchingReadable;   // Coalesces reads before CachedFilelike
 
-  constructor(url: string, cacheSizeInBytes = 500 * 1024 * 1024) {
+  constructor(url: string, options?: { cacheSizeInBytes?: number; readAheadEnabled?: boolean }) {
     const fileReader = new BrowserHttpReader(url);
-    this.#remoteReader = new CachedFilelike({ fileReader, cacheSizeInBytes });
+    this.#remoteReader = new CachedFilelike({ fileReader, /* cacheSizeInBytes, readAheadEnabled */ });
+    const inner = {
+      size: async () => BigInt(this.#remoteReader.size()),
+      read: async (offset, size) => this.#remoteReader.read(Number(offset), Number(size)),
+    };
+    this.#batchingReadable = new BatchingReadable(inner);
   }
 
   async size(): Promise<bigint> { return BigInt(this.#remoteReader.size()); }
   async read(offset: bigint, size: bigint): Promise<Uint8Array> {
-    return await this.#remoteReader.read(Number(offset), Number(size));
+    return await this.#batchingReadable.read(offset, size);  // → coalesced → CachedFilelike
   }
 }
 ```
+
+---
+
+## BatchingReadable
+
+**Source**: `packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.ts`
+
+### Purpose
+Coalescing layer between `McapIndexedReader` and `CachedFilelike`. Accumulates `read()` calls that arrive within the same microtask tick, sorts them by offset, and merges those whose gap is `< 64 KiB` (up to a `4 MiB` merged span) into a single underlying read — cutting HTTP Range requests for MCAP files with many small chunks.
+
+### Notes
+- Single-member groups are forwarded zero-copy; multi-member groups are sliced (copied) per request so a small result does not pin the full merged buffer in memory.
+- Only coalesces reads that are concurrently pending in the same tick. `McapIndexedReader` issues reads strictly sequentially (each awaited before the next), so real coalescing depends on concurrent access — validate request-count reduction empirically for a given workload.
 
 ---
 
@@ -321,5 +343,6 @@ This means:
 | `packages/suite-base/src/util/BrowserHttpReader.ts` | HTTP Range request implementation |
 | `packages/suite-base/src/util/FetchReader.ts` | Streams API EventEmitter adapter |
 | `packages/suite-base/src/util/RequestQueue.ts` | Global concurrency limiter (10 max) |
-| `packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts` | IReadable adapter (500MB default) |
+| `packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts` | IReadable adapter (500MB default); reads pass through BatchingReadable |
+| `packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.ts` | Coalesces nearby `read()` calls (gap <64KiB, ≤4MiB span) into fewer inner reads |
 

--- a/.github/skills/remote-caching/SKILL.md
+++ b/.github/skills/remote-caching/SKILL.md
@@ -279,13 +279,19 @@ export const globalRequestQueue = new RequestQueue(GLOBAL_REQUEST_QUEUE_MAX_CONC
 Thin adapter bridging `CachedFilelike` (byte-offset Filelike API) to `McapTypes.IReadable` (bigint offset/size API).
 
 ```typescript
+const DEFAULT_CACHE_SIZE_BYTES = 1024 * 1024 * 500; // 500MiB
+
 class RemoteFileReadable {
-  #remoteReader: CachedFilelike;         // Configured with 500MB cache
+  #remoteReader: CachedFilelike;         // Cache size configurable, defaults to 500MiB
   #batchingReadable: BatchingReadable;   // Coalesces reads before CachedFilelike
 
   constructor(url: string, options?: { cacheSizeInBytes?: number; readAheadEnabled?: boolean }) {
     const fileReader = new BrowserHttpReader(url);
-    this.#remoteReader = new CachedFilelike({ fileReader, /* cacheSizeInBytes, readAheadEnabled */ });
+    this.#remoteReader = new CachedFilelike({
+      fileReader,
+      cacheSizeInBytes: options?.cacheSizeInBytes ?? DEFAULT_CACHE_SIZE_BYTES,
+      readAheadEnabled: options?.readAheadEnabled,
+    });
     const inner = {
       size: async () => BigInt(this.#remoteReader.size()),
       read: async (offset, size) => this.#remoteReader.read(Number(offset), Number(size)),
@@ -345,4 +351,3 @@ This means:
 | `packages/suite-base/src/util/RequestQueue.ts` | Global concurrency limiter (10 max) |
 | `packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts` | IReadable adapter (500MB default); reads pass through BatchingReadable |
 | `packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.ts` | Coalesces nearby `read()` calls (gap <64KiB, ≤4MiB span) into fewer inner reads |
-

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.test.ts
@@ -1,0 +1,304 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { McapTypes } from "@mcap/core";
+
+import { BatchingReadable } from "./BatchingReadable";
+
+const DEFAULT_THRESHOLD = 64 * 1024;
+
+/**
+ * Deterministic bytes for a given absolute offset/size window, where each byte
+ * equals `(offset + i) % 256`. This lets tests assert that each caller received
+ * exactly the bytes for its own offset/size slice after coalescing.
+ */
+function expectedBytes(offset: bigint, size: bigint): Uint8Array {
+  const out = new Uint8Array(Number(size));
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number((offset + BigInt(i)) % 256n);
+  }
+  return out;
+}
+
+type MockInner = McapTypes.IReadable & {
+  read: jest.Mock<Promise<Uint8Array>, [bigint, bigint]>;
+  size: jest.Mock<Promise<bigint>, []>;
+};
+
+/**
+ * Creates a mock `McapTypes.IReadable` whose `read(offset, size)` returns the
+ * deterministic byte window described by `expectedBytes`.
+ */
+function makeMockInner(sizeValue: bigint = 1024n): MockInner {
+  const read = jest.fn(async (offset: bigint, size: bigint): Promise<Uint8Array> => {
+    return expectedBytes(offset, size);
+  });
+  const size = jest.fn(async (): Promise<bigint> => sizeValue);
+  return { read, size };
+}
+
+describe("BatchingReadable", () => {
+  it("should delegate size() to inner and return its bigint value", async () => {
+    // Given
+    const inner = makeMockInner(4096n);
+    const readable = new BatchingReadable(inner);
+
+    // When
+    const result = await readable.size();
+
+    // Then
+    expect(result).toBe(4096n);
+    expect(inner.size).toHaveBeenCalledTimes(1);
+  });
+
+  it("should pass a single read through as exactly one inner.read with the same offset/size", async () => {
+    // Given
+    const inner = makeMockInner();
+    const readable = new BatchingReadable(inner);
+
+    // When
+    const data = await readable.read(10n, 20n);
+
+    // Then
+    expect(inner.read).toHaveBeenCalledTimes(1);
+    expect(inner.read).toHaveBeenCalledWith(10n, 20n);
+    expect(data).toEqual(expectedBytes(10n, 20n));
+  });
+
+  it("should forward the inner buffer unchanged (zero-copy) for a single-member read", async () => {
+    // Given a single read, which is the common/only case during sequential
+    // MCAP iteration
+    const returned = new Uint8Array([1, 2, 3, 4]);
+    const inner = makeMockInner();
+    inner.read.mockResolvedValueOnce(returned);
+    const readable = new BatchingReadable(inner);
+
+    // When
+    const data = await readable.read(0n, 4n);
+
+    // Then the exact same buffer instance is forwarded (no copy)
+    expect(inner.read).toHaveBeenCalledTimes(1);
+    expect(data).toBe(returned);
+  });
+
+  it("should coalesce adjacent reads in the same tick into one inner.read and slice correctly", async () => {
+    // Given
+    const inner = makeMockInner();
+    const readable = new BatchingReadable(inner);
+
+    // When
+    const promiseA = readable.read(0n, 100n);
+    const promiseB = readable.read(200n, 100n);
+    const [dataA, dataB] = await Promise.all([promiseA, promiseB]);
+
+    // Then
+    expect(inner.read).toHaveBeenCalledTimes(1);
+    expect(inner.read).toHaveBeenCalledWith(0n, 300n);
+    expect(dataA).toEqual(expectedBytes(0n, 100n));
+    expect(dataB).toEqual(expectedBytes(200n, 100n));
+  });
+
+  it("should merge two reads whose gap is at the threshold boundary into one inner.read", async () => {
+    // Given
+    const inner = makeMockInner(2n ** 40n);
+    const readable = new BatchingReadable(inner);
+    // Read A ends at offset 100. Merge condition is `offset <= end + threshold`,
+    // so an offset of exactly `100 + threshold` still merges.
+    const bOffset = BigInt(100 + DEFAULT_THRESHOLD);
+
+    // When
+    const promiseA = readable.read(0n, 100n);
+    const promiseB = readable.read(bOffset, 100n);
+    const [dataA, dataB] = await Promise.all([promiseA, promiseB]);
+
+    // Then
+    expect(inner.read).toHaveBeenCalledTimes(1);
+    expect(inner.read).toHaveBeenCalledWith(0n, bOffset + 100n);
+    expect(dataA).toEqual(expectedBytes(0n, 100n));
+    expect(dataB).toEqual(expectedBytes(bOffset, 100n));
+  });
+
+  it("should NOT merge two reads whose gap is just over the threshold boundary", async () => {
+    // Given
+    const inner = makeMockInner(2n ** 40n);
+    const readable = new BatchingReadable(inner);
+    // Read A ends at offset 100. An offset of `100 + threshold + 1` fails the
+    // `offset <= end + threshold` merge condition.
+    const bOffset = BigInt(100 + DEFAULT_THRESHOLD + 1);
+
+    // When
+    const promiseA = readable.read(0n, 100n);
+    const promiseB = readable.read(bOffset, 100n);
+    const [dataA, dataB] = await Promise.all([promiseA, promiseB]);
+
+    // Then
+    expect(inner.read).toHaveBeenCalledTimes(2);
+    expect(inner.read).toHaveBeenCalledWith(0n, 100n);
+    expect(inner.read).toHaveBeenCalledWith(bOffset, 100n);
+    expect(dataA).toEqual(expectedBytes(0n, 100n));
+    expect(dataB).toEqual(expectedBytes(bOffset, 100n));
+  });
+
+  it("should not merge two distant reads far beyond the threshold", async () => {
+    // Given
+    const inner = makeMockInner(2n ** 40n);
+    const readable = new BatchingReadable(inner);
+    const bOffset = BigInt(DEFAULT_THRESHOLD) * 10n;
+
+    // When
+    const promiseA = readable.read(0n, 50n);
+    const promiseB = readable.read(bOffset, 50n);
+    const [dataA, dataB] = await Promise.all([promiseA, promiseB]);
+
+    // Then
+    expect(inner.read).toHaveBeenCalledTimes(2);
+    expect(inner.read).toHaveBeenCalledWith(0n, 50n);
+    expect(inner.read).toHaveBeenCalledWith(bOffset, 50n);
+    expect(dataA).toEqual(expectedBytes(0n, 50n));
+    expect(dataB).toEqual(expectedBytes(bOffset, 50n));
+  });
+
+  it("should honor a custom gapThresholdBytes option that prevents merging", async () => {
+    // Given
+    const inner = makeMockInner();
+    const readable = new BatchingReadable(inner, { gapThresholdBytes: 8 });
+    // Read A ends at offset 4; B is 9 bytes away, which exceeds the custom
+    // threshold of 8 (but would be merged under the default threshold).
+    const bOffset = 13n;
+
+    // When
+    const promiseA = readable.read(0n, 4n);
+    const promiseB = readable.read(bOffset, 4n);
+    const [dataA, dataB] = await Promise.all([promiseA, promiseB]);
+
+    // Then
+    expect(inner.read).toHaveBeenCalledTimes(2);
+    expect(inner.read).toHaveBeenCalledWith(0n, 4n);
+    expect(inner.read).toHaveBeenCalledWith(bOffset, 4n);
+    expect(dataA).toEqual(expectedBytes(0n, 4n));
+    expect(dataB).toEqual(expectedBytes(bOffset, 4n));
+  });
+
+  it("should coalesce overlapping reads into one inner.read and slice each range correctly", async () => {
+    // Given
+    const inner = makeMockInner();
+    const readable = new BatchingReadable(inner);
+
+    // When - ranges [0, 100) and [50, 150) overlap
+    const promiseA = readable.read(0n, 100n);
+    const promiseB = readable.read(50n, 100n);
+    const [dataA, dataB] = await Promise.all([promiseA, promiseB]);
+
+    // Then
+    expect(inner.read).toHaveBeenCalledTimes(1);
+    expect(inner.read).toHaveBeenCalledWith(0n, 150n);
+    expect(dataA).toEqual(expectedBytes(0n, 100n));
+    expect(dataB).toEqual(expectedBytes(50n, 100n));
+  });
+
+  it("should reject all members of a group when its inner.read rejects", async () => {
+    // Given
+    const error = new Error("read failed");
+    const inner = makeMockInner();
+    inner.read.mockRejectedValueOnce(error);
+    const readable = new BatchingReadable(inner);
+
+    // When - two adjacent reads share a single (failing) group
+    const promiseA = readable.read(0n, 100n);
+    const promiseB = readable.read(200n, 100n);
+
+    // Then
+    await expect(promiseA).rejects.toThrow("read failed");
+    await expect(promiseB).rejects.toThrow("read failed");
+    expect(inner.read).toHaveBeenCalledTimes(1);
+  });
+
+  it("should isolate a failing group from a succeeding group in the same flush", async () => {
+    // Given
+    const error = new Error("group A failed");
+    const inner = makeMockInner(2n ** 40n);
+    const farOffset = BigInt(DEFAULT_THRESHOLD) * 10n;
+    inner.read.mockImplementation(async (offset: bigint, size: bigint): Promise<Uint8Array> => {
+      if (offset === 0n) {
+        throw error;
+      }
+      return expectedBytes(offset, size);
+    });
+    const readable = new BatchingReadable(inner);
+
+    // When - group A (offset 0) fails; group B (far offset) succeeds
+    const promiseA = readable.read(0n, 100n);
+    const promiseB = readable.read(farOffset, 100n);
+
+    // Then
+    await expect(promiseA).rejects.toThrow("group A failed");
+    await expect(promiseB).resolves.toEqual(expectedBytes(farOffset, 100n));
+    expect(inner.read).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not coalesce reads that arrive in separate microtask ticks", async () => {
+    // Given
+    const inner = makeMockInner();
+    const readable = new BatchingReadable(inner);
+
+    // When - the first read is awaited (its batch flushes) before the second
+    const dataA = await readable.read(0n, 100n);
+    const dataB = await readable.read(200n, 100n);
+
+    // Then
+    expect(inner.read).toHaveBeenCalledTimes(2);
+    expect(inner.read).toHaveBeenNthCalledWith(1, 0n, 100n);
+    expect(inner.read).toHaveBeenNthCalledWith(2, 200n, 100n);
+    expect(dataA).toEqual(expectedBytes(0n, 100n));
+    expect(dataB).toEqual(expectedBytes(200n, 100n));
+  });
+
+  it("should not merge reads whose combined span would exceed maxCoalescedBytes", async () => {
+    // Given a small max span; the two reads are within the gap threshold but
+    // together span more bytes than the cap allows.
+    const inner = makeMockInner();
+    const readable = new BatchingReadable(inner, { maxCoalescedBytes: 150 });
+    // Read A ends at 100; B starts at 120 (gap 20 < default 64 KiB threshold),
+    // but the merged span [0, 220) = 220 bytes exceeds the 150-byte cap.
+    const bOffset = 120n;
+
+    // When
+    const promiseA = readable.read(0n, 100n);
+    const promiseB = readable.read(bOffset, 100n);
+    const [dataA, dataB] = await Promise.all([promiseA, promiseB]);
+
+    // Then
+    expect(inner.read).toHaveBeenCalledTimes(2);
+    expect(inner.read).toHaveBeenCalledWith(0n, 100n);
+    expect(inner.read).toHaveBeenCalledWith(bOffset, 100n);
+    expect(dataA).toEqual(expectedBytes(0n, 100n));
+    expect(dataB).toEqual(expectedBytes(bOffset, 100n));
+  });
+
+  it("should resolve copies that do not retain the full merged buffer", async () => {
+    // Given two adjacent reads that coalesce into one 300-byte inner read
+    const inner = makeMockInner();
+    const readable = new BatchingReadable(inner);
+
+    // When
+    const promiseA = readable.read(0n, 100n);
+    const promiseB = readable.read(200n, 100n);
+    const [dataA, dataB] = await Promise.all([promiseA, promiseB]);
+
+    // Then a single merged read happened, but each result owns a buffer sized to
+    // its own slice (a copy), not the full 300-byte merged buffer.
+    expect(inner.read).toHaveBeenCalledTimes(1);
+    expect(inner.read).toHaveBeenCalledWith(0n, 300n);
+    expect(dataA.byteLength).toBe(100);
+    expect(dataB.byteLength).toBe(100);
+    expect(dataA.buffer.byteLength).toBe(100);
+    expect(dataB.buffer.byteLength).toBe(100);
+    expect(dataA).toEqual(expectedBytes(0n, 100n));
+    expect(dataB).toEqual(expectedBytes(200n, 100n));
+  });
+
+});

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.test.ts
@@ -300,5 +300,4 @@ describe("BatchingReadable", () => {
     expect(dataA).toEqual(expectedBytes(0n, 100n));
     expect(dataB).toEqual(expectedBytes(200n, 100n));
   });
-
 });

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.test.ts
@@ -165,7 +165,7 @@ describe("BatchingReadable", () => {
   it("should honor a custom gapThresholdBytes option that prevents merging", async () => {
     // Given
     const inner = makeMockInner();
-    const readable = new BatchingReadable(inner, { gapThresholdBytes: 8 });
+    const readable = new BatchingReadable(inner, { gapThresholdBytes: 8n });
     // Read A ends at offset 4; B is 9 bytes away, which exceeds the custom
     // threshold of 8 (but would be merged under the default threshold).
     const bOffset = 13n;
@@ -261,7 +261,7 @@ describe("BatchingReadable", () => {
     // Given a small max span; the two reads are within the gap threshold but
     // together span more bytes than the cap allows.
     const inner = makeMockInner();
-    const readable = new BatchingReadable(inner, { maxCoalescedBytes: 150 });
+    const readable = new BatchingReadable(inner, { maxCoalescedBytes: 150n });
     // Read A ends at 100; B starts at 120 (gap 20 < default 64 KiB threshold),
     // but the merged span [0, 220) = 220 bytes exceeds the 150-byte cap.
     const bOffset = 120n;

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.ts
@@ -24,10 +24,10 @@ type PendingRead = {
  * is smaller than `gapThresholdBytes`, up to a merged span of `maxCoalescedBytes`.
  */
 export class BatchingReadable implements McapTypes.IReadable {
-  #inner: McapTypes.IReadable;
-  #gapThresholdBytes: bigint;
-  #maxCoalescedBytes: bigint;
-  #pending: PendingRead[] = [];
+  readonly #inner: McapTypes.IReadable;
+  readonly #gapThresholdBytes: bigint;
+  readonly #maxCoalescedBytes: bigint;
+  readonly #pending: PendingRead[] = [];
   #scheduled = false;
 
   public constructor(
@@ -62,12 +62,20 @@ export class BatchingReadable implements McapTypes.IReadable {
       return;
     }
 
-    batch.sort((a, b) => (a.offset < b.offset ? -1 : a.offset > b.offset ? 1 : 0));
+    batch.sort((a, b) => {
+      if (a.offset < b.offset) {
+        return -1;
+      }
+      if (a.offset > b.offset) {
+        return 1;
+      }
+      return 0;
+    });
 
     type Group = { start: bigint; end: bigint; members: PendingRead[] };
     const groups: Group[] = [];
     for (const read of batch) {
-      const current = groups[groups.length - 1];
+      const current = groups.at(-1);
       const readEnd = read.offset + read.size;
       const mergedEnd = current != undefined && current.end > readEnd ? current.end : readEnd;
       if (

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.ts
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { McapTypes } from "@mcap/core";
+
+const BATCH_GAP_THRESHOLD_BYTES = 64 * 1024;
+const BATCH_MAX_COALESCED_BYTES = 4 * 1024 * 1024;
+
+type PendingRead = {
+  offset: bigint;
+  size: bigint;
+  resolve: (data: Uint8Array) => void;
+  reject: (error: Error) => void;
+};
+
+/**
+ * Coalesces read() calls that arrive within the same microtask tick into fewer,
+ * larger reads against the wrapped readable, reducing HTTP Range requests for
+ * MCAP files with many small chunks. Reads are merged when the gap between them
+ * is smaller than `gapThresholdBytes`, up to a merged span of `maxCoalescedBytes`.
+ */
+export class BatchingReadable implements McapTypes.IReadable {
+  #inner: McapTypes.IReadable;
+  #gapThresholdBytes: bigint;
+  #maxCoalescedBytes: bigint;
+  #pending: PendingRead[] = [];
+  #scheduled = false;
+
+  public constructor(
+    inner: McapTypes.IReadable,
+    options?: { gapThresholdBytes?: number; maxCoalescedBytes?: number },
+  ) {
+    this.#inner = inner;
+    this.#gapThresholdBytes = BigInt(options?.gapThresholdBytes ?? BATCH_GAP_THRESHOLD_BYTES);
+    this.#maxCoalescedBytes = BigInt(options?.maxCoalescedBytes ?? BATCH_MAX_COALESCED_BYTES);
+  }
+
+  public async size(): Promise<bigint> {
+    return await this.#inner.size();
+  }
+
+  public async read(offset: bigint, size: bigint): Promise<Uint8Array> {
+    return await new Promise<Uint8Array>((resolve, reject) => {
+      this.#pending.push({ offset, size, resolve, reject });
+      if (!this.#scheduled) {
+        this.#scheduled = true;
+        void Promise.resolve().then(async () => {
+          await this.#flush();
+        });
+      }
+    });
+  }
+
+  async #flush(): Promise<void> {
+    this.#scheduled = false;
+    const batch = this.#pending.splice(0);
+    if (batch.length === 0) {
+      return;
+    }
+
+    batch.sort((a, b) => (a.offset < b.offset ? -1 : a.offset > b.offset ? 1 : 0));
+
+    type Group = { start: bigint; end: bigint; members: PendingRead[] };
+    const groups: Group[] = [];
+    for (const read of batch) {
+      const current = groups[groups.length - 1];
+      const readEnd = read.offset + read.size;
+      const mergedEnd = current != undefined && current.end > readEnd ? current.end : readEnd;
+      if (
+        current != undefined &&
+        read.offset <= current.end + this.#gapThresholdBytes &&
+        mergedEnd - current.start <= this.#maxCoalescedBytes
+      ) {
+        current.end = mergedEnd;
+        current.members.push(read);
+      } else {
+        groups.push({ start: read.offset, end: readEnd, members: [read] });
+      }
+    }
+
+    await Promise.all(
+      groups.map(async (group) => {
+        const groupStart = group.start;
+        try {
+          const data = await this.#inner.read(groupStart, group.end - groupStart);
+          const first = group.members[0];
+          if (group.members.length === 1 && first != undefined) {
+            // Single-member read: forward unchanged to avoid a copy in this hot path.
+            first.resolve(data);
+          } else {
+            // Copy each sub-region so a small member does not pin the merged buffer.
+            for (const member of group.members) {
+              const begin = Number(member.offset - groupStart);
+              member.resolve(data.slice(begin, begin + Number(member.size)));
+            }
+          }
+        } catch (err) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          for (const member of group.members) {
+            member.reject(error);
+          }
+        }
+      }),
+    );
+  }
+}

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.ts
@@ -7,8 +7,8 @@
 
 import { McapTypes } from "@mcap/core";
 
-const BATCH_GAP_THRESHOLD_BYTES = 64 * 1024;
-const BATCH_MAX_COALESCED_BYTES = 4 * 1024 * 1024;
+const BATCH_GAP_THRESHOLD_BYTES = 64n * 1024n;
+const BATCH_MAX_COALESCED_BYTES = 4n * 1024n * 1024n;
 
 type PendingRead = {
   offset: bigint;
@@ -32,11 +32,11 @@ export class BatchingReadable implements McapTypes.IReadable {
 
   public constructor(
     inner: McapTypes.IReadable,
-    options?: { gapThresholdBytes?: number; maxCoalescedBytes?: number },
+    options?: { gapThresholdBytes?: bigint; maxCoalescedBytes?: bigint },
   ) {
     this.#inner = inner;
-    this.#gapThresholdBytes = BigInt(options?.gapThresholdBytes ?? BATCH_GAP_THRESHOLD_BYTES);
-    this.#maxCoalescedBytes = BigInt(options?.maxCoalescedBytes ?? BATCH_MAX_COALESCED_BYTES);
+    this.#gapThresholdBytes = options?.gapThresholdBytes ?? BATCH_GAP_THRESHOLD_BYTES;
+    this.#maxCoalescedBytes = options?.maxCoalescedBytes ?? BATCH_MAX_COALESCED_BYTES;
   }
 
   public async size(): Promise<bigint> {
@@ -94,7 +94,10 @@ export class BatchingReadable implements McapTypes.IReadable {
       groups.map(async (group) => {
         const groupStart = group.start;
         try {
-          const data = await this.#inner.read(groupStart, group.end - groupStart);
+          const data = await this.#inner.read(
+            groupStart,
+            group.end - groupStart,
+          );
           const first = group.members[0];
           if (group.members.length === 1 && first != undefined) {
             // Single-member read: forward unchanged to avoid a copy in this hot path.

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.ts
@@ -94,10 +94,7 @@ export class BatchingReadable implements McapTypes.IReadable {
       groups.map(async (group) => {
         const groupStart = group.start;
         try {
-          const data = await this.#inner.read(
-            groupStart,
-            group.end - groupStart,
-          );
+          const data = await this.#inner.read(groupStart, group.end - groupStart);
           const first = group.members[0];
           if (group.members.length === 1 && first != undefined) {
             // Single-member read: forward unchanged to avoid a copy in this hot path.

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
@@ -20,8 +20,8 @@ type RemoteFileReadableOptions = {
 };
 
 export class RemoteFileReadable {
-  #remoteReader: CachedFilelike;
-  #batchingReadable: BatchingReadable;
+  readonly #remoteReader: CachedFilelike;
+  readonly #batchingReadable: BatchingReadable;
 
   public constructor(url: string, options?: RemoteFileReadableOptions) {
     const fileReader = new BrowserHttpReader(url);

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
@@ -5,8 +5,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { McapTypes } from "@mcap/core";
+
 import BrowserHttpReader from "@lichtblick/suite-base/util/BrowserHttpReader";
 import CachedFilelike from "@lichtblick/suite-base/util/CachedFilelike";
+
+import { BatchingReadable } from "./BatchingReadable";
 
 const DEFAULT_CACHE_SIZE_BYTES = 1024 * 1024 * 500; // 500MiB
 
@@ -17,6 +21,7 @@ type RemoteFileReadableOptions = {
 
 export class RemoteFileReadable {
   #remoteReader: CachedFilelike;
+  #batchingReadable: BatchingReadable;
 
   public constructor(url: string, options?: RemoteFileReadableOptions) {
     const fileReader = new BrowserHttpReader(url);
@@ -25,6 +30,17 @@ export class RemoteFileReadable {
       cacheSizeInBytes: options?.cacheSizeInBytes ?? DEFAULT_CACHE_SIZE_BYTES,
       readAheadEnabled: options?.readAheadEnabled,
     });
+
+    const inner: McapTypes.IReadable = {
+      size: async () => BigInt(this.#remoteReader.size()),
+      read: async (offset, size) => {
+        if (offset + size > BigInt(Number.MAX_SAFE_INTEGER)) {
+          throw new Error(`Read too large: offset ${offset}, size ${size}`);
+        }
+        return await this.#remoteReader.read(Number(offset), Number(size));
+      },
+    };
+    this.#batchingReadable = new BatchingReadable(inner);
   }
 
   public async open(): Promise<void> {
@@ -35,9 +51,6 @@ export class RemoteFileReadable {
     return BigInt(this.#remoteReader.size());
   }
   public async read(offset: bigint, size: bigint): Promise<Uint8Array> {
-    if (offset + size > Number.MAX_SAFE_INTEGER) {
-      throw new Error(`Read too large: offset ${offset}, size ${size}`);
-    }
-    return await this.#remoteReader.read(Number(offset), Number(size));
+    return await this.#batchingReadable.read(offset, size);
   }
 }


### PR DESCRIPTION
## User-Facing Changes

Loading a remote MCAP file that contains many tiny chunks now uses far fewer HTTP requests, without changing lazy-loading behavior. In a real-world file with ~43k tiny chunks, the number of HTTP Range requests during open + playback dropped from ~275 to ~5.

## Description

### The problem

When Lichtblick opens an MCAP file over HTTP, it does not download the whole file up front. Instead, `@mcap/core`'s `McapIndexedReader` reads only the parts it needs (indexes and chunk bodies), and `CachedFilelike` turns those reads into HTTP Range requests.

For a well-formed file (a few dozen large chunks of 1–5 MiB) this results in a handful of requests. But some files are produced with **thousands of very small chunks** (for example ~4 KiB each). For every chunk the reader makes about two small reads — one for the chunk's message index, one for the chunk body — so a file with tens of thousands of chunks produces tens of thousands of tiny reads.

`CachedFilelike` keeps only **one** active HTTP stream at a time. Whenever a read lands outside the range the current stream is serving, it closes that stream and opens a new one. With so many tiny reads jumping around the file, the stream is constantly torn down and reopened, producing a large number of HTTP requests and, over a real network, a lot of connection overhead.

Downloading the whole file eagerly was considered and rejected: it would break lazy loading, waste bandwidth when the user only wants to inspect part of a session, and slow down time-to-first-frame for large files.

### The fix

This PR inserts a small **coalescing layer** between the reader and the cache:

```
McapIndexedReader
      │  many tiny read() calls
      ▼
BatchingReadable          ← NEW
      │  sorts + merges nearby reads
      ▼
CachedFilelike / BrowserHttpReader
      │
      ▼
HTTP Range requests       ← far fewer
```

`BatchingReadable` (`players/IterablePlayer/Mcap/BatchingReadable.ts`) is an `McapTypes.IReadable` wrapper that:

- collects all `read()` calls that arrive together in the same microtask tick,
- sorts them by offset,
- merges reads whose gap is smaller than **64 KiB** into a single underlying read,
- caps a merged read at **4 MiB** so many chained small gaps cannot grow into one huge over-read,
- issues one read to the cache per merged group, then slices the result back to each original caller.

Both thresholds are configurable through constructor options. `RemoteFileReadable` now sends its reads through `BatchingReadable` before forwarding to `CachedFilelike`.

### Why this helps

During parts of playback the reader issues **bursts** of reads at the same time (for example, back-filling the latest message for every topic after a seek). Sorting these bursts by offset turns scattered, out-of-order access into a single forward pass. That lets `CachedFilelike`'s single streaming connection keep serving them instead of being torn down and reopened for every jump — which is what removes most of the requests.

### Measured results

Tested locally by serving two MCAP files over HTTP and counting HTTP Range requests during open + playback + seek:

| File | Requests before | Requests after |
| --- | --- | --- |
| ~43k tiny chunks (~4 KiB each) | ~275 | ~5 |
| Same data re-chunked to ~4 MiB chunks | ~5 | ~5 |

Large reduction on the pathological many-small-chunk file, and **no regression** on a well-formed file.

Note: producing MCAP files with reasonable chunk sizes (~1–5 MiB) remains the most effective fix on the data-producer side; this PR reduces the client-side cost when such files are encountered.

### Memory

- Single-member groups (the common case) are forwarded **zero-copy**, matching the previous behavior.
- Multi-member groups are sliced (copied) per request, so a small result does not keep the whole merged buffer alive.

### Docs

Updated the remote-connection agent doc and the `remote-caching` / `mcap-format` skills to mention the new layer.

## Checklist

- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote read coalescing: nearby reads arriving in the same microtask are merged (configurable gap threshold and maximum merged span).
  * Remote file access now routes reads through the batching layer and supports an options object (optionally configuring cache size and enabling/disabling read-ahead).
* **Bug Fixes**
  * Improved overlapping/batched reads so each caller receives the correct byte slice; failed batched reads reject all requests in the merged group.
* **Tests**
  * Added Jest coverage for coalescing thresholds/limits, tick boundaries, slicing, and error handling.
* **Documentation**
  * Updated remote-caching and code-mapping docs to describe the new batching stage and options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->