### PR TITLE
chore(deps): bump @foxglove/schemas from 1.9.0 to 1.13.0

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -5,7 +5,7 @@
     "@lichtblick/suite-base": "workspace:*"
   },
   "devDependencies": {
-    "@foxglove/schemas": "1.9.0",
+    "@foxglove/schemas": "1.13.0",
     "@lichtblick/den": "workspace:*",
     "@lichtblick/log": "workspace:*",
     "@lichtblick/rostime": "1.0.0",

--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -25,7 +25,7 @@
     "typescript": "6.0.3"
   },
   "dependencies": {
-    "@foxglove/schemas": "1.9.0",
+    "@foxglove/schemas": "1.13.0",
     "@lichtblick/message-definition": "1.0.0",
     "@lichtblick/omgidl-parser": "1.0.0",
     "@lichtblick/omgidl-serialization": "1.0.0",

--- a/packages/suite-base/package.json
+++ b/packages/suite-base/package.json
@@ -20,7 +20,7 @@
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@fluentui/react-icons": "2.0.308",
-    "@foxglove/schemas": "1.9.0",
+    "@foxglove/schemas": "1.13.0",
     "@foxglove/ws-protocol": "0.8.0",
     "@lichtblick/avl": "1.0.0",
     "@lichtblick/chartjs-plugin-zoom": "1.0.0",

--- a/packages/suite-base/src/components/TopicList/getMessagePathSearchItems.test.ts
+++ b/packages/suite-base/src/components/TopicList/getMessagePathSearchItems.test.ts
@@ -204,10 +204,7 @@ describe("getMessagePathSearchItems", () => {
     ]);
 
     expect(
-      getMessagePathSearchItems(
-        [{ name: "foo", schemaName: "Foo" }],
-        schemasByName,
-      ).items,
+      getMessagePathSearchItems([{ name: "foo", schemaName: "Foo" }], schemasByName).items,
     ).toEqual([
       {
         topic: { name: "foo", schemaName: "Foo" },
@@ -230,10 +227,7 @@ describe("getMessagePathSearchItems", () => {
     ]);
 
     expect(
-      getMessagePathSearchItems(
-        [{ name: "bar", schemaName: "Bar" }],
-        schemasByName,
-      ).items,
+      getMessagePathSearchItems([{ name: "bar", schemaName: "Bar" }], schemasByName).items,
     ).toEqual([
       {
         topic: { name: "bar", schemaName: "Bar" },
@@ -268,10 +262,8 @@ describe("getMessagePathSearchItems", () => {
     ]);
 
     expect(
-      getMessagePathSearchItems(
-        [{ name: "foo with spaces", schemaName: "Foo" }],
-        schemasByName,
-      ).items,
+      getMessagePathSearchItems([{ name: "foo with spaces", schemaName: "Foo" }], schemasByName)
+        .items,
     ).toEqual([
       {
         topic: { name: "foo with spaces", schemaName: "Foo" },

--- a/packages/suite-base/src/components/TopicList/getMessagePathSearchItems.test.ts
+++ b/packages/suite-base/src/components/TopicList/getMessagePathSearchItems.test.ts
@@ -98,13 +98,21 @@ describe("getMessagePathSearchItems", () => {
       {
         topic: { name: "foo1", schemaName: "Foo" },
         fullPath: "foo1.bar.str_array",
-        suffix: { pathSuffix: ".bar.str_array", type: "string[]", isLeaf: true },
+        suffix: {
+          pathSuffix: ".bar.str_array",
+          type: "string[]",
+          isLeaf: true,
+        },
         offset: 4,
       },
       {
         topic: { name: "foo2", schemaName: "Foo" },
         fullPath: "foo2.bar.str_array",
-        suffix: { pathSuffix: ".bar.str_array", type: "string[]", isLeaf: true },
+        suffix: {
+          pathSuffix: ".bar.str_array",
+          type: "string[]",
+          isLeaf: true,
+        },
         offset: 4,
       },
       {
@@ -122,25 +130,41 @@ describe("getMessagePathSearchItems", () => {
       {
         topic: { name: "foo1", schemaName: "Foo" },
         fullPath: "foo1.bar_array[:].str",
-        suffix: { pathSuffix: ".bar_array[:].str", type: "string", isLeaf: true },
+        suffix: {
+          pathSuffix: ".bar_array[:].str",
+          type: "string",
+          isLeaf: true,
+        },
         offset: 4,
       },
       {
         topic: { name: "foo2", schemaName: "Foo" },
         fullPath: "foo2.bar_array[:].str",
-        suffix: { pathSuffix: ".bar_array[:].str", type: "string", isLeaf: true },
+        suffix: {
+          pathSuffix: ".bar_array[:].str",
+          type: "string",
+          isLeaf: true,
+        },
         offset: 4,
       },
       {
         topic: { name: "foo1", schemaName: "Foo" },
         fullPath: "foo1.bar_array[:].str_array",
-        suffix: { pathSuffix: ".bar_array[:].str_array", type: "string[]", isLeaf: true },
+        suffix: {
+          pathSuffix: ".bar_array[:].str_array",
+          type: "string[]",
+          isLeaf: true,
+        },
         offset: 4,
       },
       {
         topic: { name: "foo2", schemaName: "Foo" },
         fullPath: "foo2.bar_array[:].str_array",
-        suffix: { pathSuffix: ".bar_array[:].str_array", type: "string[]", isLeaf: true },
+        suffix: {
+          pathSuffix: ".bar_array[:].str_array",
+          type: "string[]",
+          isLeaf: true,
+        },
         offset: 4,
       },
       {
@@ -180,7 +204,10 @@ describe("getMessagePathSearchItems", () => {
     ]);
 
     expect(
-      getMessagePathSearchItems([{ name: "foo", schemaName: "Foo" }], schemasByName).items,
+      getMessagePathSearchItems(
+        [{ name: "foo", schemaName: "Foo" }],
+        schemasByName,
+      ).items,
     ).toEqual([
       {
         topic: { name: "foo", schemaName: "Foo" },
@@ -203,7 +230,10 @@ describe("getMessagePathSearchItems", () => {
     ]);
 
     expect(
-      getMessagePathSearchItems([{ name: "bar", schemaName: "Bar" }], schemasByName).items,
+      getMessagePathSearchItems(
+        [{ name: "bar", schemaName: "Bar" }],
+        schemasByName,
+      ).items,
     ).toEqual([
       {
         topic: { name: "bar", schemaName: "Bar" },
@@ -238,8 +268,10 @@ describe("getMessagePathSearchItems", () => {
     ]);
 
     expect(
-      getMessagePathSearchItems([{ name: "foo with spaces", schemaName: "Foo" }], schemasByName)
-        .items,
+      getMessagePathSearchItems(
+        [{ name: "foo with spaces", schemaName: "Foo" }],
+        schemasByName,
+      ).items,
     ).toEqual([
       {
         topic: { name: "foo with spaces", schemaName: "Foo" },
@@ -266,814 +298,1009 @@ describe("getMessagePathSearchItems", () => {
         datatypes,
       ).items,
     ).toMatchInlineSnapshot(`
-      [
-        {
-          "fullPath": "annotations.circles",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".circles",
-            "type": "foxglove.ImageAnnotations.circles[]",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].timestamp",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".circles[:].timestamp",
-            "type": "foxglove.ImageAnnotations.circles.timestamp",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].timestamp.sec",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].timestamp.sec",
-            "type": "uint32",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].timestamp.nsec",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].timestamp.nsec",
-            "type": "uint32",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].position",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".circles[:].position",
-            "type": "foxglove.ImageAnnotations.circles.position",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].position.x",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].position.x",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].position.y",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].position.y",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].diameter",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].diameter",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].thickness",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].thickness",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].fill_color",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".circles[:].fill_color",
-            "type": "foxglove.ImageAnnotations.circles.fill_color",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].fill_color.r",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].fill_color.r",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].fill_color.g",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].fill_color.g",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].fill_color.b",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].fill_color.b",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].fill_color.a",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].fill_color.a",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].outline_color",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".circles[:].outline_color",
-            "type": "foxglove.ImageAnnotations.circles.outline_color",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].outline_color.r",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].outline_color.r",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].outline_color.g",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].outline_color.g",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].outline_color.b",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].outline_color.b",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.circles[:].outline_color.a",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".circles[:].outline_color.a",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".points",
-            "type": "foxglove.ImageAnnotations.points[]",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].timestamp",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".points[:].timestamp",
-            "type": "foxglove.ImageAnnotations.points.timestamp",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].timestamp.sec",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].timestamp.sec",
-            "type": "uint32",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].timestamp.nsec",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].timestamp.nsec",
-            "type": "uint32",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].type",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].type",
-            "type": "uint32",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].points",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".points[:].points",
-            "type": "foxglove.ImageAnnotations.points.points[]",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].points[:].x",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].points[:].x",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].points[:].y",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].points[:].y",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].outline_color",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".points[:].outline_color",
-            "type": "foxglove.ImageAnnotations.points.outline_color",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].outline_color.r",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].outline_color.r",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].outline_color.g",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].outline_color.g",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].outline_color.b",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].outline_color.b",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].outline_color.a",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].outline_color.a",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].outline_colors",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".points[:].outline_colors",
-            "type": "foxglove.ImageAnnotations.points.outline_colors[]",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].outline_colors[:].r",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].outline_colors[:].r",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].outline_colors[:].g",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].outline_colors[:].g",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].outline_colors[:].b",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].outline_colors[:].b",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].outline_colors[:].a",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].outline_colors[:].a",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].fill_color",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".points[:].fill_color",
-            "type": "foxglove.ImageAnnotations.points.fill_color",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].fill_color.r",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].fill_color.r",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].fill_color.g",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].fill_color.g",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].fill_color.b",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].fill_color.b",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].fill_color.a",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].fill_color.a",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.points[:].thickness",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".points[:].thickness",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".texts",
-            "type": "foxglove.ImageAnnotations.texts[]",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].timestamp",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".texts[:].timestamp",
-            "type": "foxglove.ImageAnnotations.texts.timestamp",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].timestamp.sec",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].timestamp.sec",
-            "type": "uint32",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].timestamp.nsec",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].timestamp.nsec",
-            "type": "uint32",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].position",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".texts[:].position",
-            "type": "foxglove.ImageAnnotations.texts.position",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].position.x",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].position.x",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].position.y",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].position.y",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].text",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].text",
-            "type": "string",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].font_size",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].font_size",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].text_color",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".texts[:].text_color",
-            "type": "foxglove.ImageAnnotations.texts.text_color",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].text_color.r",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].text_color.r",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].text_color.g",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].text_color.g",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].text_color.b",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].text_color.b",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].text_color.a",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].text_color.a",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].background_color",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": false,
-            "pathSuffix": ".texts[:].background_color",
-            "type": "foxglove.ImageAnnotations.texts.background_color",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].background_color.r",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].background_color.r",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].background_color.g",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].background_color.g",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].background_color.b",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].background_color.b",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-        {
-          "fullPath": "annotations.texts[:].background_color.a",
-          "offset": 11,
-          "suffix": {
-            "isLeaf": true,
-            "pathSuffix": ".texts[:].background_color.a",
-            "type": "float64",
-          },
-          "topic": {
-            "name": "annotations",
-            "schemaName": "foxglove.ImageAnnotations",
-          },
-        },
-      ]
+     [
+       {
+         "fullPath": "annotations.timestamp",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".timestamp",
+           "type": "foxglove.ImageAnnotations.timestamp",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.timestamp.sec",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".timestamp.sec",
+           "type": "uint32",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.timestamp.nsec",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".timestamp.nsec",
+           "type": "uint32",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".circles",
+           "type": "foxglove.ImageAnnotations.circles[]",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].timestamp",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".circles[:].timestamp",
+           "type": "foxglove.ImageAnnotations.circles.timestamp",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].timestamp.sec",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].timestamp.sec",
+           "type": "uint32",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].timestamp.nsec",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].timestamp.nsec",
+           "type": "uint32",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].position",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".circles[:].position",
+           "type": "foxglove.ImageAnnotations.circles.position",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].position.x",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].position.x",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].position.y",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].position.y",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].diameter",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].diameter",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].thickness",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].thickness",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].fill_color",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".circles[:].fill_color",
+           "type": "foxglove.ImageAnnotations.circles.fill_color",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].fill_color.r",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].fill_color.r",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].fill_color.g",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].fill_color.g",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].fill_color.b",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].fill_color.b",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].fill_color.a",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].fill_color.a",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].outline_color",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".circles[:].outline_color",
+           "type": "foxglove.ImageAnnotations.circles.outline_color",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].outline_color.r",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].outline_color.r",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].outline_color.g",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].outline_color.g",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].outline_color.b",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].outline_color.b",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].outline_color.a",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].outline_color.a",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].metadata",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".circles[:].metadata",
+           "type": "foxglove.ImageAnnotations.circles.metadata[]",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].metadata[:].key",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].metadata[:].key",
+           "type": "string",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.circles[:].metadata[:].value",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".circles[:].metadata[:].value",
+           "type": "string",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".points",
+           "type": "foxglove.ImageAnnotations.points[]",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].timestamp",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".points[:].timestamp",
+           "type": "foxglove.ImageAnnotations.points.timestamp",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].timestamp.sec",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].timestamp.sec",
+           "type": "uint32",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].timestamp.nsec",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].timestamp.nsec",
+           "type": "uint32",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].type",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].type",
+           "type": "uint32",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].points",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".points[:].points",
+           "type": "foxglove.ImageAnnotations.points.points[]",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].points[:].x",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].points[:].x",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].points[:].y",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].points[:].y",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].outline_color",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".points[:].outline_color",
+           "type": "foxglove.ImageAnnotations.points.outline_color",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].outline_color.r",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].outline_color.r",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].outline_color.g",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].outline_color.g",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].outline_color.b",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].outline_color.b",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].outline_color.a",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].outline_color.a",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].outline_colors",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".points[:].outline_colors",
+           "type": "foxglove.ImageAnnotations.points.outline_colors[]",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].outline_colors[:].r",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].outline_colors[:].r",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].outline_colors[:].g",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].outline_colors[:].g",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].outline_colors[:].b",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].outline_colors[:].b",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].outline_colors[:].a",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].outline_colors[:].a",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].fill_color",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".points[:].fill_color",
+           "type": "foxglove.ImageAnnotations.points.fill_color",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].fill_color.r",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].fill_color.r",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].fill_color.g",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].fill_color.g",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].fill_color.b",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].fill_color.b",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].fill_color.a",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].fill_color.a",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].thickness",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].thickness",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].metadata",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".points[:].metadata",
+           "type": "foxglove.ImageAnnotations.points.metadata[]",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].metadata[:].key",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].metadata[:].key",
+           "type": "string",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.points[:].metadata[:].value",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".points[:].metadata[:].value",
+           "type": "string",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".texts",
+           "type": "foxglove.ImageAnnotations.texts[]",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].timestamp",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".texts[:].timestamp",
+           "type": "foxglove.ImageAnnotations.texts.timestamp",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].timestamp.sec",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].timestamp.sec",
+           "type": "uint32",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].timestamp.nsec",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].timestamp.nsec",
+           "type": "uint32",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].position",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".texts[:].position",
+           "type": "foxglove.ImageAnnotations.texts.position",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].position.x",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].position.x",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].position.y",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].position.y",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].text",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].text",
+           "type": "string",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].font_size",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].font_size",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].text_color",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".texts[:].text_color",
+           "type": "foxglove.ImageAnnotations.texts.text_color",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].text_color.r",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].text_color.r",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].text_color.g",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].text_color.g",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].text_color.b",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].text_color.b",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].text_color.a",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].text_color.a",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].background_color",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".texts[:].background_color",
+           "type": "foxglove.ImageAnnotations.texts.background_color",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].background_color.r",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].background_color.r",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].background_color.g",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].background_color.g",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].background_color.b",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].background_color.b",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].background_color.a",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].background_color.a",
+           "type": "float64",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].metadata",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".texts[:].metadata",
+           "type": "foxglove.ImageAnnotations.texts.metadata[]",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].metadata[:].key",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].metadata[:].key",
+           "type": "string",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.texts[:].metadata[:].value",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".texts[:].metadata[:].value",
+           "type": "string",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.metadata",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": false,
+           "pathSuffix": ".metadata",
+           "type": "foxglove.ImageAnnotations.metadata[]",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.metadata[:].key",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".metadata[:].key",
+           "type": "string",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+       {
+         "fullPath": "annotations.metadata[:].value",
+         "offset": 11,
+         "suffix": {
+           "isLeaf": true,
+           "pathSuffix": ".metadata[:].value",
+           "type": "string",
+         },
+         "topic": {
+           "name": "annotations",
+           "schemaName": "foxglove.ImageAnnotations",
+         },
+       },
+     ]
     `);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2427,13 +2427,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/schemas@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@foxglove/schemas@npm:1.9.0"
+"@foxglove/schemas@npm:1.13.0":
+  version: 1.13.0
+  resolution: "@foxglove/schemas@npm:1.13.0"
   dependencies:
     "@foxglove/rosmsg-msgs-common": "npm:^3.2.2"
     tslib: "npm:^2"
-  checksum: 10/04d552371ca39b9378d913aa35337d817c6406a8c9cf2a4094467c9118e28097105144a8335f15f541b8369bab8d817addac307e45b5c90e43c95945e20c5a8b
+  checksum: 10/faefc18cb1cd898833035fc2d1b16287beb00f166275a9850ef52cea4c25acb008e100cbfadd21dc49e77ccdafa03a100949cfb2208bc2dc80b0ea3a26698e39
   languageName: node
   linkType: hard
 
@@ -3358,7 +3358,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lichtblick/mcap-support@workspace:packages/mcap-support"
   dependencies:
-    "@foxglove/schemas": "npm:1.9.0"
+    "@foxglove/schemas": "npm:1.13.0"
     "@lichtblick/message-definition": "npm:1.0.0"
     "@lichtblick/omgidl-parser": "npm:1.0.0"
     "@lichtblick/omgidl-serialization": "npm:1.0.0"
@@ -3537,7 +3537,7 @@ __metadata:
     "@emotion/react": "npm:11.14.0"
     "@emotion/styled": "npm:11.14.1"
     "@fluentui/react-icons": "npm:2.0.308"
-    "@foxglove/schemas": "npm:1.9.0"
+    "@foxglove/schemas": "npm:1.13.0"
     "@foxglove/ws-protocol": "npm:0.8.0"
     "@lichtblick/avl": "npm:1.0.0"
     "@lichtblick/chartjs-plugin-zoom": "npm:1.0.0"
@@ -8249,7 +8249,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "benchmark@workspace:benchmark"
   dependencies:
-    "@foxglove/schemas": "npm:1.9.0"
+    "@foxglove/schemas": "npm:1.13.0"
     "@lichtblick/den": "workspace:*"
     "@lichtblick/log": "workspace:*"
     "@lichtblick/rostime": "npm:1.0.0"


### PR DESCRIPTION
Bring JointState/JointStates, LocationFix heading/velocity, and CompressedPointCloud schemas in via an additive release with no app code changes.

## User-Facing Changes

- ROS 2 `.db3` bags that reference `foxglove_msgs/JointState` / `JointStates` no longer crash with `datatype not found: "foxglove_msgs/JointState"`
- Adds support for newer Foxglove schemas included in `@foxglove/schemas` 1.13.0 (`JointState` / `JointStates`, `LocationFix` heading/velocity, `CompressedPointCloud`)

## Description

Bumps `@foxglove/schemas` from **1.9.0 → 1.13.0** in `suite-base`, `mcap-support`, and `benchmark`.

This is an additive schema release (no application code changes). `basicDatatypes` already registers all schemas from `@foxglove/schemas`, so the bump makes `foxglove_msgs/JointState` available for ROS 2 db3 message-path resolution.

Fixes https://github.com/lichtblick-suite/lichtblick/issues/1114

Release notes: https://github.com/foxglove/foxglove-sdk/releases/tag/typescript%2Fschemas%2Fv1.13.0

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Foxglove schema package to v1.13.0 across benchmark and MCAP-related tooling.
  * Improved alignment with the latest available schema definitions.

* **Tests**
  * Reformatted message-path search test expectations and inline snapshots (no behavior or logic changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->