### PR TITLE
fix(desktop): ignore GPU blocklist to enable WebGL in remote environments

### DIFF
--- a/packages/suite-desktop/src/main/index.ts
+++ b/packages/suite-desktop/src/main/index.ts
@@ -68,6 +68,11 @@ export async function main(): Promise<void> {
   // https://github.com/electron/electron/issues/46538#issuecomment-2808806722
   app.commandLine.appendSwitch("gtk-version", "3");
 
+  // Allow WebGL in remote desktop environments (e.g. TurboVNC without VirtualGL).
+  // Electron 43+ (Chromium 150+) blocklists WebGL on GPUs it cannot identify, which
+  // breaks the 3D panel when the GPU is not directly accessible.
+  app.commandLine.appendSwitch("ignore-gpu-blocklist");
+
   const start = Date.now();
   log.info(`${LICHTBLICK_PRODUCT_NAME} ${LICHTBLICK_PRODUCT_VERSION}`);
 


### PR DESCRIPTION
## Problem

After upgrading to Electron 43 (v1.27.0), the 3D panel fails with `Error creating WebGL context` in remote desktop environments such as TurboVNC. The Chromium GPU blocklist rejects WebGL even when a capable GPU (e.g. NVIDIA RTX A4000) is available, because the blocklist cannot properly identify the GPU through the remote display stack.

The error manifests as:
```
ContextResult::kFatalFailure: WebGL1 blocklisted
ContextResult::kFatalFailure: WebGL2 blocklisted
```

This is a regression from v1.26.0 (Electron 42), which did not exhibit this behavior.

## Fix

Add `app.commandLine.appendSwitch("ignore-gpu-blocklist")` in the Electron main process. This tells Chromium to skip its internal GPU blocklist check, allowing WebGL context creation on GPUs that are functional but not recognized through the remote display path.

This flag does not disable any GPU safety mechanisms — it only prevents Chromium from preemptively refusing to use WebGL based on its vendor/driver blocklist. Users with genuinely broken drivers will see rendering errors rather than a blanket block.

## Testing

Verified on Ubuntu 24.04 with NVIDIA RTX A4000 (driver 595.58.03) via TurboVNC:
- **Before**: 3D panel shows "Error creating WebGL context"
- **After**: 3D panel renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebGL availability in software-rendered and remote desktop scenarios by updating Electron’s GPU blocklist behavior, helping the desktop app start and display graphics more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->