### PR TITLE
e2e: new layout, image panel, image topic

### DIFF
--- a/e2e/tests/desktop/panel/Image/add-image-panel-select-topic.desktop.spec.ts
+++ b/e2e/tests/desktop/panel/Image/add-image-panel-select-topic.desktop.spec.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+import { test, expect } from "../../../../fixtures/electron";
+import { loadFiles } from "../../../../fixtures/load-files";
+import { DataSourceDialog, LayoutManager, Sidebar } from "../../../../page-objects";
+
+const MCAP_FILE = "custom-camera-model.mcap";
+const IMAGE_TOPIC = "/image/compressed";
+
+/**
+ * GIVEN an .mcap file with an image topic is loaded
+ * AND the user creates a new layout and adds an Image panel
+ * WHEN the user opens the Panel settings tab
+ * AND selects the image topic "/image/compressed"
+ * THEN the Image panel Topic setting should show the selected topic
+ */
+test("add Image panel in a new layout and select a topic", { tag: "@regression" }, async ({
+  mainWindow,
+}) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+  const layout = new LayoutManager(mainWindow);
+
+  // Given
+  await dialog.close();
+  await loadFiles({ mainWindow, filenames: MCAP_FILE });
+
+  await sidebar.openLayoutsTab();
+  await mainWindow.getByTestId("create-new-layout").click();
+  await layout.selectPanel("Image");
+
+  // When
+  await sidebar.openPanelSettingsTab();
+  const settings = sidebar.getLeftSidebar();
+  const topicSelect = settings.getByTestId("FieldEditor-Select").first();
+  await topicSelect.click();
+  await mainWindow.getByRole("option", { name: IMAGE_TOPIC, exact: true }).click();
+
+  // Then
+  await expect(topicSelect).toHaveText(IMAGE_TOPIC);
+});

--- a/packages/suite-base/src/hooks/useLayoutTransfer.test.tsx
+++ b/packages/suite-base/src/hooks/useLayoutTransfer.test.tsx
@@ -6,6 +6,7 @@ import { act, renderHook } from "@testing-library/react";
 
 import { useCurrentLayoutActions } from "@lichtblick/suite-base/context/CurrentLayoutContext";
 import { useLayoutNavigation } from "@lichtblick/suite-base/hooks/useLayoutNavigation";
+import LayoutBuilder from "@lichtblick/suite-base/testing/builders/LayoutBuilder";
 import * as filePicker from "@lichtblick/suite-base/util/showOpenFilePicker";
 import { BasicBuilder } from "@lichtblick/test-builders";
 
@@ -13,8 +14,11 @@ import { useLayoutTransfer } from "./useLayoutTransfer";
 import { useAnalytics } from "../context/AnalyticsContext";
 import { useLayoutManager } from "../context/LayoutManagerContext";
 
