### PR TITLE
Unit tests for BottomBar section of UserScripts panel

### DIFF
--- a/packages/suite-base/src/panels/UserScriptEditor/BottomBar/DiagnosticsSection.test.tsx
+++ b/packages/suite-base/src/panels/UserScriptEditor/BottomBar/DiagnosticsSection.test.tsx
@@ -1,0 +1,108 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { DIAGNOSTIC_SEVERITY } from "@lichtblick/suite-base/players/UserScriptPlayer/constants";
+import { Diagnostic } from "@lichtblick/suite-base/players/UserScriptPlayer/types";
+import UserScriptBuilder from "@lichtblick/suite-base/testing/builders/UserScriptBuilder";
+import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
+
+import DiagnosticsSection from "./DiagnosticsSection";
+
+function renderDiagnosticsSection(diagnostics: readonly Diagnostic[]) {
+  return render(
+    <ThemeProvider isDark={false}>
+      <DiagnosticsSection diagnostics={diagnostics} />
+    </ThemeProvider>,
+  );
+}
+
+describe("DiagnosticsSection", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it("should display an empty message when there are no diagnostics", () => {
+    // Given
+    const diagnostics: readonly Diagnostic[] = [];
+
+    // When
+    renderDiagnosticsSection(diagnostics);
+
+    // Then
+    expect(screen.getByText("No alerts to display.")).toBeInTheDocument();
+  });
+
+  it("should render the message of each diagnostic", () => {
+    // Given
+    const diagnostics = UserScriptBuilder.diagnostics();
+
+    // When
+    renderDiagnosticsSection(diagnostics);
+
+    // Then
+    diagnostics.forEach((diagnostic) => {
+      expect(screen.getByText(diagnostic.message)).toBeInTheDocument();
+    });
+  });
+
+  it("should render the source and 1-based error location when line and column are provided", () => {
+    // Given
+    const diagnostic = UserScriptBuilder.diagnostic({
+      source: "Typescript",
+      startLineNumber: 4,
+      startColumn: 2,
+    });
+
+    // When
+    renderDiagnosticsSection([diagnostic]);
+
+    // Then
+    expect(screen.getByText("Typescript [5,3]")).toBeInTheDocument();
+  });
+
+  it("should render the source without a location when line and column are undefined", () => {
+    // Given
+    const diagnostic: Diagnostic = {
+      ...UserScriptBuilder.diagnostic({ source: "Runtime" }),
+      startLineNumber: undefined,
+      startColumn: undefined,
+    };
+
+    // When
+    renderDiagnosticsSection([diagnostic]);
+
+    // Then
+    expect(screen.getByText("Runtime", { exact: false })).toBeInTheDocument();
+    expect(screen.queryByText(/\[\d+,\d+\]/)).not.toBeInTheDocument();
+  });
+
+  it("should render one list item per diagnostic", () => {
+    // Given
+    const diagnostics = UserScriptBuilder.diagnostics(5);
+
+    // When
+    renderDiagnosticsSection(diagnostics);
+
+    // Then
+    expect(screen.getAllByRole("listitem")).toHaveLength(diagnostics.length);
+  });
+
+  it("should render diagnostics for every known severity level", () => {
+    // Given
+    const diagnostics = Object.values(DIAGNOSTIC_SEVERITY).map((severity) =>
+      UserScriptBuilder.diagnostic({ severity }),
+    );
+
+    // When
+    renderDiagnosticsSection(diagnostics);
+
+    // Then
+    expect(screen.getAllByRole("listitem")).toHaveLength(diagnostics.length);
+  });
+});

