### PR TITLE
[fix]: fix virtualized lists after migration to react-window v2

### DIFF
--- a/packages/suite-base/src/components/TopicList/TopicList.tsx
+++ b/packages/suite-base/src/components/TopicList/TopicList.tsx
@@ -208,7 +208,7 @@ export function TopicList(): React.JSX.Element {
               {({ width, height }) => (
                 <VirtualList
                   listRef={listRef}
-                  style={{ width, height }}
+                  style={{ width, height, maxHeight: height }}
                   rowCount={treeItems.length}
                   rowHeight={(index, data) => (data.treeItems[index]?.type === "topic" ? 50 : 28)}
                   rowProps={itemData}

--- a/packages/suite-base/src/components/TopicList/TopicList.tsx
+++ b/packages/suite-base/src/components/TopicList/TopicList.tsx
@@ -206,15 +206,17 @@ export function TopicList(): React.JSX.Element {
           <div style={{ flex: "1 1 100%" }}>
             <AutoSizer>
               {({ width, height }) => (
-                <VirtualList
-                  listRef={listRef}
-                  style={{ width, height, maxHeight: height }}
-                  rowCount={treeItems.length}
-                  rowHeight={(index, data) => (data.treeItems[index]?.type === "topic" ? 50 : 28)}
-                  rowProps={itemData}
-                  overscanCount={10}
-                  rowComponent={renderRow}
-                />
+                <div style={{ width, height }}>
+                  <VirtualList
+                    listRef={listRef}
+                    style={{ width, height }}
+                    rowCount={treeItems.length}
+                    rowHeight={(index, data) => (data.treeItems[index]?.type === "topic" ? 50 : 28)}
+                    rowProps={itemData}
+                    overscanCount={10}
+                    rowComponent={renderRow}
+                  />
+                </div>
               )}
             </AutoSizer>
           </div>

--- a/packages/suite-base/src/panels/DiagnosticSummary/DiagnosticSummary.tsx
+++ b/packages/suite-base/src/panels/DiagnosticSummary/DiagnosticSummary.tsx
@@ -174,14 +174,16 @@ const DiagnosticSummary = (props: DiagnosticSummaryProps): React.JSX.Element => 
     return (
       <AutoSizer>
         {({ height, width }) => (
-          <List<{ data: DiagnosticInfo[] }>
-            style={{ outline: "none", width, height, maxHeight: height }}
-            rowHeight={30}
-            rowProps={{ data: nodes }}
-            rowCount={nodes.length}
-            overscanCount={10}
-            rowComponent={renderRow}
-          />
+          <div style={{ width, height }}>
+            <List<{ data: DiagnosticInfo[] }>
+              style={{ outline: "none", width, height }}
+              rowHeight={30}
+              rowProps={{ data: nodes }}
+              rowCount={nodes.length}
+              overscanCount={10}
+              rowComponent={renderRow}
+            />
+          </div>
         )}
       </AutoSizer>
     );

--- a/packages/suite-base/src/panels/DiagnosticSummary/DiagnosticSummary.tsx
+++ b/packages/suite-base/src/panels/DiagnosticSummary/DiagnosticSummary.tsx
@@ -175,7 +175,7 @@ const DiagnosticSummary = (props: DiagnosticSummaryProps): React.JSX.Element => 
       <AutoSizer>
         {({ height, width }) => (
           <List<{ data: DiagnosticInfo[] }>
-            style={{ outline: "none", width, height }}
+            style={{ outline: "none", width, height, maxHeight: height }}
             rowHeight={30}
             rowProps={{ data: nodes }}
             rowCount={nodes.length}


### PR DESCRIPTION
## User-Facing Changes

Fix virtualized lists (`TopicList`, `DiagnosticSummary`) being invisibly clipped after the react-window v2 migration.

## Description

Follow-up to #1181. After the react-window v2 upgrade was merged, the `drag-and-drop-topic-on-raw-messages` e2e test started failing because topic rows were present in the DOM but had zero visible height.

**Root cause:** react-window v2's `List` injects `maxHeight: "100%"` as a default container style. `react-virtualized-auto-sizer` always sets its outer div to `height: 0` (passing the measured height to children as a prop, not as CSS). This caused `100%` to resolve to `0px`, overriding the explicit `height` and clipping all rows via `overflow-y: auto`.

**Fix:** Wrap `<List>` in an explicit-height `<div style={{ width, height }}>` inside the AutoSizer callback. This gives `maxHeight: "100%"` a proper containing block to resolve against, so no style override is needed. This matches the pattern already used by `LogList`.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sizing and layout behavior for virtualized topic and diagnostic lists.
  - Ensured list content consistently fits its available panel dimensions.
  - Reduced the likelihood of rendering issues when panels are resized or displayed in different layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->