### PR TITLE
feature: Add alert functionality in panel context

### DIFF
--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
@@ -11,6 +11,7 @@
 
 import { render } from "@testing-library/react";
 import { act } from "react";
+import { createStore } from "zustand";
 
 import { Condvar, signal } from "@lichtblick/den/async";
 import type { MessageDefinition } from "@lichtblick/message-definition";
@@ -23,6 +24,7 @@ import {
   Subscription,
 } from "@lichtblick/suite";
 import MockPanelContextProvider from "@lichtblick/suite-base/components/MockPanelContextProvider";
+import { AlertsContext, AlertsContextStore } from "@lichtblick/suite-base/context/AlertsContext";
 import { PLAYER_CAPABILITIES } from "@lichtblick/suite-base/players/constants";
 import { AdvertiseOptions } from "@lichtblick/suite-base/players/types";
 import * as PanelStateContextProvider from "@lichtblick/suite-base/providers/PanelStateContextProvider";
@@ -30,6 +32,7 @@ import PanelSetup, { Fixture } from "@lichtblick/suite-base/stories/PanelSetup";
 import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
 
 import PanelExtensionAdapter from "./PanelExtensionAdapter";
+import { BuiltinPanelExtensionContext } from "./types";
 
 describe("PanelExtensionAdapter", () => {
   it("should call initPanel", async () => {
@@ -1404,6 +1407,113 @@ describe("PanelExtensionAdapter", () => {
 
       // THEN no schema is returned
       expect(context.getSchema("known_schema/Data")).toBeUndefined();
+    });
+  });
+
+  describe("unstable_setAlert", () => {
+    function makeAlertsStore() {
+      const setAlert = jest.fn();
+      const clearAlert = jest.fn();
+      const store = createStore<AlertsContextStore>(() => ({
+        alerts: [],
+        actions: { setAlert, clearAlert, clearAlerts: jest.fn() },
+      }));
+      return { store, setAlert, clearAlert };
+    }
+
+    it("sets an app-level alert scoped to the panel", async () => {
+      // GIVEN a panel that sets an alert during init
+      const { store, setAlert } = makeAlertsStore();
+      const alert = { severity: "error", message: "boom" } as const;
+
+      const sig = signal();
+      const initPanel = (context: PanelExtensionContext) => {
+        (context as BuiltinPanelExtensionContext).unstable_setAlert?.("my-alert", alert);
+        sig.resolve();
+      };
+
+      // WHEN the panel is rendered
+      render(
+        <ThemeProvider isDark>
+          <MockPanelContextProvider>
+            <PanelSetup>
+              <AlertsContext.Provider value={store}>
+                <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+              </AlertsContext.Provider>
+            </PanelSetup>
+          </MockPanelContextProvider>
+        </ThemeProvider>,
+      );
+      await act(async () => undefined);
+      await sig;
+
+      // THEN setAlert is called with a panel-scoped tag and the alert
+      expect(setAlert).toHaveBeenCalledWith(
+        expect.stringMatching(/^panel-alert:.+:my-alert$/),
+        alert,
+      );
+    });
+
+    it("clears the alert when passed undefined", async () => {
+      // GIVEN a panel that clears an alert during init
+      const { store, clearAlert } = makeAlertsStore();
+
+      const sig = signal();
+      const initPanel = (context: PanelExtensionContext) => {
+        (context as BuiltinPanelExtensionContext).unstable_setAlert?.("my-alert", undefined);
+        sig.resolve();
+      };
+
+      // WHEN the panel is rendered
+      render(
+        <ThemeProvider isDark>
+          <MockPanelContextProvider>
+            <PanelSetup>
+              <AlertsContext.Provider value={store}>
+                <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+              </AlertsContext.Provider>
+            </PanelSetup>
+          </MockPanelContextProvider>
+        </ThemeProvider>,
+      );
+      await act(async () => undefined);
+      await sig;
+
+      // THEN clearAlert is called with the panel-scoped tag
+      expect(clearAlert).toHaveBeenCalledWith(expect.stringMatching(/^panel-alert:.+:my-alert$/));
+    });
+
+    it("clears panel alerts on unmount", async () => {
+      // GIVEN a panel that set an alert
+      const { store, clearAlert } = makeAlertsStore();
+      const alert = { severity: "warn", message: "watch out" } as const;
+
+      const sig = signal();
+      const initPanel = (context: PanelExtensionContext) => {
+        (context as BuiltinPanelExtensionContext).unstable_setAlert?.("my-alert", alert);
+        sig.resolve();
+      };
+
+      const { unmount } = render(
+        <ThemeProvider isDark>
+          <MockPanelContextProvider>
+            <PanelSetup>
+              <AlertsContext.Provider value={store}>
+                <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+              </AlertsContext.Provider>
+            </PanelSetup>
+          </MockPanelContextProvider>
+        </ThemeProvider>,
+      );
+      await act(async () => undefined);
+      await sig;
+      clearAlert.mockClear();
+
+      // WHEN the panel is unmounted
+      unmount();
+
+      // THEN the previously set alert is cleared
+      expect(clearAlert).toHaveBeenCalledWith(expect.stringMatching(/^panel-alert:.+:my-alert$/));
     });
   });
 });

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
@@ -1510,7 +1510,9 @@ describe("PanelExtensionAdapter", () => {
       clearAlert.mockClear();
 
       // WHEN the panel is unmounted
-      unmount();
+      await act(async () => {
+        unmount();
+      });
 
       // THEN the previously set alert is cleared
       expect(clearAlert).toHaveBeenCalledWith(expect.stringMatching(/^panel-alert:.+:my-alert$/));

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -184,7 +184,11 @@ function PanelExtensionAdapter(
 
   const [slowRender, setSlowRender] = useState(false);
   const [, setDefaultPanelTitle] = useDefaultPanelTitle();
-  const { setAlert } = useAlertsActions();
+  const { setAlert, clearAlert } = useAlertsActions();
+
+  // Tracks the ids of alerts this panel has set (via unstable_setAlert) so they can be cleared
+  // when the panel unmounts. Alerts are namespaced by panelId to avoid collisions across panels.
+  const panelAlertIdsRef = useRef(new Set<string>());
 
   const { globalVariables, setGlobalVariables } = useGlobalVariables();
 
@@ -655,6 +659,17 @@ function PanelExtensionAdapter(
         setDefaultPanelTitle(title);
       },
 
+      unstable_setAlert: (alertId: string, alert) => {
+        const tag = `panel-alert:${panelId}:${alertId}`;
+        if (alert == undefined) {
+          panelAlertIdsRef.current.delete(alertId);
+          clearAlert(tag);
+        } else {
+          panelAlertIdsRef.current.add(alertId);
+          setAlert(tag, alert);
+        }
+      },
+
       /**
        * EXPERIMENTAL: Subscribe to message ranges for efficient batch processing.
        *
@@ -733,6 +748,8 @@ function PanelExtensionAdapter(
     setDefaultPanelTitle,
     setMessagePathDropConfig,
     subscribeMessageRange,
+    setAlert,
+    clearAlert,
   ]);
 
   const panelContainerRef = useRef<HTMLDivElement>(ReactNull);
@@ -777,6 +794,10 @@ function PanelExtensionAdapter(
 
     setBuildRenderState(() => initRenderStateBuilder());
 
+    // Capture the stable Set that tracks this panel's alert ids. It is mutated by reference as the
+    // panel sets/clears alerts, so the cleanup below observes the latest ids.
+    const panelAlertIds = panelAlertIdsRef.current;
+
     const panelElement = document.createElement("div");
     panelElement.style.width = "100%";
     panelElement.style.height = "100%";
@@ -803,6 +824,11 @@ function PanelExtensionAdapter(
       panelElement.remove();
       getMessagePipelineContext().setSubscriptions(panelId, []);
       getMessagePipelineContext().setPublishers(panelId, []);
+      // Clear any app-level alerts this panel set so they do not linger after unmount.
+      for (const alertId of panelAlertIds) {
+        clearAlert(`panel-alert:${panelId}:${alertId}`);
+      }
+      panelAlertIds.clear();
     };
   }, [
     initPanel,
@@ -811,6 +837,7 @@ function PanelExtensionAdapter(
     getMessagePipelineContext,
     configTooNew,
     playerIsInitializing,
+    clearAlert,
   ]);
 
   const style: CSSProperties = {};

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -660,6 +660,9 @@ function PanelExtensionAdapter(
       },
 
       unstable_setAlert: (alertId: string, alert) => {
+        if (!isMounted()) {
+          return;
+        }
         const tag = `panel-alert:${panelId}:${alertId}`;
         if (alert == undefined) {
           panelAlertIdsRef.current.delete(alertId);

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -797,10 +797,6 @@ function PanelExtensionAdapter(
 
     setBuildRenderState(() => initRenderStateBuilder());
 
-    // Capture the stable Set that tracks this panel's alert ids. It is mutated by reference as the
-    // panel sets/clears alerts, so the cleanup below observes the latest ids.
-    const panelAlertIds = panelAlertIdsRef.current;
-
     const panelElement = document.createElement("div");
     panelElement.style.width = "100%";
     panelElement.style.height = "100%";
@@ -827,11 +823,6 @@ function PanelExtensionAdapter(
       panelElement.remove();
       getMessagePipelineContext().setSubscriptions(panelId, []);
       getMessagePipelineContext().setPublishers(panelId, []);
-      // Clear any app-level alerts this panel set so they do not linger after unmount.
-      for (const alertId of panelAlertIds) {
-        clearAlert(`panel-alert:${panelId}:${alertId}`);
-      }
-      panelAlertIds.clear();
     };
   }, [
     initPanel,
@@ -842,6 +833,17 @@ function PanelExtensionAdapter(
     playerIsInitializing,
     clearAlert,
   ]);
+
+  // Clear this panel's alerts on unmount.
+  useEffect(() => {
+    const panelAlertIds = panelAlertIdsRef.current;
+    return () => {
+      for (const alertId of panelAlertIds) {
+        clearAlert(`panel-alert:${panelId}:${alertId}`);
+      }
+      panelAlertIds.clear();
+    };
+  }, [panelId, clearAlert]);
 
   const style: CSSProperties = {};
   if (slowRender) {

--- a/packages/suite-base/src/components/PanelExtensionAdapter/types.ts
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/types.ts
@@ -5,9 +5,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { MessageConverterAlert, PanelExtensionContext } from "@lichtblick/suite";
+import { Immutable, MessageConverterAlert, PanelExtensionContext } from "@lichtblick/suite";
 import { IteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
-import { Topic } from "@lichtblick/suite-base/players/types";
+import { PlayerAlert, Topic } from "@lichtblick/suite-base/players/types";
 import { InstalledMessageConverter } from "@lichtblick/suite-base/types/messageConverters";
 
 /**
@@ -87,6 +87,14 @@ export type BuiltinPanelExtensionContext = {
    * indicates that the panel does not accept any dragged message paths.
    */
   unstable_setMessagePathDropConfig: (config: MessagePathDropConfig | undefined) => void;
+
+  /**
+   * Set or clear an app-level alert on behalf of this panel. The alert is surfaced in the app
+   * notifications UI. `alertId` scopes the alert within this panel; alerts are namespaced per
+   * panel and automatically cleared when the panel unmounts. Passing `undefined` for `alert`
+   * clears the alert with the given `alertId`.
+   */
+  unstable_setAlert?: (alertId: string, alert: Immutable<PlayerAlert> | undefined) => void;
 } & PanelExtensionContext;
 
 export type MessageConverterAlertHandler = (

--- a/packages/suite-base/src/i18n/en/threeDee.ts
+++ b/packages/suite-base/src/i18n/en/threeDee.ts
@@ -33,6 +33,9 @@ export const threeDee = {
   maxPreloadMessagesTooltip:
     "Maximum number of transform messages to keep in memory when preloading is enabled. Higher values provide more history but use more memory.",
   clearPreloadBuffer: "Clear preload buffer",
+  transformPreloadAlert: "Transform topics detected",
+  transformPreloadAlertTip:
+    "Activating preloading (3D panel -> Transforms -> Settings) is recommended for accurate visualization of transform topics. NOTE: this may impact performance.",
   fixed: "Fixed",
   followMode: "Follow mode",
   followModeHelp: "Change the camera behavior during playback to follow the display frame or not.",

--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.test.tsx
@@ -1254,4 +1254,120 @@ describe("ThreeDeeRender", () => {
       });
     });
   });