--- a/packages/suite-base/src/panels/UserScriptEditor/BottomBar/LogsSection.test.tsx
+++ b/packages/suite-base/src/panels/UserScriptEditor/BottomBar/LogsSection.test.tsx
@@ -1,0 +1,195 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { UserScriptLog } from "@lichtblick/suite-base/players/UserScriptPlayer/types";
+import UserScriptBuilder from "@lichtblick/suite-base/testing/builders/UserScriptBuilder";
+import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
+import { BasicBuilder } from "@lichtblick/test-builders";
+
+import LogsSection from "./LogsSection";
+
+jest.mock("react-json-tree", () => ({
+  __esModule: true,
+  default: ({ data }: { data: unknown }) => (
+    <div data-testid="json-tree">{JSON.stringify(data)}</div>
+  ),
+}));
+
+function renderLogsSection(logs: readonly UserScriptLog[]) {
+  const utils = render(
+    <ThemeProvider isDark={false}>
+      <LogsSection logs={logs} />
+    </ThemeProvider>,
+  );
+
+  const rerenderLogs = (nextLogs: readonly UserScriptLog[]) => {
+    utils.rerender(
+      <ThemeProvider isDark={false}>
+        <LogsSection logs={nextLogs} />
+      </ThemeProvider>,
+    );
+  };
+
+  return { ...utils, rerenderLogs };
+}
+
+function defineScrollMetrics(
+  element: HTMLElement,
+  { scrollHeight, clientHeight }: { scrollHeight: number; clientHeight?: number },
+) {
+  Object.defineProperty(element, "scrollHeight", { configurable: true, value: scrollHeight });
+  if (clientHeight != undefined) {
+    Object.defineProperty(element, "clientHeight", { configurable: true, value: clientHeight });
+  }
+}
+
+describe("LogsSection", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it("should display the empty state message when there are no logs", () => {
+    // Given
+    const logs: readonly UserScriptLog[] = [];
+
+    // When
+    renderLogsSection(logs);
+
+    // Then
+    expect(screen.getByText("No logs to display.")).toBeInTheDocument();
+  });
+
+  it("should render string log values as text", () => {
+    // Given
+    const value = BasicBuilder.string();
+    const log = UserScriptBuilder.log({ value });
+
+    // When
+    renderLogsSection([log]);
+
+    // Then
+    expect(screen.getByText(value)).toBeInTheDocument();
+  });
+
+  it("should render the source for each log", () => {
+    // Given
+    const log = UserScriptBuilder.log({ source: "processMessage" });
+
+    // When
+    renderLogsSection([log]);
+
+    // Then
+    expect(screen.getByText("processMessage")).toBeInTheDocument();
+  });
+
+  it("should render one list item per log", () => {
+    // Given
+    const logs = UserScriptBuilder.logs(4);
+
+    // When
+    renderLogsSection(logs);
+
+    // Then
+    expect(screen.getAllByRole("listitem")).toHaveLength(logs.length);
+  });
+
+  it("should render object values using the json tree", () => {
+    // Given
+    const value = { foo: BasicBuilder.string() };
+    const log = UserScriptBuilder.log({ value });
+
+    // When
+    renderLogsSection([log]);
+
+    // Then
+    expect(screen.getByTestId("json-tree")).toHaveTextContent(value.foo);
+  });
+
+  it("should render boolean false as its string representation", () => {
+    // Given
+    const log = UserScriptBuilder.log({ value: false });
+
+    // When
+    renderLogsSection([log]);
+
+    // Then
+    expect(screen.getByText("false")).toBeInTheDocument();
+  });
+
+  it("should render undefined values as its string representation", () => {
+    // Given
+    const log: UserScriptLog = { ...UserScriptBuilder.log(), value: undefined };
+
+    // When
+    renderLogsSection([log]);
+
+    // Then
+    expect(screen.getByText("undefined")).toBeInTheDocument();
+  });
+
+  it("should auto-scroll to the bottom when new logs arrive", () => {
+    // Given
+    const { rerenderLogs } = renderLogsSection(UserScriptBuilder.logs(1));
+    const list = screen.getByRole("list");
+    defineScrollMetrics(list, { scrollHeight: 100 });
+
+    // When
+    rerenderLogs(UserScriptBuilder.logs(2));
+
+    // Then
+    expect(list.scrollTop).toBe(100);
+  });
+
+  it("should stop auto-scrolling when the user scrolls up", () => {
+    // Given
+    const { rerenderLogs } = renderLogsSection(UserScriptBuilder.logs(1));
+    const list = screen.getByRole("list");
+    defineScrollMetrics(list, { scrollHeight: 100 });
+
+    // When
+    fireEvent.wheel(list, { deltaY: -1 });
+    list.scrollTop = 0;
+    rerenderLogs(UserScriptBuilder.logs(2));
+
+    // Then
+    expect(list.scrollTop).toBe(0);
+  });
+
+  it("should resume auto-scrolling when the user scrolls down while content is above the viewport", () => {
+    // Given
+    const { rerenderLogs } = renderLogsSection(UserScriptBuilder.logs(1));
+    const list = screen.getByRole("list");
+    defineScrollMetrics(list, { scrollHeight: 100, clientHeight: 10 });
+    fireEvent.wheel(list, { deltaY: -1 });
+    list.scrollTop = 0;
+
+    // When
+    fireEvent.wheel(list, { deltaY: 1 });
+    rerenderLogs(UserScriptBuilder.logs(2));
+
+    // Then
+    expect(list.scrollTop).toBe(100);
+  });
+
+  it("should stay stopped when the user scrolls down but content is not above the viewport", () => {
+    // Given
+    const { rerenderLogs } = renderLogsSection(UserScriptBuilder.logs(1));
+    const list = screen.getByRole("list");
+    defineScrollMetrics(list, { scrollHeight: 10, clientHeight: 100 });
+    fireEvent.wheel(list, { deltaY: -1 });
+    list.scrollTop = 0;
+
+    // When
+    fireEvent.wheel(list, { deltaY: 1 });
+    rerenderLogs(UserScriptBuilder.logs(2));
+
+    // Then
+    expect(list.scrollTop).toBe(0);
+  });
+});

