### PR TITLE
Fix: Static Transforms Lost on Backward Seek

### DIFF
--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -1981,6 +1981,40 @@ describe("Renderer backward seek behavior", () => {
     expect(regularFrame == undefined || regularFrame.transformsSize() === 0).toBe(true);
     expect(renderer.transformTree.frame("child_static")?.transformsSize()).toBe(1);
   });
+
+  it("preserves static transforms when seeking backward with allFrames", () => {
+    // Given: A renderer with preload enabled
+    const renderer = new Renderer({
+      ...rendererArgs,
+      config: {
+        ...defaultRendererConfig,
+        scene: { transforms: { enablePreloading: true } },
+      },
+    });
+
+    // When: Adding regular and static transforms
+    renderer.setCurrentTime(100n);
+    const regularMsg = createTFMessageEvent("parent", "child_regular", 50n, [50n]);
+    const staticMsg = createTFMessageEvent("parent", "child_static", 10n, [10n], "/tf_static");
+    const allFrames = [staticMsg, regularMsg];
+
+    renderer.addMessageEvent(regularMsg);
+    renderer.addMessageEvent(staticMsg);
+    renderer.animationFrame();
+
+    // Verify both are present
+    expect(renderer.transformTree.frame("child_regular")?.transformsSize()).toBe(1);
+    expect(renderer.transformTree.frame("child_static")?.transformsSize()).toBe(1);
+
+    // When: Seeking backward and providing allFrames
+    renderer.setCurrentTime(20n);
+    renderer.handleSeek(100n, allFrames);
+
+    // Then: Regular transform (at 50n) should be cleared, static transform preserved
+    const regularFrame = renderer.transformTree.frame("child_regular");
+    expect(regularFrame == undefined || regularFrame.transformsSize() === 0).toBe(true);
+    expect(renderer.transformTree.frame("child_static")?.transformsSize()).toBe(1);
+  });
 });
 
 describe("Renderer batch message processing", () => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -2235,8 +2235,8 @@ describe("Renderer static transform caching across message types", () => {
 
     // The cyclic transform should not have been cached, so a backward seek that
     // preserves the static cache should not resurrect it.
-    renderer.setCurrentTime(100n);
-    renderer.handleSeek(0n);
+    renderer.setCurrentTime(0n);
+    renderer.handleSeek(100n);
 
     const grandparentFrame = renderer.transformTree.frame("grandparent");
     expect(

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -2117,13 +2117,7 @@ describe("Renderer static transform caching across message types", () => {
 
     renderer.setCurrentTime(100n);
     const regularMsg = createFrameTransformEvent("parent", "child_regular", 50n, 50n, "/tf");
-    const staticMsg = createFrameTransformEvent(
-      "parent",
-      "child_static",
-      10n,
-      10n,
-      "/tf_static",
-    );
+    const staticMsg = createFrameTransformEvent("parent", "child_static", 10n, 10n, "/tf_static");
     renderer.addMessageEvent(regularMsg);
     renderer.addMessageEvent(staticMsg);
     renderer.animationFrame();
@@ -2189,13 +2183,7 @@ describe("Renderer static transform caching across message types", () => {
 
     renderer.setCurrentTime(100n);
     const regularMsg = createTransformStampedEvent("parent", "child_regular", 50n, 50n, "/tf");
-    const staticMsg = createTransformStampedEvent(
-      "parent",
-      "child_static",
-      10n,
-      10n,
-      "/tf_static",
-    );
+    const staticMsg = createTransformStampedEvent("parent", "child_static", 10n, 10n, "/tf_static");
     renderer.addMessageEvent(regularMsg);
     renderer.addMessageEvent(staticMsg);
     renderer.animationFrame();
@@ -2228,9 +2216,7 @@ describe("Renderer static transform caching across message types", () => {
     renderer.animationFrame();
 
     // Attempt to add a cyclic *static* transform: child -> grandparent
-    renderer.addMessageEvent(
-      createTFMessageEvent("child", "grandparent", 3n, [3n], "/tf_static"),
-    );
+    renderer.addMessageEvent(createTFMessageEvent("child", "grandparent", 3n, [3n], "/tf_static"));
     renderer.animationFrame();
 
     // The cyclic transform should not have been cached, so a backward seek that
@@ -2239,10 +2225,7 @@ describe("Renderer static transform caching across message types", () => {
     renderer.handleSeek(100n);
 
     const grandparentFrame = renderer.transformTree.frame("grandparent");
-    expect(
-      grandparentFrame == undefined ||
-        grandparentFrame.parent()?.id !== "child",
-    ).toBe(true);
+    expect(grandparentFrame == undefined || grandparentFrame.parent()?.id !== "child").toBe(true);
 
     renderer.dispose();
   });

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -6,6 +6,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { FrameTransform, FrameTransforms } from "@foxglove/schemas";
 import { setupJestCanvasMock } from "jest-canvas-mock";
 
 import { CameraModelsMap } from "@lichtblick/den/image/types";
@@ -18,7 +19,7 @@ import { DEFAULT_CAMERA_STATE } from "@lichtblick/suite-base/panels/ThreeDeeRend
 import { HOVER_PICK_THROTTLE_MS } from "@lichtblick/suite-base/panels/ThreeDeeRender/constants";
 import { CameraStateSettings } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/CameraStateSettings";
 import { DEFAULT_PUBLISH_SETTINGS } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/PublishSettings";
-import { TFMessage } from "@lichtblick/suite-base/panels/ThreeDeeRender/ros";
+import { TFMessage, TransformStamped } from "@lichtblick/suite-base/panels/ThreeDeeRender/ros";
 import IAnalytics from "@lichtblick/suite-base/services/IAnalytics";
 import { BasicBuilder } from "@lichtblick/test-builders";
 
@@ -128,6 +129,73 @@ function createTFMessageEvent(
     schemaName: "tf2_msgs/TFMessage",
     message: {
       transforms: stampedTfs,
+    },
+    sizeInBytes: 0,
+  };
+}
+
+function createFrameTransformEvent(
+  parentId: string,
+  childId: string,
+  receiveTime: bigint,
+  stamp: bigint,
+  topic: string = "/tf",
+): MessageEvent<FrameTransform> {
+  return {
+    topic,
+    receiveTime: fromNanoSec(receiveTime),
+    schemaName: "foxglove.FrameTransform",
+    message: {
+      timestamp: fromNanoSec(stamp),
+      parent_frame_id: parentId,
+      child_frame_id: childId,
+      translation: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0, w: 1 },
+    },
+    sizeInBytes: 0,
+  };
+}
+
+function createFrameTransformsEvent(
+  transforms: { parentId: string; childId: string; stamp: bigint }[],
+  receiveTime: bigint,
+  topic: string = "/tf",
+): MessageEvent<FrameTransforms> {
+  return {
+    topic,
+    receiveTime: fromNanoSec(receiveTime),
+    schemaName: "foxglove.FrameTransforms",
+    message: {
+      transforms: transforms.map(({ parentId, childId, stamp }) => ({
+        timestamp: fromNanoSec(stamp),
+        parent_frame_id: parentId,
+        child_frame_id: childId,
+        translation: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0, w: 1 },
+      })),
+    },
+    sizeInBytes: 0,
+  };
+}
+
+function createTransformStampedEvent(
+  parentId: string,
+  childId: string,
+  receiveTime: bigint,
+  stamp: bigint,
+  topic: string = "/tf",
+): MessageEvent<TransformStamped> {
+  return {
+    topic,
+    receiveTime: fromNanoSec(receiveTime),
+    schemaName: "geometry_msgs/TransformStamped",
+    message: {
+      header: {
+        stamp: fromNanoSec(stamp),
+        frame_id: parentId,
+      },
+      child_frame_id: childId,
+      transform: makeTf(),
     },
     sizeInBytes: 0,
   };
@@ -2014,6 +2082,169 @@ describe("Renderer backward seek behavior", () => {
     const regularFrame = renderer.transformTree.frame("child_regular");
     expect(regularFrame == undefined || regularFrame.transformsSize() === 0).toBe(true);
     expect(renderer.transformTree.frame("child_static")?.transformsSize()).toBe(1);
+  });
+});
+
+describe("Renderer static transform caching across message types", () => {
+  let canvas = document.createElement("canvas");
+  let parent = document.createElement("div");
+  let rendererArgs: ConstructorParameters<typeof Renderer>[0] = {
+    ...defaultRendererProps,
+    canvas,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupJestCanvasMock();
+    parent = document.createElement("div");
+    canvas = document.createElement("canvas");
+    parent.appendChild(canvas);
+    rendererArgs = { ...defaultRendererProps, canvas };
+  });
+
+  afterEach(() => {
+    (console.warn as jest.Mock).mockClear();
+  });
+
+  it("caches and preserves static transforms received as foxglove.FrameTransform messages", () => {
+    const renderer = new Renderer({
+      ...rendererArgs,
+      config: {
+        ...defaultRendererConfig,
+        scene: { transforms: { enablePreloading: false } },
+      },
+    });
+
+    renderer.setCurrentTime(100n);
+    const regularMsg = createFrameTransformEvent("parent", "child_regular", 50n, 50n, "/tf");
+    const staticMsg = createFrameTransformEvent(
+      "parent",
+      "child_static",
+      10n,
+      10n,
+      "/tf_static",
+    );
+    renderer.addMessageEvent(regularMsg);
+    renderer.addMessageEvent(staticMsg);
+    renderer.animationFrame();
+
+    expect(renderer.transformTree.frame("child_regular")?.transformsSize()).toBe(1);
+    expect(renderer.transformTree.frame("child_static")?.transformsSize()).toBe(1);
+
+    renderer.setCurrentTime(20n);
+    renderer.handleSeek(100n);
+
+    const regularFrame = renderer.transformTree.frame("child_regular");
+    expect(regularFrame == undefined || regularFrame.transformsSize() === 0).toBe(true);
+    expect(renderer.transformTree.frame("child_static")?.transformsSize()).toBe(1);
+
+    renderer.dispose();
+  });
+
+  it("caches and preserves static transforms received as foxglove.FrameTransforms messages", () => {
+    const renderer = new Renderer({
+      ...rendererArgs,
+      config: {
+        ...defaultRendererConfig,
+        scene: { transforms: { enablePreloading: false } },
+      },
+    });
+
+    renderer.setCurrentTime(100n);
+    const regularMsg = createFrameTransformsEvent(
+      [{ parentId: "parent", childId: "child_regular", stamp: 50n }],
+      50n,
+      "/tf",
+    );
+    const staticMsg = createFrameTransformsEvent(
+      [{ parentId: "parent", childId: "child_static", stamp: 10n }],
+      10n,
+      "/tf_static",
+    );
+    renderer.addMessageEvent(regularMsg);
+    renderer.addMessageEvent(staticMsg);
+    renderer.animationFrame();
+
+    expect(renderer.transformTree.frame("child_regular")?.transformsSize()).toBe(1);
+    expect(renderer.transformTree.frame("child_static")?.transformsSize()).toBe(1);
+
+    renderer.setCurrentTime(20n);
+    renderer.handleSeek(100n);
+
+    const regularFrame = renderer.transformTree.frame("child_regular");
+    expect(regularFrame == undefined || regularFrame.transformsSize() === 0).toBe(true);
+    expect(renderer.transformTree.frame("child_static")?.transformsSize()).toBe(1);
+
+    renderer.dispose();
+  });
+
+  it("caches and preserves static transforms received as geometry_msgs/TransformStamped messages", () => {
+    const renderer = new Renderer({
+      ...rendererArgs,
+      config: {
+        ...defaultRendererConfig,
+        scene: { transforms: { enablePreloading: false } },
+      },
+    });
+
+    renderer.setCurrentTime(100n);
+    const regularMsg = createTransformStampedEvent("parent", "child_regular", 50n, 50n, "/tf");
+    const staticMsg = createTransformStampedEvent(
+      "parent",
+      "child_static",
+      10n,
+      10n,
+      "/tf_static",
+    );
+    renderer.addMessageEvent(regularMsg);
+    renderer.addMessageEvent(staticMsg);
+    renderer.animationFrame();
+
+    expect(renderer.transformTree.frame("child_regular")?.transformsSize()).toBe(1);
+    expect(renderer.transformTree.frame("child_static")?.transformsSize()).toBe(1);
+
+    renderer.setCurrentTime(20n);
+    renderer.handleSeek(100n);
+
+    const regularFrame = renderer.transformTree.frame("child_regular");
+    expect(regularFrame == undefined || regularFrame.transformsSize() === 0).toBe(true);
+    expect(renderer.transformTree.frame("child_static")?.transformsSize()).toBe(1);
+
+    renderer.dispose();
+  });
+
+  it("does not cache a static transform that is rejected as a cyclic edge", () => {
+    const renderer = new Renderer({
+      ...rendererArgs,
+      config: {
+        ...defaultRendererConfig,
+        scene: { transforms: { enablePreloading: false } },
+      },
+    });
+
+    // Build a chain: grandparent -> parent -> child
+    renderer.addMessageEvent(createTFMessageEvent("grandparent", "parent", 1n, [1n], "/tf"));
+    renderer.addMessageEvent(createTFMessageEvent("parent", "child", 2n, [2n], "/tf"));
+    renderer.animationFrame();
+
+    // Attempt to add a cyclic *static* transform: child -> grandparent
+    renderer.addMessageEvent(
+      createTFMessageEvent("child", "grandparent", 3n, [3n], "/tf_static"),
+    );
+    renderer.animationFrame();
+
+    // The cyclic transform should not have been cached, so a backward seek that
+    // preserves the static cache should not resurrect it.
+    renderer.setCurrentTime(100n);
+    renderer.handleSeek(0n);
+
+    const grandparentFrame = renderer.transformTree.frame("grandparent");
+    expect(
+      grandparentFrame == undefined ||
+        grandparentFrame.parent()?.id !== "child",
+    ).toBe(true);
+
+    renderer.dispose();
   });
 });
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -1949,6 +1949,38 @@ describe("Renderer backward seek behavior", () => {
     // Frame may exist but should have no transforms, or frame doesn't exist (both are valid)
     expect(frame == undefined || frame.transformsSize() === 0).toBe(true);
   });
+
+  it("preserves static transforms when seeking backward", () => {
+    // Given: A renderer
+    const renderer = new Renderer({
+      ...rendererArgs,
+      config: {
+        ...defaultRendererConfig,
+        scene: { transforms: { enablePreloading: false } },
+      },
+    });
+
+    // When: Adding regular and static transforms
+    renderer.setCurrentTime(100n);
+    const regularMsg = createTFMessageEvent("parent", "child_regular", 50n, [50n]);
+    const staticMsg = createTFMessageEvent("parent", "child_static", 10n, [10n], "/tf_static");
+    renderer.addMessageEvent(regularMsg);
+    renderer.addMessageEvent(staticMsg);
+    renderer.animationFrame();
+
+    // Verify both are present
+    expect(renderer.transformTree.frame("child_regular")?.transformsSize()).toBe(1);
+    expect(renderer.transformTree.frame("child_static")?.transformsSize()).toBe(1);
+
+    // When: Seeking backward
+    renderer.setCurrentTime(20n);
+    renderer.handleSeek(100n);
+
+    // Then: Regular transform should be cleared, static transform preserved
+    const regularFrame = renderer.transformTree.frame("child_regular");
+    expect(regularFrame == undefined || regularFrame.transformsSize() === 0).toBe(true);
+    expect(renderer.transformTree.frame("child_static")?.transformsSize()).toBe(1);
+  });
 });
 
 describe("Renderer batch message processing", () => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -159,6 +159,14 @@ Object.defineProperty(LabelMaterial.prototype, "fragmentShaderKey", {
   configurable: true,
 });
 
+type StaticTransform = {
+  parentFrameId: string;
+  childFrameId: string;
+  stamp: bigint;
+  translation: Vector3;
+  rotation: Quaternion;
+};
+
 /**
  * An extensible 3D renderer attached to a `HTMLCanvasElement`,
  * `WebGLRenderingContext`, and `SettingsTree`.
@@ -231,6 +239,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     maxCapacity: 5 * DEFAULT_MAX_CAPACITY_PER_FRAME,
   });
   public transformTree = new TransformTree(this.#transformPool);
+  #staticTransformCache = new Map<string, StaticTransform>();
 
   public coordinateFrameList: SelectEntry[] = [];
   public currentTime = 0n;
@@ -547,6 +556,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
       // Clear transforms after current time instead of clearing everything
       this.transformTree.clearAfter(this.currentTime);
+      this.#reapplyStaticTransforms();
 
       // Update cursor to new position
       this.#allFramesCursor = {
@@ -567,6 +577,15 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     } else {
       // Forward seek or no allFrames available - use original behavior
       this.clear({ clearTransforms: movedBack, resetAllFramesCursor: movedBack });
+      if (movedBack) {
+        this.#reapplyStaticTransforms();
+      }
+    }
+  }
+
+  #reapplyStaticTransforms(): void {
+    for (const { parentFrameId, childFrameId, stamp, translation, rotation } of this.#staticTransformCache.values()) {
+      this.addTransform(parentFrameId, childFrameId, stamp, translation, rotation);
     }
   }
 
@@ -1177,13 +1196,23 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   }
 
-  #addFrameTransform(transform: FrameTransform): void {
+  #addFrameTransform(transform: FrameTransform, isStatic = false): void {
     const parentId = transform.parent_frame_id;
     const childId = transform.child_frame_id;
     try {
       const stamp = toNanoSec(transform.timestamp);
       const t = transform.translation;
       const q = transform.rotation;
+
+      if (isStatic) {
+        this.#staticTransformCache.set(childId, {
+          parentFrameId: parentId,
+          childFrameId: childId,
+          stamp,
+          translation: t,
+          rotation: q,
+        });
+      }
 
       this.addTransform(parentId, childId, stamp, t, q);
     } catch (e: unknown) {
@@ -1196,13 +1225,23 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   }
 
-  #addTransformMessage(tf: TransformStamped): void {
+  #addTransformMessage(tf: TransformStamped, isStatic = false): void {
     const normalizedParentId = this.normalizeFrameId(tf.header.frame_id);
     const normalizedChildId = this.normalizeFrameId(tf.child_frame_id);
     try {
       const stamp = toNanoSec(tf.header.stamp);
       const t = tf.transform.translation;
       const q = tf.transform.rotation;
+
+      if (isStatic) {
+        this.#staticTransformCache.set(normalizedChildId, {
+          parentFrameId: normalizedParentId,
+          childFrameId: normalizedChildId,
+          stamp,
+          translation: t,
+          rotation: q,
+        });
+      }
 
       this.addTransform(normalizedParentId, normalizedChildId, stamp, t, q);
     } catch (e: unknown) {
@@ -1492,32 +1531,36 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.emit("renderableHovered", selections, cursorCoords, this);
   };
 
-  #handleFrameTransform = ({ message }: MessageEvent<DeepPartial<FrameTransform>>): void => {
+  #handleFrameTransform = ({ message, topic }: MessageEvent<DeepPartial<FrameTransform>>): void => {
     // foxglove.FrameTransform - Ingest this single transform into our TF tree
     const transform = normalizeFrameTransform(message);
-    this.#addFrameTransform(transform);
+    const isStatic = topic.endsWith("tf_static") || topic.endsWith("static_transform");
+    this.#addFrameTransform(transform, isStatic);
   };
 
-  #handleFrameTransforms = ({ message }: MessageEvent<DeepPartial<FrameTransforms>>): void => {
+  #handleFrameTransforms = ({ message, topic }: MessageEvent<DeepPartial<FrameTransforms>>): void => {
     // foxglove.FrameTransforms - Ingest the list of transforms into our TF tree
     const frameTransforms = normalizeFrameTransforms(message);
+    const isStatic = topic.endsWith("tf_static") || topic.endsWith("static_transform");
     for (const transform of frameTransforms.transforms) {
-      this.#addFrameTransform(transform);
+      this.#addFrameTransform(transform, isStatic);
     }
   };
 
-  #handleTFMessage = ({ message }: MessageEvent<DeepPartial<TFMessage>>): void => {
+  #handleTFMessage = ({ message, topic }: MessageEvent<DeepPartial<TFMessage>>): void => {
     // tf2_msgs/TFMessage - Ingest the list of transforms into our TF tree
     const tfMessage = normalizeTFMessage(message);
+    const isStatic = topic.endsWith("tf_static") || topic.endsWith("static_transform");
     for (const tf of tfMessage.transforms) {
-      this.#addTransformMessage(tf);
+      this.#addTransformMessage(tf, isStatic);
     }
   };
 
-  #handleTransformStamped = ({ message }: MessageEvent<DeepPartial<TransformStamped>>): void => {
+  #handleTransformStamped = ({ message, topic }: MessageEvent<DeepPartial<TransformStamped>>): void => {
     // geometry_msgs/TransformStamped - Ingest this single transform into our TF tree
     const tf = normalizeTransformStamped(message);
-    this.#addTransformMessage(tf);
+    const isStatic = topic.endsWith("tf_static") || topic.endsWith("static_transform");
+    this.#addTransformMessage(tf, isStatic);
   };
 
   #handleTopicsAction = (action: SettingsTreeAction): void => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -239,7 +239,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     maxCapacity: 5 * DEFAULT_MAX_CAPACITY_PER_FRAME,
   });
   public transformTree = new TransformTree(this.#transformPool);
-  #staticTransformCache = new Map<string, StaticTransform>();
+  readonly #staticTransformCache = new Map<string, StaticTransform>();
 
   public coordinateFrameList: SelectEntry[] = [];
   public currentTime = 0n;
@@ -576,7 +576,11 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       this.queueAnimationFrame();
     } else {
       // Forward seek or no allFrames available - use original behavior
-      this.clear({ clearTransforms: movedBack, resetAllFramesCursor: movedBack, preserveStaticTransforms: movedBack });
+      this.clear({
+        clearTransforms: movedBack,
+        resetAllFramesCursor: movedBack,
+        preserveStaticTransforms: movedBack,
+      });
       if (movedBack) {
         this.#reapplyStaticTransforms();
       }
@@ -584,7 +588,13 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   }
 
   #reapplyStaticTransforms(): void {
-    for (const { parentFrameId, childFrameId, stamp, translation, rotation } of this.#staticTransformCache.values()) {
+    for (const {
+      parentFrameId,
+      childFrameId,
+      stamp,
+      translation,
+      rotation,
+    } of this.#staticTransformCache.values()) {
       this.addTransform(parentFrameId, childFrameId, stamp, translation, rotation);
     }
   }
@@ -791,8 +801,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   }
 
-  // eslint-disable-next-line @lichtblick/no-boolean-parameters
-  #clearTransformTree = (preserveStaticTransforms?: boolean | IRenderer) => {
+  readonly #clearTransformTree = (preserveStaticTransforms?: boolean | IRenderer) => {
     this.transformTree.clear();
     if (preserveStaticTransforms !== true) {
       this.#staticTransformCache.clear();
@@ -1540,14 +1549,20 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.emit("renderableHovered", selections, cursorCoords, this);
   };
 
-  #handleFrameTransform = ({ message, topic }: MessageEvent<DeepPartial<FrameTransform>>): void => {
+  readonly #handleFrameTransform = ({
+    message,
+    topic,
+  }: MessageEvent<DeepPartial<FrameTransform>>): void => {
     // foxglove.FrameTransform - Ingest this single transform into our TF tree
     const transform = normalizeFrameTransform(message);
     const isStatic = topic.endsWith("tf_static") || topic.endsWith("static_transform");
     this.#addFrameTransform(transform, { isStatic });
   };
 
-  #handleFrameTransforms = ({ message, topic }: MessageEvent<DeepPartial<FrameTransforms>>): void => {
+  readonly #handleFrameTransforms = ({
+    message,
+    topic,
+  }: MessageEvent<DeepPartial<FrameTransforms>>): void => {
     // foxglove.FrameTransforms - Ingest the list of transforms into our TF tree
     const frameTransforms = normalizeFrameTransforms(message);
     const isStatic = topic.endsWith("tf_static") || topic.endsWith("static_transform");
@@ -1556,7 +1571,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   };
 
-  #handleTFMessage = ({ message, topic }: MessageEvent<DeepPartial<TFMessage>>): void => {
+  readonly #handleTFMessage = ({ message, topic }: MessageEvent<DeepPartial<TFMessage>>): void => {
     // tf2_msgs/TFMessage - Ingest the list of transforms into our TF tree
     const tfMessage = normalizeTFMessage(message);
     const isStatic = topic.endsWith("tf_static") || topic.endsWith("static_transform");
@@ -1565,7 +1580,10 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   };
 
-  #handleTransformStamped = ({ message, topic }: MessageEvent<DeepPartial<TransformStamped>>): void => {
+  readonly #handleTransformStamped = ({
+    message,
+    topic,
+  }: MessageEvent<DeepPartial<TransformStamped>>): void => {
     // geometry_msgs/TransformStamped - Ingest this single transform into our TF tree
     const tf = normalizeTransformStamped(message);
     const isStatic = topic.endsWith("tf_static") || topic.endsWith("static_transform");

--- a/packages/suite-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -576,7 +576,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       this.queueAnimationFrame();
     } else {
       // Forward seek or no allFrames available - use original behavior
-      this.clear({ clearTransforms: movedBack, resetAllFramesCursor: movedBack });
+      this.clear({ clearTransforms: movedBack, resetAllFramesCursor: movedBack, preserveStaticTransforms: movedBack });
       if (movedBack) {
         this.#reapplyStaticTransforms();
       }
@@ -601,24 +601,28 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
    * @param {boolean} params.resetAllFramesCursor - whether to reset the cursor for the allFrames array.
    * Order to clear ImageMode renderables or not. Defaults to true. Not relevant in 3D panel.
    * @param {boolean} params.clearImageModeExtension - whether to reset ImageMode renderables in clear.
+   * @param {boolean} params.preserveStaticTransforms - whether to preserve the static transform cache during a transform tree clear.
    */
   public clear(
     {
       clearTransforms,
       resetAllFramesCursor,
       clearImageModeExtension = true,
+      preserveStaticTransforms = false,
     }: {
       clearTransforms?: boolean;
       resetAllFramesCursor?: boolean;
       clearImageModeExtension?: boolean;
+      preserveStaticTransforms?: boolean;
     } = {
       clearTransforms: false,
       resetAllFramesCursor: false,
+      preserveStaticTransforms: false,
     },
   ): void {
     this.#clearSubscriptionQueues();
     if (clearTransforms === true) {
-      this.#clearTransformTree();
+      this.#clearTransformTree(preserveStaticTransforms);
     }
     if (resetAllFramesCursor === true) {
       this.#resetAllFramesCursor();
@@ -787,8 +791,12 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   }
 
-  #clearTransformTree = () => {
+  // eslint-disable-next-line @lichtblick/no-boolean-parameters
+  #clearTransformTree = (preserveStaticTransforms?: boolean | IRenderer) => {
     this.transformTree.clear();
+    if (preserveStaticTransforms !== true) {
+      this.#staticTransformCache.clear();
+    }
   };
 
   // Call on scene extensions to add subscriptions to the renderer
@@ -1196,7 +1204,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   }
 
-  #addFrameTransform(transform: FrameTransform, isStatic = false): void {
+  #addFrameTransform(transform: FrameTransform, options?: { isStatic?: boolean }): void {
     const parentId = transform.parent_frame_id;
     const childId = transform.child_frame_id;
     try {
@@ -1204,7 +1212,9 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       const t = transform.translation;
       const q = transform.rotation;
 
-      if (isStatic) {
+      const result = this.addTransform(parentId, childId, stamp, t, q);
+
+      if (options?.isStatic === true && result !== AddTransformResult.CYCLE_DETECTED) {
         this.#staticTransformCache.set(childId, {
           parentFrameId: parentId,
           childFrameId: childId,
@@ -1213,8 +1223,6 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
           rotation: q,
         });
       }
-
-      this.addTransform(parentId, childId, stamp, t, q);
     } catch (e: unknown) {
       const err = e as Error;
       this.settings.errors.add(
@@ -1225,7 +1233,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   }
 
-  #addTransformMessage(tf: TransformStamped, isStatic = false): void {
+  #addTransformMessage(tf: TransformStamped, options?: { isStatic?: boolean }): void {
     const normalizedParentId = this.normalizeFrameId(tf.header.frame_id);
     const normalizedChildId = this.normalizeFrameId(tf.child_frame_id);
     try {
@@ -1233,7 +1241,9 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       const t = tf.transform.translation;
       const q = tf.transform.rotation;
 
-      if (isStatic) {
+      const result = this.addTransform(normalizedParentId, normalizedChildId, stamp, t, q);
+
+      if (options?.isStatic === true && result !== AddTransformResult.CYCLE_DETECTED) {
         this.#staticTransformCache.set(normalizedChildId, {
           parentFrameId: normalizedParentId,
           childFrameId: normalizedChildId,
@@ -1242,8 +1252,6 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
           rotation: q,
         });
       }
-
-      this.addTransform(normalizedParentId, normalizedChildId, stamp, t, q);
     } catch (e: unknown) {
       const err = e as Error;
       this.settings.errors.add(
@@ -1262,7 +1270,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     translation: Vector3,
     rotation: Quaternion,
     errorSettingsPath?: string[],
-  ): void {
+  ): AddTransformResult {
     const t = translation;
     const q = rotation;
 
@@ -1309,6 +1317,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
         `[Warning] Transform history is at capacity (${frame.maxCapacity}), old TFs will be dropped`,
       );
     }
+    return status;
   }
 
   public removeTransform(childFrameId: string, parentFrameId: string, stamp: bigint): void {
@@ -1535,7 +1544,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     // foxglove.FrameTransform - Ingest this single transform into our TF tree
     const transform = normalizeFrameTransform(message);
     const isStatic = topic.endsWith("tf_static") || topic.endsWith("static_transform");
-    this.#addFrameTransform(transform, isStatic);
+    this.#addFrameTransform(transform, { isStatic });
   };
 
   #handleFrameTransforms = ({ message, topic }: MessageEvent<DeepPartial<FrameTransforms>>): void => {
@@ -1543,7 +1552,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     const frameTransforms = normalizeFrameTransforms(message);
     const isStatic = topic.endsWith("tf_static") || topic.endsWith("static_transform");
     for (const transform of frameTransforms.transforms) {
-      this.#addFrameTransform(transform, isStatic);
+      this.#addFrameTransform(transform, { isStatic });
     }
   };
 