+
+  describe("transform preload alert", () => {
+    const TRANSFORM_ALERT_ID = "transform-preload";
+
+    const lastAlertFor = (mockContext: BuiltinPanelExtensionContext, alertId: string): unknown => {
+      const calls = (mockContext.unstable_setAlert as jest.Mock).mock.calls.filter(
+        (call) => call[0] === alertId,
+      );
+      return calls.at(-1)?.[1];
+    };
+
+    it("surfaces an info alert when a transform topic exists and preloading is disabled", async () => {
+      // Given
+      const topics = [
+        RenderStateBuilder.topic({ name: "/tf", schemaName: "tf2_msgs/TFMessage" }),
+        RenderStateBuilder.topic({ name: "/other", schemaName: "std_msgs/String" }),
+      ];
+      const mockContext = createMockContext();
+      const props = setup({}, mockContext);
+
+      render(<ThreeDeeRender {...props} />);
+      await waitFor(() => {
+        expect(mockContext.onRender).toBeDefined();
+      });
+
+      // When
+      act(() => {
+        mockContext.onRender!({ topics }, jest.fn());
+      });
+
+      // Then
+      await waitFor(() => {
+        expect(lastAlertFor(mockContext, TRANSFORM_ALERT_ID)).toEqual(
+          expect.objectContaining({
+            severity: "info",
+            message: expect.any(String),
+            tip: expect.any(String),
+          }),
+        );
+      });
+    });
+
+    it("clears the alert when a transform topic exists but preloading is enabled", async () => {
+      // Given
+      const topics = [RenderStateBuilder.topic({ name: "/tf", schemaName: "tf2_msgs/TFMessage" })];
+      const mockContext = createMockContext({
+        initialState: {
+          scene: {
+            transforms: {
+              enablePreloading: true,
+            },
+          },
+        },
+      });
+      const props = setup({}, mockContext);
+
+      render(<ThreeDeeRender {...props} />);
+      await waitFor(() => {
+        expect(mockContext.onRender).toBeDefined();
+      });
+      (mockContext.unstable_setAlert as jest.Mock).mockClear();
+
+      // When
+      act(() => {
+        mockContext.onRender!({ topics }, jest.fn());
+      });
+
+      // Then
+      await waitFor(() => {
+        expect(mockContext.unstable_setAlert).toHaveBeenCalledWith(TRANSFORM_ALERT_ID, undefined);
+      });
+      expect(lastAlertFor(mockContext, TRANSFORM_ALERT_ID)).toBeUndefined();
+    });
+
+    it("does not show the alert when no transform topic exists", async () => {
+      // Given
+      const topics = [RenderStateBuilder.topic({ name: "/other", schemaName: "std_msgs/String" })];
+      const mockContext = createMockContext();
+      const props = setup({}, mockContext);
+
+      render(<ThreeDeeRender {...props} />);
+      await waitFor(() => {
+        expect(mockContext.onRender).toBeDefined();
+      });
+
+      // When
+      act(() => {
+        mockContext.onRender!({ topics }, jest.fn());
+      });
+
+      // Then
+      await waitFor(() => {
+        expect(mockContext.unstable_setAlert).toHaveBeenCalledWith(TRANSFORM_ALERT_ID, undefined);
+      });
+      expect(lastAlertFor(mockContext, TRANSFORM_ALERT_ID)).toBeUndefined();
+    });
+
+    it("does not throw when the host does not provide unstable_setAlert", async () => {
+      // Given
+      const topics = [RenderStateBuilder.topic({ name: "/tf", schemaName: "tf2_msgs/TFMessage" })];
+      const mockContext = createMockContext({ unstable_setAlert: undefined });
+      const props = setup({}, mockContext);
+
+      render(<ThreeDeeRender {...props} />);
+      await waitFor(() => {
+        expect(mockContext.onRender).toBeDefined();
+      });
+
+      // When / Then
+      expect(() => {
+        act(() => {
+          mockContext.onRender!({ topics }, jest.fn());
+        });
+      }).not.toThrow();
+    });
+  });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.test.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.test.tsx
@@ -134,6 +134,7 @@ const createMockContext = (
     unstable_fetchAsset: jest.fn(),
     unstable_setMessagePathDropConfig: jest.fn(),
     unstable_subscribeMessageRange: jest.fn(),
+    unstable_setAlert: jest.fn(),
     dataSourceProfile: "ros1",
     layout: {
       addPanel: jest.fn(),

--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -383,10 +383,6 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
     }
   }, [topics, renderer]);
 
