### PR TITLE
e2e: add Image panel in new layout and select a topic

### DIFF
--- a/e2e/tests/desktop/panel/Image/add-image-panel-select-topic.desktop.spec.ts
+++ b/e2e/tests/desktop/panel/Image/add-image-panel-select-topic.desktop.spec.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+import { test, expect } from "../../../../fixtures/electron";
+import { loadFiles } from "../../../../fixtures/load-files";
+import { DataSourceDialog, LayoutManager, Sidebar } from "../../../../page-objects";
+
+const MCAP_FILE = "custom-camera-model.mcap";
+const IMAGE_TOPIC = "/image/compressed";
+
+/**
+ * GIVEN an .mcap file with an image topic is loaded
+ * AND the user creates a new layout and adds an Image panel
+ * WHEN the user opens the Panel settings tab
+ * AND selects the image topic "/image/compressed"
+ * THEN the Image panel Topic setting should show the selected topic
+ */
+test("add Image panel in a new layout and select a topic", { tag: "@regression" }, async ({
+  mainWindow,
+}) => {
+  const dialog = new DataSourceDialog(mainWindow);
+  const sidebar = new Sidebar(mainWindow);
+  const layout = new LayoutManager(mainWindow);
+
+  // Given
+  await dialog.close();
+  await loadFiles({ mainWindow, filenames: MCAP_FILE });
+
+  await sidebar.openLayoutsTab();
+  await mainWindow.getByTestId("create-new-layout").click();
+  await layout.selectPanel("Image");
+
+  // When
+  await sidebar.openPanelSettingsTab();
+  const settings = sidebar.getLeftSidebar();
+  const topicSelect = settings.getByTestId("FieldEditor-Select").first();
+  await topicSelect.click();
+  await mainWindow.getByRole("option", { name: IMAGE_TOPIC, exact: true }).click();
+
+  // Then
+  await expect(topicSelect).toHaveText(IMAGE_TOPIC);
+});

--- a/e2e/tests/desktop/panel/Image/add-image-panel-select-topic.desktop.spec.ts
+++ b/e2e/tests/desktop/panel/Image/add-image-panel-select-topic.desktop.spec.ts
@@ -32,7 +32,7 @@ test("add Image panel in a new layout and select a topic", { tag: "@regression" 
   // When
   await sidebar.openPanelSettingsTab();
   const settings = sidebar.getLeftSidebar();
-  const topicSelect = settings.getByTestId("FieldEditor-Select").first();
+  const topicSelect = settings.getByTestId("FieldEditor-Select").getByText(IMAGE_TOPIC);
   await topicSelect.click();
   await mainWindow.getByRole("option", { name: IMAGE_TOPIC, exact: true }).click();
 


### PR DESCRIPTION
## User-Facing Changes
N/A

## Description

Add E2E test: create a new layout with an Image panel and select an image topic.

## Checklist
- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end desktop test verifying that an Image panel can select and display the `/image/compressed` topic from its settings sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->