+const mockEnqueueSnackbar = jest.fn();
+
 jest.mock("notistack", () => ({
   useSnackbar: () => ({ enqueueSnackbar: jest.fn() }),
+  enqueueSnackbar: (...args: unknown[]) => mockEnqueueSnackbar(...args),
 }));
 
 jest.mock("@lichtblick/suite-base/context/CurrentLayoutContext", () => ({
@@ -70,7 +74,7 @@ describe("useLayoutTransfer", () => {
 
   it("should import a layout and call onSelectLayout", async () => {
     promptForUnsavedChangesMock.mockResolvedValue(true);
-    const content = JSON.stringify({ data: BasicBuilder.string() }) ?? "";
+    const content = JSON.stringify(LayoutBuilder.data()) ?? "";
     const mockFile = new File([content], "test-layout.json", {
       type: "application/json",
     });
@@ -98,5 +102,35 @@ describe("useLayoutTransfer", () => {
     expect(saveNewLayoutMock).toHaveBeenCalled();
     expect(onSelectLayoutMock).toHaveBeenCalled();
     expect(logEventMock).toHaveBeenCalled();
+  });
+
+  it("should not install a layout that fails validation", async () => {
+    promptForUnsavedChangesMock.mockResolvedValue(true);
+    // Missing required fields such as configById, globalVariables, etc.
+    const content = JSON.stringify({ foo: BasicBuilder.string() }) ?? "";
+    const mockFile = new File([content], "invalid-layout.json", {
+      type: "application/json",
+    });
+
+    mockFile.text = async () => content;
+
+    (filePicker.default as jest.Mock).mockResolvedValue([
+      {
+        getFile: async () => mockFile,
+      },
+    ]);
+
+    const { result } = renderHook(() => useLayoutTransfer());
+
+    await act(async () => {
+      await result.current.importLayout();
+    });
+
+    expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+      expect.stringContaining("is not a valid layout"),
+      { variant: "error" },
+    );
+    expect(saveNewLayoutMock).not.toHaveBeenCalled();
+    expect(onSelectLayoutMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/suite-base/src/hooks/useLayoutTransfer.test.tsx
+++ b/packages/suite-base/src/hooks/useLayoutTransfer.test.tsx
@@ -17,7 +17,7 @@ import { useLayoutManager } from "../context/LayoutManagerContext";
 const mockEnqueueSnackbar = jest.fn();
 
 jest.mock("notistack", () => ({
-  useSnackbar: () => ({ enqueueSnackbar: jest.fn() }),
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueueSnackbar }),
   enqueueSnackbar: (...args: unknown[]) => mockEnqueueSnackbar(...args),
 }));
 

--- a/packages/suite-base/src/hooks/useLayoutTransfer.tsx
+++ b/packages/suite-base/src/hooks/useLayoutTransfer.tsx
@@ -15,6 +15,7 @@ import { useLayoutNavigation } from "@lichtblick/suite-base/hooks/useLayoutNavig
 import { Layout } from "@lichtblick/suite-base/services/ILayoutStorage";
 import { Namespace } from "@lichtblick/suite-base/types";
 import { downloadTextFile } from "@lichtblick/suite-base/util/download";
+import { validateLayoutData } from "@lichtblick/suite-base/util/layout";
 import showOpenFilePicker from "@lichtblick/suite-base/util/showOpenFilePicker";
 
 import { useAnalytics } from "../context/AnalyticsContext";
@@ -58,7 +59,16 @@ export function useLayoutTransfer(): UseLayoutTransfer {
         return;
       }
 
-      const data = parsedState as LayoutData;
+      let data: LayoutData;
+      try {
+        data = validateLayoutData(parsedState);
+      } catch (err: unknown) {
+        enqueueSnackbar(`${file.name} is not a valid layout: ${(err as Error).message}`, {
+          variant: "error",
+        });
+        return;
+      }
+
       const newLayout = await layoutManager.saveNewLayout({
         name: layoutName,
         data,

--- a/packages/suite-base/src/hooks/useLayoutTransfer.tsx
+++ b/packages/suite-base/src/hooks/useLayoutTransfer.tsx
@@ -63,7 +63,8 @@ export function useLayoutTransfer(): UseLayoutTransfer {
       try {
         data = validateLayoutData(parsedState);
       } catch (err: unknown) {
-        enqueueSnackbar(`${file.name} is not a valid layout: ${(err as Error).message}`, {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        enqueueSnackbar(`${file.name} is not a valid layout: ${errorMessage}`, {
           variant: "error",
         });
         return;

--- a/packages/suite-base/src/util/layout.test.ts
+++ b/packages/suite-base/src/util/layout.test.ts
@@ -32,6 +32,7 @@ import {
   reorderTabWithinTabPanel,
   getPathFromNode,
   getParentTabPanelByPanelId,
+  validateLayoutData,
 } from "./layout";
 
 const tabConfig = {
@@ -640,6 +641,116 @@ describe("layout", () => {
       };
       const parentTabsByPanelId = getParentTabPanelByPanelId(configById);
       expect(parentTabsByPanelId).toEqual({});
+    });
+  });
+
+  describe("validateLayoutData", () => {
+    function validData(): Record<string, unknown> {
+      return {
+        configById: {},
+        globalVariables: {},
+        userNodes: {},
+        playbackConfig: { speed: 1 },
+      };
+    }
+
+    it("returns the data when all required fields are valid", () => {
+      // Given a fully populated layout
+      const data = {
+        ...validData(),
+        layout: { first: "Plot!1", second: "Plot!2", direction: "row" },
+        version: 1,
+      };
+
+      // When validating it
+      // Then the same object is returned without throwing
+      expect(validateLayoutData(data)).toBe(data);
+    });
+
+    it("accepts optional layout as a string and omitted version", () => {
+      // Given a layout whose root is a single panel id
+      const data = { ...validData(), layout: "Plot!1" };
+
+      // When validating it
+      // Then it is accepted
+      expect(validateLayoutData(data)).toBe(data);
+    });
+
+    it.each([undefined, null, 42, "string", []])(
+      "throws when the value is not an object (%p)",
+      (value) => {
+        // Given a non-object value
+        // When validating it
+        // Then it throws
+        expect(() => validateLayoutData(value)).toThrow("Invalid layout: expected an object");
+      },
+    );
+
+    it.each(["configById", "globalVariables", "userNodes"] as const)(
+      "throws when required object field %s is missing",
+      (field) => {
+        // Given a layout missing a required object field
+        const data = validData();
+        delete data[field];
+
+        // When validating it
+        // Then it throws referencing that field
+        expect(() => validateLayoutData(data)).toThrow(
+          `Invalid layout: missing or invalid "${field}"`,
+        );
+      },
+    );
+
+    it("throws when playbackConfig is missing", () => {
+      // Given a layout without playbackConfig
+      const data = validData();
+      delete data.playbackConfig;
+
+      // When validating it
+      // Then it throws
+      expect(() => validateLayoutData(data)).toThrow(
+        'Invalid layout: missing or invalid "playbackConfig"',
+      );
+    });
+
+    it("throws when playbackConfig.speed is not a number", () => {
+      // Given a layout whose playbackConfig has a non-numeric speed
+      const data = { ...validData(), playbackConfig: { speed: "fast" } };
+
+      // When validating it
+      // Then it throws
+      expect(() => validateLayoutData(data)).toThrow(
+        'Invalid layout: missing or invalid "playbackConfig"',
+      );
+    });
+
+    it("throws when layout has an invalid type", () => {
+      // Given a layout whose layout field is a number
+      const data = { ...validData(), layout: 5 };
+
+      // When validating it
+      // Then it throws
+      expect(() => validateLayoutData(data)).toThrow('Invalid layout: invalid "layout"');
+    });
+
+    it("throws when version has an invalid type", () => {
+      // Given a layout whose version is a string
+      const data = { ...validData(), version: "1" };
+
+      // When validating it
+      // Then it throws
+      expect(() => validateLayoutData(data)).toThrow('Invalid layout: invalid "version"');
+    });
+
+    it("aggregates multiple errors into a single message", () => {
+      // Given a layout missing several fields
+      const data = { globalVariables: {} };
+
+      // When validating it
+      // Then all invalid fields are reported
+      expect(() => validateLayoutData(data)).toThrow(
+        'Invalid layout: missing or invalid "configById", missing or invalid "userNodes", missing or invalid "playbackConfig"',
+      );
     });
   });
 });

--- a/packages/suite-base/src/util/layout.test.ts
+++ b/packages/suite-base/src/util/layout.test.ts
@@ -676,30 +676,32 @@ describe("layout", () => {
       expect(validateLayoutData(data)).toBe(data);
     });
 
-    it.each([undefined, null, 42, "string", []])(
-      "throws when the value is not an object (%p)",
-      (value) => {
-        // Given a non-object value
-        // When validating it
-        // Then it throws
-        expect(() => validateLayoutData(value)).toThrow("expected an object");
-      },
-    );
+    it.each([
+      undefined,
+      null,
+      42,
+      "string",
+      [],
+    ])("throws when the value is not an object (%p)", (value) => {
+      // Given a non-object value
+      // When validating it
+      // Then it throws
+      expect(() => validateLayoutData(value)).toThrow("expected an object");
+    });
 
-    it.each(["configById", "globalVariables", "userNodes"] as const)(
-      "throws when required object field %s is missing",
-      (field) => {
-        // Given a layout missing a required object field
-        const data = validData();
-        delete data[field];
+    it.each([
+      "configById",
+      "globalVariables",
+      "userNodes",
+    ] as const)("throws when required object field %s is missing", (field) => {
+      // Given a layout missing a required object field
+      const data = validData();
+      delete data[field];
 
-        // When validating it
-        // Then it throws referencing that field
-        expect(() => validateLayoutData(data)).toThrow(
-          `missing or invalid "${field}"`,
-        );
-      },
-    );
+      // When validating it
+      // Then it throws referencing that field
+      expect(() => validateLayoutData(data)).toThrow(`missing or invalid "${field}"`);
+    });
 
     it("throws when playbackConfig is missing", () => {
       // Given a layout without playbackConfig
@@ -708,9 +710,7 @@ describe("layout", () => {
 
       // When validating it
       // Then it throws
-      expect(() => validateLayoutData(data)).toThrow(
-        'missing or invalid "playbackConfig"',
-      );
+      expect(() => validateLayoutData(data)).toThrow('missing or invalid "playbackConfig"');
     });
 
     it("throws when playbackConfig.speed is not a number", () => {
@@ -719,9 +719,7 @@ describe("layout", () => {
 
       // When validating it
       // Then it throws
-      expect(() => validateLayoutData(data)).toThrow(
-        'missing or invalid "playbackConfig"',
-      );
+      expect(() => validateLayoutData(data)).toThrow('missing or invalid "playbackConfig"');
     });
 
     it("throws when layout has an invalid type", () => {

--- a/packages/suite-base/src/util/layout.test.ts
+++ b/packages/suite-base/src/util/layout.test.ts
@@ -682,7 +682,7 @@ describe("layout", () => {
         // Given a non-object value
         // When validating it
         // Then it throws
-        expect(() => validateLayoutData(value)).toThrow("Invalid layout: expected an object");
+        expect(() => validateLayoutData(value)).toThrow("expected an object");
       },
     );
 
@@ -696,7 +696,7 @@ describe("layout", () => {
         // When validating it
         // Then it throws referencing that field
         expect(() => validateLayoutData(data)).toThrow(
-          `Invalid layout: missing or invalid "${field}"`,
+          `missing or invalid "${field}"`,
         );
       },
     );
@@ -709,7 +709,7 @@ describe("layout", () => {
       // When validating it
       // Then it throws
       expect(() => validateLayoutData(data)).toThrow(
-        'Invalid layout: missing or invalid "playbackConfig"',
+        'missing or invalid "playbackConfig"',
       );
     });
 
@@ -720,7 +720,7 @@ describe("layout", () => {
       // When validating it
       // Then it throws
       expect(() => validateLayoutData(data)).toThrow(
-        'Invalid layout: missing or invalid "playbackConfig"',
+        'missing or invalid "playbackConfig"',
       );
     });
 
@@ -730,7 +730,7 @@ describe("layout", () => {
 
       // When validating it
       // Then it throws
-      expect(() => validateLayoutData(data)).toThrow('Invalid layout: invalid "layout"');
+      expect(() => validateLayoutData(data)).toThrow('invalid "layout"');
     });
 
     it("throws when version has an invalid type", () => {
@@ -739,7 +739,7 @@ describe("layout", () => {
 
       // When validating it
       // Then it throws
-      expect(() => validateLayoutData(data)).toThrow('Invalid layout: invalid "version"');
+      expect(() => validateLayoutData(data)).toThrow('invalid "version"');
     });
 
     it("aggregates multiple errors into a single message", () => {
@@ -749,7 +749,7 @@ describe("layout", () => {
       // When validating it
       // Then all invalid fields are reported
       expect(() => validateLayoutData(data)).toThrow(
-        'Invalid layout: missing or invalid "configById", missing or invalid "userNodes", missing or invalid "playbackConfig"',
+        'missing or invalid "configById", missing or invalid "userNodes", missing or invalid "playbackConfig"',
       );
     });
   });

--- a/packages/suite-base/src/util/layout.ts
+++ b/packages/suite-base/src/util/layout.ts
@@ -30,6 +30,7 @@ import { filterMap } from "@lichtblick/den/collection";
 import Logger from "@lichtblick/log";
 import {
   ConfigsPayload,
+  LayoutData,
   SaveConfigsPayload,
 } from "@lichtblick/suite-base/context/CurrentLayoutContext/actions";
 import { reportError } from "@lichtblick/suite-base/reportError";
@@ -561,4 +562,52 @@ export function getConfigsForNestedPanelsInsideTab(
     }
   });
   return configs;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != undefined && !Array.isArray(value);
+}
+
+/**
+ * Validates that a parsed value has the shape required by {@link LayoutData} before it is
+ * installed. Throws an Error whose message lists every missing or invalid field so the caller can
+ * surface it to the user.
+ *
+ * @param data The unknown value parsed from a layout file.
+ * @returns The same value narrowed to {@link LayoutData} when valid.
+ */
+export function validateLayoutData(data: unknown): LayoutData {
+  const errors: string[] = [];
+
+  if (!isPlainObject(data)) {
+    throw new Error("Invalid layout: expected an object");
+  }
+
+  for (const field of ["configById", "globalVariables", "userNodes"] as const) {
+    if (!isPlainObject(data[field])) {
+      errors.push(`missing or invalid "${field}"`);
+    }
+  }
+
+  if (!isPlainObject(data.playbackConfig) || typeof data.playbackConfig.speed !== "number") {
+    errors.push(`missing or invalid "playbackConfig"`);
+  }
+
+  if (
+    data.layout != undefined &&
+    typeof data.layout !== "string" &&
+    !isPlainObject(data.layout)
+  ) {
+    errors.push(`invalid "layout"`);
+  }
+
+  if (data.version != undefined && typeof data.version !== "number") {
+    errors.push(`invalid "version"`);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid layout: ${errors.join(", ")}`);
+  }
+
+  return data as LayoutData;
 }

--- a/packages/suite-base/src/util/layout.ts
+++ b/packages/suite-base/src/util/layout.ts
@@ -580,7 +580,7 @@ export function validateLayoutData(data: unknown): LayoutData {
   const errors: string[] = [];
 
   if (!isPlainObject(data)) {
-    throw new Error("Invalid layout: expected an object");
+    throw new Error("expected an object");
   }
 
   for (const field of ["configById", "globalVariables", "userNodes"] as const) {
@@ -606,7 +606,7 @@ export function validateLayoutData(data: unknown): LayoutData {
   }
 
   if (errors.length > 0) {
-    throw new Error(`Invalid layout: ${errors.join(", ")}`);
+    throw new Error(errors.join(", "));
   }
 
   return data as LayoutData;

--- a/packages/suite-base/src/util/layout.ts
+++ b/packages/suite-base/src/util/layout.ts
@@ -593,11 +593,7 @@ export function validateLayoutData(data: unknown): LayoutData {
     errors.push(`missing or invalid "playbackConfig"`);
   }
 
-  if (
-    data.layout != undefined &&
-    typeof data.layout !== "string" &&
-    !isPlainObject(data.layout)
-  ) {
+  if (data.layout != undefined && typeof data.layout !== "string" && !isPlainObject(data.layout)) {
     errors.push(`invalid "layout"`);
   }
 


### PR DESCRIPTION
## User-Facing Changes
N/A

## Description
Add E2E test: create a new layout with an Image panel and select an image topic.

## Checklist
- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for imported layouts to ensure required data is present and correctly formatted.
  * Invalid layout imports now display a clear error message and are not saved.
  * Added support for selecting compressed image topics in Image panel settings.

* **Bug Fixes**
  * Improved protection against malformed or invalid layout files during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->