@@ -1552,7 +1561,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     const tfMessage = normalizeTFMessage(message);
     const isStatic = topic.endsWith("tf_static") || topic.endsWith("static_transform");
     for (const tf of tfMessage.transforms) {
-      this.#addTransformMessage(tf, isStatic);
+      this.#addTransformMessage(tf, { isStatic });
     }
   };
 
@@ -1560,7 +1569,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     // geometry_msgs/TransformStamped - Ingest this single transform into our TF tree
     const tf = normalizeTransformStamped(message);
     const isStatic = topic.endsWith("tf_static") || topic.endsWith("static_transform");
-    this.#addTransformMessage(tf, isStatic);
+    this.#addTransformMessage(tf, { isStatic });
   };
 
   #handleTopicsAction = (action: SettingsTreeAction): void => {


### PR DESCRIPTION
In ROS2, /tf_static publishes transforms that are permanently valid — they are latched and apply for all time. Unlike /tf which has time-stamped transforms that are valid only around a specific moment, static transforms are typically stored in the TransformTree with the header timestamp of the message (e.g., t=0 or the time the robot was turned on).

When the user seeks backward in a log, the current code calls transformTree.clearAfter(currentTime), which removes all transform entries with a timestamp greater than the new seek target. This is correct for dynamic /tf transforms (future transforms should be discarded), but it incorrectly removes static transforms that were stamped at a time before the new seek target — because clearAfter operates on header stamp times stored in the transform history, not the message receive time.