-  // Keep transform preloading in sync with the current data source.
-  // Preloading is disabled by default, but transform topics generally need to be preloaded to render correctly.
-  // Whenever the presence of transform topics changes (e.g. a new data source is loaded), we alert the user and recommend enabling preloading for accurate visualization of transform topics.
-  // const topicsLoaded = topics != undefined;
   const hasTransformTopics = useMemo(
     () => topics?.some((topic) => TRANSFORM_TOPIC_SCHEMAS.has(topic.schemaName)) ?? false,
     [topics],

--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -33,8 +33,14 @@ import {
   PANEL_STYLE,
   MAX_TRANSFORM_MESSAGES,
 } from "@lichtblick/suite-base/panels/ThreeDeeRender/constants";
-import { FRAME_TRANSFORM_DATATYPES, FRAME_TRANSFORMS_DATATYPES } from "@lichtblick/suite-base/panels/ThreeDeeRender/foxglove";
-import { TF_DATATYPES, TRANSFORM_STAMPED_DATATYPES } from "@lichtblick/suite-base/panels/ThreeDeeRender/ros";
+import {
+  FRAME_TRANSFORM_DATATYPES,
+  FRAME_TRANSFORMS_DATATYPES,
+} from "@lichtblick/suite-base/panels/ThreeDeeRender/foxglove";
+import {
+  TF_DATATYPES,
+  TRANSFORM_STAMPED_DATATYPES,
+} from "@lichtblick/suite-base/panels/ThreeDeeRender/ros";
 import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
 
 import type { IRenderer, ImageModeConfig, RendererConfig, RendererSubscription } from "./IRenderer";

--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -479,7 +479,6 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
   // Subscribe to eligible and enabled topics for range messages
   useLayoutEffect(() => {
     const transformTopics = transformTopicsToPreload;
-    const isPreloadingEnabled = config.scene.transforms?.enablePreloading === true;
     const maxMessages: number =
       config.scene.transforms?.maxPreloadMessages ?? MAX_TRANSFORM_MESSAGES;
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -391,12 +391,12 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
     () => topics?.some((topic) => TRANSFORM_TOPIC_SCHEMAS.has(topic.schemaName)) ?? false,
     [topics],
   );
+  const isPreloadingEnabled = config.scene.transforms?.enablePreloading === true;
   useEffect(() => {
-    // Surface an informational alert whenever we auto-toggle preloading, and clear it when preloading is
-    // auto-disabled (e.g. a data source without transform topics is loaded).
+    // Surface an informational alert whenever there's a transform topic
     setPanelAlert?.(
       "transform-preload",
-      hasTransformTopics
+      hasTransformTopics && !isPreloadingEnabled
         ? {
             severity: "info",
             message: t("transformPreloadAlert"),
@@ -404,7 +404,7 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
           }
         : undefined,
     );
-  }, [hasTransformTopics, setPanelAlert, t]);
+  }, [hasTransformTopics, isPreloadingEnabled, setPanelAlert, t]);
 
   // Tell the renderer if we are connected to a ROS data source
   useEffect(() => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -7,6 +7,7 @@
 
 import * as _ from "lodash-es";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useLatest } from "react-use";
 import { DeepPartial } from "ts-essentials";
 import { useDebouncedCallback } from "use-debounce";
