### PR TITLE
Feature/add arg to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,26 +6,48 @@ COPY . ./
 RUN corepack enable
 RUN yarn install --immutable
 
-RUN yarn run web:build:prod
+ARG API_URL
+RUN if [ -n "$API_URL" ]; then \
+			escaped_api_url=$(printf '%s\n' "$API_URL" | sed 's/[\\&#]/\\&/g'); \
+			sed -i "s#^API_URL=.*#API_URL=\"$escaped_api_url\"#" .env; \
+		fi && \
+		resolved_api_url=$(grep '^API_URL=' .env | sed -E 's/^API_URL="?([^"]*)"?$/\1/') && \
+		printf '%s' "$resolved_api_url" > /tmp/build-api-url.txt && \
+		yarn run web:build:prod
 
 # Release stage
 FROM caddy:2.5.2-alpine
 WORKDIR /src
 COPY --from=build /src/web/.webpack ./
+COPY --from=build /tmp/build-api-url.txt /src/.build-api-url
 
 EXPOSE 8080
 
-COPY <<EOF /entrypoint.sh
+COPY <<'EOF' /entrypoint.sh
+# Optionally override API_URL at runtime with API_URL env var (or API for backward compatibility)
+runtime_api=${API_URL:-$API}
+if [ -n "$runtime_api" ] && [ -f /src/.build-api-url ]; then
+  build_api=$(cat /src/.build-api-url)
+  if [ -n "$build_api" ] && [ "$build_api" != "$runtime_api" ]; then
+    escaped_build_api=$(printf '%s\n' "$build_api" | sed 's/[][\/.*^$&|]/\\&/g')
+    escaped_runtime_api=$(printf '%s\n' "$runtime_api" | sed 's/[\\&|]/\\&/g')
+    find /src -type f \( -name "*.js" -o -name "*.html" -o -name "*.css" \) \
+      -exec sed -i "s|$escaped_build_api|$escaped_runtime_api|g" {} +
+  fi
+fi
+
 # Optionally override the default layout with one provided via bind mount
 mkdir -p /lichtblick
 touch /lichtblick/default-layout.json
-index_html=\$(cat index.html)
+index_html=$(cat index.html)
 replace_pattern='/*LICHTBLICK_SUITE_DEFAULT_LAYOUT_PLACEHOLDER*/'
-replace_value=\$(cat /lichtblick/default-layout.json)
-echo "\${index_html/"\$replace_pattern"/\$replace_value}" > index.html
+replace_value=$(cat /lichtblick/default-layout.json)
+escaped_pattern=$(printf '%s\n' "$replace_pattern" | sed 's/[][\/.*^$]/\\&/g')
+escaped_value=$(printf '%s\n' "$replace_value" | sed 's/[\\&]/\\&/g')
+printf '%s\n' "$index_html" | sed "s/$escaped_pattern/$escaped_value/" > index.html
 
 # Continue executing the CMD
-exec "\$@"
+exec "$@"
 EOF
 
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,45 +6,29 @@ COPY . ./
 RUN corepack enable
 RUN yarn install --immutable
 
-ARG API_URL
-RUN if [ -n "$API_URL" ]; then \
-			escaped_api_url=$(printf '%s\n' "$API_URL" | sed 's/[\\&#]/\\&/g'); \
-			sed -i "s#^API_URL=.*#API_URL=\"$escaped_api_url\"#" .env; \
-		fi && \
-		resolved_api_url=$(grep '^API_URL=' .env | sed -E 's/^API_URL="?([^"]*)"?$/\1/') && \
-		printf '%s' "$resolved_api_url" > /tmp/build-api-url.txt && \
-		yarn run web:build:prod
+RUN yarn run web:build:prod
 
 # Release stage
 FROM caddy:2.5.2-alpine
 WORKDIR /src
 COPY --from=build /src/web/.webpack ./
-COPY --from=build /tmp/build-api-url.txt /src/.build-api-url
 
 EXPOSE 8080
 
 COPY <<'EOF' /entrypoint.sh