## User-Facing Changes

Fixes an issue in the 3D panel where static transform (`/tf_static`) information would disappear when seeking backward on the time slider during log playback.

## Description

When scrubbing the time slider backward, the `Renderer`'s `handleSeek` method clears future transforms from the `TransformTree` (or resets the entire tree depending on preloading settings) to avoid rendering future state. 

However, because static transforms in ROS (`/tf_static`) are latched and permanently valid, clearing them during a backward seek breaks the 3D visualization. Players often only backfill messages from the *current* frame after a seek, meaning historical static transforms are not re-published, leaving the tree missing static frames.

This PR implements a caching mechanism inside the `Renderer`:
- Transforms originating from topics ending in `tf_static` or `static_transform` are flagged during ingestion and cached in a new `#staticTransformCache` Map.
- Immediately after clearing the `transformTree` during a backward seek, a new `#reapplyStaticTransforms` method restores all cached static transforms.
- Added a new unit test in `Renderer.test.ts` to ensure static transforms are successfully preserved on backward seeks.

## How to Test

### Automated
- Run the updated unit tests: `yarn jest Renderer.test.ts` (or the specific test path in `packages/suite-base/src/panels/ThreeDeeRender/Renderer.test.ts`). New/updated cases cover backward seeks with and without `allFrames` preloading, across `/tf`, `/tf_static`, `foxglove.FrameTransform`, `foxglove.FrameTransforms`, and `geometry_msgs/TransformStamped` message types, plus a case confirming a transform rejected as a cyclic edge is never cached.

