### PR TITLE
Fix log interface contract 

### DIFF
--- a/packages/suite-base/src/components/CurrentLayoutSyncAdapter.tsx
+++ b/packages/suite-base/src/components/CurrentLayoutSyncAdapter.tsx
@@ -86,7 +86,7 @@ export function CurrentLayoutSyncAdapter(): ReactNull {
       }
     }
 
-    void analytics.logEvent(AppEvent.LAYOUT_UPDATE);
+    analytics.logEvent(AppEvent.LAYOUT_UPDATE);
   }, [analytics, debouncedUnsavedLayouts, isMounted, layoutManager]);
 
   return ReactNull;

--- a/packages/suite-base/src/components/DataSourceDialog/Connection.tsx
+++ b/packages/suite-base/src/components/DataSourceDialog/Connection.tsx
@@ -118,7 +118,7 @@ export default function Connection(): React.JSX.Element {
   const [selectedConnectionIdx, setSelectedConnectionIdx] = useState<number>(() => {
     const foundIdx = connectionSources.findIndex((source) => source === activeDataSource);
     const selectedIdx = foundIdx < 0 ? 0 : foundIdx;
-    void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, {
+    analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, {
       type: "live",
       data: enabledSourcesFirst[selectedIdx]?.id,
     });
@@ -156,7 +156,7 @@ export default function Connection(): React.JSX.Element {
       return;
     }
     selectSource(selectedSource.id, { type: "connection", params: fieldValues });
-    void analytics.logEvent(AppEvent.DIALOG_CLOSE, { activeDataSource });
+    analytics.logEvent(AppEvent.DIALOG_CLOSE, { activeDataSource });
     dialogActions.dataSource.close();
   }, [
     selectedSource,
@@ -195,7 +195,7 @@ export default function Connection(): React.JSX.Element {
             orientation={mdUp ? "vertical" : "horizontal"}
             onChange={(_event, newValue: number) => {
               setSelectedConnectionIdx(newValue);
-              void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, {
+              analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, {
                 type: "live",
                 data: enabledSourcesFirst[newValue]?.id,
               });

--- a/packages/suite-base/src/components/DataSourceDialog/DataSourceDialog.tsx
+++ b/packages/suite-base/src/components/DataSourceDialog/DataSourceDialog.tsx
@@ -61,7 +61,7 @@ export function DataSourceDialog(props: DataSourceDialogProps): React.JSX.Elemen
   const analytics = useAnalytics();
 
   const onModalClose = useCallback(() => {
-    void analytics.logEvent(AppEvent.DIALOG_CLOSE, { activeDataSource });
+    analytics.logEvent(AppEvent.DIALOG_CLOSE, { activeDataSource });
     dialogActions.dataSource.close();
   }, [analytics, activeDataSource, dialogActions.dataSource]);
 

--- a/packages/suite-base/src/components/DataSourceDialog/SidebarItems.tsx
+++ b/packages/suite-base/src/components/DataSourceDialog/SidebarItems.tsx
@@ -34,8 +34,8 @@ const SidebarItems = (props: {
           <Button
             onClick={() => {
               onSelectView("demo");
-              void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, { type: "demo" });
-              void analytics.logEvent(AppEvent.DIALOG_CLICK_CTA, {
+              analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, { type: "demo" });
+              analytics.logEvent(AppEvent.DIALOG_CLICK_CTA, {
                 user: currentUserType,
                 cta: "demo",
               });
@@ -72,7 +72,7 @@ const SidebarItems = (props: {
                 target="_blank"
                 className={classes.button}
                 onClick={() => {
-                  void analytics.logEvent(AppEvent.DIALOG_CLICK_CTA, {
+                  analytics.logEvent(AppEvent.DIALOG_CLICK_CTA, {
                     user: currentUserType,
                     cta: "tutorials",
                   });
@@ -105,7 +105,7 @@ const SidebarItems = (props: {
                   variant="outlined"
                   className={classes.button}
                   onClick={() => {
-                    void analytics.logEvent(AppEvent.DIALOG_CLICK_CTA, {
+                    analytics.logEvent(AppEvent.DIALOG_CLICK_CTA, {
                       user: currentUserType,
                       cta: "upload-to-dp",
                     });

--- a/packages/suite-base/src/components/DataSourceDialog/Start.tsx
+++ b/packages/suite-base/src/components/DataSourceDialog/Start.tsx
@@ -40,7 +40,7 @@ export default function Start(): React.JSX.Element {
         ),
         onClick: () => {
           dialogActions.dataSource.open("file");
-          void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, { type: "local" });
+          analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, { type: "local" });
         },
       },
       {
@@ -54,7 +54,7 @@ export default function Start(): React.JSX.Element {
         ),
         onClick: () => {
           dialogActions.dataSource.open("connection");
-          void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, { type: "live" });
+          analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, { type: "live" });
         },
       },
     ];

--- a/packages/suite-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/suite-base/src/components/ExperimentalFeatureSettings.tsx
@@ -75,7 +75,7 @@ function ExperimentalFeatureItem(props: { feature: Feature }) {
           checked={enabled ?? false}
           onChange={(_, checked) => {
             void setEnabled(checked);
-            void analytics.logEvent(AppEvent.EXPERIMENTAL_FEATURE_TOGGLE, {
+            analytics.logEvent(AppEvent.EXPERIMENTAL_FEATURE_TOGGLE, {
               feature: feature.key,
               checked,
             });

--- a/packages/suite-base/src/components/ExtensionsSettings/components/ExtensionList/ExtensionList.tsx
+++ b/packages/suite-base/src/components/ExtensionsSettings/components/ExtensionList/ExtensionList.tsx
@@ -71,7 +71,7 @@ export default function ExtensionList({
         await new Promise((resolve) => setTimeout(resolve, 100));
         await uninstallExtension(extension.namespace ?? "local", extension.id);
         successCount++;
-        await analytics.logEvent(AppEvent.EXTENSION_UNINSTALL, { type: extension.id });
+        analytics.logEvent(AppEvent.EXTENSION_UNINSTALL, { type: extension.id });
       } catch (error) {
         console.error("Failed to uninstall extension:", error);
         failCount++;

--- a/packages/suite-base/src/components/ExtensionsSettings/hooks/useExtensionOperations.ts
+++ b/packages/suite-base/src/components/ExtensionsSettings/hooks/useExtensionOperations.ts
@@ -59,7 +59,7 @@ export function useExtensionOperations(
         const extensionBuffer = await downloadExtension(url);
         await installExtensions("local", [{ buffer: extensionBuffer }]);
         enqueueSnackbar(`${extension.name} installed successfully`, { variant: "success" });
-        await analytics.logEvent(AppEvent.EXTENSION_INSTALL, { type: extension.id });
+        analytics.logEvent(AppEvent.EXTENSION_INSTALL, { type: extension.id });
         onInstallSuccess?.(extension.id);
       } catch (error) {
         enqueueSnackbar(error instanceof Error ? error.message : "Failed to install extension", {
@@ -82,7 +82,7 @@ export function useExtensionOperations(
         await new Promise((resolve) => setTimeout(resolve, 200));
         await uninstallExtension(extension.namespace ?? "local", extension.id);
         enqueueSnackbar(`${extension.name} uninstalled successfully`, { variant: "success" });
-        await analytics.logEvent(AppEvent.EXTENSION_UNINSTALL, { type: extension.id });
+        analytics.logEvent(AppEvent.EXTENSION_UNINSTALL, { type: extension.id });
         onUninstallSuccess?.(extension.id);
       } catch (error) {
         enqueueSnackbar(error instanceof Error ? error.message : "Failed to uninstall extension", {

--- a/packages/suite-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/index.tsx
@@ -224,7 +224,7 @@ export default function LayoutBrowser({
     await onSelectLayout(newLayout);
     setPersonalSectionExpanded(true);
 
-    void analytics.logEvent(AppEvent.LAYOUT_CREATE);
+    void Promise.resolve(analytics.logEvent(AppEvent.LAYOUT_CREATE));
   }, [
     currentDateForStorybook,
     layoutManager,

--- a/packages/suite-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/index.tsx
@@ -224,7 +224,7 @@ export default function LayoutBrowser({
     await onSelectLayout(newLayout);
     setPersonalSectionExpanded(true);
 
-    await analytics.logEvent(AppEvent.LAYOUT_CREATE);
+    void analytics.logEvent(AppEvent.LAYOUT_CREATE);
   }, [
     currentDateForStorybook,
     layoutManager,

--- a/packages/suite-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/index.tsx
@@ -224,7 +224,7 @@ export default function LayoutBrowser({
     await onSelectLayout(newLayout);
     setPersonalSectionExpanded(true);
 
-    void Promise.resolve(analytics.logEvent(AppEvent.LAYOUT_CREATE));
+    analytics.logEvent(AppEvent.LAYOUT_CREATE);
   }, [
     currentDateForStorybook,
     layoutManager,
@@ -247,7 +247,7 @@ export default function LayoutBrowser({
           data: item.working?.data ?? item.baseline.data,
           permission: "ORG_WRITE",
         });
-        await analytics.logEvent(AppEvent.LAYOUT_SHARE, { permission: item.permission });
+        analytics.logEvent(AppEvent.LAYOUT_SHARE, { permission: item.permission });
         setSharedSectionExpanded(true);
         await onSelectLayout(newLayout);
       }
@@ -263,7 +263,7 @@ export default function LayoutBrowser({
       });
       setPersonalSectionExpanded(true);
       await onSelectLayout(newLayout);
-      await analytics.logEvent(AppEvent.LAYOUT_MAKE_PERSONAL_COPY, {
+      analytics.logEvent(AppEvent.LAYOUT_MAKE_PERSONAL_COPY, {
         permission: item.permission,
         syncStatus: item.syncInfo?.status,
       });

--- a/packages/suite-base/src/components/VariablesList/Variable.tsx
+++ b/packages/suite-base/src/components/VariablesList/Variable.tsx
@@ -137,7 +137,7 @@ export default function Variable(props: {
 
   const deleteVariable = useCallback(() => {
     setGlobalVariables({ [name]: undefined });
-    void analytics.logEvent(AppEvent.VARIABLE_DELETE);
+    analytics.logEvent(AppEvent.VARIABLE_DELETE);
     handleClose();
   }, [analytics, name, setGlobalVariables]);
 

--- a/packages/suite-base/src/components/VariablesList/index.tsx
+++ b/packages/suite-base/src/components/VariablesList/index.tsx
@@ -82,7 +82,7 @@ export default function VariablesList(): ReactElement {
           disabled={globalVariables[""] != undefined}
           onClick={() => {
             setGlobalVariables({ "": '""' });
-            void analytics.logEvent(AppEvent.VARIABLE_ADD);
+            analytics.logEvent(AppEvent.VARIABLE_ADD);
           }}
         >
           Add variable

--- a/packages/suite-base/src/hooks/useLayoutActions.tsx
+++ b/packages/suite-base/src/hooks/useLayoutActions.tsx
@@ -38,7 +38,7 @@ export function useLayoutActions({ state, dispatch }: LayoutSetupOptions): UseLa
     async (item: Layout, newName: string) => {
       await layoutManager.updateLayout({ id: item.id, name: newName });
       setSelectedLayoutId(item.id);
-      void analytics.logEvent(AppEvent.LAYOUT_RENAME, { permission: item.permission });
+      analytics.logEvent(AppEvent.LAYOUT_RENAME, { permission: item.permission });
     },
     [analytics, layoutManager, setSelectedLayoutId],
   );
@@ -56,7 +56,7 @@ export function useLayoutActions({ state, dispatch }: LayoutSetupOptions): UseLa
         permission: "CREATOR_WRITE",
       });
       await onSelectLayout(newLayout);
-      void analytics.logEvent(AppEvent.LAYOUT_DUPLICATE, { permission: item.permission });
+      analytics.logEvent(AppEvent.LAYOUT_DUPLICATE, { permission: item.permission });
     },
     [analytics, dispatch, layoutManager, onSelectLayout, state.selectedIds.length],
   );
@@ -68,7 +68,7 @@ export function useLayoutActions({ state, dispatch }: LayoutSetupOptions): UseLa
         return;
       }
 
-      void analytics.logEvent(AppEvent.LAYOUT_DELETE, { permission: item.permission });
+      analytics.logEvent(AppEvent.LAYOUT_DELETE, { permission: item.permission });
 
       // If the layout was selected, select a different available layout.
       //
@@ -117,7 +117,7 @@ export function useLayoutActions({ state, dispatch }: LayoutSetupOptions): UseLa
         }
       }
       await layoutManager.overwriteLayout({ id: item.id });
-      void analytics.logEvent(AppEvent.LAYOUT_OVERWRITE, { permission: item.permission });
+      analytics.logEvent(AppEvent.LAYOUT_OVERWRITE, { permission: item.permission });
     },
     [analytics, confirm, dispatch, layoutManager, state.selectedIds.length],
   );
@@ -130,7 +130,7 @@ export function useLayoutActions({ state, dispatch }: LayoutSetupOptions): UseLa
       }
 
       await layoutManager.revertLayout({ id: item.id });
-      void analytics.logEvent(AppEvent.LAYOUT_REVERT, { permission: item.permission });
+      analytics.logEvent(AppEvent.LAYOUT_REVERT, { permission: item.permission });
     },
     [analytics, dispatch, layoutManager, state.selectedIds.length],
   );

--- a/packages/suite-base/src/hooks/useLayoutNavigation.tsx
+++ b/packages/suite-base/src/hooks/useLayoutNavigation.tsx
@@ -66,7 +66,7 @@ export function useLayoutNavigation(menuClose?: () => void): UseLayoutNavigation
       { selectedViaClick = false, event }: { selectedViaClick?: boolean; event?: MouseEvent } = {},
     ) => {
       if (selectedViaClick) {
-        void analytics.logEvent(AppEvent.LAYOUT_SELECT, { permission: item.permission });
+        analytics.logEvent(AppEvent.LAYOUT_SELECT, { permission: item.permission });
       }
       if (event?.ctrlKey === true || event?.metaKey === true || event?.shiftKey === true) {
         if (item.id !== currentLayoutId) {

--- a/packages/suite-base/src/hooks/useLayoutTransfer.tsx
+++ b/packages/suite-base/src/hooks/useLayoutTransfer.tsx
@@ -101,7 +101,7 @@ export function useLayoutTransfer(): UseLayoutTransfer {
       return;
     }
 
-    void analytics.logEvent(AppEvent.LAYOUT_IMPORT, { numLayouts: fileHandles.length });
+    analytics.logEvent(AppEvent.LAYOUT_IMPORT, { numLayouts: fileHandles.length });
   }, [analytics, isMounted, parseAndInstallLayout]);
 
   const exportLayout = useCallbackWithToast(async () => {
@@ -114,7 +114,7 @@ export function useLayoutTransfer(): UseLayoutTransfer {
     const layoutName = name.length > 0 ? name : "lichtblick-layout";
     const content = JSON.stringify(item, undefined, 2) ?? "";
     downloadTextFile(content, `${layoutName}.json`);
-    void analytics.logEvent(AppEvent.LAYOUT_EXPORT);
+    analytics.logEvent(AppEvent.LAYOUT_EXPORT);
   }, [analytics, getCurrentLayoutState]);
 
   return { importLayout, exportLayout, parseAndInstallLayout };

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -1055,7 +1055,7 @@ export class ImageMode
         // remove any leading / so the image name doesn't start with _
         const topicName = topic.replace(/^\/+/, "");
         const fileName = `${topicName}-${stamp.sec}-${stamp.nsec}`;
-        void this.renderer.analytics?.logEvent(AppEvent.IMAGE_DOWNLOAD);
+        this.renderer.analytics?.logEvent(AppEvent.IMAGE_DOWNLOAD);
         if (this.renderer.testOptions.onDownloadImage) {
           this.renderer.testOptions.onDownloadImage(blob, fileName);
         } else {

--- a/packages/suite-base/src/players/AnalyticsMetricsCollector.ts
+++ b/packages/suite-base/src/players/AnalyticsMetricsCollector.ts
@@ -27,7 +27,7 @@ export default class AnalyticsMetricsCollector implements PlayerMetricsCollector
   }
 
   public logEvent(event: AppEvent, data?: EventData): void {
-    void this.#analytics.logEvent(event, { ...this.#metadata, ...data });
+    this.#analytics.logEvent(event, { ...this.#metadata, ...data });
   }
 
   public playerConstructed(): void {

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -381,7 +381,7 @@ export default function CurrentLayoutProvider({
       createTabPanel: (payload: CreateTabPanelPayload) => {
         performAction({ type: "CREATE_TAB_PANEL", payload });
         setSelectedPanelIds([]);
-        void analytics.logEvent(AppEvent.PANEL_ADD, { type: "Tab" });
+        analytics.logEvent(AppEvent.PANEL_ADD, { type: "Tab" });
       },
       changePanelLayout: (payload: ChangePanelLayoutPayload) => {
         performAction({ type: "CHANGE_PANEL_LAYOUT", payload });
@@ -405,7 +405,7 @@ export default function CurrentLayoutProvider({
         // Deselect the removed panel
         setSelectedPanelIds((ids) => ids.filter((id) => id !== closedId));
 
-        void analytics.logEvent(
+        analytics.logEvent(
           AppEvent.PANEL_DELETE,
           typeof closedId === "string" ? { type: getPanelTypeFromId(closedId) } : undefined,
         );
@@ -428,8 +428,8 @@ export default function CurrentLayoutProvider({
           );
           setSelectedPanelIds(_.difference(afterPanelIds, beforePanelIds));
         }
-        void analytics.logEvent(AppEvent.PANEL_ADD, { type: payload.type, action: "swap" });
-        void analytics.logEvent(AppEvent.PANEL_DELETE, {
+        analytics.logEvent(AppEvent.PANEL_ADD, { type: payload.type, action: "swap" });
+        analytics.logEvent(AppEvent.PANEL_DELETE, {
           type: getPanelTypeFromId(payload.originalId),
           action: "swap",
         });
@@ -439,11 +439,11 @@ export default function CurrentLayoutProvider({
       },
       addPanel: (payload: AddPanelPayload) => {
         performAction({ type: "ADD_PANEL", payload });
-        void analytics.logEvent(AppEvent.PANEL_ADD, { type: getPanelTypeFromId(payload.id) });
+        analytics.logEvent(AppEvent.PANEL_ADD, { type: getPanelTypeFromId(payload.id) });
       },
       dropPanel: (payload: DropPanelPayload) => {
         performAction({ type: "DROP_PANEL", payload });
-        void analytics.logEvent(AppEvent.PANEL_ADD, {
+        analytics.logEvent(AppEvent.PANEL_ADD, {
           type: payload.newPanelType,
           action: "drop",
         });

--- a/packages/suite-base/src/services/IAnalytics.ts
+++ b/packages/suite-base/src/services/IAnalytics.ts
@@ -71,7 +71,7 @@ enum AppEvent {
 }
 
 interface IAnalytics {
-  logEvent(event: AppEvent, data?: { [key: string]: unknown }): void | Promise<void>;
+  logEvent(event: AppEvent, data?: { [key: string]: unknown }): void;
 }
 
 export { AppEvent };

--- a/packages/suite-base/src/services/NullAnalytics.ts
+++ b/packages/suite-base/src/services/NullAnalytics.ts
@@ -8,5 +8,5 @@
 import IAnalytics from "@lichtblick/suite-base/services/IAnalytics";
 
 export default class NullAnalytics implements IAnalytics {
-  public logEvent(): void | Promise<void> {}
+  public logEvent(): void {}
 }


### PR DESCRIPTION
## User-Facing Changes

N/A

## Description

Changed the `IAnalytics.logEvent` method to return only `void` instead of `void | Promise<void>`.

Analytics logging should be a synchronous, fire-and-forget operation. It should not block any user action or slow down the application. The previous return type allowed `logEvent` to return a `Promise`, which led to inconsistent usage across the codebase:

- Some call sites used `await analytics.logEvent(...)`, which unnecessarily waited for the event to be sent before continuing.
- Other call sites used `void analytics.logEvent(...)` to explicitly discard a potential Promise.

Both patterns are no longer needed. Now that `logEvent` always returns `void`:

- All `await` calls were replaced with direct calls.
- All `void` operator prefixes were removed since there is no Promise to discard.

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Analytics tracking now runs without delaying layout, data source, extension, variable, image, and settings interactions.
* **Reliability**
  * Analytics reporting uses a consistent non-blocking behavior across application actions.
* **Behavior**
  * Existing analytics events and recorded details remain unchanged while user actions continue immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->