### PR TITLE
Fix packaging regression that doubles Lichtblick artifacts size

### DIFF
--- a/packages/suite-desktop/src/electronBuilderConfig.js
+++ b/packages/suite-desktop/src/electronBuilderConfig.js
@@ -18,6 +18,7 @@ function makeElectronBuilderConfig(params) {
     appId: "dev.lichtblick.suite",
     npmRebuild: false,
     asar: true,
+    files: ["**/*", "!**/node_modules/**"],
     directories: {
       app: params.appPath,
       buildResources: path.join(__dirname, "../resources"),


### PR DESCRIPTION
## User-Facing Changes

<!-- will be used as a changelog entry -->
Fixed a packaging regression that caused Lichtblick desktop release artifacts (Linux `.deb`/`.tar.gz`, Windows `nsis`, macOS `.dmg`) to more than double in size (e.g. amd64 `.deb`: 107MB → 229MB). Desktop app downloads are now back to their expected size.

## Description

Between v1.26.0 and v1.27.0, the packaged `app.asar` grew from ~191MB to ~636MB because a `node_modules/` folder (~482MB) was being bundled into the app that shouldn't have been there. It included:

- `node_modules/desktop` and `node_modules/web` — entire sibling monorepo workspace source trees (including build output and test folders)
- devDependencies never needed at runtime: `typescript`, `@babel`, `node-gyp`, `tar`, `cacache`

Root cause: the Yarn 3.6.3 → 4.17.0 upgrade changed workspace hoisting/symlinking behavior under `nodeLinker: node-modules`, which caused `electron-builder`'s automatic dependency collector (no explicit `files` allowlist was configured) to bundle directories it previously skipped.

This affects all platform targets sharing this config ( linux ,  win ,  mac ), since  app.asar  is built once and reused across them.



## Checklist

- [ ] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated     now fill this for me and give to me in md format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop application packaging to include all required application files while excluding unnecessary dependency folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->