### PR TITLE
feature: Add smart preload setting in 3D panel

### DIFF
--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.test.tsx
@@ -1327,5 +1327,51 @@ describe("ThreeDeeRender", () => {
         expect(lastRendererPreloading()).toBe(false);
       });
     });
+
+    it("should preserve a manual toggle across renders with the same transform-topic presence", async () => {
+      // Given a persistent renderer instance so configChange (a user toggle) can be emitted across
+      // the renderer re-creations that happen when enablePreloading flips.
+      const persistentRenderer = createMockRenderer();
+      mockedRenderer.mockImplementation(() => persistentRenderer as unknown as Renderer);
+
+      const mockContext = createMockContext();
+      const props = setup({}, mockContext);
+      render(<ThreeDeeRender {...props} />);
+      await waitFor(() => {
+        expect(mockContext.onRender).toBeDefined();
+      });
+
+      // Transform topics auto-enable preloading.
+      act(() => {
+        mockContext.onRender!({ topics: [tfTopic, plainTopic] }, jest.fn());
+      });
+      await waitFor(() => {
+        expect(lastRendererPreloading()).toBe(true);
+      });
+
+      // When the user manually disables preloading (simulated via a configChange event).
+      const currentConfig = mockedRenderer.mock.calls.at(-1)![0].config;
+      persistentRenderer.config = {
+        ...currentConfig,
+        scene: {
+          ...currentConfig.scene,
+          transforms: { ...currentConfig.scene.transforms, enablePreloading: false },
+        },
+      };
+      act(() => {
+        persistentRenderer.emit("configChange", persistentRenderer);
+      });
+      await waitFor(() => {
+        expect(lastRendererPreloading()).toBe(false);
+      });
+
+      // And subsequent renders arrive with the same transform-topic presence.
+      act(() => {
+        mockContext.onRender!({ topics: [tfTopic, plainTopic] }, jest.fn());
+      });
+
+      // Then the manual choice is preserved and not overwritten back to true.
+      expect(lastRendererPreloading()).toBe(false);
+    });
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.test.tsx
@@ -21,6 +21,7 @@ import type { MessageEvent } from "@lichtblick/suite-base/players/types";
 import MessageEventBuilder from "@lichtblick/suite-base/testing/builders/MessageEventBuilder";
 import RenderStateBuilder from "@lichtblick/suite-base/testing/builders/RenderStateBuilder";
 
+import type { RendererConfig } from "./IRenderer";
 import { Renderer } from "./Renderer";
 import { ThreeDeeRender } from "./ThreeDeeRender";
 import { DEFAULT_CAMERA_STATE } from "./camera";
@@ -1250,6 +1251,80 @@ describe("ThreeDeeRender", () => {
         );
         const seekCall = customRendererInstance.handleSeek.mock.calls[0];
         expect(seekCall?.[1]).toHaveLength(50);
+      });
+    });
+  });
+
+  describe("auto transform preloading", () => {
+    const tfTopic = RenderStateBuilder.topic({ name: "/tf", schemaName: "tf2_msgs/TFMessage" });
+    const plainTopic = RenderStateBuilder.topic({
+      name: "/other",
+      schemaName: "std_msgs/String",
+    });
+
+    // The renderer is re-created whenever `enablePreloading` flips, so the config passed to the most
+    // recent Renderer construction reflects the current value of the setting.
+    const lastRendererPreloading = (): boolean | undefined =>
+      (mockedRenderer.mock.calls.at(-1)?.[0] as { config: RendererConfig } | undefined)?.config
+        .scene.transforms?.enablePreloading;
+
+    it("should enable preloading when a transform topic is present", async () => {
+      // Given
+      const mockContext = createMockContext();
+      const props = setup({}, mockContext);
+      render(<ThreeDeeRender {...props} />);
+      await waitFor(() => {
+        expect(mockContext.onRender).toBeDefined();
+      });
+
+      // When
+      act(() => {
+        mockContext.onRender!({ topics: [tfTopic, plainTopic] }, jest.fn());
+      });
+
+      // Then
+      await waitFor(() => {
+        expect(lastRendererPreloading()).toBe(true);
+      });
+    });
+
+    it("should keep preloading disabled when no transform topic is present", async () => {
+      // Given
+      const mockContext = createMockContext();
+      const props = setup({}, mockContext);
+      render(<ThreeDeeRender {...props} />);
+      await waitFor(() => {
+        expect(mockContext.onRender).toBeDefined();
+      });
+
+      // When
+      act(() => {
+        mockContext.onRender!({ topics: [plainTopic] }, jest.fn());
+      });
+
+      // Then
+      expect(lastRendererPreloading()).not.toBe(true);
+    });
+
+    it("should reset preloading to false when switching to a source without transform topics", async () => {
+      // Given
+      const mockContext = createMockContext({
+        initialState: { scene: { transforms: { enablePreloading: true } } },
+      });
+      const props = setup({}, mockContext);
+      render(<ThreeDeeRender {...props} />);
+      await waitFor(() => {
+        expect(mockContext.onRender).toBeDefined();
+      });
+
+      // When
+      act(() => {
+        mockContext.onRender!({ topics: [plainTopic] }, jest.fn());
+      });
+
+      // Then
+      await waitFor(() => {
+        expect(lastRendererPreloading()).toBe(false);
       });
     });
   });

--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -43,6 +43,7 @@ import { RendererContext, useRendererEvent, useRendererProperty } from "./Render
 import { RendererOverlay } from "./RendererOverlay";
 import { useStyles } from "./ThreeDeeRender.style";
 import { CameraState, DEFAULT_CAMERA_STATE } from "./camera";