@@ -32,6 +33,8 @@ import {
   PANEL_STYLE,
   MAX_TRANSFORM_MESSAGES,
 } from "@lichtblick/suite-base/panels/ThreeDeeRender/constants";
+import { FRAME_TRANSFORM_DATATYPES, FRAME_TRANSFORMS_DATATYPES } from "@lichtblick/suite-base/panels/ThreeDeeRender/foxglove";
+import { TF_DATATYPES, TRANSFORM_STAMPED_DATATYPES } from "@lichtblick/suite-base/panels/ThreeDeeRender/ros";
 import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
 
 import type { IRenderer, ImageModeConfig, RendererConfig, RendererSubscription } from "./IRenderer";
@@ -55,6 +58,17 @@ import { PublishClickEventMap } from "./renderables/PublishClickTool";
 import { DEFAULT_PUBLISH_SETTINGS } from "./renderables/PublishSettings";
 import { Shared3DPanelState, ThreeDeeRenderProps } from "./types";
 
+/**
+ * Schemas that carry coordinate frame transforms. Topics with one of these schemas generally
+ * require preloading so that transforms are available across the whole playback range.
+ */
+const TRANSFORM_TOPIC_SCHEMAS = new Set<string>([
+  ...FRAME_TRANSFORM_DATATYPES,
+  ...FRAME_TRANSFORMS_DATATYPES,
+  ...TF_DATATYPES,
+  ...TRANSFORM_STAMPED_DATATYPES,
+]);
+
 const log = Logger.getLogger(__filename);
 
 /**
@@ -75,9 +89,11 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
     saveState,
     unstable_fetchAsset: fetchAsset,
     unstable_setMessagePathDropConfig: setMessagePathDropConfig,
+    unstable_setAlert: setPanelAlert,
   } = context;
   const analytics = useAnalytics();
   const { classes } = useStyles();
+  const { t } = useTranslation("threeDee");
 
   // Load and save the persisted panel configuration
   const [config, setConfig] = useState<Immutable<RendererConfig>>(() => {
@@ -361,6 +377,33 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
     }
   }, [topics, renderer]);
 
+  // Keep transform preloading in sync with the current data source.
+  // Preloading is disabled by default, but transform topics generally need to be preloaded to render correctly.
+  // Whenever the presence of transform topics changes (e.g. a new data source is loaded), we enable preloading
+  // if the source exposes transform topics and disable it otherwise. Because we only react to that
+  // presence flipping, a manual toggle by the user within the same data source is preserved.
+  // const topicsLoaded = topics != undefined;
+  const hasTransformTopics = useMemo(
+    () => topics?.some((topic) => TRANSFORM_TOPIC_SCHEMAS.has(topic.schemaName)) ?? false,
+    [topics],
+  );
+  // const prevHasTransformTopicsRef = useRef<boolean | undefined>(undefined);
+  useEffect(() => {
+
+    // Surface an informational alert whenever we auto-toggle preloading, and clear it when preloading is
+    // auto-disabled (e.g. a data source without transform topics is loaded).
+    setPanelAlert?.(
+      "transform-preload",
+      hasTransformTopics
+        ? {
+            severity: "info",
+            message: t("transformPreloadAlert"),
+            tip: t("transformPreloadAlertTip"),
+          }
+        : undefined,
+    );
+  }, [hasTransformTopics, setPanelAlert, t]);
+
   // Tell the renderer if we are connected to a ROS data source
   useEffect(() => {
     if (renderer) {
@@ -640,7 +683,9 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
     if (!topicsToSubscribe) {
       return;
     }
-    log.debug(`Subscribing to [${topicsToSubscribe.map((t) => JSON.stringify(t)).join(", ")}]`);
+    log.debug(
+      `Subscribing to [${topicsToSubscribe.map((topic) => JSON.stringify(topic)).join(", ")}]`,
+    );
     context.subscribe(topicsToSubscribe);
   }, [context, topicsToSubscribe]);
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -379,17 +379,13 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
 
   // Keep transform preloading in sync with the current data source.
   // Preloading is disabled by default, but transform topics generally need to be preloaded to render correctly.
-  // Whenever the presence of transform topics changes (e.g. a new data source is loaded), we enable preloading
-  // if the source exposes transform topics and disable it otherwise. Because we only react to that
-  // presence flipping, a manual toggle by the user within the same data source is preserved.
+  // Whenever the presence of transform topics changes (e.g. a new data source is loaded), we alert the user and recommend enabling preloading for accurate visualization of transform topics.
   // const topicsLoaded = topics != undefined;
   const hasTransformTopics = useMemo(
     () => topics?.some((topic) => TRANSFORM_TOPIC_SCHEMAS.has(topic.schemaName)) ?? false,
     [topics],
   );
-  // const prevHasTransformTopicsRef = useRef<boolean | undefined>(undefined);
   useEffect(() => {
-
     // Surface an informational alert whenever we auto-toggle preloading, and clear it when preloading is
     // auto-disabled (e.g. a data source without transform topics is loaded).
     setPanelAlert?.(


### PR DESCRIPTION
## User-Facing Changes

Introduced alerts for transform topics and preloading in the panel context.

## Description

This update adds an interface for alerts in the panel context and implements an alert for transform topics, enhancing user awareness regarding preloading settings.

## Checklist

- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Panels can now set and clear panel-scoped alerts via `unstable_setAlert`.
  * The 3D panel shows a localized informational alert when transform topics are detected, guiding users to enable preloading.
* **Localization**
  * Added English copy for the “transform preload” alert and its tooltip.
* **Bug Fixes**
  * Prevented stale alerts by clearing panel-scoped alerts when they’re unset or when the panel unmounts.
* **Tests**
  * Added/expanded tests to verify alert wiring and the 3D panel alert behavior, including safe handling when the alert API is undefined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->