### PR TITLE
feat(3d-panel): per-URDF opacity control

### DIFF
--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
@@ -21,6 +21,7 @@ import {
 import { DEFAULT_PUBLISH_SETTINGS } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/PublishSettings";
 
 import { RendererConfig } from "../IRenderer";
+import { MarkerUserData } from "./markers/RenderableMarker";
 import { LayerSettingsCustomUrdf, LayerSettingsUrdf, Urdfs } from "./Urdfs";
 
 let mockOrbitControls!: {
@@ -176,7 +177,9 @@ describe("Urdfs opacity", () => {
         value: 0.6,
       },
     });
-    expect(renderer.config.layers.ghost?.opacity).toBe(0.6);
+    expect((renderer.config.layers.ghost as LayerSettingsCustomUrdf | undefined)?.opacity).toBe(
+      0.6,
+    );
     renderer.dispose();
   });
 
@@ -266,7 +269,8 @@ describe("Urdfs opacity", () => {
     await waitFor(() => {
       const robot = urdfs.renderables.get("/robot_description");
       const child = robot?.userData.renderables.values().next().value;
-      expect(child?.userData.marker.color.a).toBeCloseTo(expectedAlpha);
+      const markerAlpha = (child?.userData as MarkerUserData | undefined)?.marker.color.a;
+      expect(markerAlpha).toBeCloseTo(expectedAlpha);
     });
 
     renderer.dispose();

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
@@ -1,0 +1,274 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { waitFor } from "@testing-library/react";
+import { setupJestCanvasMock } from "jest-canvas-mock";
+import * as THREE from "three";
+
+import { MessageEvent } from "@lichtblick/suite";
+import { Renderer } from "@lichtblick/suite-base/panels/ThreeDeeRender/Renderer";
+import { DEFAULT_SCENE_EXTENSION_CONFIG } from "@lichtblick/suite-base/panels/ThreeDeeRender/SceneExtensionConfig";
+import {
+  DEFAULT_CAMERA_STATE,
+  DEFAULT_ORBIT_CONTROLS_CONFIG,
+} from "@lichtblick/suite-base/panels/ThreeDeeRender/camera";
+import { DEFAULT_PUBLISH_SETTINGS } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/PublishSettings";
+
+import { RendererConfig } from "../IRenderer";
+import { LayerSettingsCustomUrdf, LayerSettingsUrdf, Urdfs } from "./Urdfs";
+
+let mockOrbitControls!: {
+  screenSpacePanning: boolean;
+  mouseButtons: { LEFT: number; RIGHT: number };
+  touches: { ONE: number; TWO: number };
+  keys: { LEFT: string; RIGHT: string; UP: string; BOTTOM: string };
+  addEventListener: jest.Mock;
+  listenToKeyEvents: jest.Mock;
+  getDistance: jest.Mock;
+  getPolarAngle: jest.Mock;
+  getAzimuthalAngle: jest.Mock;
+  target: THREE.Vector3;
+  update: jest.Mock;
+  minPolarAngle: number;
+  maxPolarAngle: number;
+};
+
+jest.mock("three/examples/jsm/libs/draco/draco_decoder.wasm", () => "");
+jest.mock("three/examples/jsm/controls/OrbitControls", () => ({
+  OrbitControls: jest.fn().mockImplementation(() => mockOrbitControls),
+}));
+jest.mock("three", () => {
+  const ActualTHREE = jest.requireActual("three");
+  return {
+    ...ActualTHREE,
+    WebGLRenderer: function WebGLRenderer() {
+      return {
+        capabilities: { isWebGL2: true },
+        setPixelRatio: jest.fn(),
+        setSize: jest.fn(),
+        render: jest.fn(),
+        clear: jest.fn(),
+        setClearColor: jest.fn(),
+        readRenderTargetPixels: jest.fn(),
+        info: { reset: jest.fn() },
+        shadowMap: {},
+        dispose: jest.fn(),
+        clearDepth: jest.fn(),
+        getDrawingBufferSize: () => ({ width: 100, height: 100 }),
+      };
+    },
+  };
+});
+
+const URDF = `<?xml version="1.0"?>
+<robot name="opacity-test">
+  <link name="box">
+    <visual>
+      <geometry><box size="1 1 1"/></geometry>
+      <material><color rgba="1 0 0 0.8"/></material>
+    </visual>
+  </link>
+</robot>`;
+
+function makeConfig(overrides: Partial<RendererConfig> = {}): RendererConfig {
+  return {
+    cameraState: DEFAULT_CAMERA_STATE,
+    followMode: "follow-pose",
+    followTf: undefined,
+    scene: {},
+    transforms: {},
+    topics: {},
+    layers: {},
+    publish: DEFAULT_PUBLISH_SETTINGS,
+    imageMode: {},
+    ...overrides,
+  };
+}
+
+function makeRenderer(config: RendererConfig): Renderer {
+  const parent = document.createElement("div");
+  const canvas = document.createElement("canvas");
+  parent.appendChild(canvas);
+  return new Renderer({
+    canvas,
+    config,
+    interfaceMode: "3d",
+    fetchAsset: async () => {
+      throw new Error("Unexpected asset fetch");
+    },
+    sceneExtensionConfig: DEFAULT_SCENE_EXTENSION_CONFIG,
+    testOptions: {},
+    customCameraModels: new Map(),
+  });
+}
+
+describe("Urdfs opacity", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: undefined,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+    setupJestCanvasMock();
+    mockOrbitControls = {
+      ...DEFAULT_ORBIT_CONTROLS_CONFIG,
+      addEventListener: jest.fn(),
+      listenToKeyEvents: jest.fn(),
+      getDistance: jest.fn().mockReturnValue(DEFAULT_CAMERA_STATE.distance),
+      getPolarAngle: jest.fn().mockReturnValue(0),
+      getAzimuthalAngle: jest.fn().mockReturnValue(0),
+      target: new THREE.Vector3(),
+      update: jest.fn(),
+      minPolarAngle: 0,
+      maxPolarAngle: Math.PI,
+    };
+  });
+
+  afterEach(() => {
+    (console.warn as jest.Mock).mockClear();
+  });
+
+  it("exposes an opacity control for custom URDF layers", () => {
+    const layer: LayerSettingsCustomUrdf = {
+      layerId: "foxglove.Urdf",
+      instanceId: "ghost",
+      label: "Ghost",
+      visible: true,
+      frameLocked: true,
+      sourceType: "url",
+      url: "",
+      framePrefix: "",
+      displayMode: "auto",
+      opacity: 0.35,
+    };
+    const renderer = makeRenderer(makeConfig({ layers: { ghost: layer } }));
+    const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+
+    const settingsNode = urdfs.settingsNodes()[0];
+    const opacityField = settingsNode?.node.fields?.opacity;
+
+    expect(opacityField).toMatchObject({
+      input: "number",
+      min: 0,
+      max: 1,
+      step: 0.05,
+      value: 0.35,
+    });
+    settingsNode?.node.handler?.({
+      action: "update",
+      payload: {
+        path: ["layers", "ghost", "opacity"],
+        input: "number",
+        value: 0.6,
+      },
+    });
+    expect(renderer.config.layers.ghost?.opacity).toBe(0.6);
+    renderer.dispose();
+  });
+
+  it("exposes opacity for topic and parameter URDFs", () => {
+    const renderer = makeRenderer(
+      makeConfig({
+        topics: {
+          "/robot_description": { visible: true, opacity: 0.4 } as Partial<LayerSettingsUrdf>,
+          "param:/robot_description": {
+            visible: true,
+            opacity: 0.7,
+          } as Partial<LayerSettingsUrdf>,
+        },
+      }),
+    );
+    renderer.setTopics([{ name: "/robot_description", schemaName: "std_msgs/String" }]);
+    renderer.setParameters(new Map([["/robot_description", 123]]));
+    const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+
+    const nodes = urdfs.settingsNodes();
+
+    expect(
+      nodes.find((entry) => entry.path[1] === "/robot_description")?.node.fields?.opacity,
+    ).toMatchObject({
+      value: 0.4,
+    });
+    expect(
+      nodes.find((entry) => entry.path[1] === "param:/robot_description")?.node.fields?.opacity,
+    ).toMatchObject({ value: 0.7 });
+    renderer.dispose();
+  });
+
+  it("defaults every URDF source opacity to fully opaque", () => {
+    const layer: LayerSettingsCustomUrdf = {
+      layerId: "foxglove.Urdf",
+      instanceId: "default-opacity",
+      label: "Default opacity",
+      visible: true,
+      frameLocked: true,
+      sourceType: "url",
+      url: "",
+      framePrefix: "",
+      displayMode: "auto",
+    };
+    const renderer = makeRenderer(
+      makeConfig({
+        topics: {
+          "/robot_description": { visible: true },
+          "param:/robot_description": { visible: true },
+        },
+        layers: { "default-opacity": layer },
+      }),
+    );
+    renderer.setTopics([{ name: "/robot_description", schemaName: "std_msgs/String" }]);
+    renderer.setParameters(new Map([["/robot_description", 123]]));
+    const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+
+    const opacityValues = urdfs.settingsNodes().map((entry) => entry.node.fields?.opacity?.value);
+
+    expect(opacityValues).toEqual([1, 1, 1]);
+    renderer.dispose();
+  });
+
+  it.each([
+    { opacity: 0.25, expectedAlpha: 0.2 },
+    { opacity: undefined, expectedAlpha: 0.8 },
+  ])("applies layer opacity $opacity to URDF material alpha", async ({
+    opacity,
+    expectedAlpha,
+  }) => {
+    const topicSettings: Partial<LayerSettingsUrdf> = { visible: true, opacity };
+    const renderer = makeRenderer(makeConfig({ topics: { "/robot_description": topicSettings } }));
+    const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+    const topicSubscription = urdfs.getSubscriptions()[0];
+    if (topicSubscription?.type !== "topic") {
+      throw new Error("Expected /robot_description topic subscription");
+    }
+    const messageEvent: MessageEvent<{ data: string }> = {
+      topic: "/robot_description",
+      schemaName: "std_msgs/String",
+      receiveTime: { sec: 0, nsec: 0 },
+      message: { data: URDF },
+      sizeInBytes: URDF.length,
+    };
+
+    topicSubscription.subscription.handler(messageEvent);
+    await waitFor(() => {
+      const robot = urdfs.renderables.get("/robot_description");
+      const child = robot?.userData.renderables.values().next().value;
+      expect(child?.userData.marker.color.a).toBeCloseTo(expectedAlpha);
+    });
+
+    renderer.dispose();
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -651,14 +651,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       } else if (field === "parameter") {
         urdf = this.renderer.parameters?.get(action.payload.value as string) as string | undefined;
         this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
-      } else if (field === "framePrefix") {
+      } else if (field === "framePrefix" || field === "opacity") {
+        // Opacity is a slider; debounce so dragging does not spam parse/reload work.
         this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
-      } else if (
-        field === "displayMode" ||
-        field === "visible" ||
-        field === "fallbackColor" ||
-        field === "opacity"
-      ) {
+      } else if (field === "displayMode" || field === "visible" || field === "fallbackColor") {
         this.#loadUrdf({ instanceId, urdf, forceReload: true });
       } else if (field === "sourceType") {
         const sourceType = action.payload.value as LayerSettingsCustomUrdf["sourceType"];

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -88,6 +88,7 @@ export type LayerSettingsUrdf = BaseSettings & {
   displayMode: "auto" | "visual" | "collision";
   label: string;
   fallbackColor?: string;
+  opacity?: number;
 };
 
 export type LayerSettingsCustomUrdf = CustomLayerSettings & {
@@ -100,6 +101,7 @@ export type LayerSettingsCustomUrdf = CustomLayerSettings & {
   framePrefix: string;
   displayMode: "auto" | "visual" | "collision";
   fallbackColor?: string;
+  opacity?: number;
 };
 
 const DEFAULT_SETTINGS: LayerSettingsUrdf = {
@@ -109,6 +111,7 @@ const DEFAULT_SETTINGS: LayerSettingsUrdf = {
   displayMode: "auto",
   label: "URDF",
   fallbackColor: DEFAULT_COLOR_STR,
+  opacity: 1,
 };
 
 const DEFAULT_CUSTOM_SETTINGS: LayerSettingsCustomUrdf = {
@@ -125,6 +128,7 @@ const DEFAULT_CUSTOM_SETTINGS: LayerSettingsCustomUrdf = {
   framePrefix: "",
   displayMode: "auto",
   fallbackColor: DEFAULT_COLOR_STR,
+  opacity: 1,
 };
 const URDF_TOPIC_SCHEMAS = new Set<string>(["std_msgs/String", "std_msgs/msg/String"]);
 
@@ -267,6 +271,15 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       help: "Fallback color used in case a link does not specify any color itself",
       input: "rgb",
     };
+    const baseOpacityField: SettingsTreeField = {
+      label: "Opacity",
+      help: "Overall opacity of this URDF layer. Lower values create a transparent ghost overlay.",
+      input: "number",
+      min: 0,
+      max: 1,
+      step: 0.05,
+      precision: 2,
+    };
 
     // /robot_description topic entry
     const topic = this.renderer.topicsByName?.get(TOPIC_NAME);
@@ -280,6 +293,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         fallbackColor: {
           ...baseFallbackColorField,
           value: config.fallbackColor ?? DEFAULT_SETTINGS.fallbackColor,
+        },
+        opacity: {
+          ...baseOpacityField,
+          value: config.opacity ?? DEFAULT_SETTINGS.opacity,
         },
       };
       entries.push({
@@ -312,6 +329,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         fallbackColor: {
           ...baseFallbackColorField,
           value: config.fallbackColor ?? DEFAULT_SETTINGS.fallbackColor,
+        },
+        opacity: {
+          ...baseOpacityField,
+          value: config.opacity ?? DEFAULT_SETTINGS.opacity,
         },
       };
 
@@ -423,6 +444,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
           fallbackColor: {
             ...baseFallbackColorField,
             value: config.fallbackColor ?? DEFAULT_SETTINGS.fallbackColor,
+          },
+          opacity: {
+            ...baseOpacityField,
+            value: config.opacity ?? DEFAULT_CUSTOM_SETTINGS.opacity,
           },
         };
 
@@ -628,7 +653,12 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
       } else if (field === "framePrefix") {
         this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
-      } else if (field === "displayMode" || field === "visible" || field === "fallbackColor") {
+      } else if (
+        field === "displayMode" ||
+        field === "visible" ||
+        field === "fallbackColor" ||
+        field === "opacity"
+      ) {
         this.#loadUrdf({ instanceId, urdf, forceReload: true });
       } else if (field === "sourceType") {
         const sourceType = action.payload.value as LayerSettingsCustomUrdf["sourceType"];
@@ -935,6 +965,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     const fallbackColor = settings.fallbackColor
       ? stringToRgba(makeRgba(), settings.fallbackColor)
       : undefined;
+    const opacity = THREE.MathUtils.clamp(settings.opacity ?? 1, 0, 1);
 
     this.#loadFrames(instanceId, frames);
     this.#loadTransforms(instanceId, transforms);
@@ -952,6 +983,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         renderer,
         baseUrl,
         fallbackColor,
+        opacity,
       });
       // Set the childRenderable settingsPath so errors route to the correct place
       childRenderable.userData.settingsPath = renderable.userData.settingsPath;
@@ -1068,12 +1100,14 @@ function createRenderable(args: {
   renderer: IRenderer;
   baseUrl?: string;
   fallbackColor?: ColorRGBA;
+  opacity: number;
 }): Renderable {
-  const { visual, robot, id, frameId, renderer, baseUrl, fallbackColor } = args;
+  const { visual, robot, id, frameId, renderer, baseUrl, fallbackColor, opacity } = args;
   const name = `${frameId}-${id}-${visual.geometry.geometryType}`;
   const orientation = eulerToQuaternion(visual.origin.rpy);
   const pose = { position: visual.origin.xyz, orientation };
-  const color = getColor(visual, robot) ?? fallbackColor ?? DEFAULT_COLOR;
+  const baseColor = getColor(visual, robot) ?? fallbackColor ?? DEFAULT_COLOR;
+  const color = { ...baseColor, a: baseColor.a * opacity };
   const type = visual.geometry.geometryType;
   switch (type) {
     case "box": {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
@@ -50,7 +50,7 @@ function embeddedMaterial(renderable: RenderableMeshResource): THREE.Material | 
 }
 
 describe("RenderableMeshResource embedded opacity", () => {
-  it("reloads embedded materials when opacity changes without changing the resource", async () => {
+  it("updates embedded materials in place when only opacity changes", async () => {
     const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 0.8 });
     const cachedModel = new THREE.Group();
     cachedModel.add(new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial));
@@ -80,14 +80,20 @@ describe("RenderableMeshResource embedded opacity", () => {
       expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.8);
     });
 
+    const materialAfterLoad = embeddedMaterial(renderable);
     renderable.update(makeMarker(0.5), 1n);
 
-    await waitFor(() => {
-      expect(load).toHaveBeenCalledTimes(2);
-      expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.4);
-      expect(embeddedMaterial(renderable)?.transparent).toBe(true);
-      expect(embeddedMaterial(renderable)?.depthWrite).toBe(false);
-    });
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(embeddedMaterial(renderable)).toBe(materialAfterLoad);
+    expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.4);
+    expect(embeddedMaterial(renderable)?.transparent).toBe(true);
+    expect(embeddedMaterial(renderable)?.depthWrite).toBe(false);
+
+    // A second opacity change must keep multiplying against the original, not the previous result.
+    renderable.update(makeMarker(0.25), 2n);
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.2);
+
     expect(cachedMaterial.opacity).toBe(0.8);
     expect(cachedMaterial.transparent).toBe(false);
     renderable.dispose();

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
@@ -98,4 +98,49 @@ describe("RenderableMeshResource embedded opacity", () => {
     expect(cachedMaterial.transparent).toBe(false);
     renderable.dispose();
   });
+
+  it("re-applies the latest opacity when it changes during an in-flight load", async () => {
+    const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 0.8 });
+    const cachedModel = new THREE.Group();
+    cachedModel.add(new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial));
+
+    let resolveLoad!: (model: THREE.Group) => void;
+    const load = jest.fn().mockImplementation(async () => {
+      return await new Promise<THREE.Group>((resolve) => {
+        resolveLoad = resolve;
+      });
+    });
+    const renderer = {
+      normalizeFrameId: (frameId: string) => frameId,
+      config: { topics: {} },
+      modelCache: { load },
+      settings: {
+        errors: {
+          add: jest.fn(),
+          remove: jest.fn(),
+          hasError: jest.fn().mockReturnValue(false),
+        },
+      },
+      queueAnimationFrame: jest.fn(),
+    } as unknown as IRenderer;
+
+    const renderable = new RenderableMeshResource(
+      "/robot_description",
+      makeMarker(1),
+      0n,
+      renderer,
+    );
+    expect(load).toHaveBeenCalledTimes(1);
+
+    // Opacity changes while the mesh is still loading — cannot update in place yet.
+    renderable.update(makeMarker(0.5), 1n);
+    expect(load).toHaveBeenCalledTimes(1);
+
+    resolveLoad(cachedModel);
+
+    await waitFor(() => {
+      expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.4);
+    });
+    renderable.dispose();
+  });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
@@ -1,0 +1,95 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { waitFor } from "@testing-library/react";
+import * as THREE from "three";
+
+import { RenderableMeshResource } from "./RenderableMeshResource";
+import { IRenderer } from "../../IRenderer";
+import { Marker, MarkerAction, MarkerType } from "../../ros";
+
+jest.mock("three/examples/jsm/libs/draco/draco_decoder.wasm", () => "");
+
+function makeMarker(opacity: number): Marker {
+  return {
+    header: { frame_id: "map", stamp: { sec: 0, nsec: 0 } },
+    ns: "",
+    id: 1,
+    type: MarkerType.MESH_RESOURCE,
+    action: MarkerAction.ADD,
+    pose: {
+      position: { x: 0, y: 0, z: 0 },
+      orientation: { x: 0, y: 0, z: 0, w: 1 },
+    },
+    scale: { x: 1, y: 1, z: 1 },
+    color: { r: 1, g: 1, b: 1, a: opacity },
+    lifetime: { sec: 0, nsec: 0 },
+    frame_locked: true,
+    points: [],
+    colors: [],
+    text: "",
+    mesh_resource: "package://robot/model.dae",
+    mesh_use_embedded_materials: true,
+  };
+}
+
+function embeddedMaterial(renderable: RenderableMeshResource): THREE.Material | undefined {
+  let result: THREE.Material | undefined;
+  renderable.traverse((child) => {
+    if (child instanceof THREE.Mesh && !Array.isArray(child.material)) {
+      result = child.material;
+    }
+  });
+  return result;
+}
+
+describe("RenderableMeshResource embedded opacity", () => {
+  it("reloads embedded materials when opacity changes without changing the resource", async () => {
+    const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 0.8 });
+    const cachedModel = new THREE.Group();
+    cachedModel.add(new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial));
+    const load = jest.fn().mockResolvedValue(cachedModel);
+    const renderer = {
+      normalizeFrameId: (frameId: string) => frameId,
+      config: { topics: {} },
+      modelCache: { load },
+      settings: {
+        errors: {
+          add: jest.fn(),
+          remove: jest.fn(),
+          hasError: jest.fn().mockReturnValue(false),
+        },
+      },
+      queueAnimationFrame: jest.fn(),
+    } as unknown as IRenderer;
+    const renderable = new RenderableMeshResource(
+      "/robot_description",
+      makeMarker(1),
+      0n,
+      renderer,
+    );
+
+    await waitFor(() => {
+      expect(load).toHaveBeenCalledTimes(1);
+      expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.8);
+    });
+
+    renderable.update(makeMarker(0.5), 1n);
+
+    await waitFor(() => {
+      expect(load).toHaveBeenCalledTimes(2);
+      expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.4);
+      expect(embeddedMaterial(renderable)?.transparent).toBe(true);
+      expect(embeddedMaterial(renderable)?.depthWrite).toBe(false);
+    });
+    expect(cachedMaterial.opacity).toBe(0.8);
+    expect(cachedMaterial.transparent).toBe(false);
+    renderable.dispose();
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -15,7 +15,12 @@ import type { IRenderer } from "../../IRenderer";
 import { rgbToThreeColor } from "../../color";
 import { disposeMeshesRecursive } from "../../dispose";
 import { Marker } from "../../ros";
