### PR TITLE
feat(3d-panel): per-URDF opacity control

### DIFF
--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
@@ -275,4 +275,57 @@ describe("Urdfs opacity", () => {
 
     renderer.dispose();
   });
+
+  it("updates opacity in place without rebuilding child renderables", async () => {
+    const renderer = makeRenderer(
+      makeConfig({ topics: { "/robot_description": { visible: true, opacity: 1 } } }),
+    );
+    renderer.setTopics([{ name: "/robot_description", schemaName: "std_msgs/String" }]);
+    const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+    const topicSubscription = urdfs.getSubscriptions()[0];
+    if (topicSubscription?.type !== "topic") {
+      throw new Error("Expected /robot_description topic subscription");
+    }
+    const messageEvent: MessageEvent<{ data: string }> = {
+      topic: "/robot_description",
+      schemaName: "std_msgs/String",
+      receiveTime: { sec: 0, nsec: 0 },
+      message: { data: URDF },
+      sizeInBytes: URDF.length,
+    };
+
+    topicSubscription.subscription.handler(messageEvent);
+    let childBefore: unknown;
+    await waitFor(() => {
+      const robot = urdfs.renderables.get("/robot_description");
+      childBefore = robot?.userData.renderables.values().next().value;
+      expect(childBefore).toBeDefined();
+    });
+
+    const removeChildren = jest.spyOn(
+      urdfs.renderables.get("/robot_description")!,
+      "removeChildren",
+    );
+
+    const settingsNode = urdfs
+      .settingsNodes()
+      .find((entry) => entry.path[1] === "/robot_description");
+    expect(settingsNode?.node.handler).toBeDefined();
+    settingsNode?.node.handler?.({
+      action: "update",
+      payload: {
+        path: ["topics", "/robot_description", "opacity"],
+        input: "number",
+        value: 0.25,
+      },
+    });
+
+    const robot = urdfs.renderables.get("/robot_description");
+    const childAfter = robot?.userData.renderables.values().next().value;
+    expect(childAfter).toBe(childBefore);
+    expect(removeChildren).not.toHaveBeenCalled();
+    expect((childAfter?.userData as MarkerUserData).marker.color.a).toBeCloseTo(0.2);
+
+    renderer.dispose();
+  });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
@@ -278,7 +278,11 @@ describe("Urdfs opacity", () => {
 
   it("updates opacity in place without rebuilding child renderables", async () => {
     const renderer = makeRenderer(
-      makeConfig({ topics: { "/robot_description": { visible: true, opacity: 1 } } }),
+      makeConfig({
+        topics: {
+          "/robot_description": { visible: true, opacity: 1 } as Partial<LayerSettingsUrdf>,
+        },
+      }),
     );
     renderer.setTopics([{ name: "/robot_description", schemaName: "std_msgs/String" }]);
     const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
@@ -335,5 +339,44 @@ describe("Urdfs opacity", () => {
     expect(outlineVisible).toBe(false);
 
     renderer.dispose();
+  });
+
+  it("dispose cancels pending debounced URDF loads", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const layer: LayerSettingsCustomUrdf = {
+        layerId: "foxglove.Urdf",
+        instanceId: "debounce-test",
+        label: "Debounce test",
+        visible: true,
+        frameLocked: true,
+        sourceType: "url",
+        url: "",
+        framePrefix: "",
+        displayMode: "auto",
+      };
+      const renderer = makeRenderer(makeConfig({ layers: { "debounce-test": layer } }));
+      const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+      const settingsNode = urdfs
+        .settingsNodes()
+        .find((entry) => entry.path[1] === "debounce-test");
+
+      settingsNode?.node.handler?.({
+        action: "update",
+        payload: {
+          path: ["layers", "debounce-test", "framePrefix"],
+          input: "string",
+          value: "hw_",
+        },
+      });
+
+      expect(() => {
+        urdfs.dispose();
+      }).not.toThrow();
+
+      renderer.dispose();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
@@ -91,7 +91,10 @@ const SHAPES_URDF = `<?xml version="1.0"?>
   </link>
 </robot>`;
 
-function makeCustomLayer(instanceId: string, overrides: Partial<LayerSettingsCustomUrdf> = {}): LayerSettingsCustomUrdf {
+function makeCustomLayer(
+  instanceId: string,
+  overrides: Partial<LayerSettingsCustomUrdf> = {},
+): LayerSettingsCustomUrdf {
   return {
     layerId: "foxglove.Urdf",
     instanceId,
@@ -423,9 +426,7 @@ describe("Urdfs opacity", () => {
       const layer = makeCustomLayer("debounce-test");
       const renderer = makeRenderer(makeConfig({ layers: { "debounce-test": layer } }));
       const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
-      const settingsNode = urdfs
-        .settingsNodes()
-        .find((entry) => entry.path[1] === "debounce-test");
+      const settingsNode = urdfs.settingsNodes().find((entry) => entry.path[1] === "debounce-test");
       expect(settingsNode).toBeDefined();
       expect(settingsNode?.node.handler).toBeDefined();
 
@@ -495,7 +496,7 @@ describe("Urdfs opacity", () => {
     try {
       const renderer = makeRenderer(
         makeConfig({
-          topics: { "/robot_description": { visible: true } as Partial<LayerSettingsUrdf> },
+          topics: { "/robot_description": { visible: true } },
         }),
       );
       renderer.setTopics([{ name: "/robot_description", schemaName: "std_msgs/String" }]);
@@ -531,7 +532,9 @@ describe("Urdfs opacity", () => {
   it("applies layer opacity to cylinder and sphere visuals", async () => {
     const renderer = makeRenderer(
       makeConfig({
-        topics: { "/robot_description": { visible: true, opacity: 0.5 } as Partial<LayerSettingsUrdf> },
+        topics: {
+          "/robot_description": { visible: true, opacity: 0.5 } as Partial<LayerSettingsUrdf>,
+        },
       }),
     );
     renderer.setTopics([{ name: "/robot_description", schemaName: "std_msgs/String" }]);
@@ -554,7 +557,9 @@ describe("Urdfs opacity", () => {
       expect(robot?.userData.renderables.size).toBe(2);
     });
 
-    const alphas = [...(urdfs.renderables.get("/robot_description")?.userData.renderables.values() ?? [])]
+    const alphas = [
+      ...(urdfs.renderables.get("/robot_description")?.userData.renderables.values() ?? []),
+    ]
       .map((child) => (child.userData as MarkerUserData).marker.color.a)
       .sort((a, b) => a - b);
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
@@ -442,7 +442,7 @@ describe("Urdfs opacity", () => {
       urdfs.dispose();
       const callsAfterDispose = removeChildren.mock.calls.length;
       jest.advanceTimersByTime(1000);
-      expect(removeChildren.mock.calls.length).toBe(callsAfterDispose);
+      expect(removeChildren.mock.calls).toHaveLength(callsAfterDispose);
 
       renderer.dispose();
     } finally {
@@ -481,7 +481,7 @@ describe("Urdfs opacity", () => {
       expect(urdfs.renderables.has("delete-debounce")).toBe(false);
       const callsAfterDelete = removeChildren.mock.calls.length;
       jest.advanceTimersByTime(1000);
-      expect(removeChildren.mock.calls.length).toBe(callsAfterDelete);
+      expect(removeChildren.mock.calls).toHaveLength(callsAfterDelete);
 
       renderer.dispose();
     } finally {
@@ -517,10 +517,10 @@ describe("Urdfs opacity", () => {
         },
       });
 
-      expect(removeChildren.mock.calls.length).toBe(callsBefore);
+      expect(removeChildren.mock.calls).toHaveLength(callsBefore);
 
       jest.advanceTimersByTime(500);
-      expect(removeChildren.mock.calls.length - callsBefore).toBe(1);
+      expect(removeChildren.mock.calls).toHaveLength(callsBefore + 1);
 
       renderer.dispose();
     } finally {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
@@ -77,6 +77,34 @@ const URDF = `<?xml version="1.0"?>
   </link>
 </robot>`;
 
+const SHAPES_URDF = `<?xml version="1.0"?>
+<robot name="shapes-test">
+  <link name="base">
+    <visual>
+      <geometry><cylinder radius="0.5" length="1.0"/></geometry>
+      <material><color rgba="1 0 0 0.8"/></material>
+    </visual>
+    <visual>
+      <geometry><sphere radius="0.3"/></geometry>
+      <material><color rgba="0 1 0 1.0"/></material>
+    </visual>
+  </link>
+</robot>`;
+
+function makeCustomLayer(instanceId: string): LayerSettingsCustomUrdf {
+  return {
+    layerId: "foxglove.Urdf",
+    instanceId,
+    label: instanceId,
+    visible: true,
+    frameLocked: true,
+    sourceType: "url",
+    url: "",
+    framePrefix: "",
+    displayMode: "auto",
+  };
+}
+
 function makeConfig(overrides: Partial<RendererConfig> = {}): RendererConfig {
   return {
     cameraState: DEFAULT_CAMERA_STATE,
@@ -344,17 +372,7 @@ describe("Urdfs opacity", () => {
   it("dispose cancels pending debounced URDF loads", () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     try {
-      const layer: LayerSettingsCustomUrdf = {
-        layerId: "foxglove.Urdf",
-        instanceId: "debounce-test",
-        label: "Debounce test",
-        visible: true,
-        frameLocked: true,
-        sourceType: "url",
-        url: "",
-        framePrefix: "",
-        displayMode: "auto",
-      };
+      const layer = makeCustomLayer("debounce-test");
       const renderer = makeRenderer(makeConfig({ layers: { "debounce-test": layer } }));
       const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
       const settingsNode = urdfs
@@ -378,5 +396,121 @@ describe("Urdfs opacity", () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  it("deleting a custom URDF layer cancels pending debounced loads", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const layer = makeCustomLayer("delete-debounce");
+      const renderer = makeRenderer(makeConfig({ layers: { "delete-debounce": layer } }));
+      const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+      const settingsNode = urdfs
+        .settingsNodes()
+        .find((entry) => entry.path[1] === "delete-debounce");
+
+      settingsNode?.node.handler?.({
+        action: "update",
+        payload: {
+          path: ["layers", "delete-debounce", "framePrefix"],
+          input: "string",
+          value: "hw_",
+        },
+      });
+
+      settingsNode?.node.handler?.({
+        action: "perform-node-action",
+        payload: { id: "delete", path: ["layers", "delete-debounce"] },
+      });
+
+      expect(urdfs.renderables.has("delete-debounce")).toBe(false);
+      renderer.dispose();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("framePrefix changes still debounce a URDF reload", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const renderer = makeRenderer(
+        makeConfig({
+          topics: { "/robot_description": { visible: true } as Partial<LayerSettingsUrdf> },
+        }),
+      );
+      renderer.setTopics([{ name: "/robot_description", schemaName: "std_msgs/String" }]);
+      const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+      const topicSubscription = urdfs.getSubscriptions()[0];
+      if (topicSubscription?.type !== "topic") {
+        throw new Error("Expected /robot_description topic subscription");
+      }
+
+      topicSubscription.subscription.handler({
+        topic: "/robot_description",
+        schemaName: "std_msgs/String",
+        receiveTime: { sec: 0, nsec: 0 },
+        message: { data: URDF },
+        sizeInBytes: URDF.length,
+      });
+
+      await waitFor(() => {
+        expect(urdfs.renderables.get("/robot_description")?.userData.renderables.size).toBe(1);
+      });
+
+      const removeChildren = jest.spyOn(
+        urdfs.renderables.get("/robot_description")!,
+        "removeChildren",
+      );
+
+      urdfs
+        .settingsNodes()
+        .find((entry) => entry.path[1] === "/robot_description")
+        ?.node.handler?.({
+          action: "update",
+          payload: {
+            path: ["topics", "/robot_description", "framePrefix"],
+            input: "string",
+            value: "hw_",
+          },
+        });
+
+      expect(removeChildren).not.toHaveBeenCalled();
+      renderer.dispose();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("applies layer opacity to cylinder and sphere visuals", async () => {
+    const renderer = makeRenderer(
+      makeConfig({
+        topics: { "/robot_description": { visible: true, opacity: 0.5 } as Partial<LayerSettingsUrdf> },
+      }),
+    );
+    renderer.setTopics([{ name: "/robot_description", schemaName: "std_msgs/String" }]);
+    const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+    const topicSubscription = urdfs.getSubscriptions()[0];
+    if (topicSubscription?.type !== "topic") {
+      throw new Error("Expected /robot_description topic subscription");
+    }
+
+    topicSubscription.subscription.handler({
+      topic: "/robot_description",
+      schemaName: "std_msgs/String",
+      receiveTime: { sec: 0, nsec: 0 },
+      message: { data: SHAPES_URDF },
+      sizeInBytes: SHAPES_URDF.length,
+    });
+
+    await waitFor(() => {
+      const robot = urdfs.renderables.get("/robot_description");
+      expect(robot?.userData.renderables.size).toBe(2);
+    });
+
+    const alphas = [...(urdfs.renderables.get("/robot_description")?.userData.renderables.values() ?? [])]
+      .map((child) => (child.userData as MarkerUserData).marker.color.a)
+      .sort((a, b) => a - b);
+
+    expect(alphas).toEqual([0.4, 0.5]);
+    renderer.dispose();
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
@@ -21,6 +21,7 @@ import {
 import { DEFAULT_PUBLISH_SETTINGS } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/PublishSettings";
 
 import { RendererConfig } from "../IRenderer";
+import { MarkerUserData } from "./markers/RenderableMarker";
 import { LayerSettingsCustomUrdf, LayerSettingsUrdf, Urdfs } from "./Urdfs";
 
 let mockOrbitControls!: {
@@ -176,7 +177,9 @@ describe("Urdfs opacity", () => {
         value: 0.6,
       },
     });
-    expect(renderer.config.layers.ghost?.opacity).toBe(0.6);
+    expect((renderer.config.layers.ghost as LayerSettingsCustomUrdf | undefined)?.opacity).toBe(
+      0.6,
+    );
     renderer.dispose();
   });
 
@@ -266,7 +269,8 @@ describe("Urdfs opacity", () => {
     await waitFor(() => {
       const robot = urdfs.renderables.get("/robot_description");
       const child = robot?.userData.renderables.values().next().value;
-      expect(child?.userData.marker.color.a).toBeCloseTo(expectedAlpha);
+      const markerAlpha = (child?.userData as MarkerUserData | undefined)?.marker.color.a;
+      expect(markerAlpha).toBeCloseTo(expectedAlpha);
     });
 
     renderer.dispose();

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
@@ -1,0 +1,274 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { waitFor } from "@testing-library/react";
+import { setupJestCanvasMock } from "jest-canvas-mock";
+import * as THREE from "three";
+
+import { MessageEvent } from "@lichtblick/suite";
+import { Renderer } from "@lichtblick/suite-base/panels/ThreeDeeRender/Renderer";
+import { DEFAULT_SCENE_EXTENSION_CONFIG } from "@lichtblick/suite-base/panels/ThreeDeeRender/SceneExtensionConfig";
+import {
+  DEFAULT_CAMERA_STATE,
+  DEFAULT_ORBIT_CONTROLS_CONFIG,
+} from "@lichtblick/suite-base/panels/ThreeDeeRender/camera";
+import { DEFAULT_PUBLISH_SETTINGS } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/PublishSettings";
+
+import { RendererConfig } from "../IRenderer";
+import { LayerSettingsCustomUrdf, LayerSettingsUrdf, Urdfs } from "./Urdfs";
+
+let mockOrbitControls!: {
+  screenSpacePanning: boolean;
+  mouseButtons: { LEFT: number; RIGHT: number };
+  touches: { ONE: number; TWO: number };
+  keys: { LEFT: string; RIGHT: string; UP: string; BOTTOM: string };
+  addEventListener: jest.Mock;
+  listenToKeyEvents: jest.Mock;
+  getDistance: jest.Mock;
+  getPolarAngle: jest.Mock;
+  getAzimuthalAngle: jest.Mock;
+  target: THREE.Vector3;
+  update: jest.Mock;
+  minPolarAngle: number;
+  maxPolarAngle: number;
+};
+
+jest.mock("three/examples/jsm/libs/draco/draco_decoder.wasm", () => "");
+jest.mock("three/examples/jsm/controls/OrbitControls", () => ({
+  OrbitControls: jest.fn().mockImplementation(() => mockOrbitControls),
+}));
+jest.mock("three", () => {
+  const ActualTHREE = jest.requireActual("three");
+  return {
+    ...ActualTHREE,
+    WebGLRenderer: function WebGLRenderer() {
+      return {
+        capabilities: { isWebGL2: true },
+        setPixelRatio: jest.fn(),
+        setSize: jest.fn(),
+        render: jest.fn(),
+        clear: jest.fn(),
+        setClearColor: jest.fn(),
+        readRenderTargetPixels: jest.fn(),
+        info: { reset: jest.fn() },
+        shadowMap: {},
+        dispose: jest.fn(),
+        clearDepth: jest.fn(),
+        getDrawingBufferSize: () => ({ width: 100, height: 100 }),
+      };
+    },
+  };
+});
+
+const URDF = `<?xml version="1.0"?>
+<robot name="opacity-test">
+  <link name="box">
+    <visual>
+      <geometry><box size="1 1 1"/></geometry>
+      <material><color rgba="1 0 0 0.8"/></material>
+    </visual>
+  </link>
+</robot>`;
+
+function makeConfig(overrides: Partial<RendererConfig> = {}): RendererConfig {
+  return {
+    cameraState: DEFAULT_CAMERA_STATE,
+    followMode: "follow-pose",
+    followTf: undefined,
+    scene: {},
+    transforms: {},
+    topics: {},
+    layers: {},
+    publish: DEFAULT_PUBLISH_SETTINGS,
+    imageMode: {},
+    ...overrides,
+  };
+}
+
+function makeRenderer(config: RendererConfig): Renderer {
+  const parent = document.createElement("div");
+  const canvas = document.createElement("canvas");
+  parent.appendChild(canvas);
+  return new Renderer({
+    canvas,
+    config,
+    interfaceMode: "3d",
+    fetchAsset: async () => {
+      throw new Error("Unexpected asset fetch");
+    },
+    sceneExtensionConfig: DEFAULT_SCENE_EXTENSION_CONFIG,
+    testOptions: {},
+    customCameraModels: new Map(),
+  });
+}
+
+describe("Urdfs opacity", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: undefined,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+    setupJestCanvasMock();
+    mockOrbitControls = {
+      ...DEFAULT_ORBIT_CONTROLS_CONFIG,
+      addEventListener: jest.fn(),
+      listenToKeyEvents: jest.fn(),
+      getDistance: jest.fn().mockReturnValue(DEFAULT_CAMERA_STATE.distance),
+      getPolarAngle: jest.fn().mockReturnValue(0),
+      getAzimuthalAngle: jest.fn().mockReturnValue(0),
+      target: new THREE.Vector3(),
+      update: jest.fn(),
+      minPolarAngle: 0,
+      maxPolarAngle: Math.PI,
+    };
+  });
+
+  afterEach(() => {
+    (console.warn as jest.Mock).mockClear();
+  });
+
+  it("exposes an opacity control for custom URDF layers", () => {
+    const layer: LayerSettingsCustomUrdf = {
+      layerId: "foxglove.Urdf",
+      instanceId: "ghost",
+      label: "Ghost",
+      visible: true,
+      frameLocked: true,
+      sourceType: "url",
+      url: "",
+      framePrefix: "",
+      displayMode: "auto",
+      opacity: 0.35,
+    };
+    const renderer = makeRenderer(makeConfig({ layers: { ghost: layer } }));
+    const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+
+    const settingsNode = urdfs.settingsNodes()[0];
+    const opacityField = settingsNode?.node.fields?.opacity;
+
+    expect(opacityField).toMatchObject({
+      input: "number",
+      min: 0,
+      max: 1,
+      step: 0.05,
+      value: 0.35,
+    });
+    settingsNode?.node.handler?.({
+      action: "update",
+      payload: {
+        path: ["layers", "ghost", "opacity"],
+        input: "number",
+        value: 0.6,
+      },
+    });
+    expect(renderer.config.layers.ghost?.opacity).toBe(0.6);
+    renderer.dispose();
+  });
+
+  it("exposes opacity for topic and parameter URDFs", () => {
+    const renderer = makeRenderer(
+      makeConfig({
+        topics: {
+          "/robot_description": { visible: true, opacity: 0.4 } as Partial<LayerSettingsUrdf>,
+          "param:/robot_description": {
+            visible: true,
+            opacity: 0.7,
+          } as Partial<LayerSettingsUrdf>,
+        },
+      }),
+    );
+    renderer.setTopics([{ name: "/robot_description", schemaName: "std_msgs/String" }]);
+    renderer.setParameters(new Map([["/robot_description", 123]]));
+    const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+
+    const nodes = urdfs.settingsNodes();
+
+    expect(
+      nodes.find((entry) => entry.path[1] === "/robot_description")?.node.fields?.opacity,
+    ).toMatchObject({
+      value: 0.4,
+    });
+    expect(
+      nodes.find((entry) => entry.path[1] === "param:/robot_description")?.node.fields?.opacity,
+    ).toMatchObject({ value: 0.7 });
+    renderer.dispose();
+  });
+
+  it("defaults every URDF source opacity to fully opaque", () => {
+    const layer: LayerSettingsCustomUrdf = {
+      layerId: "foxglove.Urdf",
+      instanceId: "default-opacity",
+      label: "Default opacity",
+      visible: true,
+      frameLocked: true,
+      sourceType: "url",
+      url: "",
+      framePrefix: "",
+      displayMode: "auto",
+    };
+    const renderer = makeRenderer(
+      makeConfig({
+        topics: {
+          "/robot_description": { visible: true },
+          "param:/robot_description": { visible: true },
+        },
+        layers: { "default-opacity": layer },
+      }),
+    );
+    renderer.setTopics([{ name: "/robot_description", schemaName: "std_msgs/String" }]);
+    renderer.setParameters(new Map([["/robot_description", 123]]));
+    const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+
+    const opacityValues = urdfs.settingsNodes().map((entry) => entry.node.fields?.opacity?.value);
+
+    expect(opacityValues).toEqual([1, 1, 1]);
+    renderer.dispose();
+  });
+
+  it.each([
+    { opacity: 0.25, expectedAlpha: 0.2 },
+    { opacity: undefined, expectedAlpha: 0.8 },
+  ])("applies layer opacity $opacity to URDF material alpha", async ({
+    opacity,
+    expectedAlpha,
+  }) => {
+    const topicSettings: Partial<LayerSettingsUrdf> = { visible: true, opacity };
+    const renderer = makeRenderer(makeConfig({ topics: { "/robot_description": topicSettings } }));
+    const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+    const topicSubscription = urdfs.getSubscriptions()[0];
+    if (topicSubscription?.type !== "topic") {
+      throw new Error("Expected /robot_description topic subscription");
+    }
+    const messageEvent: MessageEvent<{ data: string }> = {
+      topic: "/robot_description",
+      schemaName: "std_msgs/String",
+      receiveTime: { sec: 0, nsec: 0 },
+      message: { data: URDF },
+      sizeInBytes: URDF.length,
+    };
+
+    topicSubscription.subscription.handler(messageEvent);
+    await waitFor(() => {
+      const robot = urdfs.renderables.get("/robot_description");
+      const child = robot?.userData.renderables.values().next().value;
+      expect(child?.userData.marker.color.a).toBeCloseTo(expectedAlpha);
+    });
+
+    renderer.dispose();
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
@@ -21,8 +21,8 @@ import {
 import { DEFAULT_PUBLISH_SETTINGS } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/PublishSettings";
 
 import { RendererConfig } from "../IRenderer";
-import { MarkerUserData } from "./markers/RenderableMarker";
 import { LayerSettingsCustomUrdf, LayerSettingsUrdf, Urdfs } from "./Urdfs";
+import { MarkerUserData } from "./markers/RenderableMarker";
 
 let mockOrbitControls!: {
   screenSpacePanning: boolean;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
@@ -21,7 +21,7 @@ import {
 import { DEFAULT_PUBLISH_SETTINGS } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/PublishSettings";
 
 import { RendererConfig } from "../IRenderer";
-import { LayerSettingsCustomUrdf, LayerSettingsUrdf, Urdfs } from "./Urdfs";
+import { LayerSettingsCustomUrdf, LayerSettingsUrdf, UrdfRenderable, Urdfs } from "./Urdfs";
 import { MarkerUserData } from "./markers/RenderableMarker";
 
 let mockOrbitControls!: {
@@ -91,7 +91,7 @@ const SHAPES_URDF = `<?xml version="1.0"?>
   </link>
 </robot>`;
 
-function makeCustomLayer(instanceId: string): LayerSettingsCustomUrdf {
+function makeCustomLayer(instanceId: string, overrides: Partial<LayerSettingsCustomUrdf> = {}): LayerSettingsCustomUrdf {
   return {
     layerId: "foxglove.Urdf",
     instanceId,
@@ -100,8 +100,12 @@ function makeCustomLayer(instanceId: string): LayerSettingsCustomUrdf {
     frameLocked: true,
     sourceType: "url",
     url: "",
+    filePath: "",
+    parameter: "",
+    topic: "",
     framePrefix: "",
     displayMode: "auto",
+    ...overrides,
   };
 }
 
@@ -369,8 +373,52 @@ describe("Urdfs opacity", () => {
     renderer.dispose();
   });
 
+  it("exposes topic, parameter, and file path fields for custom URDF sources", () => {
+    const renderer = makeRenderer(
+      makeConfig({
+        layers: {
+          "topic-layer": makeCustomLayer("topic-layer", {
+            sourceType: "topic",
+            topic: "/robot_description",
+          }),
+          "param-layer": makeCustomLayer("param-layer", {
+            sourceType: "param",
+            parameter: "/robot_description",
+          }),
+          "file-layer": makeCustomLayer("file-layer", {
+            sourceType: "filePath",
+            filePath: "/tmp/robot.urdf",
+          }),
+        },
+      }),
+    );
+    renderer.setTopics([{ name: "/robot_description", schemaName: "std_msgs/String" }]);
+    renderer.setParameters(new Map([["/robot_description", URDF]]));
+    const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
+
+    const nodes = urdfs.settingsNodes();
+    const topicFields = nodes.find((entry) => entry.path[1] === "topic-layer")?.node.fields;
+    const paramFields = nodes.find((entry) => entry.path[1] === "param-layer")?.node.fields;
+    const fileFields = nodes.find((entry) => entry.path[1] === "file-layer")?.node.fields;
+
+    expect(topicFields?.topic).toMatchObject({
+      value: "/robot_description",
+      items: ["/robot_description"],
+    });
+    expect(paramFields?.parameter).toMatchObject({
+      value: "/robot_description",
+      items: ["/robot_description"],
+    });
+    expect(fileFields?.filePath).toMatchObject({
+      value: "/tmp/robot.urdf",
+    });
+
+    renderer.dispose();
+  });
+
   it("dispose cancels pending debounced URDF loads", () => {
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.useFakeTimers();
+    const removeChildren = jest.spyOn(UrdfRenderable.prototype, "removeChildren");
     try {
       const layer = makeCustomLayer("debounce-test");
       const renderer = makeRenderer(makeConfig({ layers: { "debounce-test": layer } }));
@@ -378,8 +426,10 @@ describe("Urdfs opacity", () => {
       const settingsNode = urdfs
         .settingsNodes()
         .find((entry) => entry.path[1] === "debounce-test");
+      expect(settingsNode).toBeDefined();
+      expect(settingsNode?.node.handler).toBeDefined();
 
-      settingsNode?.node.handler?.({
+      settingsNode!.node.handler!({
         action: "update",
         payload: {
           path: ["layers", "debounce-test", "framePrefix"],
@@ -388,18 +438,21 @@ describe("Urdfs opacity", () => {
         },
       });
 
-      expect(() => {
-        urdfs.dispose();
-      }).not.toThrow();
+      urdfs.dispose();
+      const callsAfterDispose = removeChildren.mock.calls.length;
+      jest.advanceTimersByTime(1000);
+      expect(removeChildren.mock.calls.length).toBe(callsAfterDispose);
 
       renderer.dispose();
     } finally {
-      warnSpy.mockRestore();
+      removeChildren.mockRestore();
+      jest.useRealTimers();
     }
   });
 
   it("deleting a custom URDF layer cancels pending debounced loads", () => {
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.useFakeTimers();
+    const removeChildren = jest.spyOn(UrdfRenderable.prototype, "removeChildren");
     try {
       const layer = makeCustomLayer("delete-debounce");
       const renderer = makeRenderer(makeConfig({ layers: { "delete-debounce": layer } }));
@@ -407,8 +460,10 @@ describe("Urdfs opacity", () => {
       const settingsNode = urdfs
         .settingsNodes()
         .find((entry) => entry.path[1] === "delete-debounce");
+      expect(settingsNode).toBeDefined();
+      expect(settingsNode?.node.handler).toBeDefined();
 
-      settingsNode?.node.handler?.({
+      settingsNode!.node.handler!({
         action: "update",
         payload: {
           path: ["layers", "delete-debounce", "framePrefix"],
@@ -417,20 +472,26 @@ describe("Urdfs opacity", () => {
         },
       });
 
-      settingsNode?.node.handler?.({
+      settingsNode!.node.handler!({
         action: "perform-node-action",
         payload: { id: "delete", path: ["layers", "delete-debounce"] },
       });
 
       expect(urdfs.renderables.has("delete-debounce")).toBe(false);
+      const callsAfterDelete = removeChildren.mock.calls.length;
+      jest.advanceTimersByTime(1000);
+      expect(removeChildren.mock.calls.length).toBe(callsAfterDelete);
+
       renderer.dispose();
     } finally {
-      warnSpy.mockRestore();
+      removeChildren.mockRestore();
+      jest.useRealTimers();
     }
   });
 
-  it("framePrefix changes still debounce a URDF reload", async () => {
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  it("framePrefix changes still debounce a URDF reload", () => {
+    jest.useFakeTimers();
+    const removeChildren = jest.spyOn(UrdfRenderable.prototype, "removeChildren");
     try {
       const renderer = makeRenderer(
         makeConfig({
@@ -439,44 +500,31 @@ describe("Urdfs opacity", () => {
       );
       renderer.setTopics([{ name: "/robot_description", schemaName: "std_msgs/String" }]);
       const urdfs = renderer.sceneExtensions.get(Urdfs.extensionId) as Urdfs;
-      const topicSubscription = urdfs.getSubscriptions()[0];
-      if (topicSubscription?.type !== "topic") {
-        throw new Error("Expected /robot_description topic subscription");
-      }
-
-      topicSubscription.subscription.handler({
-        topic: "/robot_description",
-        schemaName: "std_msgs/String",
-        receiveTime: { sec: 0, nsec: 0 },
-        message: { data: URDF },
-        sizeInBytes: URDF.length,
-      });
-
-      await waitFor(() => {
-        expect(urdfs.renderables.get("/robot_description")?.userData.renderables.size).toBe(1);
-      });
-
-      const removeChildren = jest.spyOn(
-        urdfs.renderables.get("/robot_description")!,
-        "removeChildren",
-      );
-
-      urdfs
+      const settingsNode = urdfs
         .settingsNodes()
-        .find((entry) => entry.path[1] === "/robot_description")
-        ?.node.handler?.({
-          action: "update",
-          payload: {
-            path: ["topics", "/robot_description", "framePrefix"],
-            input: "string",
-            value: "hw_",
-          },
-        });
+        .find((entry) => entry.path[1] === "/robot_description");
+      expect(settingsNode).toBeDefined();
+      expect(settingsNode?.node.handler).toBeDefined();
 
-      expect(removeChildren).not.toHaveBeenCalled();
+      const callsBefore = removeChildren.mock.calls.length;
+      settingsNode!.node.handler!({
+        action: "update",
+        payload: {
+          path: ["topics", "/robot_description", "framePrefix"],
+          input: "string",
+          value: "hw_",
+        },
+      });
+
+      expect(removeChildren.mock.calls.length).toBe(callsBefore);
+
+      jest.advanceTimersByTime(500);
+      expect(removeChildren.mock.calls.length - callsBefore).toBe(1);
+
       renderer.dispose();
     } finally {
-      warnSpy.mockRestore();
+      removeChildren.mockRestore();
+      jest.useRealTimers();
     }
   });
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.test.ts
@@ -326,6 +326,14 @@ describe("Urdfs opacity", () => {
     expect(removeChildren).not.toHaveBeenCalled();
     expect((childAfter?.userData as MarkerUserData).marker.color.a).toBeCloseTo(0.2);
 
+    let outlineVisible = true;
+    childAfter?.traverse((obj) => {
+      if (obj instanceof THREE.LineSegments) {
+        outlineVisible = obj.visible;
+      }
+    });
+    expect(outlineVisible).toBe(false);
+
     renderer.dispose();
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -194,6 +194,11 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
   #jointStates = new Map<string, JointPosition>();
   #textDecoder = new TextDecoder();
   #urdfsByTopic = new Map<string, string>();
+  // One debounce per URDF instance so rapid multi-layer slider updates don't drop loads.
+  #debouncedLoadUrdfByInstanceId = new Map<
+    string,
+    _.DebouncedFunc<(args: { instanceId: string; urdf?: string; forceReload?: boolean }) => void>
+  >();
 
   public constructor(renderer: IRenderer, name: string = Urdfs.extensionId) {
     super(name, renderer);
@@ -212,6 +217,14 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         this.#loadUrdf({ instanceId, urdf: undefined });
       }
     }
+  }
+
+  public override dispose(): void {
+    for (const debounced of this.#debouncedLoadUrdfByInstanceId.values()) {
+      debounced.cancel();
+    }
+    this.#debouncedLoadUrdfByInstanceId.clear();
+    super.dispose();
   }
 
   public override getSubscriptions(): readonly AnyRendererSubscription[] {
@@ -562,6 +575,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
           this.remove(renderable);
           this.renderables.delete(instanceId);
         }
+        this.#cancelDebouncedLoadUrdf(instanceId);
 
         // Remove transforms from the TF tree
         const transforms = this.#transformsByInstanceId.get(instanceId);
@@ -947,7 +961,25 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       });
   }
 
-  #debouncedLoadUrdf = _.debounce(this.#loadUrdf.bind(this), 500);
+  #debouncedLoadUrdf(args: { instanceId: string; urdf?: string; forceReload?: boolean }): void {
+    let debounced = this.#debouncedLoadUrdfByInstanceId.get(args.instanceId);
+    if (!debounced) {
+      debounced = _.debounce(
+        (loadArgs: { instanceId: string; urdf?: string; forceReload?: boolean }) => {
+          this.#loadUrdf(loadArgs);
+        },
+        500,
+      );
+      this.#debouncedLoadUrdfByInstanceId.set(args.instanceId, debounced);
+    }
+    debounced(args);
+  }
+
+  #cancelDebouncedLoadUrdf(instanceId: string): void {
+    const debounced = this.#debouncedLoadUrdfByInstanceId.get(instanceId);
+    debounced?.cancel();
+    this.#debouncedLoadUrdfByInstanceId.delete(instanceId);
+  }
 
   #loadRobot(
     renderable: UrdfRenderable,

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -651,14 +651,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       } else if (field === "parameter") {
         urdf = this.renderer.parameters?.get(action.payload.value as string) as string | undefined;
         this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
-      } else if (field === "framePrefix") {
+      } else if (field === "framePrefix" || field === "opacity") {
+        // Opacity is a slider; debounce so dragging does not spam parse/reload work.
         this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
-      } else if (
-        field === "displayMode" ||
-        field === "visible" ||
-        field === "fallbackColor" ||
-        field === "opacity"
-      ) {
+      } else if (field === "displayMode" || field === "visible" || field === "fallbackColor") {
         this.#loadUrdf({ instanceId, urdf, forceReload: true });
       } else if (field === "sourceType") {
         const sourceType = action.payload.value as LayerSettingsCustomUrdf["sourceType"];

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -88,6 +88,7 @@ export type LayerSettingsUrdf = BaseSettings & {
   displayMode: "auto" | "visual" | "collision";
   label: string;
   fallbackColor?: string;
+  opacity?: number;
 };
 
 export type LayerSettingsCustomUrdf = CustomLayerSettings & {
@@ -100,6 +101,7 @@ export type LayerSettingsCustomUrdf = CustomLayerSettings & {
   framePrefix: string;
   displayMode: "auto" | "visual" | "collision";
   fallbackColor?: string;
+  opacity?: number;
 };
 
 const DEFAULT_SETTINGS: LayerSettingsUrdf = {
@@ -109,6 +111,7 @@ const DEFAULT_SETTINGS: LayerSettingsUrdf = {
   displayMode: "auto",
   label: "URDF",
   fallbackColor: DEFAULT_COLOR_STR,
+  opacity: 1,
 };
 
 const DEFAULT_CUSTOM_SETTINGS: LayerSettingsCustomUrdf = {
@@ -125,6 +128,7 @@ const DEFAULT_CUSTOM_SETTINGS: LayerSettingsCustomUrdf = {
   framePrefix: "",
   displayMode: "auto",
   fallbackColor: DEFAULT_COLOR_STR,
+  opacity: 1,
 };
 const URDF_TOPIC_SCHEMAS = new Set<string>(["std_msgs/String", "std_msgs/msg/String"]);
 
@@ -267,6 +271,15 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       help: "Fallback color used in case a link does not specify any color itself",
       input: "rgb",
     };
+    const baseOpacityField: SettingsTreeField = {
+      label: "Opacity",
+      help: "Overall opacity of this URDF layer. Lower values create a transparent ghost overlay.",
+      input: "number",
+      min: 0,
+      max: 1,
+      step: 0.05,
+      precision: 2,
+    };
 
     // /robot_description topic entry
     const topic = this.renderer.topicsByName?.get(TOPIC_NAME);
@@ -280,6 +293,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         fallbackColor: {
           ...baseFallbackColorField,
           value: config.fallbackColor ?? DEFAULT_SETTINGS.fallbackColor,
+        },
+        opacity: {
+          ...baseOpacityField,
+          value: config.opacity ?? DEFAULT_SETTINGS.opacity,
         },
       };
       entries.push({
@@ -312,6 +329,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         fallbackColor: {
           ...baseFallbackColorField,
           value: config.fallbackColor ?? DEFAULT_SETTINGS.fallbackColor,
+        },
+        opacity: {
+          ...baseOpacityField,
+          value: config.opacity ?? DEFAULT_SETTINGS.opacity,
         },
       };
 
@@ -423,6 +444,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
           fallbackColor: {
             ...baseFallbackColorField,
             value: config.fallbackColor ?? DEFAULT_SETTINGS.fallbackColor,
+          },
+          opacity: {
+            ...baseOpacityField,
+            value: config.opacity ?? DEFAULT_CUSTOM_SETTINGS.opacity,
           },
         };
 
@@ -628,7 +653,12 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
       } else if (field === "framePrefix") {
         this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
-      } else if (field === "displayMode" || field === "visible" || field === "fallbackColor") {
+      } else if (
+        field === "displayMode" ||
+        field === "visible" ||
+        field === "fallbackColor" ||
+        field === "opacity"
+      ) {
         this.#loadUrdf({ instanceId, urdf, forceReload: true });
       } else if (field === "sourceType") {
         const sourceType = action.payload.value as LayerSettingsCustomUrdf["sourceType"];
@@ -935,6 +965,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     const fallbackColor = settings.fallbackColor
       ? stringToRgba(makeRgba(), settings.fallbackColor)
       : undefined;
+    const opacity = THREE.MathUtils.clamp(settings.opacity ?? 1, 0, 1);
 
     this.#loadFrames(instanceId, frames);
     this.#loadTransforms(instanceId, transforms);
@@ -952,6 +983,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         renderer,
         baseUrl,
         fallbackColor,
+        opacity,
       });
       // Set the childRenderable settingsPath so errors route to the correct place
       childRenderable.userData.settingsPath = renderable.userData.settingsPath;
@@ -1068,12 +1100,14 @@ function createRenderable(args: {
   renderer: IRenderer;
   baseUrl?: string;
   fallbackColor?: ColorRGBA;
+  opacity: number;
 }): Renderable {
-  const { visual, robot, id, frameId, renderer, baseUrl, fallbackColor } = args;
+  const { visual, robot, id, frameId, renderer, baseUrl, fallbackColor, opacity } = args;
   const name = `${frameId}-${id}-${visual.geometry.geometryType}`;
   const orientation = eulerToQuaternion(visual.origin.rpy);
   const pose = { position: visual.origin.xyz, orientation };
-  const color = getColor(visual, robot) ?? fallbackColor ?? DEFAULT_COLOR;
+  const baseColor = getColor(visual, robot) ?? fallbackColor ?? DEFAULT_COLOR;
+  const color = { ...baseColor, a: baseColor.a * opacity };
   const type = visual.geometry.geometryType;
   switch (type) {
     case "box": {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -34,6 +34,7 @@ import { isValidUrl } from "@lichtblick/suite-base/util/isValidURL";
 
 import { RenderableCube } from "./markers/RenderableCube";
 import { RenderableCylinder } from "./markers/RenderableCylinder";
+import { RenderableMarker } from "./markers/RenderableMarker";
 import { RenderableMeshResource } from "./markers/RenderableMeshResource";
 import { RenderableSphere } from "./markers/RenderableSphere";
 import { missingTransformMessage, MISSING_TRANSFORM } from "./transforms";
@@ -137,6 +138,9 @@ const tempVec3b = new THREE.Vector3();
 const tempQuaternion1 = new THREE.Quaternion();
 const tempQuaternion2 = new THREE.Quaternion();
 const tempEuler = new THREE.Euler();
+
+/** Intrinsic URDF visual alpha before layer opacity is applied (per child renderable). */
+const urdfBaseColorAByChild = new WeakMap<object, number>();
 
 export type UrdfUserData = BaseUserData & {
   settings: LayerSettingsUrdf | LayerSettingsCustomUrdf;
@@ -665,9 +669,11 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       } else if (field === "parameter") {
         urdf = this.renderer.parameters?.get(action.payload.value as string) as string | undefined;
         this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
-      } else if (field === "framePrefix" || field === "opacity") {
-        // Opacity is a slider; debounce so dragging does not spam parse/reload work.
+      } else if (field === "framePrefix") {
         this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
+      } else if (field === "opacity") {
+        // Opacity is visual-only; update materials in place (no reparse / rebuild).
+        this.#updateUrdfOpacity(instanceId);
       } else if (field === "displayMode" || field === "visible" || field === "fallbackColor") {
         this.#loadUrdf({ instanceId, urdf, forceReload: true });
       } else if (field === "sourceType") {
@@ -981,6 +987,35 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     this.#debouncedLoadUrdfByInstanceId.delete(instanceId);
   }
 
+  /**
+   * Apply layer opacity to existing child renderables without reparsing the URDF or disposing
+   * meshes. Relies on RenderableMeshResource's opacity-only update path for embedded materials.
+   */
+  #updateUrdfOpacity(instanceId: string): void {
+    const renderable = this.renderables.get(instanceId);
+    if (!renderable) {
+      return;
+    }
+
+    const settings = this.#getCurrentSettings(instanceId);
+    renderable.userData.settings = settings;
+    const opacity = THREE.MathUtils.clamp(settings.opacity ?? 1, 0, 1);
+
+    for (const child of renderable.userData.renderables.values()) {
+      if (!(child instanceof RenderableMarker)) {
+        continue;
+      }
+      const baseColorA = urdfBaseColorAByChild.get(child) ?? 1;
+      const prevMarker = child.userData.marker;
+      const nextMarker = {
+        ...prevMarker,
+        color: { ...prevMarker.color, a: baseColorA * opacity },
+      };
+      child.update(nextMarker, undefined);
+    }
+    this.renderer.queueAnimationFrame();
+  }
+
   #loadRobot(
     renderable: UrdfRenderable,
     { robot, frames, transforms }: ParsedUrdf,
@@ -1141,28 +1176,36 @@ function createRenderable(args: {
     case "box": {
       const scale = visual.geometry.size;
       const marker = createMarker(frameId, MarkerType.CUBE, pose, scale, color);
-      return new RenderableCube(name, marker, undefined, renderer);
+      const renderable = new RenderableCube(name, marker, undefined, renderer);
+      urdfBaseColorAByChild.set(renderable, baseColor.a);
+      return renderable;
     }
     case "cylinder": {
       const cylinder = visual.geometry;
       const scale = { x: cylinder.radius * 2, y: cylinder.radius * 2, z: cylinder.length };
       const marker = createMarker(frameId, MarkerType.CUBE, pose, scale, color);
-      return new RenderableCylinder(name, marker, undefined, renderer);
+      const renderable = new RenderableCylinder(name, marker, undefined, renderer);
+      urdfBaseColorAByChild.set(renderable, baseColor.a);
+      return renderable;
     }
     case "sphere": {
       const sphere = visual.geometry;
       const scale = { x: sphere.radius * 2, y: sphere.radius * 2, z: sphere.radius * 2 };
       const marker = createMarker(frameId, MarkerType.CUBE, pose, scale, color);
-      return new RenderableSphere(name, marker, undefined, renderer);
+      const renderable = new RenderableSphere(name, marker, undefined, renderer);
+      urdfBaseColorAByChild.set(renderable, baseColor.a);
+      return renderable;
     }
     case "mesh": {
       const isCollada = visual.geometry.filename.toLowerCase().endsWith(".dae");
       // Use embedded materials if the mesh is a Collada file
       const embedded = isCollada ? EmbeddedMaterialUsage.Use : EmbeddedMaterialUsage.Ignore;
       const marker = createMeshMarker(frameId, pose, embedded, visual.geometry, baseUrl, color);
-      return new RenderableMeshResource(name, marker, undefined, renderer, {
+      const renderable = new RenderableMeshResource(name, marker, undefined, renderer, {
         referenceUrl: baseUrl,
       });
+      urdfBaseColorAByChild.set(renderable, baseColor.a);
+      return renderable;
     }
     default:
       throw new Error(`Unrecognized visual geometryType: ${type}`);

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
@@ -7,19 +7,12 @@
 
 import * as THREE from "three";
 
-import { RenderableMarker } from "./RenderableMarker";
-import {
-  makeStandardMaterial,
-  shouldShowMarkerOutlines,
-  updateStandardMaterialColor,
-} from "./materials";
+import { RenderableOutlinedMeshMarker } from "./RenderableOutlinedMeshMarker";
+import { makeStandardMaterial } from "./materials";
 import type { IRenderer } from "../../IRenderer";
 import { Marker } from "../../ros";
 
-export class RenderableCube extends RenderableMarker {
-  #mesh: THREE.Mesh<THREE.BoxGeometry, THREE.MeshStandardMaterial>;
-  #outline: THREE.LineSegments;
-
+export class RenderableCube extends RenderableOutlinedMeshMarker {
   public constructor(
     topic: string,
     marker: Marker,
@@ -37,34 +30,17 @@ export class RenderableCube extends RenderableMarker {
       `${this.constructor.name}-cube-edges`,
       () => createEdgesGeometry(cubeGeometry),
     );
-    this.#mesh = new THREE.Mesh(cubeGeometry, makeStandardMaterial(marker.color));
-    this.#mesh.castShadow = true;
-    this.#mesh.receiveShadow = true;
-    this.add(this.#mesh);
+    this.mesh = new THREE.Mesh(cubeGeometry, makeStandardMaterial(marker.color));
+    this.mesh.castShadow = true;
+    this.mesh.receiveShadow = true;
+    this.add(this.mesh);
 
     // Cube outline
-    this.#outline = new THREE.LineSegments(cubeEdgesGeometry, renderer.outlineMaterial);
-    this.#outline.userData.picking = false;
-    this.#mesh.add(this.#outline);
+    this.outline = new THREE.LineSegments(cubeEdgesGeometry, renderer.outlineMaterial);
+    this.outline.userData.picking = false;
+    this.mesh.add(this.outline);
 
     this.update(marker, receiveTime);
-  }
-
-  public override dispose(): void {
-    this.#mesh.material.dispose();
-  }
-
-  public override update(newMarker: Marker, receiveTime: bigint | undefined): void {
-    super.update(newMarker, receiveTime);
-    const marker = this.userData.marker;
-
-    updateStandardMaterialColor(this.#mesh.material, marker.color);
-    this.#outline.visible = shouldShowMarkerOutlines({
-      showOutlines: this.getSettings()?.showOutlines,
-      alpha: marker.color.a,
-    });
-
-    this.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
   }
 }
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
@@ -8,9 +8,12 @@
 import * as THREE from "three";
 
 import { RenderableMarker } from "./RenderableMarker";
-import { makeStandardMaterial } from "./materials";
+import {
+  makeStandardMaterial,
+  shouldShowMarkerOutlines,
+  updateStandardMaterialColor,
+} from "./materials";
 import type { IRenderer } from "../../IRenderer";
-import { rgbToThreeColor } from "../../color";
 import { Marker } from "../../ros";
 
 export class RenderableCube extends RenderableMarker {
@@ -55,18 +58,11 @@ export class RenderableCube extends RenderableMarker {
     super.update(newMarker, receiveTime);
     const marker = this.userData.marker;
 
-    const transparent = marker.color.a < 1;
-    if (transparent !== this.#mesh.material.transparent) {
-      this.#mesh.material.transparent = transparent;
-      this.#mesh.material.depthWrite = !transparent;
-      this.#mesh.material.needsUpdate = true;
-    }
-
-    const showOutlines = (this.getSettings()?.showOutlines ?? true) && marker.color.a >= 1;
-    this.#outline.visible = showOutlines;
-
-    rgbToThreeColor(this.#mesh.material.color, marker.color);
-    this.#mesh.material.opacity = marker.color.a;
+    updateStandardMaterialColor(this.#mesh.material, marker.color);
+    this.#outline.visible = shouldShowMarkerOutlines({
+      showOutlines: this.getSettings()?.showOutlines,
+      alpha: marker.color.a,
+    });
 
     this.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
   }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
@@ -62,7 +62,8 @@ export class RenderableCube extends RenderableMarker {
       this.#mesh.material.needsUpdate = true;
     }
 
-    this.#outline.visible = this.getSettings()?.showOutlines ?? true;
+    const showOutlines = (this.getSettings()?.showOutlines ?? true) && marker.color.a >= 1;
+    this.#outline.visible = showOutlines;
 
     rgbToThreeColor(this.#mesh.material.color, marker.color);
     this.#mesh.material.opacity = marker.color.a;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
@@ -8,9 +8,12 @@
 import * as THREE from "three";
 
 import { RenderableMarker } from "./RenderableMarker";
-import { makeStandardMaterial } from "./materials";
+import {
+  makeStandardMaterial,
+  shouldShowMarkerOutlines,
+  updateStandardMaterialColor,
+} from "./materials";
 import type { IRenderer } from "../../IRenderer";
-import { rgbToThreeColor } from "../../color";
 import { cylinderSubdivisions, DetailLevel } from "../../lod";
 import { Marker } from "../../ros";
 
@@ -57,18 +60,11 @@ export class RenderableCylinder extends RenderableMarker {
     super.update(newMarker, receiveTime);
     const marker = this.userData.marker;
 
-    const transparent = marker.color.a < 1;
-    if (transparent !== this.#mesh.material.transparent) {
-      this.#mesh.material.transparent = transparent;
-      this.#mesh.material.depthWrite = !transparent;
-      this.#mesh.material.needsUpdate = true;
-    }
-
-    const showOutlines = (this.getSettings()?.showOutlines ?? true) && marker.color.a >= 1;
-    this.#outline.visible = showOutlines;
-
-    rgbToThreeColor(this.#mesh.material.color, marker.color);
-    this.#mesh.material.opacity = marker.color.a;
+    updateStandardMaterialColor(this.#mesh.material, marker.color);
+    this.#outline.visible = shouldShowMarkerOutlines({
+      showOutlines: this.getSettings()?.showOutlines,
+      alpha: marker.color.a,
+    });
 
     this.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
   }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
@@ -64,7 +64,8 @@ export class RenderableCylinder extends RenderableMarker {
       this.#mesh.material.needsUpdate = true;
     }
 
-    this.#outline.visible = this.getSettings()?.showOutlines ?? true;
+    const showOutlines = (this.getSettings()?.showOutlines ?? true) && marker.color.a >= 1;
+    this.#outline.visible = showOutlines;
 
     rgbToThreeColor(this.#mesh.material.color, marker.color);
     this.#mesh.material.opacity = marker.color.a;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
@@ -7,20 +7,13 @@
 
 import * as THREE from "three";
 
-import { RenderableMarker } from "./RenderableMarker";
-import {
-  makeStandardMaterial,
-  shouldShowMarkerOutlines,
-  updateStandardMaterialColor,
-} from "./materials";
+import { RenderableOutlinedMeshMarker } from "./RenderableOutlinedMeshMarker";
+import { makeStandardMaterial } from "./materials";
 import type { IRenderer } from "../../IRenderer";
 import { cylinderSubdivisions, DetailLevel } from "../../lod";
 import { Marker } from "../../ros";
 
-export class RenderableCylinder extends RenderableMarker {
-  #mesh: THREE.Mesh<THREE.CylinderGeometry, THREE.MeshStandardMaterial>;
-  #outline: THREE.LineSegments;
-
+export class RenderableCylinder extends RenderableOutlinedMeshMarker {
   public constructor(
     topic: string,
     marker: Marker,
@@ -35,38 +28,21 @@ export class RenderableCylinder extends RenderableMarker {
       `${this.constructor.name}-cylinder-${renderer.maxLod}`,
       () => createGeometry(renderer.maxLod),
     );
-    this.#mesh = new THREE.Mesh(cylinderGeometry, material);
-    this.#mesh.castShadow = true;
-    this.#mesh.receiveShadow = true;
-    this.add(this.#mesh);
+    this.mesh = new THREE.Mesh(cylinderGeometry, material);
+    this.mesh.castShadow = true;
+    this.mesh.receiveShadow = true;
+    this.add(this.mesh);
 
     // Cylinder outline
     const edgesGeometry = renderer.sharedGeometry.getGeometry(
       `${this.constructor.name}-edges-${renderer.maxLod}`,
       () => createEdgesGeometry(cylinderGeometry),
     );
-    this.#outline = new THREE.LineSegments(edgesGeometry, renderer.outlineMaterial);
-    this.#outline.userData.picking = false;
-    this.#mesh.add(this.#outline);
+    this.outline = new THREE.LineSegments(edgesGeometry, renderer.outlineMaterial);
+    this.outline.userData.picking = false;
+    this.mesh.add(this.outline);
 
     this.update(marker, receiveTime);
-  }
-
-  public override dispose(): void {
-    this.#mesh.material.dispose();
-  }
-
-  public override update(newMarker: Marker, receiveTime: bigint | undefined): void {
-    super.update(newMarker, receiveTime);
-    const marker = this.userData.marker;
-
-    updateStandardMaterialColor(this.#mesh.material, marker.color);
-    this.#outline.visible = shouldShowMarkerOutlines({
-      showOutlines: this.getSettings()?.showOutlines,
-      alpha: marker.color.a,
-    });
-
-    this.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
   }
 }
 function createGeometry(lod: DetailLevel): THREE.CylinderGeometry {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
@@ -51,6 +51,16 @@ function embeddedMaterial(renderable: RenderableMeshResource): THREE.Material | 
   return result;
 }
 
+function outlineVisible(renderable: RenderableMeshResource): boolean | undefined {
+  let visible: boolean | undefined;
+  renderable.traverse((obj) => {
+    if (obj instanceof THREE.LineSegments && obj.name === EDGE_LINE_SEGMENTS_NAME) {
+      visible = obj.visible;
+    }
+  });
+  return visible;
+}
+
 describe("RenderableMeshResource embedded opacity", () => {
   it("updates embedded materials in place when only opacity changes", async () => {
     const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 0.8 });
@@ -181,31 +191,20 @@ describe("RenderableMeshResource embedded opacity", () => {
 
     await waitFor(() => {
       expect(load).toHaveBeenCalledTimes(1);
+      expect(outlineVisible(renderable)).toBe(true);
     });
-
-    let outlineVisible = true;
-    renderable.traverse((obj) => {
-      if (obj instanceof THREE.LineSegments && obj.name === EDGE_LINE_SEGMENTS_NAME) {
-        outlineVisible = obj.visible;
-      }
-    });
-    expect(outlineVisible).toBe(true);
 
     renderable.update(makeMarker(0.5), 1n);
 
-    renderable.traverse((obj) => {
-      if (obj instanceof THREE.LineSegments && obj.name === EDGE_LINE_SEGMENTS_NAME) {
-        outlineVisible = obj.visible;
-      }
-    });
-    expect(outlineVisible).toBe(false);
+    expect(outlineVisible(renderable)).toBe(false);
 
     renderable.dispose();
   });
 
   it("updates non-embedded mesh material opacity in place", async () => {
+    const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 1, transparent: false });
     const cachedModel = new THREE.Group();
-    cachedModel.add(new THREE.Mesh(new THREE.BoxGeometry(), new THREE.MeshStandardMaterial()));
+    cachedModel.add(new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial));
     const load = jest.fn().mockResolvedValue(cachedModel);
     const renderer = {
       normalizeFrameId: (frameId: string) => frameId,
@@ -226,10 +225,16 @@ describe("RenderableMeshResource embedded opacity", () => {
 
     await waitFor(() => {
       expect(load).toHaveBeenCalledTimes(1);
+      expect(embeddedMaterial(renderable)?.opacity).toBe(1);
     });
 
     renderable.update({ ...makeMarker(0.5), mesh_use_embedded_materials: false }, 1n);
     expect(load).toHaveBeenCalledTimes(1);
+
+    const material = embeddedMaterial(renderable);
+    expect(material?.opacity).toBeCloseTo(0.5);
+    expect(material?.transparent).toBe(true);
+    expect(material?.depthWrite).toBe(false);
 
     renderable.dispose();
   });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
@@ -50,7 +50,7 @@ function embeddedMaterial(renderable: RenderableMeshResource): THREE.Material | 
 }
 
 describe("RenderableMeshResource embedded opacity", () => {
-  it("reloads embedded materials when opacity changes without changing the resource", async () => {
+  it("updates embedded materials in place when only opacity changes", async () => {
     const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 0.8 });
     const cachedModel = new THREE.Group();
     cachedModel.add(new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial));
@@ -80,14 +80,20 @@ describe("RenderableMeshResource embedded opacity", () => {
       expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.8);
     });
 
+    const materialAfterLoad = embeddedMaterial(renderable);
     renderable.update(makeMarker(0.5), 1n);
 
-    await waitFor(() => {
-      expect(load).toHaveBeenCalledTimes(2);
-      expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.4);
-      expect(embeddedMaterial(renderable)?.transparent).toBe(true);
-      expect(embeddedMaterial(renderable)?.depthWrite).toBe(false);
-    });
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(embeddedMaterial(renderable)).toBe(materialAfterLoad);
+    expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.4);
+    expect(embeddedMaterial(renderable)?.transparent).toBe(true);
+    expect(embeddedMaterial(renderable)?.depthWrite).toBe(false);
+
+    // A second opacity change must keep multiplying against the original, not the previous result.
+    renderable.update(makeMarker(0.25), 2n);
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.2);
+
     expect(cachedMaterial.opacity).toBe(0.8);
     expect(cachedMaterial.transparent).toBe(false);
     renderable.dispose();

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
@@ -98,4 +98,49 @@ describe("RenderableMeshResource embedded opacity", () => {
     expect(cachedMaterial.transparent).toBe(false);
     renderable.dispose();
   });
+
+  it("re-applies the latest opacity when it changes during an in-flight load", async () => {
+    const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 0.8 });
+    const cachedModel = new THREE.Group();
+    cachedModel.add(new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial));
+
+    let resolveLoad!: (model: THREE.Group) => void;
+    const load = jest.fn().mockImplementation(async () => {
+      return await new Promise<THREE.Group>((resolve) => {
+        resolveLoad = resolve;
+      });
+    });
+    const renderer = {
+      normalizeFrameId: (frameId: string) => frameId,
+      config: { topics: {} },
+      modelCache: { load },
+      settings: {
+        errors: {
+          add: jest.fn(),
+          remove: jest.fn(),
+          hasError: jest.fn().mockReturnValue(false),
+        },
+      },
+      queueAnimationFrame: jest.fn(),
+    } as unknown as IRenderer;
+
+    const renderable = new RenderableMeshResource(
+      "/robot_description",
+      makeMarker(1),
+      0n,
+      renderer,
+    );
+    expect(load).toHaveBeenCalledTimes(1);
+
+    // Opacity changes while the mesh is still loading — cannot update in place yet.
+    renderable.update(makeMarker(0.5), 1n);
+    expect(load).toHaveBeenCalledTimes(1);
+
+    resolveLoad(cachedModel);
+
+    await waitFor(() => {
+      expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.4);
+    });
+    renderable.dispose();
+  });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
@@ -1,0 +1,95 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { waitFor } from "@testing-library/react";
+import * as THREE from "three";
+
+import { RenderableMeshResource } from "./RenderableMeshResource";
+import { IRenderer } from "../../IRenderer";
+import { Marker, MarkerAction, MarkerType } from "../../ros";
+
+jest.mock("three/examples/jsm/libs/draco/draco_decoder.wasm", () => "");
+
+function makeMarker(opacity: number): Marker {
+  return {
+    header: { frame_id: "map", stamp: { sec: 0, nsec: 0 } },
+    ns: "",
+    id: 1,
+    type: MarkerType.MESH_RESOURCE,
+    action: MarkerAction.ADD,
+    pose: {
+      position: { x: 0, y: 0, z: 0 },
+      orientation: { x: 0, y: 0, z: 0, w: 1 },
+    },
+    scale: { x: 1, y: 1, z: 1 },
+    color: { r: 1, g: 1, b: 1, a: opacity },
+    lifetime: { sec: 0, nsec: 0 },
+    frame_locked: true,
+    points: [],
+    colors: [],
+    text: "",
+    mesh_resource: "package://robot/model.dae",
+    mesh_use_embedded_materials: true,
+  };
+}
+
+function embeddedMaterial(renderable: RenderableMeshResource): THREE.Material | undefined {
+  let result: THREE.Material | undefined;
+  renderable.traverse((child) => {
+    if (child instanceof THREE.Mesh && !Array.isArray(child.material)) {
+      result = child.material;
+    }
+  });
+  return result;
+}
+
+describe("RenderableMeshResource embedded opacity", () => {
+  it("reloads embedded materials when opacity changes without changing the resource", async () => {
+    const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 0.8 });
+    const cachedModel = new THREE.Group();
+    cachedModel.add(new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial));
+    const load = jest.fn().mockResolvedValue(cachedModel);
+    const renderer = {
+      normalizeFrameId: (frameId: string) => frameId,
+      config: { topics: {} },
+      modelCache: { load },
+      settings: {
+        errors: {
+          add: jest.fn(),
+          remove: jest.fn(),
+          hasError: jest.fn().mockReturnValue(false),
+        },
+      },
+      queueAnimationFrame: jest.fn(),
+    } as unknown as IRenderer;
+    const renderable = new RenderableMeshResource(
+      "/robot_description",
+      makeMarker(1),
+      0n,
+      renderer,
+    );
+
+    await waitFor(() => {
+      expect(load).toHaveBeenCalledTimes(1);
+      expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.8);
+    });
+
+    renderable.update(makeMarker(0.5), 1n);
+
+    await waitFor(() => {
+      expect(load).toHaveBeenCalledTimes(2);
+      expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.4);
+      expect(embeddedMaterial(renderable)?.transparent).toBe(true);
+      expect(embeddedMaterial(renderable)?.depthWrite).toBe(false);
+    });
+    expect(cachedMaterial.opacity).toBe(0.8);
+    expect(cachedMaterial.transparent).toBe(false);
+    renderable.dispose();
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
@@ -10,6 +10,8 @@
 import { waitFor } from "@testing-library/react";
 import * as THREE from "three";
 
+import { EDGE_LINE_SEGMENTS_NAME } from "@lichtblick/suite-base/panels/ThreeDeeRender/ModelCache";
+
 import { RenderableMeshResource } from "./RenderableMeshResource";
 import { IRenderer } from "../../IRenderer";
 import { Marker, MarkerAction, MarkerType } from "../../ros";
@@ -141,6 +143,63 @@ describe("RenderableMeshResource embedded opacity", () => {
     await waitFor(() => {
       expect(embeddedMaterial(renderable)?.opacity).toBeCloseTo(0.4);
     });
+    renderable.dispose();
+  });
+
+  it("hides mesh edge outlines when marker alpha is below 1", async () => {
+    const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 1 });
+    const cachedModel = new THREE.Group();
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial);
+    const edges = new THREE.LineSegments(
+      new THREE.EdgesGeometry(new THREE.BoxGeometry()),
+      new THREE.LineBasicMaterial(),
+    );
+    edges.name = EDGE_LINE_SEGMENTS_NAME;
+    cachedModel.add(mesh, edges);
+
+    const load = jest.fn().mockResolvedValue(cachedModel);
+    const renderer = {
+      normalizeFrameId: (frameId: string) => frameId,
+      config: { topics: {} },
+      modelCache: { load },
+      settings: {
+        errors: {
+          add: jest.fn(),
+          remove: jest.fn(),
+          hasError: jest.fn().mockReturnValue(false),
+        },
+      },
+      queueAnimationFrame: jest.fn(),
+    } as unknown as IRenderer;
+
+    const renderable = new RenderableMeshResource(
+      "/robot_description",
+      makeMarker(1),
+      0n,
+      renderer,
+    );
+
+    await waitFor(() => {
+      expect(load).toHaveBeenCalledTimes(1);
+    });
+
+    let outlineVisible = true;
+    renderable.traverse((obj) => {
+      if (obj instanceof THREE.LineSegments && obj.name === EDGE_LINE_SEGMENTS_NAME) {
+        outlineVisible = obj.visible;
+      }
+    });
+    expect(outlineVisible).toBe(true);
+
+    renderable.update(makeMarker(0.5), 1n);
+
+    renderable.traverse((obj) => {
+      if (obj instanceof THREE.LineSegments && obj.name === EDGE_LINE_SEGMENTS_NAME) {
+        outlineVisible = obj.visible;
+      }
+    });
+    expect(outlineVisible).toBe(false);
+
     renderable.dispose();
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.test.ts
@@ -202,4 +202,35 @@ describe("RenderableMeshResource embedded opacity", () => {
 
     renderable.dispose();
   });
+
+  it("updates non-embedded mesh material opacity in place", async () => {
+    const cachedModel = new THREE.Group();
+    cachedModel.add(new THREE.Mesh(new THREE.BoxGeometry(), new THREE.MeshStandardMaterial()));
+    const load = jest.fn().mockResolvedValue(cachedModel);
+    const renderer = {
+      normalizeFrameId: (frameId: string) => frameId,
+      config: { topics: {} },
+      modelCache: { load },
+      settings: {
+        errors: {
+          add: jest.fn(),
+          remove: jest.fn(),
+          hasError: jest.fn().mockReturnValue(false),
+        },
+      },
+      queueAnimationFrame: jest.fn(),
+    } as unknown as IRenderer;
+
+    const marker = { ...makeMarker(1), mesh_use_embedded_materials: false };
+    const renderable = new RenderableMeshResource("/robot_description", marker, 0n, renderer);
+
+    await waitFor(() => {
+      expect(load).toHaveBeenCalledTimes(1);
+    });
+
+    renderable.update({ ...makeMarker(0.5), mesh_use_embedded_materials: false }, 1n);
+    expect(load).toHaveBeenCalledTimes(1);
+
+    renderable.dispose();
+  });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -10,9 +10,12 @@ import * as THREE from "three";
 import { EDGE_LINE_SEGMENTS_NAME } from "@lichtblick/suite-base/panels/ThreeDeeRender/ModelCache";
 
 import { RenderableMarker } from "./RenderableMarker";
-import { makeStandardMaterial } from "./materials";
+import {
+  makeStandardMaterial,
+  shouldShowMarkerOutlines,
+  updateStandardMaterialColor,
+} from "./materials";
 import type { IRenderer } from "../../IRenderer";
-import { rgbToThreeColor } from "../../color";
 import { disposeMeshesRecursive } from "../../dispose";
 import { Marker } from "../../ros";
 import {
@@ -63,15 +66,7 @@ export class RenderableMeshResource extends RenderableMarker {
     super.update(newMarker, receiveTime);
     const marker = this.userData.marker;
 
-    const transparent = marker.color.a < 1;
-    if (transparent !== this.#material.transparent) {
-      this.#material.transparent = transparent;
-      this.#material.depthWrite = !transparent;
-      this.#material.needsUpdate = true;
-    }
-
-    rgbToThreeColor(this.#material.color, marker.color);
-    this.#material.opacity = marker.color.a;
+    updateStandardMaterialColor(this.#material, marker.color);
 
     const embeddedMaterialUsageChanged =
       marker.mesh_use_embedded_materials !== prevMarker.mesh_use_embedded_materials;
@@ -133,8 +128,10 @@ export class RenderableMeshResource extends RenderableMarker {
   }
 
   #updateOutlineVisibility(): void {
-    const showOutlines =
-      (this.getSettings()?.showOutlines ?? true) && this.userData.marker.color.a >= 1;
+    const showOutlines = shouldShowMarkerOutlines({
+      showOutlines: this.getSettings()?.showOutlines,
+      alpha: this.userData.marker.color.a,
+    });
     this.traverse((lineSegments) => {
       // Want to avoid picking up the LineSegments from the model itself
       // only update line segments that we've added with the special name

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -133,7 +133,8 @@ export class RenderableMeshResource extends RenderableMarker {
   }
 
   #updateOutlineVisibility(): void {
-    const showOutlines = this.getSettings()?.showOutlines ?? true;
+    const showOutlines =
+      (this.getSettings()?.showOutlines ?? true) && this.userData.marker.color.a >= 1;
     this.traverse((lineSegments) => {
       // Want to avoid picking up the LineSegments from the model itself
       // only update line segments that we've added with the special name

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -15,7 +15,12 @@ import type { IRenderer } from "../../IRenderer";
 import { rgbToThreeColor } from "../../color";
 import { disposeMeshesRecursive } from "../../dispose";
 import { Marker } from "../../ros";
-import { removeLights, replaceMaterials, setEmbeddedMaterialsOpacity } from "../models";
+import {
+  removeLights,
+  replaceMaterials,
+  setEmbeddedMaterialsOpacity,
+  updateEmbeddedMaterialsOpacity,
+} from "../models";
 
 const MESH_FETCH_FAILED = "MESH_FETCH_FAILED";
 
@@ -68,13 +73,13 @@ export class RenderableMeshResource extends RenderableMarker {
     rgbToThreeColor(this.#material.color, marker.color);
     this.#material.opacity = marker.color.a;
 
-    const embeddedMaterialOptionsChanged =
-      marker.mesh_use_embedded_materials !== prevMarker.mesh_use_embedded_materials ||
-      (marker.mesh_use_embedded_materials && marker.color.a !== prevMarker.color.a);
+    const embeddedMaterialUsageChanged =
+      marker.mesh_use_embedded_materials !== prevMarker.mesh_use_embedded_materials;
+    const opacityChanged = marker.color.a !== prevMarker.color.a;
     if (
       forceLoad === true ||
       marker.mesh_resource !== prevMarker.mesh_resource ||
-      embeddedMaterialOptionsChanged
+      embeddedMaterialUsageChanged
     ) {
       const curUpdateId = ++this.#updateId;
 
@@ -114,6 +119,9 @@ export class RenderableMeshResource extends RenderableMarker {
             `Unhandled error loading mesh from "${marker.mesh_resource}": ${(err as Error).message}`,
           );
         });
+    } else if (opacityChanged && marker.mesh_use_embedded_materials && this.#mesh != undefined) {
+      // Opacity-only updates must not destroy/recreate GPU resources on the hot path.
+      updateEmbeddedMaterialsOpacity(this.#mesh, marker.color.a);
     }
     this.#updateOutlineVisibility();
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -104,6 +104,10 @@ export class RenderableMeshResource extends RenderableMarker {
             return;
           }
           this.#mesh = mesh;
+          // Opacity may have changed while the load was in flight; apply the latest value.
+          if (this.userData.marker.mesh_use_embedded_materials) {
+            updateEmbeddedMaterialsOpacity(mesh, this.userData.marker.color.a);
+          }
           this.add(mesh);
           this.#updateOutlineVisibility();
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -15,7 +15,7 @@ import type { IRenderer } from "../../IRenderer";
 import { rgbToThreeColor } from "../../color";
 import { disposeMeshesRecursive } from "../../dispose";
 import { Marker } from "../../ros";
-import { removeLights, replaceMaterials } from "../models";
+import { removeLights, replaceMaterials, setEmbeddedMaterialsOpacity } from "../models";
 
 const MESH_FETCH_FAILED = "MESH_FETCH_FAILED";
 
@@ -68,10 +68,20 @@ export class RenderableMeshResource extends RenderableMarker {
     rgbToThreeColor(this.#material.color, marker.color);
     this.#material.opacity = marker.color.a;
 
-    if (forceLoad === true || marker.mesh_resource !== prevMarker.mesh_resource) {
+    const embeddedMaterialOptionsChanged =
+      marker.mesh_use_embedded_materials !== prevMarker.mesh_use_embedded_materials ||
+      (marker.mesh_use_embedded_materials && marker.color.a !== prevMarker.color.a);
+    if (
+      forceLoad === true ||
+      marker.mesh_resource !== prevMarker.mesh_resource ||
+      embeddedMaterialOptionsChanged
+    ) {
       const curUpdateId = ++this.#updateId;
 
-      const opts = { useEmbeddedMaterials: marker.mesh_use_embedded_materials };
+      const opts = {
+        useEmbeddedMaterials: marker.mesh_use_embedded_materials,
+        opacity: marker.color.a,
+      };
       const errors = this.renderer.settings.errors;
       if (this.#mesh) {
         this.remove(this.#mesh);
@@ -126,7 +136,7 @@ export class RenderableMeshResource extends RenderableMarker {
 
   async #loadModel(
     url: string,
-    opts: { useEmbeddedMaterials: boolean },
+    opts: { useEmbeddedMaterials: boolean; opacity: number },
   ): Promise<THREE.Group | THREE.Scene | undefined> {
     const cachedModel = await this.renderer.modelCache.load(
       url,
@@ -155,6 +165,8 @@ export class RenderableMeshResource extends RenderableMarker {
     removeLights(mesh);
     if (!opts.useEmbeddedMaterials) {
       replaceMaterials(mesh, this.#material);
+    } else {
+      setEmbeddedMaterialsOpacity(mesh, opts.opacity);
     }
 
     return mesh;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableOutlinedMeshMarker.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableOutlinedMeshMarker.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as THREE from "three";
+
+import { RenderableMarker } from "./RenderableMarker";
+import { updateStandardMeshMarker } from "./materials";
+import { Marker } from "../../ros";
+
+/** Shared update/dispose path for markers that use one standard mesh plus an outline. */
+export abstract class RenderableOutlinedMeshMarker extends RenderableMarker {
+  protected mesh!: THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
+  protected outline!: THREE.Object3D;
+
+  public override dispose(): void {
+    this.mesh.material.dispose();
+  }
+
+  public override update(newMarker: Marker, receiveTime: bigint | undefined): void {
+    super.update(newMarker, receiveTime);
+    updateStandardMeshMarker(
+      this,
+      this.mesh,
+      this.outline,
+      this.getSettings(),
+      this.userData.marker,
+    );
+  }
+}

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderablePrimitiveOpacity.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderablePrimitiveOpacity.test.ts
@@ -1,0 +1,86 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as THREE from "three";
+
+import { RenderableCube } from "./RenderableCube";
+import { RenderableCylinder } from "./RenderableCylinder";
+import { IRenderer } from "../../IRenderer";
+import { Marker, MarkerAction, MarkerType } from "../../ros";
+
+function makePrimitiveMarker(opacity: number): Marker {
+  return {
+    header: { frame_id: "link", stamp: { sec: 0, nsec: 0 } },
+    ns: "",
+    id: 0,
+    type: MarkerType.CUBE,
+    action: MarkerAction.ADD,
+    pose: {
+      position: { x: 0, y: 0, z: 0 },
+      orientation: { x: 0, y: 0, z: 0, w: 1 },
+    },
+    scale: { x: 1, y: 1, z: 1 },
+    color: { r: 1, g: 0, b: 0, a: opacity },
+    lifetime: { sec: 0, nsec: 0 },
+    frame_locked: true,
+    points: [],
+    colors: [],
+    text: "",
+    mesh_resource: "",
+    mesh_use_embedded_materials: false,
+  };
+}
+
+function makeRenderer(): IRenderer {
+  return {
+    normalizeFrameId: (frameId: string) => frameId,
+    config: { topics: {} },
+    maxLod: 0,
+    sharedGeometry: {
+      getGeometry: (_key: string, factory: () => THREE.BufferGeometry) => factory(),
+    },
+    outlineMaterial: new THREE.LineBasicMaterial(),
+  } as unknown as IRenderer;
+}
+
+function outlineVisible(renderable: THREE.Object3D): boolean | undefined {
+  let visible: boolean | undefined;
+  renderable.traverse((obj) => {
+    if (obj instanceof THREE.LineSegments) {
+      visible = obj.visible;
+    }
+  });
+  return visible;
+}
+
+describe("primitive marker outline opacity", () => {
+  it("RenderableCube hides outline when marker alpha is below 1", () => {
+    const renderer = makeRenderer();
+    const renderable = new RenderableCube("urdf", makePrimitiveMarker(1), 0n, renderer);
+
+    expect(outlineVisible(renderable)).toBe(true);
+
+    renderable.update(makePrimitiveMarker(0.5), 1n);
+    expect(outlineVisible(renderable)).toBe(false);
+
+    renderable.dispose();
+  });
+
+  it("RenderableCylinder hides outline when marker alpha is below 1", () => {
+    const renderer = makeRenderer();
+    const renderable = new RenderableCylinder("urdf", makePrimitiveMarker(1), 0n, renderer);
+
+    expect(outlineVisible(renderable)).toBe(true);
+
+    renderable.update(makePrimitiveMarker(0.25), 1n);
+    expect(outlineVisible(renderable)).toBe(false);
+
+    renderable.dispose();
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
@@ -8,9 +8,8 @@
 import * as THREE from "three";
 
 import { RenderableMarker } from "./RenderableMarker";
-import { makeStandardMaterial } from "./materials";
+import { makeStandardMaterial, updateStandardMaterialColor } from "./materials";
 import type { IRenderer } from "../../IRenderer";
-import { rgbToThreeColor } from "../../color";
 import { DetailLevel, sphereSubdivisions } from "../../lod";
 import { Marker } from "../../ros";
 
@@ -46,15 +45,7 @@ export class RenderableSphere extends RenderableMarker {
     super.update(newMarker, receiveTime);
     const marker = this.userData.marker;
 
-    const transparent = marker.color.a < 1;
-    if (transparent !== this.mesh.material.transparent) {
-      this.mesh.material.transparent = transparent;
-      this.mesh.material.depthWrite = !transparent;
-      this.mesh.material.needsUpdate = true;
-    }
-
-    rgbToThreeColor(this.mesh.material.color, marker.color);
-    this.mesh.material.opacity = marker.color.a;
+    updateStandardMaterialColor(this.mesh.material, marker.color);
 
     this.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
   }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/materials.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/materials.test.ts
@@ -9,7 +9,35 @@
 
 import * as THREE from "three";
 
-import { shouldShowMarkerOutlines, updateStandardMaterialColor } from "./materials";
+import {
+  shouldShowMarkerOutlines,
+  updateStandardMaterialColor,
+  updateStandardMeshMarker,
+} from "./materials";
+import { Marker, MarkerAction, MarkerType } from "../../ros";
+
+function makeMarker(opacity: number): Marker {
+  return {
+    header: { frame_id: "link", stamp: { sec: 0, nsec: 0 } },
+    ns: "",
+    id: 0,
+    type: MarkerType.CUBE,
+    action: MarkerAction.ADD,
+    pose: {
+      position: { x: 0, y: 0, z: 0 },
+      orientation: { x: 0, y: 0, z: 0, w: 1 },
+    },
+    scale: { x: 1, y: 1, z: 1 },
+    color: { r: 1, g: 0, b: 0, a: opacity },
+    lifetime: { sec: 0, nsec: 0 },
+    frame_locked: true,
+    points: [],
+    colors: [],
+    text: "",
+    mesh_resource: "",
+    mesh_use_embedded_materials: false,
+  };
+}
 
 describe("shouldShowMarkerOutlines", () => {
   it("defaults showOutlines to true and requires opaque alpha", () => {
@@ -40,5 +68,30 @@ describe("updateStandardMaterialColor", () => {
     expect(material.opacity).toBe(1);
     expect(material.transparent).toBe(false);
     expect(material.depthWrite).toBe(true);
+  });
+});
+
+describe("updateStandardMeshMarker", () => {
+  it("updates material, scale, and hides outlines when translucent", () => {
+    const material = new THREE.MeshStandardMaterial({
+      transparent: false,
+      depthWrite: true,
+      opacity: 1,
+    });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), material);
+    const outline = new THREE.Object3D();
+    outline.visible = true;
+    const target = new THREE.Object3D();
+    const marker = makeMarker(0.5);
+    marker.scale = { x: 2, y: 3, z: 4 };
+
+    updateStandardMeshMarker(target, mesh, outline, { showOutlines: true }, marker);
+
+    expect(material.opacity).toBe(0.5);
+    expect(material.transparent).toBe(true);
+    expect(outline.visible).toBe(false);
+    expect(target.scale.x).toBe(2);
+    expect(target.scale.y).toBe(3);
+    expect(target.scale.z).toBe(4);
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/materials.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/materials.test.ts
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as THREE from "three";
+
+import { shouldShowMarkerOutlines, updateStandardMaterialColor } from "./materials";
+
+describe("shouldShowMarkerOutlines", () => {
+  it("defaults showOutlines to true and requires opaque alpha", () => {
+    expect(shouldShowMarkerOutlines({ showOutlines: undefined, alpha: 1 })).toBe(true);
+    expect(shouldShowMarkerOutlines({ showOutlines: undefined, alpha: 0.5 })).toBe(false);
+    expect(shouldShowMarkerOutlines({ showOutlines: true, alpha: 1 })).toBe(true);
+    expect(shouldShowMarkerOutlines({ showOutlines: false, alpha: 1 })).toBe(false);
+    expect(shouldShowMarkerOutlines({ showOutlines: true, alpha: 0.99 })).toBe(false);
+  });
+});
+
+describe("updateStandardMaterialColor", () => {
+  it("updates color, opacity, and transparency flags", () => {
+    const material = new THREE.MeshStandardMaterial({
+      transparent: false,
+      depthWrite: true,
+      opacity: 1,
+    });
+
+    updateStandardMaterialColor(material, { r: 1, g: 0, b: 0, a: 0.4 });
+
+    expect(material.opacity).toBe(0.4);
+    expect(material.transparent).toBe(true);
+    expect(material.depthWrite).toBe(false);
+
+    updateStandardMaterialColor(material, { r: 0, g: 1, b: 0, a: 1 });
+
+    expect(material.opacity).toBe(1);
+    expect(material.transparent).toBe(false);
+    expect(material.depthWrite).toBe(true);
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/materials.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/materials.ts
@@ -8,12 +8,37 @@
 import * as THREE from "three";
 
 import { LineMaterialWithAlphaVertex } from "../../LineMaterialWithAlphaVertex";
+import { rgbToThreeColor } from "../../color";
 import { ColorRGBA, Marker, MarkerType } from "../../ros";
 
 export type LineOptions = {
   resolution: THREE.Vector2;
   worldUnits?: boolean;
 };
+
+/** Outlines are hidden when the marker is translucent so edges don't poke through. */
+export function shouldShowMarkerOutlines(options: {
+  showOutlines: boolean | undefined;
+  alpha: number;
+}): boolean {
+  return (options.showOutlines ?? true) && options.alpha >= 1;
+}
+
+/** Sync MeshStandardMaterial color/opacity and transparency flags from a ColorRGBA. */
+export function updateStandardMaterialColor(
+  material: THREE.MeshStandardMaterial,
+  color: ColorRGBA,
+): void {
+  const transparent = color.a < 1;
+  if (transparent !== material.transparent) {
+    material.transparent = transparent;
+    material.depthWrite = !transparent;
+    material.needsUpdate = true;
+  }
+
+  rgbToThreeColor(material.color, color);
+  material.opacity = color.a;
+}
 
 export function markerHasTransparency(marker: Marker): boolean {
   switch (marker.type) {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/materials.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/markers/materials.ts
@@ -40,6 +40,22 @@ export function updateStandardMaterialColor(
   material.opacity = color.a;
 }
 
+/** Update a standard mesh marker's material, outline visibility, and scale from a Marker. */
+export function updateStandardMeshMarker(
+  target: THREE.Object3D,
+  mesh: THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>,
+  outline: THREE.Object3D,
+  settings: { showOutlines?: boolean } | undefined,
+  marker: Marker,
+): void {
+  updateStandardMaterialColor(mesh.material, marker.color);
+  outline.visible = shouldShowMarkerOutlines({
+    showOutlines: settings?.showOutlines,
+    alpha: marker.color.a,
+  });
+  target.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
+}
+
 export function markerHasTransparency(marker: Marker): boolean {
   switch (marker.type) {
     case MarkerType.ARROW:

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
@@ -75,4 +75,28 @@ describe("updateEmbeddedMaterialsOpacity", () => {
     expect(instanceMaterial.depthWrite).toBe(false);
     expect(cachedMaterial.opacity).toBe(0.8);
   });
+
+  it("increments material version only when transparent or depthWrite flip", () => {
+    const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 1, transparent: false });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial);
+    const model = new THREE.Group();
+    model.add(mesh);
+
+    setEmbeddedMaterialsOpacity(model, 1);
+    const instanceMaterial = mesh.material;
+    const versionAfterSetup = instanceMaterial.version;
+
+    // Same structural flags (still fully opaque) — no shader recompile needed.
+    updateEmbeddedMaterialsOpacity(model, 1);
+    expect(instanceMaterial.version).toBe(versionAfterSetup);
+
+    // Crossing into translucent flips transparent/depthWrite.
+    updateEmbeddedMaterialsOpacity(model, 0.5);
+    expect(instanceMaterial.transparent).toBe(true);
+    expect(instanceMaterial.version).toBeGreaterThan(versionAfterSetup);
+
+    const versionAfterFlip = instanceMaterial.version;
+    updateEmbeddedMaterialsOpacity(model, 0.25);
+    expect(instanceMaterial.version).toBe(versionAfterFlip);
+  });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
@@ -52,7 +52,6 @@ describe("setEmbeddedMaterialsOpacity", () => {
   });
 
   it("applies opacity to LineSegments and Points as well as meshes", () => {
-    // Given
     const meshMaterial = new THREE.MeshStandardMaterial({ opacity: 1 });
     const lineMaterial = new THREE.LineBasicMaterial({ opacity: 1 });
     const pointsMaterial = new THREE.PointsMaterial({ opacity: 1 });
@@ -62,10 +61,8 @@ describe("setEmbeddedMaterialsOpacity", () => {
     const model = new THREE.Group();
     model.add(mesh, lines, points);
 
-    // When
     setEmbeddedMaterialsOpacity(model, 0.25);
 
-    // Then
     expect((mesh.material as THREE.Material).opacity).toBeCloseTo(0.25);
     expect((lines.material as THREE.Material).opacity).toBeCloseTo(0.25);
     expect((points.material as THREE.Material).opacity).toBeCloseTo(0.25);
@@ -75,7 +72,6 @@ describe("setEmbeddedMaterialsOpacity", () => {
   });
 
   it("updates every material in a multi-material mesh", () => {
-    // Given
     const opaqueMaterial = new THREE.MeshStandardMaterial({ opacity: 1 });
     const transparentMaterial = new THREE.MeshStandardMaterial({
       opacity: 0.5,
@@ -86,15 +82,25 @@ describe("setEmbeddedMaterialsOpacity", () => {
     const model = new THREE.Group();
     model.add(mesh);
 
-    // When
     setEmbeddedMaterialsOpacity(model, 1);
 
-    // Then
     const materials = mesh.material;
     expect(materials[0]).not.toBe(opaqueMaterial);
     expect(materials[0]).toMatchObject({ opacity: 1, transparent: false, depthWrite: true });
     expect(materials[1]).not.toBe(transparentMaterial);
     expect(materials[1]).toMatchObject({ opacity: 0.5, transparent: true, depthWrite: false });
+  });
+
+  it("skips children without a material property", () => {
+    const material = new THREE.MeshStandardMaterial({ opacity: 1 });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), material);
+    const model = new THREE.Group();
+    model.add(new THREE.Group(), mesh);
+
+    expect(() => {
+      setEmbeddedMaterialsOpacity(model, 0.5);
+    }).not.toThrow();
+    expect((mesh.material as THREE.Material).opacity).toBeCloseTo(0.5);
   });
 });
 
@@ -125,7 +131,6 @@ describe("updateEmbeddedMaterialsOpacity", () => {
   });
 
   it("updates LineSegments opacity in place", () => {
-    // Given
     const cachedMaterial = new THREE.LineBasicMaterial({ opacity: 1 });
     const lines = new THREE.LineSegments(new THREE.BufferGeometry(), cachedMaterial);
     const model = new THREE.Group();
@@ -134,12 +139,29 @@ describe("updateEmbeddedMaterialsOpacity", () => {
     setEmbeddedMaterialsOpacity(model, 0.5);
     const instanceMaterial = lines.material as THREE.Material;
 
-    // When
     updateEmbeddedMaterialsOpacity(model, 0.25);
 
-    // Then
     expect(lines.material).toBe(instanceMaterial);
     expect(instanceMaterial.opacity).toBeCloseTo(0.25);
+  });
+
+  it("updates every material in a multi-material mesh in place", () => {
+    const opaqueMaterial = new THREE.MeshStandardMaterial({ opacity: 1 });
+    const transparentMaterial = new THREE.MeshStandardMaterial({
+      opacity: 0.5,
+      transparent: true,
+      depthWrite: false,
+    });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), [opaqueMaterial, transparentMaterial]);
+    const model = new THREE.Group();
+    model.add(mesh);
+
+    setEmbeddedMaterialsOpacity(model, 1);
+    const cloned = mesh.material as THREE.Material[];
+
+    updateEmbeddedMaterialsOpacity(model, 0.5);
+    expect(cloned[0].opacity).toBeCloseTo(0.5);
+    expect(cloned[1].opacity).toBeCloseTo(0.25);
   });
 
   it("increments material version only when transparent or depthWrite flip", () => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as THREE from "three";
+
+import { setEmbeddedMaterialsOpacity } from "./models";
+
+describe("setEmbeddedMaterialsOpacity", () => {
+  it("clones embedded materials and applies opacity without mutating cached materials", () => {
+    const cachedMaterial = new THREE.MeshStandardMaterial({
+      opacity: 0.8,
+      transparent: false,
+    });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial);
+    const model = new THREE.Group();
+    model.add(mesh);
+
+    setEmbeddedMaterialsOpacity(model, 0.5);
+
+    const instanceMaterial = mesh.material;
+    expect(instanceMaterial).not.toBe(cachedMaterial);
+    expect(instanceMaterial.opacity).toBeCloseTo(0.4);
+    expect(instanceMaterial.transparent).toBe(true);
+    expect(instanceMaterial.depthWrite).toBe(false);
+    expect(cachedMaterial.opacity).toBe(0.8);
+    expect(cachedMaterial.transparent).toBe(false);
+    expect(cachedMaterial.depthWrite).toBe(true);
+  });
+
+  it("updates every material in a multi-material mesh", () => {
+    const opaqueMaterial = new THREE.MeshStandardMaterial({ opacity: 1 });
+    const transparentMaterial = new THREE.MeshStandardMaterial({
+      opacity: 0.5,
+      transparent: true,
+      depthWrite: false,
+    });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), [opaqueMaterial, transparentMaterial]);
+    const model = new THREE.Group();
+    model.add(mesh);
+
+    setEmbeddedMaterialsOpacity(model, 1);
+
+    const materials = mesh.material;
+    expect(materials[0]).not.toBe(opaqueMaterial);
+    expect(materials[0]).toMatchObject({ opacity: 1, transparent: false, depthWrite: true });
+    expect(materials[1]).not.toBe(transparentMaterial);
+    expect(materials[1]).toMatchObject({ opacity: 0.5, transparent: true, depthWrite: false });
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
@@ -160,8 +160,8 @@ describe("updateEmbeddedMaterialsOpacity", () => {
     const cloned = mesh.material as THREE.Material[];
 
     updateEmbeddedMaterialsOpacity(model, 0.5);
-    expect(cloned[0].opacity).toBeCloseTo(0.5);
-    expect(cloned[1].opacity).toBeCloseTo(0.25);
+    expect(cloned[0]).toMatchObject({ opacity: 0.5 });
+    expect(cloned[1]).toMatchObject({ opacity: 0.25 });
   });
 
   it("increments material version only when transparent or depthWrite flip", () => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
@@ -11,6 +11,7 @@ import { setEmbeddedMaterialsOpacity, updateEmbeddedMaterialsOpacity } from "./m
 
 describe("setEmbeddedMaterialsOpacity", () => {
   it("clones embedded materials and applies opacity without mutating cached materials", () => {
+    // Given
     const cachedMaterial = new THREE.MeshStandardMaterial({
       opacity: 0.8,
       transparent: false,
@@ -19,8 +20,10 @@ describe("setEmbeddedMaterialsOpacity", () => {
     const model = new THREE.Group();
     model.add(mesh);
 
+    // When
     setEmbeddedMaterialsOpacity(model, 0.5);
 
+    // Then
     const instanceMaterial = mesh.material;
     expect(instanceMaterial).not.toBe(cachedMaterial);
     expect(instanceMaterial.opacity).toBeCloseTo(0.4);
@@ -31,7 +34,48 @@ describe("setEmbeddedMaterialsOpacity", () => {
     expect(cachedMaterial.depthWrite).toBe(true);
   });
 
+  it("reuses one cloned material when multiple children share the source material", () => {
+    // Given
+    const sharedMaterial = new THREE.MeshStandardMaterial({ opacity: 1 });
+    const meshA = new THREE.Mesh(new THREE.BoxGeometry(), sharedMaterial);
+    const meshB = new THREE.Mesh(new THREE.BoxGeometry(), sharedMaterial);
+    const model = new THREE.Group();
+    model.add(meshA, meshB);
+
+    // When
+    setEmbeddedMaterialsOpacity(model, 0.5);
+
+    // Then
+    expect(meshA.material).not.toBe(sharedMaterial);
+    expect(meshA.material).toBe(meshB.material);
+    expect((meshA.material as THREE.Material).opacity).toBeCloseTo(0.5);
+  });
+
+  it("applies opacity to LineSegments and Points as well as meshes", () => {
+    // Given
+    const meshMaterial = new THREE.MeshStandardMaterial({ opacity: 1 });
+    const lineMaterial = new THREE.LineBasicMaterial({ opacity: 1 });
+    const pointsMaterial = new THREE.PointsMaterial({ opacity: 1 });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), meshMaterial);
+    const lines = new THREE.LineSegments(new THREE.BufferGeometry(), lineMaterial);
+    const points = new THREE.Points(new THREE.BufferGeometry(), pointsMaterial);
+    const model = new THREE.Group();
+    model.add(mesh, lines, points);
+
+    // When
+    setEmbeddedMaterialsOpacity(model, 0.25);
+
+    // Then
+    expect((mesh.material as THREE.Material).opacity).toBeCloseTo(0.25);
+    expect((lines.material as THREE.Material).opacity).toBeCloseTo(0.25);
+    expect((points.material as THREE.Material).opacity).toBeCloseTo(0.25);
+    expect(meshMaterial.opacity).toBe(1);
+    expect(lineMaterial.opacity).toBe(1);
+    expect(pointsMaterial.opacity).toBe(1);
+  });
+
   it("updates every material in a multi-material mesh", () => {
+    // Given
     const opaqueMaterial = new THREE.MeshStandardMaterial({ opacity: 1 });
     const transparentMaterial = new THREE.MeshStandardMaterial({
       opacity: 0.5,
@@ -42,8 +86,10 @@ describe("setEmbeddedMaterialsOpacity", () => {
     const model = new THREE.Group();
     model.add(mesh);
 
+    // When
     setEmbeddedMaterialsOpacity(model, 1);
 
+    // Then
     const materials = mesh.material;
     expect(materials[0]).not.toBe(opaqueMaterial);
     expect(materials[0]).toMatchObject({ opacity: 1, transparent: false, depthWrite: true });
@@ -54,6 +100,7 @@ describe("setEmbeddedMaterialsOpacity", () => {
 
 describe("updateEmbeddedMaterialsOpacity", () => {
   it("updates opacity in place without recloning or compounding multipliers", () => {
+    // Given
     const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 0.8 });
     const mesh = new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial);
     const model = new THREE.Group();
@@ -63,6 +110,7 @@ describe("updateEmbeddedMaterialsOpacity", () => {
     const instanceMaterial = mesh.material;
     expect(instanceMaterial.opacity).toBeCloseTo(0.4);
 
+    // When / Then
     updateEmbeddedMaterialsOpacity(model, 0.25);
     expect(mesh.material).toBe(instanceMaterial);
     expect(instanceMaterial.opacity).toBeCloseTo(0.2);
@@ -76,7 +124,26 @@ describe("updateEmbeddedMaterialsOpacity", () => {
     expect(cachedMaterial.opacity).toBe(0.8);
   });
 
+  it("updates LineSegments opacity in place", () => {
+    // Given
+    const cachedMaterial = new THREE.LineBasicMaterial({ opacity: 1 });
+    const lines = new THREE.LineSegments(new THREE.BufferGeometry(), cachedMaterial);
+    const model = new THREE.Group();
+    model.add(lines);
+
+    setEmbeddedMaterialsOpacity(model, 0.5);
+    const instanceMaterial = lines.material as THREE.Material;
+
+    // When
+    updateEmbeddedMaterialsOpacity(model, 0.25);
+
+    // Then
+    expect(lines.material).toBe(instanceMaterial);
+    expect(instanceMaterial.opacity).toBeCloseTo(0.25);
+  });
+
   it("increments material version only when transparent or depthWrite flip", () => {
+    // Given
     const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 1, transparent: false });
     const mesh = new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial);
     const model = new THREE.Group();
@@ -86,7 +153,7 @@ describe("updateEmbeddedMaterialsOpacity", () => {
     const instanceMaterial = mesh.material;
     const versionAfterSetup = instanceMaterial.version;
 
-    // Same structural flags (still fully opaque) — no shader recompile needed.
+    // When / Then — same structural flags (still fully opaque) — no shader recompile needed.
     updateEmbeddedMaterialsOpacity(model, 1);
     expect(instanceMaterial.version).toBe(versionAfterSetup);
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.test.ts
@@ -7,7 +7,7 @@
 
 import * as THREE from "three";
 
-import { setEmbeddedMaterialsOpacity } from "./models";
+import { setEmbeddedMaterialsOpacity, updateEmbeddedMaterialsOpacity } from "./models";
 
 describe("setEmbeddedMaterialsOpacity", () => {
   it("clones embedded materials and applies opacity without mutating cached materials", () => {
@@ -49,5 +49,30 @@ describe("setEmbeddedMaterialsOpacity", () => {
     expect(materials[0]).toMatchObject({ opacity: 1, transparent: false, depthWrite: true });
     expect(materials[1]).not.toBe(transparentMaterial);
     expect(materials[1]).toMatchObject({ opacity: 0.5, transparent: true, depthWrite: false });
+  });
+});
+
+describe("updateEmbeddedMaterialsOpacity", () => {
+  it("updates opacity in place without recloning or compounding multipliers", () => {
+    const cachedMaterial = new THREE.MeshStandardMaterial({ opacity: 0.8 });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), cachedMaterial);
+    const model = new THREE.Group();
+    model.add(mesh);
+
+    setEmbeddedMaterialsOpacity(model, 0.5);
+    const instanceMaterial = mesh.material;
+    expect(instanceMaterial.opacity).toBeCloseTo(0.4);
+
+    updateEmbeddedMaterialsOpacity(model, 0.25);
+    expect(mesh.material).toBe(instanceMaterial);
+    expect(instanceMaterial.opacity).toBeCloseTo(0.2);
+
+    // Full layer opacity restores the intrinsic 0.8 (still translucent because base < 1).
+    updateEmbeddedMaterialsOpacity(model, 1);
+    expect(mesh.material).toBe(instanceMaterial);
+    expect(instanceMaterial.opacity).toBeCloseTo(0.8);
+    expect(instanceMaterial.transparent).toBe(true);
+    expect(instanceMaterial.depthWrite).toBe(false);
+    expect(cachedMaterial.opacity).toBe(0.8);
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
@@ -83,26 +83,43 @@ function applyOpacityToMaterial(material: THREE.Material, opacity: number): void
   }
 }
 
+type MaterialBearer = THREE.Object3D & {
+  material: THREE.Material | THREE.Material[];
+};
+
+function isMaterialBearer(child: THREE.Object3D): child is MaterialBearer {
+  return "material" in child && (child as Partial<MaterialBearer>).material != undefined;
+}
+
 /**
  * Clone embedded materials for this model instance and apply a layer opacity multiplier.
  *
  * Object3D.clone() keeps material references shared with the cached model. Cloning here prevents
  * one transparent URDF from changing other instances that use the same cached mesh. Intrinsic
  * opacity/transparency are stored on the clone so later updates can adjust opacity in place.
+ *
+ * Clones are keyed by the original material uuid so meshes/lines/points that shared a material
+ * in the source model keep sharing a single cloned material on this instance.
  */
 export function setEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number): void {
+  const clonedMaterials = new Map<string, THREE.Material>();
+
   model.traverse((child: THREE.Object3D) => {
-    if (!(child instanceof THREE.Mesh)) {
+    if (!isMaterialBearer(child)) {
       return;
     }
 
     const cloneWithOpacity = (material: THREE.Material): THREE.Material => {
-      const clonedMaterial = material.clone();
-      applyOpacityToMaterial(clonedMaterial, opacity);
+      let clonedMaterial = clonedMaterials.get(material.uuid);
+      if (!clonedMaterial) {
+        clonedMaterial = material.clone();
+        applyOpacityToMaterial(clonedMaterial, opacity);
+        clonedMaterials.set(material.uuid, clonedMaterial);
+      }
       return clonedMaterial;
     };
 
-    const materials = child.material as THREE.Material | THREE.Material[];
+    const materials = child.material;
     child.material = Array.isArray(materials)
       ? materials.map(cloneWithOpacity)
       : cloneWithOpacity(materials);
@@ -113,11 +130,11 @@ export function setEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number)
 let updateOpacityState = 1;
 
 const updateEmbeddedOpacityCallback = (child: THREE.Object3D): void => {
-  if (!(child instanceof THREE.Mesh)) {
+  if (!isMaterialBearer(child)) {
     return;
   }
 
-  const materials = child.material as THREE.Material | THREE.Material[];
+  const materials = child.material;
   if (Array.isArray(materials)) {
     for (const material of materials) {
       applyOpacityToMaterial(material, updateOpacityState);

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
@@ -52,11 +52,37 @@ export function replaceMaterials(model: LoadedModel, material: THREE.MeshStandar
   });
 }
 
+const ORIGINAL_OPACITY_KEY = "originalOpacity";
+const ORIGINAL_TRANSPARENT_KEY = "originalTransparent";
+const ORIGINAL_DEPTH_WRITE_KEY = "originalDepthWrite";
+
+function applyOpacityToMaterial(material: THREE.Material, opacity: number): void {
+  const storedOpacity = material.userData[ORIGINAL_OPACITY_KEY];
+  const storedTransparent = material.userData[ORIGINAL_TRANSPARENT_KEY];
+  const storedDepthWrite = material.userData[ORIGINAL_DEPTH_WRITE_KEY];
+
+  const originalOpacity = typeof storedOpacity === "number" ? storedOpacity : material.opacity;
+  const originalTransparent =
+    typeof storedTransparent === "boolean" ? storedTransparent : material.transparent;
+  const originalDepthWrite =
+    typeof storedDepthWrite === "boolean" ? storedDepthWrite : material.depthWrite;
+
+  material.userData[ORIGINAL_OPACITY_KEY] = originalOpacity;
+  material.userData[ORIGINAL_TRANSPARENT_KEY] = originalTransparent;
+  material.userData[ORIGINAL_DEPTH_WRITE_KEY] = originalDepthWrite;
+
+  material.opacity = originalOpacity * opacity;
+  material.transparent = originalTransparent || material.opacity < 1;
+  material.depthWrite = material.opacity >= 1 && originalDepthWrite;
+  material.needsUpdate = true;
+}
+
 /**
  * Clone embedded materials for this model instance and apply a layer opacity multiplier.
  *
  * Object3D.clone() keeps material references shared with the cached model. Cloning here prevents
- * one transparent URDF from changing other instances that use the same cached mesh.
+ * one transparent URDF from changing other instances that use the same cached mesh. Intrinsic
+ * opacity/transparency are stored on the clone so later updates can adjust opacity in place.
  */
 export function setEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number): void {
   model.traverse((child: THREE.Object3D) => {
@@ -64,19 +90,34 @@ export function setEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number)
       return;
     }
 
-    const applyOpacity = (material: THREE.Material): THREE.Material => {
+    const cloneWithOpacity = (material: THREE.Material): THREE.Material => {
       const clonedMaterial = material.clone();
-      clonedMaterial.opacity = material.opacity * opacity;
-      clonedMaterial.transparent = material.transparent || clonedMaterial.opacity < 1;
-      clonedMaterial.depthWrite = clonedMaterial.opacity >= 1 && material.depthWrite;
-      clonedMaterial.needsUpdate = true;
+      applyOpacityToMaterial(clonedMaterial, opacity);
       return clonedMaterial;
     };
 
     const materials = child.material as THREE.Material | THREE.Material[];
     child.material = Array.isArray(materials)
-      ? materials.map(applyOpacity)
-      : applyOpacity(materials);
+      ? materials.map(cloneWithOpacity)
+      : cloneWithOpacity(materials);
+  });
+}
+
+/** Update previously prepared embedded materials in place (no clone, no multiplier compounding). */
+export function updateEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number): void {
+  model.traverse((child: THREE.Object3D) => {
+    if (!(child instanceof THREE.Mesh)) {
+      return;
+    }
+
+    const materials = child.material as THREE.Material | THREE.Material[];
+    if (Array.isArray(materials)) {
+      for (const material of materials) {
+        applyOpacityToMaterial(material, opacity);
+      }
+    } else {
+      applyOpacityToMaterial(materials, opacity);
+    }
   });
 }
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
@@ -52,6 +52,34 @@ export function replaceMaterials(model: LoadedModel, material: THREE.MeshStandar
   });
 }
 
+/**
+ * Clone embedded materials for this model instance and apply a layer opacity multiplier.
+ *
+ * Object3D.clone() keeps material references shared with the cached model. Cloning here prevents
+ * one transparent URDF from changing other instances that use the same cached mesh.
+ */
+export function setEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number): void {
+  model.traverse((child: THREE.Object3D) => {
+    if (!(child instanceof THREE.Mesh)) {
+      return;
+    }
+
+    const applyOpacity = (material: THREE.Material): THREE.Material => {
+      const clonedMaterial = material.clone();
+      clonedMaterial.opacity = material.opacity * opacity;
+      clonedMaterial.transparent = material.transparent || clonedMaterial.opacity < 1;
+      clonedMaterial.depthWrite = clonedMaterial.opacity >= 1 && material.depthWrite;
+      clonedMaterial.needsUpdate = true;
+      return clonedMaterial;
+    };
+
+    const materials = child.material as THREE.Material | THREE.Material[];
+    child.material = Array.isArray(materials)
+      ? materials.map(applyOpacity)
+      : applyOpacity(materials);
+  });
+}
+
 /** Generic MeshStandardMaterial dispose function for materials loaded from an external source */
 function disposeStandardMaterial(material: THREE.MeshStandardMaterial): void {
   material.map?.dispose();

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/models.ts
@@ -72,9 +72,15 @@ function applyOpacityToMaterial(material: THREE.Material, opacity: number): void
   material.userData[ORIGINAL_DEPTH_WRITE_KEY] = originalDepthWrite;
 
   material.opacity = originalOpacity * opacity;
-  material.transparent = originalTransparent || material.opacity < 1;
-  material.depthWrite = material.opacity >= 1 && originalDepthWrite;
-  material.needsUpdate = true;
+
+  // opacity is a uniform; only flip structural flags when they change to avoid shader recompiles
+  const newTransparent = originalTransparent || material.opacity < 1;
+  const newDepthWrite = material.opacity >= 1 && originalDepthWrite;
+  if (material.transparent !== newTransparent || material.depthWrite !== newDepthWrite) {
+    material.transparent = newTransparent;
+    material.depthWrite = newDepthWrite;
+    material.needsUpdate = true;
+  }
 }
 
 /**
@@ -103,22 +109,28 @@ export function setEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number)
   });
 }
 
+/** Opacity state for the reused traverse callback (safe: traverse is synchronous). */
+let updateOpacityState = 1;
+
+const updateEmbeddedOpacityCallback = (child: THREE.Object3D): void => {
+  if (!(child instanceof THREE.Mesh)) {
+    return;
+  }
+
+  const materials = child.material as THREE.Material | THREE.Material[];
+  if (Array.isArray(materials)) {
+    for (const material of materials) {
+      applyOpacityToMaterial(material, updateOpacityState);
+    }
+  } else {
+    applyOpacityToMaterial(materials, updateOpacityState);
+  }
+};
+
 /** Update previously prepared embedded materials in place (no clone, no multiplier compounding). */
 export function updateEmbeddedMaterialsOpacity(model: LoadedModel, opacity: number): void {
-  model.traverse((child: THREE.Object3D) => {
-    if (!(child instanceof THREE.Mesh)) {
-      return;
-    }
-
-    const materials = child.material as THREE.Material | THREE.Material[];
-    if (Array.isArray(materials)) {
-      for (const material of materials) {
-        applyOpacityToMaterial(material, opacity);
-      }
-    } else {
-      applyOpacityToMaterial(materials, opacity);
-    }
-  });
+  updateOpacityState = opacity;
+  model.traverse(updateEmbeddedOpacityCallback);
 }
 
 /** Generic MeshStandardMaterial dispose function for materials loaded from an external source */


### PR DESCRIPTION
## User-Facing Changes


New setting for URDF layers in the 3D panel:

- **Opacity** — adjust the transparency of each URDF independently, making it easier to distinguish overlapping robot models. 

The default remains fully opaque, so existing layouts are unaffected.

## Description

Adds per-URDF opacity control for comparing multiple robot poses in the same scene.

A common use case is overlaying a reference or software-estimated pose with a measured hardware pose. One URDF can remain fully opaque while the other is rendered as a semi-transparent “ghost”, making differences between their link positions immediately visible.

The opacity control is available for:

- The `/robot_description` topic
- The `/robot_description` parameter
- Custom URDF layers

Opacity is applied to primitive geometry and mesh resources, including meshes that use embedded materials. Embedded materials are cloned per model instance so changing one URDF’s opacity does not affect another URDF using the same cached mesh.

Values are constrained to the range `0–1`, where:

- `0` is fully transparent
- `1` is fully opaque

<p align="center">
  <img width="1185" height="884" alt="Opaque reference robot overlaid with a transparent comparison robot" src="https://github.com/user-attachments/assets/49a23b48-5646-4118-b157-b7e9bccab35e" />
  <br />
  <em>An opaque reference pose overlaid with a semi-transparent comparison pose, making differences between the robot bodies visible.</em>
</p>

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-URDF-layer opacity controls for custom, topic-based, and parameter-based URDFs in the settings UI (0–1, defaulting to fully opaque).
* **Bug Fixes**
  * URDF opacity updates now apply to existing renderables in place (no URDF rebuild) and correctly update embedded-material alpha, including when opacity changes during model loading.
  * Outline/edge rendering now hides when marker opacity is below 1 (when outlines are enabled).
* **Tests**
  * Expanded Jest coverage for URDF opacity, embedded-material opacity cloning/updating behavior, and debounced URDF load/dispose scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
