### PR TITLE
feat(3d-panel): camera target frame tracking

### DIFF
--- a/packages/suite-base/src/i18n/en/threeDee.ts
+++ b/packages/suite-base/src/i18n/en/threeDee.ts
@@ -82,6 +82,10 @@ export const threeDee = {
   hemisphereLightIntensity: "Hemisphere light intensity",
 
   // Camera
+  cameraTargetFrame: "Camera target frame",
+  cameraTargetFrameHelp:
+    "The coordinate frame the camera orbits around. Tracks this frame's position each render frame, like RViz's Orbit target frame. Leave empty to orbit a fixed point.",
+  cameraTargetFrameNone: "None (fixed point)",
   distance: "Distance",
   far: "Far",
   fovy: "Y-Axis FOV",

--- a/packages/suite-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -123,6 +123,8 @@ export type RendererConfig = {
   followTf: string | undefined;
   /** Camera follow mode */
   followMode: FollowMode;
+  /** Coordinate frameId the camera orbits around, tracked independently of followTf */
+  cameraTf?: string | undefined;
   scene: {
     /** Show rendering metrics in a DOM overlay */
     enableStats?: boolean;

--- a/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/suite-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -121,6 +121,7 @@ export function ThreeDeeRender(props: Readonly<ThreeDeeRenderProps>): React.JSX.
       cameraState,
       followMode: partialConfig?.followMode ?? DEFAULT_FOLLOW_MODE,
       followTf: partialConfig?.followTf,
+      cameraTf: partialConfig?.cameraTf,
       scene: partialConfig?.scene ?? {},
       transforms,
       topics: partialConfig?.topics ?? {},

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.test.ts
@@ -176,6 +176,191 @@ describe("CameraStateSettings", () => {
     });
   });
 
+  describe("camera target frame", () => {
+    it("tracks frame translation without changing the frame-relative camera state", () => {
+      renderer.addTransform(
+        "map",
+        "base_link",
+        0n,
+        { x: 1, y: 2, z: 3 },
+        { x: 0, y: 0, z: 0, w: 1 },
+      );
+      renderer.addTransform(
+        "map",
+        "base_link",
+        1n,
+        { x: 4, y: 6, z: 8 },
+        { x: 0, y: 0, z: 0, w: 1 },
+      );
+      renderer.updateConfig((draft) => {
+        draft.cameraTf = "base_link";
+      });
+      const cameraStateSettings = new CameraStateSettings(renderer, canvas, 16 / 9);
+      cameraStateSettings.setCameraState(DEFAULT_CAMERA_STATE);
+
+      cameraStateSettings.startFrame(0n, "map", "map");
+      const initialCameraOffset = cameraStateSettings
+        .getActiveCamera()
+        .position.clone()
+        .sub(mockOrbitControls.target);
+      expect(mockOrbitControls.target.toArray()).toEqual([1, 2, 3]);
+
+      cameraStateSettings.startFrame(1n, "map", "map");
+
+      expect(mockOrbitControls.target.toArray()).toEqual([4, 6, 8]);
+      expect(
+        cameraStateSettings.getActiveCamera().position.clone().sub(mockOrbitControls.target),
+      ).toEqual(initialCameraOffset);
+      expect(cameraStateSettings.getCameraState().targetOffset).toEqual(
+        DEFAULT_CAMERA_STATE.targetOffset,
+      );
+    });
+
+    it("offers known frames and stores the selected target", () => {
+      renderer.addTransform(
+        "map",
+        "base_link",
+        0n,
+        { x: 0, y: 0, z: 0 },
+        { x: 0, y: 0, z: 0, w: 1 },
+      );
+      const cameraStateSettings = new CameraStateSettings(renderer, canvas, 16 / 9);
+      const cameraTfField = cameraStateSettings.settingsNodes()[0]?.node.fields?.cameraTf;
+
+      expect(cameraTfField).toMatchObject({
+        input: "select",
+        value: "",
+        options: expect.arrayContaining([
+          expect.objectContaining({ value: "" }),
+          expect.objectContaining({ value: "base_link" }),
+        ]),
+      });
+
+      cameraStateSettings.handleSettingsAction({
+        action: "update",
+        payload: {
+          path: ["cameraState", "cameraTf"],
+          input: "select",
+          value: "base_link",
+        },
+      });
+
+      expect(renderer.config.cameraTf).toBe("base_link");
+    });
+
+    it("lists a configured frame that has not been seen yet", () => {
+      renderer.updateConfig((draft) => {
+        draft.cameraTf = "missing_frame";
+      });
+      const cameraStateSettings = new CameraStateSettings(renderer, canvas, 16 / 9);
+      const cameraTfField = cameraStateSettings.settingsNodes()[0]?.node.fields?.cameraTf;
+
+      expect(cameraTfField).toMatchObject({
+        value: "missing_frame",
+        options: expect.arrayContaining([expect.objectContaining({ value: "missing_frame" })]),
+      });
+    });
+
+    it("undoes the tracked offset when the camera target frame is cleared", () => {
+      renderer.addTransform(
+        "map",
+        "base_link",
+        0n,
+        { x: 1, y: 2, z: 3 },
+        { x: 0, y: 0, z: 0, w: 1 },
+      );
+      renderer.updateConfig((draft) => {
+        draft.cameraTf = "base_link";
+      });
+      const cameraStateSettings = new CameraStateSettings(renderer, canvas, 16 / 9);
+      cameraStateSettings.setCameraState(DEFAULT_CAMERA_STATE);
+
+      cameraStateSettings.startFrame(0n, "map", "map");
+      expect(mockOrbitControls.target.toArray()).toEqual([1, 2, 3]);
+
+      cameraStateSettings.handleSettingsAction({
+        action: "update",
+        payload: {
+          path: ["cameraState", "cameraTf"],
+          input: "select",
+          value: "",
+        },
+      });
+      cameraStateSettings.startFrame(0n, "map", "map");
+
+      expect(renderer.config.cameraTf).toBeUndefined();
+      expect(mockOrbitControls.target.toArray()).toEqual(DEFAULT_CAMERA_STATE.targetOffset);
+    });
+
+    it("reports an error when the target frame cannot be transformed", () => {
+      renderer.addTransform(
+        "map",
+        "base_link",
+        0n,
+        { x: 0, y: 0, z: 0 },
+        { x: 0, y: 0, z: 0, w: 1 },
+      );
+      renderer.addCoordinateFrame("orphan");
+      renderer.updateConfig((draft) => {
+        draft.cameraTf = "orphan";
+      });
+      const cameraStateSettings = new CameraStateSettings(renderer, canvas, 16 / 9);
+
+      cameraStateSettings.startFrame(0n, "map", "map");
+
+      expect(renderer.settings.errors.errors.errorAtPath(["cameraState", "cameraTf"])).toBe(
+        "Frame orphan not found",
+      );
+    });
+
+    it("applies the tracked frame when rebuilding camera state", () => {
+      renderer.addTransform(
+        "map",
+        "base_link",
+        0n,
+        { x: 5, y: 7, z: 9 },
+        { x: 0, y: 0, z: 0, w: 1 },
+      );
+      renderer.setFollowFrameId("map");
+      renderer.fixedFrameId = "map";
+      renderer.setCurrentTime(0n);
+      renderer.updateConfig((draft) => {
+        draft.cameraTf = "base_link";
+        draft.cameraState.perspective = false;
+      });
+      const cameraStateSettings = new CameraStateSettings(renderer, canvas, 16 / 9);
+      const cameraState = {
+        ...DEFAULT_CAMERA_STATE,
+        perspective: false,
+      };
+
+      cameraStateSettings.setCameraState(cameraState);
+
+      expect(mockOrbitControls.target.toArray()).toEqual([5, 7, 9]);
+      expect(cameraStateSettings.getActiveCamera().type).toBe("OrthographicCamera");
+      expect(cameraStateSettings.getActiveCamera().position.x).toBeCloseTo(5);
+      expect(cameraStateSettings.getActiveCamera().position.y).toBeCloseTo(7);
+      expect(cameraStateSettings.getCameraState().targetOffset).toEqual(
+        DEFAULT_CAMERA_STATE.targetOffset,
+      );
+    });
+
+    it("skips applying a target frame that cannot be transformed during setCameraState", () => {
+      renderer.addCoordinateFrame("orphan");
+      renderer.setFollowFrameId("map");
+      renderer.fixedFrameId = "map";
+      renderer.setCurrentTime(0n);
+      renderer.updateConfig((draft) => {
+        draft.cameraTf = "orphan";
+      });
+      const cameraStateSettings = new CameraStateSettings(renderer, canvas, 16 / 9);
+
+      cameraStateSettings.setCameraState(DEFAULT_CAMERA_STATE);
+
+      expect(mockOrbitControls.target.toArray()).toEqual(DEFAULT_CAMERA_STATE.targetOffset);
+    });
+  });
+
   describe("screen space panning", () => {
     const aspect = 16 / 9;
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.test.ts
@@ -261,6 +261,19 @@ describe("CameraStateSettings", () => {
       });
     });
 
+    it("reports an error when the configured target frame has never been seen", () => {
+      renderer.updateConfig((draft) => {
+        draft.cameraTf = "missing_frame";
+      });
+      const cameraStateSettings = new CameraStateSettings(renderer, canvas, 16 / 9);
+
+      cameraStateSettings.startFrame(0n, "map", "map");
+
+      expect(renderer.settings.errors.errors.errorAtPath(["cameraState", "cameraTf"])).toBe(
+        "Frame missing_frame not found",
+      );
+    });
+
     it("undoes the tracked offset when the camera target frame is cleared", () => {
       renderer.addTransform(
         "map",
@@ -311,6 +324,85 @@ describe("CameraStateSettings", () => {
       expect(renderer.settings.errors.errors.errorAtPath(["cameraState", "cameraTf"])).toBe(
         "Frame orphan not found",
       );
+    });
+
+    it("tracks frame translation in orthographic mode across frames", () => {
+      renderer.addTransform(
+        "map",
+        "base_link",
+        0n,
+        { x: 1, y: 2, z: 3 },
+        { x: 0, y: 0, z: 0, w: 1 },
+      );
+      renderer.addTransform(
+        "map",
+        "base_link",
+        1n,
+        { x: 4, y: 6, z: 8 },
+        { x: 0, y: 0, z: 0, w: 1 },
+      );
+      renderer.setFollowFrameId("map");
+      renderer.fixedFrameId = "map";
+      renderer.setCurrentTime(0n);
+      renderer.updateConfig((draft) => {
+        draft.cameraTf = "base_link";
+        draft.cameraState.perspective = false;
+      });
+      const cameraStateSettings = new CameraStateSettings(renderer, canvas, 16 / 9);
+      const cameraState = {
+        ...DEFAULT_CAMERA_STATE,
+        perspective: false,
+      };
+      cameraStateSettings.setCameraState(cameraState);
+
+      cameraStateSettings.startFrame(0n, "map", "map");
+      expect(mockOrbitControls.target.toArray()).toEqual([1, 2, 3]);
+      expect(cameraStateSettings.getActiveCamera().position.x).toBeCloseTo(1);
+      expect(cameraStateSettings.getActiveCamera().position.y).toBeCloseTo(2);
+
+      cameraStateSettings.startFrame(1n, "map", "map");
+
+      expect(mockOrbitControls.target.toArray()).toEqual([4, 6, 8]);
+      expect(cameraStateSettings.getActiveCamera().position.x).toBeCloseTo(4);
+      expect(cameraStateSettings.getActiveCamera().position.y).toBeCloseTo(6);
+    });
+
+    it("undoes orthographic offsets when the camera target frame is cleared", () => {
+      renderer.addTransform(
+        "map",
+        "base_link",
+        0n,
+        { x: 5, y: 7, z: 9 },
+        { x: 0, y: 0, z: 0, w: 1 },
+      );
+      renderer.setFollowFrameId("map");
+      renderer.fixedFrameId = "map";
+      renderer.setCurrentTime(0n);
+      renderer.updateConfig((draft) => {
+        draft.cameraTf = "base_link";
+        draft.cameraState.perspective = false;
+      });
+      const cameraStateSettings = new CameraStateSettings(renderer, canvas, 16 / 9);
+      cameraStateSettings.setCameraState({
+        ...DEFAULT_CAMERA_STATE,
+        perspective: false,
+      });
+      cameraStateSettings.startFrame(0n, "map", "map");
+      expect(cameraStateSettings.getActiveCamera().position.x).toBeCloseTo(5);
+      expect(cameraStateSettings.getActiveCamera().position.y).toBeCloseTo(7);
+
+      cameraStateSettings.handleSettingsAction({
+        action: "update",
+        payload: {
+          path: ["cameraState", "cameraTf"],
+          input: "select",
+          value: "",
+        },
+      });
+      cameraStateSettings.startFrame(0n, "map", "map");
+
+      expect(cameraStateSettings.getActiveCamera().position.x).toBeCloseTo(0);
+      expect(cameraStateSettings.getActiveCamera().position.y).toBeCloseTo(0);
     });
 
     it("applies the tracked frame when rebuilding camera state", () => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
@@ -457,15 +457,21 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
 
     if (
       !cameraTf ||
-      !transformTree.hasFrame(cameraTf) ||
       renderFrameId === CoordinateFrame.FALLBACK_FRAME_ID ||
       fixedFrameId === CoordinateFrame.FALLBACK_FRAME_ID
     ) {
-      if (this.#dynamicTargetPos.lengthSq() > 0) {
-        this.#controls.target.sub(this.#dynamicTargetPos);
-        this.#perspectiveCamera.position.sub(this.#dynamicTargetPos);
-        this.#dynamicTargetPos.set(0, 0, 0);
-      }
+      this.renderer.settings.errors.remove(CAMERA_TF_PATH, CAMERA_TF_NOT_FOUND);
+      this.#clearDynamicTargetOffset();
+      return;
+    }
+
+    if (!transformTree.hasFrame(cameraTf)) {
+      this.renderer.settings.errors.add(
+        CAMERA_TF_PATH,
+        CAMERA_TF_NOT_FOUND,
+        t("threeDee:frameNotFound", { frameId: cameraTf }),
+      );
+      this.#clearDynamicTargetOffset();
       return;
     }
 
@@ -498,14 +504,37 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     const dy = newPosition.y - this.#dynamicTargetPos.y;
     const dz = newPosition.z - this.#dynamicTargetPos.z;
     if (dx !== 0 || dy !== 0 || dz !== 0) {
-      this.#controls.target.x += dx;
-      this.#controls.target.y += dy;
-      this.#controls.target.z += dz;
-      this.#perspectiveCamera.position.x += dx;
-      this.#perspectiveCamera.position.y += dy;
-      this.#perspectiveCamera.position.z += dz;
+      this.#translateCamerasByDynamicOffset(dx, dy, dz);
       this.#dynamicTargetPos.copy(newPosition);
     }
+  }
+
+  /** Undo any accumulated cameraTf offset from the orbit target and both cameras. */
+  #clearDynamicTargetOffset(): void {
+    if (this.#dynamicTargetPos.lengthSq() === 0) {
+      return;
+    }
+    this.#translateCamerasByDynamicOffset(
+      -this.#dynamicTargetPos.x,
+      -this.#dynamicTargetPos.y,
+      -this.#dynamicTargetPos.z,
+    );
+    this.#dynamicTargetPos.set(0, 0, 0);
+  }
+
+  /**
+   * Translate orbit target + cameras by the same delta. Orthographic mode only follows x/y
+   * (matching #updateCameras / #applyDynamicTargetToCamera).
+   */
+  #translateCamerasByDynamicOffset(dx: number, dy: number, dz: number): void {
+    this.#controls.target.x += dx;
+    this.#controls.target.y += dy;
+    this.#controls.target.z += dz;
+    this.#perspectiveCamera.position.x += dx;
+    this.#perspectiveCamera.position.y += dy;
+    this.#perspectiveCamera.position.z += dz;
+    this.#orthographicCamera.position.x += dx;
+    this.#orthographicCamera.position.y += dy;
   }
 
   #handleCameraMove = (): void => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
@@ -27,6 +27,8 @@ import { CameraState, DEFAULT_CAMERA_STATE, DEFAULT_ORBIT_CONTROLS_CONFIG } from
 import { PRECISION_DEGREES, PRECISION_DISTANCE } from "../settings";
 
 const DISPLAY_FRAME_NOT_FOUND = "DISPLAY_FRAME_NOT_FOUND";
+const CAMERA_TF_NOT_FOUND = "CAMERA_TF_NOT_FOUND";
+const CAMERA_TF_PATH = ["cameraState", "cameraTf"];
 
 const UNIT_X = new THREE.Vector3(1, 0, 0);
 const UNIT_Z = new THREE.Vector3(0, 0, 1);
@@ -64,6 +66,10 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
   #perspectiveCamera: THREE.PerspectiveCamera;
   #orthographicCamera: THREE.OrthographicCamera;
   #aspect: number;
+
+  // Position last applied on top of the frame-relative camera state.
+  #dynamicTargetPos = new THREE.Vector3();
+  #tempDynamicTargetPos = new THREE.Vector3();
 
   public constructor(renderer: IRenderer, canvas: HTMLCanvasElement, aspect: number) {
     super("foxglove.CameraStateSettings", renderer);
@@ -140,6 +146,18 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     const { cameraState: camera } = config;
     const handler = this.handleSettingsAction;
 
+    const cameraTfOptions = [
+      { label: t("threeDee:cameraTargetFrameNone"), value: "" },
+      ...this.renderer.coordinateFrameList,
+    ];
+    const cameraTfValue = config.cameraTf ?? "";
+    if (config.cameraTf != undefined && !this.renderer.transformTree.hasFrame(config.cameraTf)) {
+      cameraTfOptions.splice(1, 0, {
+        label: CoordinateFrame.DisplayName(config.cameraTf),
+        value: config.cameraTf,
+      });
+    }
+
     return {
       path: ["cameraState"],
       node: {
@@ -153,6 +171,14 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
             error: this.renderer.cameraSyncError(),
             value: config.scene.syncCamera ?? false,
             help: t("threeDee:syncCameraHelp"),
+          },
+          cameraTf: {
+            label: t("threeDee:cameraTargetFrame"),
+            help: t("threeDee:cameraTargetFrameHelp"),
+            input: "select",
+            options: cameraTfOptions,
+            value: cameraTfValue,
+            error: this.renderer.settings.errors.errors.errorAtPath(CAMERA_TF_PATH),
           },
           distance: {
             label: t("threeDee:distance"),
@@ -296,6 +322,16 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
         this.renderer.updateConfig((draft) => {
           draft.scene.syncCamera = value as boolean;
         });
+      } else if (path[1] === "cameraTf") {
+        const cameraTf = (value as string) || undefined;
+        this.renderer.settings.errors.clearPath(CAMERA_TF_PATH);
+        this.renderer.updateConfig((draft) => {
+          draft.cameraTf = cameraTf;
+          if (cameraTf) {
+            // Center on the selected frame while preserving the current orbit angles and distance.
+            draft.cameraState.targetOffset = [...DEFAULT_CAMERA_STATE.targetOffset];
+          }
+        });
       } else {
         this.renderer.updateConfig((draft) => _.set(draft, path, value));
       }
@@ -342,6 +378,8 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     renderFrameId: AnyFrameId,
     fixedFrameId: AnyFrameId,
   ): void {
+    this.#updateDynamicTargetPos(currentTime, renderFrameId, fixedFrameId);
+
     const followMode = this.renderer.config.followMode;
 
     if (
@@ -402,6 +440,71 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
         snapshotInRenderFrame.orientation.z,
         snapshotInRenderFrame.orientation.w,
       );
+    }
+  }
+
+  /**
+   * Track cameraTf by translating the orbit target and camera together. The camera-to-target
+   * vector is unchanged, so OrbitControls preserves the current distance and angles.
+   */
+  #updateDynamicTargetPos(
+    currentTime: bigint,
+    renderFrameId: AnyFrameId,
+    fixedFrameId: AnyFrameId,
+  ): void {
+    const { cameraTf } = this.renderer.config;
+    const { transformTree } = this.renderer;
+
+    if (
+      !cameraTf ||
+      !transformTree.hasFrame(cameraTf) ||
+      renderFrameId === CoordinateFrame.FALLBACK_FRAME_ID ||
+      fixedFrameId === CoordinateFrame.FALLBACK_FRAME_ID
+    ) {
+      if (this.#dynamicTargetPos.lengthSq() > 0) {
+        this.#controls.target.sub(this.#dynamicTargetPos);
+        this.#perspectiveCamera.position.sub(this.#dynamicTargetPos);
+        this.#dynamicTargetPos.set(0, 0, 0);
+      }
+      return;
+    }
+
+    const pose = makePose();
+    const transformApplied = transformTree.apply(
+      pose,
+      pose,
+      renderFrameId,
+      fixedFrameId,
+      cameraTf,
+      currentTime,
+      currentTime,
+    );
+    if (!transformApplied) {
+      this.renderer.settings.errors.add(
+        CAMERA_TF_PATH,
+        CAMERA_TF_NOT_FOUND,
+        t("threeDee:frameNotFound", { frameId: cameraTf }),
+      );
+      return;
+    }
+    this.renderer.settings.errors.remove(CAMERA_TF_PATH, CAMERA_TF_NOT_FOUND);
+
+    const newPosition = this.#tempDynamicTargetPos.set(
+      pose.position.x,
+      pose.position.y,
+      pose.position.z,
+    );
+    const dx = newPosition.x - this.#dynamicTargetPos.x;
+    const dy = newPosition.y - this.#dynamicTargetPos.y;
+    const dz = newPosition.z - this.#dynamicTargetPos.z;
+    if (dx !== 0 || dy !== 0 || dz !== 0) {
+      this.#controls.target.x += dx;
+      this.#controls.target.y += dy;
+      this.#controls.target.z += dz;
+      this.#perspectiveCamera.position.x += dx;
+      this.#perspectiveCamera.position.y += dy;
+      this.#perspectiveCamera.position.z += dz;
+      this.#dynamicTargetPos.copy(newPosition);
     }
   }
 
