### PR TITLE
Protobuf message field names are now preserved in their original snake_case format

### DIFF
--- a/packages/mcap-support/src/parseProtobufSchema.ts
+++ b/packages/mcap-support/src/parseProtobufSchema.ts
@@ -25,7 +25,9 @@ export function parseProtobufSchema(
   deserialize: (buffer: ArrayBufferView) => unknown;
 } {
   // `Root.fromDescriptor` accepts the raw FileDescriptorSet bytes and decodes them internally.
-  const root = protobufjs.Root.fromDescriptor(schemaData);
+  // `keepCase: true` preserves the original proto field names (snake_case) instead of converting
+  // them to camelCase (the protobufjs v8 default), which would break existing layouts and paths.
+  const root = protobufjs.Root.fromDescriptor(schemaData, { keepCase: true });
   root.resolveAll();
   const rootType = root.lookupType(schemaName);
 


### PR DESCRIPTION
## User-Facing Changes

Protobuf message field names are now preserved in their original snake_case format (e.g. `lane_validation_word_test`) instead of being converted to camelCase (`laneValidationWordTest`). This restores the behavior from before the protobufjs v8 upgrade and fixes broken layouts that reference fields by path.

## Description

The protobufjs bump from 7.2.5 to 8.6.5 (#1173) introduced a breaking change: `Root.fromDescriptor()` now defaults `keepCase` to `false`, which converts all proto field names to their JSON (camelCase) representation. This broke any saved layout referencing protobuf fields by their original snake_case names (plots, raw messages, state transitions, etc.).

The fix passes `{ keepCase: true }` to `Root.fromDescriptor()` to preserve the original `.proto` field names.

Fixes the regression introduced in #1173.

## Checklist

- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved original protobuf field names, including snake_case names, when reading schemas.
  * Prevented existing layouts and data paths from being altered during protobuf deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->