### Manual verification
1. Load a log file (bag/mcap) that publishes both a `/tf` (or equivalent dynamic transform topic) and a `/tf_static` (or `static_transform`) topic, in the 3D panel.
2. Play the log forward a few seconds so multiple dynamic transforms have been ingested, and confirm the static frames (e.g. sensor mounts, base_link → sensor frames) render correctly.
3. Drag the time slider **backward** to a point earlier in the log.
4. **Expected (fixed behavior):** the 3D scene continues to render the static frames correctly — no missing/disconnected static transforms, no "frame not found" errors in the panel's error list.
   **Previous (buggy) behavior:** static frames would disappear or the scene would show transform errors after seeking backward, because `/tf_static` transforms were cleared along with the dynamic ones.
5. Repeat the above with **transform preloading enabled and disabled** (`scene.transforms.enablePreloading` in panel settings), since the seek path differs between the binary-search/`allFrames` code path and the standard `clear()` path — both should preserve static transforms.
6. Seek backward multiple times in a row, and also seek all the way to the start of the log, to confirm static transforms are never lost regardless of how many times the tree is cleared.
7. As a regression check, load a log/scenario with a transform tree cycle (or intentionally malformed static transform data) and confirm the existing cycle-detection error still appears and the cyclic transform is not incorrectly cached/resurrected on a later seek.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backward seeking in the 3D renderer by caching and restoring static TF transforms, preventing static TF relationships from being lost during scene resets.
  * Ensures static transforms are preserved appropriately across different incoming static TF message formats and seeking/preloading scenarios.

* **Tests**
  * Expanded backward-seek Jest coverage for both `/tf` and `/tf_static`, including preloading variations.
  * Added caching/regression tests across multiple static TF message types and verified cyclic static transforms are not cached or restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