-# Optionally override API_URL at runtime with API_URL env var (or API for backward compatibility)
-runtime_api=${API_URL:-$API}
-if [ -n "$runtime_api" ] && [ -f /src/.build-api-url ]; then
-  build_api=$(cat /src/.build-api-url)
-  if [ -n "$build_api" ] && [ "$build_api" != "$runtime_api" ]; then
-    escaped_build_api=$(printf '%s\n' "$build_api" | sed 's/[][\/.*^$&|]/\\&/g')
-    escaped_runtime_api=$(printf '%s\n' "$runtime_api" | sed 's/[\\&|]/\\&/g')
-    find /src -type f \( -name "*.js" -o -name "*.html" -o -name "*.css" \) \
-      -exec sed -i "s|$escaped_build_api|$escaped_runtime_api|g" {} +
-  fi
-fi
+# Optionally override API_URL at runtime using environment variable
+index_html=$(cat index.html)
+runtime_api_url="${API_URL:-}"
+runtime_api_placeholder='/*LICHTBLICK_SUITE_RUNTIME_API_URL_PLACEHOLDER*/'
+index_html="${index_html/"$runtime_api_placeholder"/$runtime_api_url}"
 
 # Optionally override the default layout with one provided via bind mount
 mkdir -p /lichtblick
 touch /lichtblick/default-layout.json
-index_html=$(cat index.html)
 replace_pattern='/*LICHTBLICK_SUITE_DEFAULT_LAYOUT_PLACEHOLDER*/'
 replace_value=$(cat /lichtblick/default-layout.json)
-escaped_pattern=$(printf '%s\n' "$replace_pattern" | sed 's/[][\/.*^$]/\\&/g')
-escaped_value=$(printf '%s\n' "$replace_value" | sed 's/[\\&]/\\&/g')
-printf '%s\n' "$index_html" | sed "s/$escaped_pattern/$escaped_value/" > index.html
+index_html="${index_html/"$replace_pattern"/$replace_value}"
+echo "$index_html" > index.html
 
 # Continue executing the CMD
 exec "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,11 @@ COPY <<'EOF' /entrypoint.sh
 # Optionally override API_URL at runtime using environment variable
 index_html=$(cat index.html)
 runtime_api_url="${API_URL:-}"
-runtime_api_placeholder='/*LICHTBLICK_SUITE_RUNTIME_API_URL_PLACEHOLDER*/'
-index_html="${index_html/"$runtime_api_placeholder"/$runtime_api_url}"
+# Serialize API_URL to JSON-safe string: escape backslashes and quotes (and defensively encode HTML/special chars in case of edge cases)
+runtime_api_url_json=$(printf '%s' "$runtime_api_url" | awk 'BEGIN { printf "\"" } { if (NR > 1) { printf "\\n" } gsub(/\\/, "\\\\"); gsub(/"/, "\\\""); gsub(/</, "\\u003c"); gsub(/>/, "\\u003e"); gsub(/&/, "\\u0026"); printf "%s", $0 } END { printf "\"" }')
+runtime_api_url_json=${runtime_api_url_json:-'""'}
+runtime_api_placeholder='/*LICHTBLICK_SUITE_RUNTIME_API_URL_PLACEHOLDER*/ null'
+index_html="${index_html/"$runtime_api_placeholder"/$runtime_api_url_json}"
 
 # Optionally override the default layout with one provided via bind mount
 mkdir -p /lichtblick