@@ -499,7 +602,11 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
       distance: this.#controls.getDistance(),
       phi: THREE.MathUtils.radToDeg(this.#controls.getPolarAngle()),
       thetaOffset: THREE.MathUtils.radToDeg(-this.#controls.getAzimuthalAngle()),
-      targetOffset: [this.#controls.target.x, this.#controls.target.y, this.#controls.target.z],
+      targetOffset: [
+        this.#controls.target.x - this.#dynamicTargetPos.x,
+        this.#controls.target.y - this.#dynamicTargetPos.y,
+        this.#controls.target.z - this.#dynamicTargetPos.z,
+      ],
       target: config.cameraState.target,
       targetOrientation: config.cameraState.targetOrientation,
       fovy: config.cameraState.fovy,
@@ -511,12 +618,45 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
   public setCameraState(cameraState: CameraState): void {
     this.#isUpdatingCameraState = true;
     this.#updateCameras(cameraState);
+    this.#dynamicTargetPos.set(0, 0, 0);
+    this.#applyDynamicTargetToCamera({ isPerspective: cameraState.perspective });
     // only active for follow pose mode because it introduces strange behavior into the other modes
     // due to the fact that they are manipulating the camera after update with the `cameraGroup`
     if (this.renderer.config.followMode === "follow-pose") {
       this.#controls.update();
     }
     this.#isUpdatingCameraState = false;
+  }
+
+  /** Apply the current cameraTf position after rebuilding cameras from frame-relative state. */
+  #applyDynamicTargetToCamera({ isPerspective }: { isPerspective: boolean }): void {
+    const { cameraTf } = this.renderer.config;
+    const { transformTree, followFrameId, fixedFrameId, currentTime } = this.renderer;
+    if (!cameraTf || !followFrameId || !fixedFrameId || !transformTree.hasFrame(cameraTf)) {
+      return;
+    }
+
+    const pose = makePose();
+    const transformApplied = transformTree.apply(
+      pose,
+      pose,
+      followFrameId,
+      fixedFrameId,
+      cameraTf,
+      currentTime,
+      currentTime,
+    );
+    if (!transformApplied) {
+      return;
+    }
+
+    this.#dynamicTargetPos.set(pose.position.x, pose.position.y, pose.position.z);
+    this.#controls.target.add(this.#dynamicTargetPos);
+    this.#perspectiveCamera.position.add(this.#dynamicTargetPos);
+    if (!isPerspective) {
+      this.#orthographicCamera.position.x += this.#dynamicTargetPos.x;
+      this.#orthographicCamera.position.y += this.#dynamicTargetPos.y;
+    }
   }
 
   /** Translate a CameraState to the three.js coordinate system */


### PR DESCRIPTION
## User-Facing Changes

New setting in the 3D panel's **View** section:

- **Camera target frame** — select a TF frame for the camera's orbit center to track on every render while preserving the current viewing distance and angles, similar to RViz's Orbit **Target Frame**.

Select **None (fixed point)** to retain the existing behavior. Existing layouts are unaffected.

## Description

Adds RViz-like target-frame tracking for users visualising moving robots and models.

The selected frame is stored in the optional `cameraTf` panel setting. Camera state remains frame-relative, preventing tracked movement from being persisted as part of the orbit offset. Missing or unavailable transforms are reported in the settings UI.

<table>
  <tr>
    <td width="50%" align="center">
      <img alt="Camera tracking katana_gripper_tool_frame in its lower position" src="https://github.com/user-attachments/assets/7295f870-e07d-48e8-837c-3f51874cd63e" />
    </td>
    <td width="50%" align="center">
      <img alt="Camera tracking katana_gripper_tool_frame in its upper position" src="https://github.com/user-attachments/assets/c2948934-40b1-4f69-bdf4-5d23c11d885a" />
    </td>
  </tr>
  <tr>
    <td align="center"><sub><b>Lower gripper position</b></sub></td>
    <td align="center"><sub><b>Upper gripper position</b></sub></td>
  </tr>
</table>

As an example, this camera target is set to `katana_gripper_tool_frame`. As the gripper moves from the lower position to the upper position, the camera orbit center follows it while retaining the viewing distance and angles. 

This is useful when inspecting moving objects such as robot end effectors, mobile bases, or sensors. By tracking the selected TF frame, the camera keeps that object centered as it moves, removing the need to manually reposition the view during playback while preserving the chosen viewing distance and angles.

## Checklist



- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a camera target frame setting for 3D views.
  * Choose a coordinate frame to control the camera’s orbit target, or select “None (fixed point).”
  * Camera positioning now updates as the selected frame moves.
  * Camera settings preserve the selected target frame when saved and restored.
  * Added clear error feedback when the selected frame cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->