-import { removeLights, replaceMaterials, setEmbeddedMaterialsOpacity } from "../models";
+import {
+  removeLights,
+  replaceMaterials,
+  setEmbeddedMaterialsOpacity,
+  updateEmbeddedMaterialsOpacity,
+} from "../models";
 
 const MESH_FETCH_FAILED = "MESH_FETCH_FAILED";
 
@@ -68,13 +73,13 @@ export class RenderableMeshResource extends RenderableMarker {
     rgbToThreeColor(this.#material.color, marker.color);
     this.#material.opacity = marker.color.a;
 
-    const embeddedMaterialOptionsChanged =
-      marker.mesh_use_embedded_materials !== prevMarker.mesh_use_embedded_materials ||
-      (marker.mesh_use_embedded_materials && marker.color.a !== prevMarker.color.a);
+    const embeddedMaterialUsageChanged =
+      marker.mesh_use_embedded_materials !== prevMarker.mesh_use_embedded_materials;
+    const opacityChanged = marker.color.a !== prevMarker.color.a;
     if (
       forceLoad === true ||
       marker.mesh_resource !== prevMarker.mesh_resource ||
-      embeddedMaterialOptionsChanged
+      embeddedMaterialUsageChanged
     ) {
       const curUpdateId = ++this.#updateId;
 
@@ -114,6 +119,9 @@ export class RenderableMeshResource extends RenderableMarker {
             `Unhandled error loading mesh from "${marker.mesh_resource}": ${(err as Error).message}`,
           );
         });
+    } else if (opacityChanged && marker.mesh_use_embedded_materials && this.#mesh != undefined) {
+      // Opacity-only updates must not destroy/recreate GPU resources on the hot path.
+      updateEmbeddedMaterialsOpacity(this.#mesh, marker.color.a);
     }
     this.#updateOutlineVisibility();
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -104,6 +104,10 @@ export class RenderableMeshResource extends RenderableMarker {
             return;
           }
           this.#mesh = mesh;
+          // Opacity may have changed while the load was in flight; apply the latest value.
+          if (this.userData.marker.mesh_use_embedded_materials) {
+            updateEmbeddedMaterialsOpacity(mesh, this.userData.marker.color.a);
+          }
           this.add(mesh);
           this.#updateOutlineVisibility();
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -15,7 +15,7 @@ import type { IRenderer } from "../../IRenderer";
 import { rgbToThreeColor } from "../../color";
 import { disposeMeshesRecursive } from "../../dispose";
 import { Marker } from "../../ros";
-import { removeLights, replaceMaterials } from "../models";
+import { removeLights, replaceMaterials, setEmbeddedMaterialsOpacity } from "../models";
 
 const MESH_FETCH_FAILED = "MESH_FETCH_FAILED";
 
@@ -68,10 +68,20 @@ export class RenderableMeshResource extends RenderableMarker {
     rgbToThreeColor(this.#material.color, marker.color);
     this.#material.opacity = marker.color.a;
 
-    if (forceLoad === true || marker.mesh_resource !== prevMarker.mesh_resource) {
+    const embeddedMaterialOptionsChanged =
+      marker.mesh_use_embedded_materials !== prevMarker.mesh_use_embedded_materials ||
+      (marker.mesh_use_embedded_materials && marker.color.a !== prevMarker.color.a);
+    if (
+      forceLoad === true ||
+      marker.mesh_resource !== prevMarker.mesh_resource ||
+      embeddedMaterialOptionsChanged
+    ) {
       const curUpdateId = ++this.#updateId;
 
-      const opts = { useEmbeddedMaterials: marker.mesh_use_embedded_materials };
+      const opts = {
+        useEmbeddedMaterials: marker.mesh_use_embedded_materials,
+        opacity: marker.color.a,
+      };
       const errors = this.renderer.settings.errors;
       if (this.#mesh) {
         this.remove(this.#mesh);
@@ -126,7 +136,7 @@ export class RenderableMeshResource extends RenderableMarker {
 
   async #loadModel(
     url: string,
-    opts: { useEmbeddedMaterials: boolean },
+    opts: { useEmbeddedMaterials: boolean; opacity: number },
   ): Promise<THREE.Group | THREE.Scene | undefined> {
     const cachedModel = await this.renderer.modelCache.load(
       url,
@@ -155,6 +165,8 @@ export class RenderableMeshResource extends RenderableMarker {
     removeLights(mesh);
     if (!opts.useEmbeddedMaterials) {
       replaceMaterials(mesh, this.#material);
+    } else {
+      setEmbeddedMaterialsOpacity(mesh, opts.opacity);
     }
 
     return mesh;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
@@ -75,4 +75,28 @@ describe("updateEmbeddedMaterialsOpacity", () => {
     expect(instanceMaterial.depthWrite).toBe(false);
     expect(cachedMaterial.opacity).toBe(0.8);
   });
+
+  it("increments material version only when transparent or depthWrite flip", () => {
+    const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 1, transparent: false });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial);
+    const model = new THREE.Group();
+    model.add(mesh);
+
+    setEmbeddedMaterialsOpacity(model, 1);
+    const instanceMaterial = mesh.material;
+    const versionAfterSetup = instanceMaterial.version;
+
+    // Same structural flags (still fully opaque) — no shader recompile needed.
+    updateEmbeddedMaterialsOpacity(model, 1);
+    expect(instanceMaterial.version).toBe(versionAfterSetup);
+
+    // Crossing into translucent flips transparent/depthWrite.
+    updateEmbeddedMaterialsOpacity(model, 0.5);
+    expect(instanceMaterial.transparent).toBe(true);
+    expect(instanceMaterial.version).toBeGreaterThan(versionAfterSetup);
+
+    const versionAfterFlip = instanceMaterial.version;
+    updateEmbeddedMaterialsOpacity(model, 0.25);
+    expect(instanceMaterial.version).toBe(versionAfterFlip);
+  });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as THREE from "three";
+
+import { setEmbeddedMaterialsOpacity } from "./models";
+
+describe("setEmbeddedMaterialsOpacity", () => {
+  it("clones embedded materials and applies opacity without mutating cached materials", () => {
+    const cachedMaterial = new THREE.MeshStandardMaterial({
+      opacity: 0.8,
+      transparent: false,
+    });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial);
+    const model = new THREE.Group();
+    model.add(mesh);
+
+    setEmbeddedMaterialsOpacity(model, 0.5);
+
+    const instanceMaterial = mesh.material;
+    expect(instanceMaterial).not.toBe(cachedMaterial);
+    expect(instanceMaterial.opacity).toBeCloseTo(0.4);
+    expect(instanceMaterial.transparent).toBe(true);
+    expect(instanceMaterial.depthWrite).toBe(false);
+    expect(cachedMaterial.opacity).toBe(0.8);
+    expect(cachedMaterial.transparent).toBe(false);
+    expect(cachedMaterial.depthWrite).toBe(true);
+  });
+
+  it("updates every material in a multi-material mesh", () => {
+    const opaqueMaterial = new THREE.MeshStandardMaterial({ opacity: 1 });
+    const transparentMaterial = new THREE.MeshStandardMaterial({
+      opacity: 0.5,
+      transparent: true,
+      depthWrite: false,
+    });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), [opaqueMaterial, transparentMaterial]);
+    const model = new THREE.Group();
+    model.add(mesh);
+
+    setEmbeddedMaterialsOpacity(model, 1);
+
+    const materials = mesh.material;
+    expect(materials[0]).not.toBe(opaqueMaterial);
+    expect(materials[0]).toMatchObject({ opacity: 1, transparent: false, depthWrite: true });
+    expect(materials[1]).not.toBe(transparentMaterial);
+    expect(materials[1]).toMatchObject({ opacity: 0.5, transparent: true, depthWrite: false });
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
@@ -7,7 +7,7 @@
 
 import * as THREE from "three";
 
-import { setEmbeddedMaterialsOpacity } from "./models";
+import { setEmbeddedMaterialsOpacity, updateEmbeddedMaterialsOpacity } from "./models";
 
 describe("setEmbeddedMaterialsOpacity", () => {
   it("clones embedded materials and applies opacity without mutating cached materials", () => {
@@ -49,5 +49,30 @@ describe("setEmbeddedMaterialsOpacity", () => {
     expect(materials[0]).toMatchObject({ opacity: 1, transparent: false, depthWrite: true });
     expect(materials[1]).not.toBe(transparentMaterial);
     expect(materials[1]).toMatchObject({ opacity: 0.5, transparent: true, depthWrite: false });
+  });
+});
+
+describe("updateEmbeddedMaterialsOpacity", () => {
+  it("updates opacity in place without recloning or compounding multipliers", () => {
+    const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 0.8 });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial);
+    const model = new THREE.Group();
+    model.add(mesh);
+
+    setEmbeddedMaterialsOpacity(model, 0.5);
+    const instanceMaterial = mesh.material;
+    expect(instanceMaterial.opacity).toBeCloseTo(0.4);
+
+    updateEmbeddedMaterialsOpacity(model, 0.25);
+    expect(mesh.material).toBe(instanceMaterial);
+    expect(instanceMaterial.opacity).toBeCloseTo(0.2);
+
+    // Full layer opacity restores the intrinsic 0.8 (still translucent because base < 1).
+    updateEmbeddedMaterialsOpacity(model, 1);
+    expect(mesh.material).toBe(instanceMaterial);
+    expect(instanceMaterial.opacity).toBeCloseTo(0.8);
+    expect(instanceMaterial.transparent).toBe(true);
+    expect(instanceMaterial.depthWrite).toBe(false);
+    expect(cachedMaterial.opacity).toBe(0.8);
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
@@ -52,11 +52,37 @@ export function replaceMaterials(model: LoadedModel, material: THREE.MeshStandar
   });
 }
 
+const ORIGINAL_OPACITY_KEY = "originalOpacity";
+const ORIGINAL_TRANSPARENT_KEY = "originalTransparent";
+const ORIGINAL_DEPTH_WRITE_KEY = "originalDepthWrite";
+
+function applyOpacityToMaterial(material: THREE.Material, opacity: number): void {
+  const storedOpacity = material.userData[ORIGINAL_OPACITY_KEY];
+  const storedTransparent = material.userData[ORIGINAL_TRANSPARENT_KEY];
+  const storedDepthWrite = material.userData[ORIGINAL_DEPTH_WRITE_KEY];
+
+  const originalOpacity = typeof storedOpacity === "number" ? storedOpacity : material.opacity;
+  const originalTransparent =
+    typeof storedTransparent === "boolean" ? storedTransparent : material.transparent;
+  const originalDepthWrite =
+    typeof storedDepthWrite === "boolean" ? storedDepthWrite : material.depthWrite;
+
+  material.userData[ORIGINAL_OPACITY_KEY] = originalOpacity;
+  material.userData[ORIGINAL_TRANSPARENT_KEY] = originalTransparent;
+  material.userData[ORIGINAL_DEPTH_WRITE_KEY] = originalDepthWrite;
+
+  material.opacity = originalOpacity * opacity;
+  material.transparent = originalTransparent || material.opacity < 1;
+  material.depthWrite = material.opacity >= 1 && originalDepthWrite;
+  material.needsUpdate = true;
+}
+
 /**
  * Clone embedded materials for this model instance and apply a layer opacity multiplier.
  *
  * Object3D.clone() keeps material references shared with the cached model. Cloning here prevents
- * one transparent URDF from changing other instances that use the same cached mesh.
+ * one transparent URDF from changing other instances that use the same cached mesh. Intrinsic
+ * opacity/transparency are stored on the clone so later updates can adjust opacity in place.
  */
 export function setEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number): void {
   model.traverse((child: THREE.Object3D) => {
@@ -64,19 +90,34 @@ export function setEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number)
       return;
     }
 
-    const applyOpacity = (material: THREE.Material): THREE.Material => {
+    const cloneWithOpacity = (material: THREE.Material): THREE.Material => {
       const clonedMaterial = material.clone();
-      clonedMaterial.opacity = material.opacity * opacity;
-      clonedMaterial.transparent = material.transparent || clonedMaterial.opacity < 1;
-      clonedMaterial.depthWrite = clonedMaterial.opacity >= 1 && material.depthWrite;
-      clonedMaterial.needsUpdate = true;
+      applyOpacityToMaterial(clonedMaterial, opacity);
       return clonedMaterial;
     };
 
     const materials = child.material as THREE.Material | THREE.Material[];
     child.material = Array.isArray(materials)
-      ? materials.map(applyOpacity)
-      : applyOpacity(materials);
+      ? materials.map(cloneWithOpacity)
+      : cloneWithOpacity(materials);
+  });
+}
+
+/** Update previously prepared embedded materials in place (no clone, no multiplier compounding). */
+export function updateEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number): void {
+  model.traverse((child: THREE.Object3D) => {
+    if (!(child instanceof THREE.Mesh)) {
+      return;
+    }
+
+    const materials = child.material as THREE.Material | THREE.Material[];
+    if (Array.isArray(materials)) {
+      for (const material of materials) {
+        applyOpacityToMaterial(material, opacity);
+      }
+    } else {
+      applyOpacityToMaterial(materials, opacity);
+    }
   });
 }
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
@@ -52,6 +52,34 @@ export function replaceMaterials(model: LoadedModel, material: THREE.MeshStandar
   });
 }
 
+/**
+ * Clone embedded materials for this model instance and apply a layer opacity multiplier.
+ *
+ * Object3D.clone() keeps material references shared with the cached model. Cloning here prevents
+ * one transparent URDF from changing other instances that use the same cached mesh.
+ */
+export function setEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number): void {
+  model.traverse((child: THREE.Object3D) => {
+    if (!(child instanceof THREE.Mesh)) {
+      return;
+    }
+
+    const applyOpacity = (material: THREE.Material): THREE.Material => {
+      const clonedMaterial = material.clone();
+      clonedMaterial.opacity = material.opacity * opacity;
+      clonedMaterial.transparent = material.transparent || clonedMaterial.opacity < 1;
+      clonedMaterial.depthWrite = clonedMaterial.opacity >= 1 && material.depthWrite;
+      clonedMaterial.needsUpdate = true;
+      return clonedMaterial;
+    };
+
+    const materials = child.material as THREE.Material | THREE.Material[];
+    child.material = Array.isArray(materials)
+      ? materials.map(applyOpacity)
+      : applyOpacity(materials);
+  });
+}
+
 /** Generic MeshStandardMaterial dispose function for materials loaded from an external source */
 function disposeStandardMaterial(material: THREE.MeshStandardMaterial): void {
   material.map?.dispose();

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
@@ -72,9 +72,15 @@ function applyOpacityToMaterial(material: THREE.Material, opacity: number): void
   material.userData[ORIGINAL_DEPTH_WRITE_KEY] = originalDepthWrite;
 
   material.opacity = originalOpacity * opacity;
-  material.transparent = originalTransparent || material.opacity < 1;
-  material.depthWrite = material.opacity >= 1 && originalDepthWrite;
-  material.needsUpdate = true;
+
+  // opacity is a uniform; only flip structural flags when they change to avoid shader recompiles
+  const newTransparent = originalTransparent || material.opacity < 1;
+  const newDepthWrite = material.opacity >= 1 && originalDepthWrite;
+  if (material.transparent !== newTransparent || material.depthWrite !== newDepthWrite) {
+    material.transparent = newTransparent;
+    material.depthWrite = newDepthWrite;
+    material.needsUpdate = true;
+  }
 }
 
 /**
@@ -103,22 +109,28 @@ export function setEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number)
   });
 }
 
+/** Opacity state for the reused traverse callback (safe: traverse is synchronous). */
+let updateOpacityState = 1;
+
+const updateEmbeddedOpacityCallback = (child: THREE.Object3D): void => {
+  if (!(child instanceof THREE.Mesh)) {
+    return;
+  }
+
+  const materials = child.material as THREE.Material | THREE.Material[];
+  if (Array.isArray(materials)) {
+    for (const material of materials) {
+      applyOpacityToMaterial(material, updateOpacityState);
+    }
+  } else {
+    applyOpacityToMaterial(materials, updateOpacityState);
+  }
+};
+
 /** Update previously prepared embedded materials in place (no clone, no multiplier compounding). */
 export function updateEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number): void {
-  model.traverse((child: THREE.Object3D) => {
-    if (!(child instanceof THREE.Mesh)) {
-      return;
-    }
-
-    const materials = child.material as THREE.Material | THREE.Material[];
-    if (Array.isArray(materials)) {
-      for (const material of materials) {
-        applyOpacityToMaterial(material, opacity);
-      }
-    } else {
-      applyOpacityToMaterial(materials, opacity);
-    }
-  });
+  updateOpacityState = opacity;
+  model.traverse(updateEmbeddedOpacityCallback);
 }
 
 /** Generic MeshStandardMaterial dispose function for materials loaded from an external source */


### PR DESCRIPTION
## User-Facing Changes


New setting for URDF layers in the 3D panel:

- **Opacity** — adjust the transparency of each URDF independently, making it easier to distinguish overlapping robot models. 

The default remains fully opaque, so existing layouts are unaffected.

## Description

Adds per-URDF opacity control for comparing multiple robot poses in the same scene.

A common use case is overlaying a reference or software-estimated pose with a measured hardware pose. One URDF can remain fully opaque while the other is rendered as a semi-transparent “ghost”, making differences between their link positions immediately visible.

The opacity control is available for:

- The `/robot_description` topic
- The `/robot_description` parameter
- Custom URDF layers

Opacity is applied to primitive geometry and mesh resources, including meshes that use embedded materials. Embedded materials are cloned per model instance so changing one URDF’s opacity does not affect another URDF using the same cached mesh.

Values are constrained to the range `0–1`, where:

- `0` is fully transparent
- `1` is fully opaque

<p align="center">
  <img width="1185" height="884" alt="Opaque reference robot overlaid with a transparent comparison robot" src="https://github.com/user-attachments/assets/49a23b48-5646-4118-b157-b7e9bccab35e" />
  <br />
  <em>An opaque reference pose overlaid with a semi-transparent comparison pose, making differences between the robot bodies visible.</em>
</p>

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-layer/per-source opacity controls for URDF visualizations (topic, parameter, and custom layers), defaulting to fully opaque when unset (opacity clamped to 0–1).
  - Embedded mesh materials now apply the configured opacity to marker visuals.

- **Bug Fixes**
  - URDF visuals now update correctly when opacity changes (using the debounced reload path) and when embedded-material mode toggles.
  - Embedded-material opacity updates no longer compound and apply in place when possible.

- **Tests**
  - Added Jest coverage for URDF opacity behavior and embedded-material opacity cloning vs in-place updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->