--- a/packages/suite-base/src/constants/config.test.ts
+++ b/packages/suite-base/src/constants/config.test.ts
@@ -16,6 +16,7 @@ describe("APP_CONFIG", () => {
     delete (globalThis as any).API_URL;
     delete (globalThis as any).LICHTBLICK_SUITE_VERSION;
     delete (globalThis as any).DEV_WORKSPACE;
+    delete (globalThis as any).LICHTBLICK_RUNTIME_CONFIG;
 
     // Clear module cache to ensure fresh imports
     jest.resetModules();
@@ -31,7 +32,7 @@ describe("APP_CONFIG", () => {
     (globalThis as any).API_URL = undefined;
     (globalThis as any).LICHTBLICK_SUITE_VERSION = undefined;
     (globalThis as any).DEV_WORKSPACE = undefined;
-
+    (globalThis as any).LICHTBLICK_RUNTIME_CONFIG = undefined;
     const { APP_CONFIG } = await import("./config");
 
     expect(APP_CONFIG.apiUrl).toBe(undefined);
@@ -44,7 +45,7 @@ describe("APP_CONFIG", () => {
     (globalThis as any).API_URL = "https://api.example.com";
     (globalThis as any).LICHTBLICK_SUITE_VERSION = "1.2.3";
     (globalThis as any).DEV_WORKSPACE = "test-workspace";
-
+    (globalThis as any).LICHTBLICK_RUNTIME_CONFIG = undefined;
     const { APP_CONFIG } = await import("./config");
 
     expect(APP_CONFIG.apiUrl).toBe("https://api.example.com");
@@ -57,6 +58,7 @@ describe("APP_CONFIG", () => {
     (globalThis as any).API_URL = "https://partial.example.com";
     (globalThis as any).LICHTBLICK_SUITE_VERSION = undefined;
     (globalThis as any).DEV_WORKSPACE = "partial-workspace";
+    (globalThis as any).LICHTBLICK_RUNTIME_CONFIG = undefined;
 
     const { APP_CONFIG } = await import("./config");
 
@@ -70,6 +72,7 @@ describe("APP_CONFIG", () => {
     (globalThis as any).API_URL = undefined;
     (globalThis as any).LICHTBLICK_SUITE_VERSION = undefined;
     (globalThis as any).DEV_WORKSPACE = undefined;
+    (globalThis as any).LICHTBLICK_RUNTIME_CONFIG = undefined;
 
     const { APP_CONFIG } = await import("./config");
 
@@ -85,11 +88,59 @@ describe("APP_CONFIG", () => {
     (globalThis as any).API_URL = "";
     (globalThis as any).LICHTBLICK_SUITE_VERSION = "";
     (globalThis as any).DEV_WORKSPACE = "";
-
+    (globalThis as any).LICHTBLICK_RUNTIME_CONFIG = undefined;
     const { APP_CONFIG } = await import("./config");
 
     expect(APP_CONFIG.apiUrl).toBe(""); // Empty string, not default
     expect(APP_CONFIG.version).toBe(""); // Empty string, not default
     expect(APP_CONFIG.devWorkspace).toBe(""); // Empty string, not default
+  });
+
+  it("should prefer runtime API_URL over build-time API_URL", async () => {
+    (globalThis as any).API_URL = "https://build-time.example.com";
+    (globalThis as any).LICHTBLICK_SUITE_VERSION = undefined;
+    (globalThis as any).DEV_WORKSPACE = undefined;
+    (globalThis as any).LICHTBLICK_RUNTIME_CONFIG = {
+      API_URL: "https://runtime.example.com",
+    };
+
+    const { APP_CONFIG } = await import("./config");
+
+    expect(APP_CONFIG.apiUrl).toBe("https://runtime.example.com");
+  });
+
+  it("should fallback to build-time API_URL when runtime API_URL is missing", async () => {
+    (globalThis as any).API_URL = "https://build-time.example.com";
+    (globalThis as any).LICHTBLICK_SUITE_VERSION = undefined;
+    (globalThis as any).DEV_WORKSPACE = undefined;
+    (globalThis as any).LICHTBLICK_RUNTIME_CONFIG = {};
+
+    const { APP_CONFIG } = await import("./config");
+
+    expect(APP_CONFIG.apiUrl).toBe("https://build-time.example.com");
+  });
+
+  it("should fallback to build-time API_URL when runtime API_URL is an empty string", async () => {
+    (globalThis as any).API_URL = "https://build-time.example.com";
+    (globalThis as any).LICHTBLICK_SUITE_VERSION = undefined;
+    (globalThis as any).DEV_WORKSPACE = undefined;
+    (globalThis as any).LICHTBLICK_RUNTIME_CONFIG = { API_URL: "" };
+
+    const { APP_CONFIG } = await import("./config");
+
+    expect(APP_CONFIG.apiUrl).toBe("https://build-time.example.com");
+  });
+
+  it("should use runtime API_URL when build-time API_URL is undefined", async () => {
+    (globalThis as any).API_URL = undefined;
+    (globalThis as any).LICHTBLICK_SUITE_VERSION = undefined;
+    (globalThis as any).DEV_WORKSPACE = undefined;
+    (globalThis as any).LICHTBLICK_RUNTIME_CONFIG = {
+      API_URL: "https://runtime-only.example.com",
+    };
+
+    const { APP_CONFIG } = await import("./config");
+
+    expect(APP_CONFIG.apiUrl).toBe("https://runtime-only.example.com");
   });
 });

--- a/packages/suite-base/src/constants/config.ts
+++ b/packages/suite-base/src/constants/config.ts
@@ -21,11 +21,13 @@ const runtimeConfig = (
   }
 ).LICHTBLICK_RUNTIME_CONFIG;
 
+const useRuntimeApiUrl: boolean = !!(runtimeConfig?.API_URL && runtimeConfig.API_URL !== "");
+
 export const APP_CONFIG = {
   /**
    * API base URL for HTTP requests
    */
-  apiUrl: runtimeConfig?.API_URL || API_URL,
+  apiUrl: useRuntimeApiUrl ? runtimeConfig?.API_URL : API_URL,
 
   /**
    * Application version

--- a/packages/suite-base/src/constants/config.ts
+++ b/packages/suite-base/src/constants/config.ts
@@ -11,11 +11,21 @@ declare const API_URL: string | undefined;
 declare const LICHTBLICK_SUITE_VERSION: string | undefined;
 declare const DEV_WORKSPACE: string | undefined;
 
+type RuntimeConfig = {
+  API_URL?: string;
+};
+
+const runtimeConfig = (
+  globalThis as typeof globalThis & {
+    LICHTBLICK_RUNTIME_CONFIG?: RuntimeConfig;
+  }
+).LICHTBLICK_RUNTIME_CONFIG;
+
 export const APP_CONFIG = {
   /**
    * API base URL for HTTP requests
    */
-  apiUrl: API_URL,
+  apiUrl: runtimeConfig?.API_URL || API_URL,
 
   /**
    * Application version

--- a/packages/suite-web/src/webpackConfigs.ts
+++ b/packages/suite-web/src/webpackConfigs.ts
@@ -179,6 +179,9 @@ export const mainConfig =
     <script>
       global = globalThis;
       globalThis.LICHTBLICK_SUITE_DEFAULT_LAYOUT = [/*LICHTBLICK_SUITE_DEFAULT_LAYOUT_PLACEHOLDER*/][0];
+      globalThis.LICHTBLICK_RUNTIME_CONFIG = {
+        API_URL: "/*LICHTBLICK_SUITE_RUNTIME_API_URL_PLACEHOLDER*/",
+      };
     </script>
     <body>
       <div id="root"></div>

--- a/packages/suite-web/src/webpackConfigs.ts
+++ b/packages/suite-web/src/webpackConfigs.ts
@@ -180,7 +180,7 @@ export const mainConfig =
       global = globalThis;
       globalThis.LICHTBLICK_SUITE_DEFAULT_LAYOUT = [/*LICHTBLICK_SUITE_DEFAULT_LAYOUT_PLACEHOLDER*/][0];
       globalThis.LICHTBLICK_RUNTIME_CONFIG = {
-        API_URL: "/*LICHTBLICK_SUITE_RUNTIME_API_URL_PLACEHOLDER*/",
+        API_URL: /*LICHTBLICK_SUITE_RUNTIME_API_URL_PLACEHOLDER*/ null,
       };
     </script>
     <body>


### PR DESCRIPTION
## User-Facing Changes
This PR modifies the dockerfile to allow the user to fill a API_URL during the docker image runtime

## Description
In order to allow several users to work with different API_URL based on the same docker image, we wanted to modify the dockerfile to run the image getting an API_URL arg rather than build their own docker image from their own .env variables.

## What is implemented
- API_URL arg is added to the dockerfile
- if an API_URL is filled during the runtime, it will overwrite the one difenid during the build time

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime API URL support by injecting a runtime configuration object into generated web assets and preferring it when set.
  * Improved container startup to substitute runtime placeholders in the delivered HTML, including default layout insertion.

* **Bug Fixes**
  * Fixed container startup behavior to reliably replace placeholder values and then execute the intended command.

* **Tests**
  * Expanded tests to verify runtime API URL precedence and prevent runtime configuration leakage across test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->