+import { FRAME_TRANSFORM_DATATYPES, FRAME_TRANSFORMS_DATATYPES } from "./foxglove";
 import {
   PublishRos1Datatypes,
   PublishRos2Datatypes,
@@ -53,9 +54,21 @@ import {
 import type { LayerSettingsTransform } from "./renderables/FrameAxes";
 import { PublishClickEventMap } from "./renderables/PublishClickTool";
 import { DEFAULT_PUBLISH_SETTINGS } from "./renderables/PublishSettings";
+import { TF_DATATYPES, TRANSFORM_STAMPED_DATATYPES } from "./ros";
 import { Shared3DPanelState, ThreeDeeRenderProps } from "./types";
 
 const log = Logger.getLogger(__filename);
+
+/**
+ * Schemas that carry coordinate frame transforms. Topics with one of these schemas generally
+ * require preloading so that transforms are available across the whole playback range.
+ */
+const TRANSFORM_TOPIC_SCHEMAS = new Set<string>([
+  ...FRAME_TRANSFORM_DATATYPES,
+  ...FRAME_TRANSFORMS_DATATYPES,
+  ...TF_DATATYPES,
+  ...TRANSFORM_STAMPED_DATATYPES,
+]);
 
 /**
  * A panel that renders a 3D scene. This is a thin wrapper around a `Renderer` instance.
@@ -360,6 +373,30 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
       renderRef.current.needsRender = true;
     }
   }, [topics, renderer]);
+
+  // Preloading is disabled by default, but transform topics generally need to be preloaded to render correctly.
+  // Whenever the presence of transform topics changes (e.g. a new data source is loaded), we enable preloading
+  // if the source exposes transform topics and disable it otherwise. Because we only react to that
+  // presence flipping, a manual toggle by the user within the same data source is preserved.
+  const hasTransformTopics = useMemo(
+    () => topics?.some((topic) => TRANSFORM_TOPIC_SCHEMAS.has(topic.schemaName)),
+    [topics],
+  );
+  const [prevHasTransformTopics, setPrevHasTransformTopics] = useState<boolean | undefined>(
+    undefined,
+  );
+  if (hasTransformTopics != undefined && hasTransformTopics !== prevHasTransformTopics) {
+    setPrevHasTransformTopics(hasTransformTopics);
+    if ((config.scene.transforms?.enablePreloading ?? false) !== hasTransformTopics) {
+      setConfig((prevConfig) => ({
+        ...prevConfig,
+        scene: {
+          ...prevConfig.scene,
+          transforms: { ...prevConfig.scene.transforms, enablePreloading: hasTransformTopics },
+        },
+      }));
+    }
+  }
 
   // Tell the renderer if we are connected to a ROS data source
   useEffect(() => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -374,29 +374,34 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
     }
   }, [topics, renderer]);
 
+  // Keep transform preloading in sync with the current data source.
   // Preloading is disabled by default, but transform topics generally need to be preloaded to render correctly.
   // Whenever the presence of transform topics changes (e.g. a new data source is loaded), we enable preloading
   // if the source exposes transform topics and disable it otherwise. Because we only react to that
   // presence flipping, a manual toggle by the user within the same data source is preserved.
+  const topicsLoaded = topics != undefined;
   const hasTransformTopics = useMemo(
-    () => topics?.some((topic) => TRANSFORM_TOPIC_SCHEMAS.has(topic.schemaName)),
+    () => topics?.some((topic) => TRANSFORM_TOPIC_SCHEMAS.has(topic.schemaName)) ?? false,
     [topics],
   );
-  const [prevHasTransformTopics, setPrevHasTransformTopics] = useState<boolean | undefined>(
-    undefined,
-  );
-  if (hasTransformTopics != undefined && hasTransformTopics !== prevHasTransformTopics) {
-    setPrevHasTransformTopics(hasTransformTopics);
-    if ((config.scene.transforms?.enablePreloading ?? false) !== hasTransformTopics) {
-      setConfig((prevConfig) => ({
-        ...prevConfig,
-        scene: {
-          ...prevConfig.scene,
-          transforms: { ...prevConfig.scene.transforms, enablePreloading: hasTransformTopics },
-        },
-      }));
+  const prevHasTransformTopicsRef = useRef<boolean | undefined>(undefined);
+  useEffect(() => {
+    if (!topicsLoaded || prevHasTransformTopicsRef.current === hasTransformTopics) {
+      return;
     }
-  }
+    prevHasTransformTopicsRef.current = hasTransformTopics;
+
+    if ((config.scene.transforms?.enablePreloading ?? false) === hasTransformTopics) {
+      return;
+    }
+    setConfig((prevConfig) => ({
+      ...prevConfig,
+      scene: {
+        ...prevConfig.scene,
+        transforms: { ...prevConfig.scene.transforms, enablePreloading: hasTransformTopics },
+      },
+    }));
+  }, [topicsLoaded, hasTransformTopics, config.scene.transforms?.enablePreloading]);
 
   // Tell the renderer if we are connected to a ROS data source
   useEffect(() => {


### PR DESCRIPTION
## User-Facing Changes
Enhance the preloading behavior for transform topics in the 3D renderer.

## Description
Implement smarter preloading logic that automatically enables preloading when transform topics are present and preserves user manual toggles across renders. 

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 3D rendering performance by automatically enabling transform preloading when supported transform topics are available.
  * Preloading now disables when no transform topics are present or when switching data sources.
  * Preserved manually selected preloading settings across renderer updates and recreations.
  * Added broader support for transform topic types to ensure preloading behavior remains consistent across compatible data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->