--- a/packages/suite-base/src/panels/UserScriptEditor/BottomBar/index.test.tsx
+++ b/packages/suite-base/src/panels/UserScriptEditor/BottomBar/index.test.tsx
@@ -1,0 +1,192 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { useUserScriptState } from "@lichtblick/suite-base/context/UserScriptStateContext";
+import { Diagnostic, UserScriptLog } from "@lichtblick/suite-base/players/UserScriptPlayer/types";
+import UserScriptBuilder from "@lichtblick/suite-base/testing/builders/UserScriptBuilder";
+import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
+import { BasicBuilder } from "@lichtblick/test-builders";
+
+import BottomBar from "./index";
+
+jest.mock("@lichtblick/suite-base/context/UserScriptStateContext", () => ({
+  useUserScriptState: jest.fn(),
+}));
+
+jest.mock("./DiagnosticsSection", () => ({
+  __esModule: true,
+  default: () => <div data-testid="diagnostics-section" />,
+}));
+
+jest.mock("./LogsSection", () => ({
+  __esModule: true,
+  default: () => <div data-testid="logs-section" />,
+}));
+
+const mockClearUserScriptLogs = jest.fn();
+const mockUseUserScriptState = useUserScriptState as jest.MockedFunction<typeof useUserScriptState>;
+
+type SetupProps = {
+  diagnostics?: readonly Diagnostic[];
+  isSaved?: boolean;
+  logs?: readonly UserScriptLog[];
+  scriptId?: string;
+  onChangeTab?: () => void;
+  save?: () => void;
+};
+
+function setup(props: SetupProps = {}) {
+  const onChangeTab = props.onChangeTab ?? jest.fn();
+  const save = props.save ?? jest.fn();
+  const scriptId = "scriptId" in props ? props.scriptId : BasicBuilder.string();
+
+  const utils = render(
+    <ThemeProvider isDark={false}>
+      <BottomBar
+        diagnostics={props.diagnostics ?? []}
+        isSaved={props.isSaved ?? false}
+        logs={props.logs ?? []}
+        scriptId={scriptId}
+        onChangeTab={onChangeTab}
+        save={save}
+      />
+    </ThemeProvider>,
+  );
+
+  return { ...utils, onChangeTab, save };
+}
+
+describe("BottomBar", () => {
+  beforeEach(() => {
+    mockUseUserScriptState.mockReturnValue({
+      clearUserScriptLogs: mockClearUserScriptLogs,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it("should render the diagnostics section by default", () => {
+    // Given
+    // default tab
+
+    // When
+    setup();
+
+    // Then
+    expect(screen.getByTestId("diagnostics-section")).toBeInTheDocument();
+    expect(screen.queryByTestId("logs-section")).not.toBeInTheDocument();
+  });
+
+  it("should switch to the logs section when the logs tab is clicked", () => {
+    // Given
+    setup();
+
+    // When
+    fireEvent.click(screen.getByTestId("np-logs"));
+
+    // Then
+    expect(screen.getByTestId("logs-section")).toBeInTheDocument();
+    expect(screen.queryByTestId("diagnostics-section")).not.toBeInTheDocument();
+  });
+
+  it("should call onChangeTab when a tab is clicked", () => {
+    // Given
+    const { onChangeTab } = setup();
+
+    // When
+    fireEvent.click(screen.getByTestId("np-logs"));
+
+    // Then
+    expect(onChangeTab).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render the Save label when the script is not saved", () => {
+    // Given
+    // isSaved false
+
+    // When
+    setup({ isSaved: false });
+
+    // Then
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+
+  it("should render the Saved label and disable the button when the script is saved", () => {
+    // Given
+    // isSaved true
+
+    // When
+    setup({ isSaved: true });
+
+    // Then
+    expect(screen.getByRole("button", { name: "Saved" })).toBeDisabled();
+  });
+
+  it("should save and clear logs when the Save button is clicked with a scriptId", () => {
+    // Given
+    const scriptId = BasicBuilder.string();
+    const { save } = setup({ scriptId, isSaved: false });
+
+    // When
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    // Then
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(mockClearUserScriptLogs).toHaveBeenCalledWith(scriptId);
+  });
+
+  it("should not save when the Save button is clicked without a scriptId", () => {
+    // Given
+    const { save } = setup({ scriptId: undefined, isSaved: false });
+
+    // When
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    // Then
+    expect(save).not.toHaveBeenCalled();
+    expect(mockClearUserScriptLogs).not.toHaveBeenCalled();
+  });
+
+  it("should disable the Clear logs button when there are no logs", () => {
+    // Given
+    setup({ logs: [] });
+
+    // When
+    fireEvent.click(screen.getByTestId("np-logs"));
+
+    // Then
+    expect(screen.getByRole("button", { name: "Clear logs" })).toBeDisabled();
+  });
+
+  it("should clear logs when the Clear logs button is clicked", () => {
+    // Given
+    const scriptId = BasicBuilder.string();
+    setup({ scriptId, logs: UserScriptBuilder.logs() });
+
+    // When
+    fireEvent.click(screen.getByTestId("np-logs"));
+    fireEvent.click(screen.getByRole("button", { name: "Clear logs" }));
+
+    // Then
+    expect(mockClearUserScriptLogs).toHaveBeenCalledWith(scriptId);
+  });
+
+  it("should show the diagnostics count as a badge", () => {
+    // Given
+    const diagnostics = UserScriptBuilder.diagnostics(2);
+
+    // When
+    setup({ diagnostics });
+
+    // Then
+    expect(screen.getByText(String(diagnostics.length))).toBeInTheDocument();
+  });
+});

--- a/packages/suite-base/src/testing/builders/UserScriptBuilder.ts
+++ b/packages/suite-base/src/testing/builders/UserScriptBuilder.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import {
+  DIAGNOSTIC_SEVERITY,
+  SOURCES,
+} from "@lichtblick/suite-base/players/UserScriptPlayer/constants";
+import { Diagnostic, UserScriptLog } from "@lichtblick/suite-base/players/UserScriptPlayer/types";
+import { BasicBuilder, defaults } from "@lichtblick/test-builders";
+
+class UserScriptBuilder {
+  public static diagnostic(props: Partial<Diagnostic> = {}): Diagnostic {
+    return defaults<Diagnostic>(props, {
+      severity: BasicBuilder.sample(DIAGNOSTIC_SEVERITY),
+      message: BasicBuilder.string(),
+      source: BasicBuilder.sample(SOURCES),
+      startLineNumber: BasicBuilder.number(),
+      startColumn: BasicBuilder.number(),
+      endLineNumber: BasicBuilder.number(),
+      endColumn: BasicBuilder.number(),
+      code: BasicBuilder.number(),
+    });
+  }
+
+  public static diagnostics(count = 3): Diagnostic[] {
+    return BasicBuilder.multiple(UserScriptBuilder.diagnostic, count);
+  }
+
+  public static log(props: Partial<UserScriptLog> = {}): UserScriptLog {
+    return defaults<UserScriptLog>(props, {
+      source: BasicBuilder.sample(["registerScript", "processMessage"]),
+      value: BasicBuilder.string(),
+    });
+  }
+
+  public static logs(count = 3): UserScriptLog[] {
+    return BasicBuilder.multiple(UserScriptBuilder.log, count);
+  }
+}
+
+export default UserScriptBuilder;


### PR DESCRIPTION
## User-Facing Changes

N/A

## Description

Adds unit tests for the `UserScriptEditor/BottomBar` panel components and introduces a reusable test builder for UserScript player types.

**New tests** :
- `DiagnosticsSection.test.tsx` — empty state, message rendering, 1-based error-location formatting, missing-location case, list item count, and all severity levels.
- `LogsSection.test.tsx` — empty state, string values, source labels, item count, object values (json tree), `false`/`undefined` string rendering, and full auto-scroll wheel behavior (enable/disable/resume). 
- `index.test.tsx` (BottomBar) — default diagnostics tab, tab switching, `onChangeTab`, Save/Saved label + disabled state, save + clear-logs behavior with/without `scriptId`, Clear logs disabled/enabled, and diagnostics badge count.

**New builder**:
- `testing/builders/UserScriptBuilder.ts` — builds `Diagnostic` and `UserScriptLog` objects (`@lichtblick/suite-base/players/UserScriptPlayer/types`) following the existing builder conventions.

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for displaying diagnostics, including messages, severity levels, sources, locations, and empty states.
  * Added coverage for rendering logs, structured values, empty states, and automatic scrolling behavior.
  * Added coverage for tab switching, saving, clearing logs, and diagnostic count badges.
* **Testing Tools**
  * Added reusable builders for generating diagnostic and log data in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->