### PR TITLE
fix: stop the Map panel accumulating every GeoJSON message

### DIFF
--- a/packages/suite-base/src/panels/Map/MapPanel.test.tsx
+++ b/packages/suite-base/src/panels/Map/MapPanel.test.tsx
@@ -201,4 +201,12 @@ describe("MapPanel", () => {
     // THEN nothing from the historical range is drawn as GeoJSON
     expect(drawnFeatureNames()).toEqual([]);
   });
+
+  it("should not render stray text into the panel", () => {
+    // GIVEN a freshly mounted panel
+    const { container } = setup();
+
+    // THEN the only text shown is the empty state, with no leftover debug characters
+    expect(container.textContent).toBe("Waiting for first GPS point...");
+  });
 });

--- a/packages/suite-base/src/panels/Map/MapPanel.test.tsx
+++ b/packages/suite-base/src/panels/Map/MapPanel.test.tsx
@@ -1,0 +1,204 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { act, render } from "@testing-library/react";
+
+import { MessageEvent, PanelExtensionContext, RenderState, Topic } from "@lichtblick/suite";
+
+import MapPanel from "./MapPanel";
+
+const mockGeoJSON = jest.fn();
+
+jest.mock("leaflet", () => {
+  class FakeLayer {
+    public addTo = jest.fn().mockReturnThis();
+    public addLayer = jest.fn();
+    public clearLayers = jest.fn();
+    public remove = jest.fn();
+    public bringToBack = jest.fn();
+    public bindTooltip = jest.fn();
+    public on = jest.fn();
+  }
+  return {
+    CircleMarker: FakeLayer,
+    FeatureGroup: FakeLayer,
+    LayerGroup: FakeLayer,
+    LatLngBounds: FakeLayer,
+    Layer: FakeLayer,
+    TileLayer: class {
+      public options: Record<string, unknown> = {};
+      public setUrl = jest.fn();
+    },
+    Map: class {
+      public attributionControl = { setPrefix: jest.fn() };
+      public setView = jest.fn();
+      public addLayer = jest.fn();
+      public removeLayer = jest.fn();
+      public invalidateSize = jest.fn();
+      public getBounds = jest.fn();
+      public getCenter = jest.fn().mockReturnValue({ lat: 0, lng: 0 });
+      public getZoom = jest.fn().mockReturnValue(10);
+      public on = jest.fn();
+      public off = jest.fn();
+      public remove = jest.fn();
+    },
+    geoJSON: (...args: unknown[]) => {
+      mockGeoJSON(...args);
+      return { addTo: jest.fn() };
+    },
+  };
+});
+
+jest.mock("@lichtblick/suite-base/panels/Map/FilteredPointLayer", () => ({
+  __esModule: true,
+  default: () => ({ bringToBack: jest.fn(), addTo: jest.fn() }),
+}));
+
+const NAV_TOPIC: Topic = { name: "/gps", schemaName: "sensor_msgs/NavSatFix" };
+const GEO_TOPIC: Topic = { name: "/route", schemaName: "foxglove.GeoJSON" };
+
+function geoJsonMessage(name: string, receiveTimeSec: number): MessageEvent {
+  return {
+    topic: GEO_TOPIC.name,
+    schemaName: GEO_TOPIC.schemaName,
+    receiveTime: { sec: receiveTimeSec, nsec: 0 },
+    sizeInBytes: 0,
+    message: {
+      geojson: JSON.stringify({
+        type: "Feature",
+        properties: { name },
+        geometry: { type: "LineString", coordinates: [[0, 0], [1, 1]] },
+      }),
+    },
+  };
+}
+
+function navMessage(receiveTimeSec: number): MessageEvent {
+  return {
+    topic: NAV_TOPIC.name,
+    schemaName: NAV_TOPIC.schemaName,
+    receiveTime: { sec: receiveTimeSec, nsec: 0 },
+    sizeInBytes: 0,
+    message: { latitude: 1, longitude: 2 },
+  };
+}
+
+function setup() {
+  const subscribe = jest.fn();
+  const subscribeMessageRange = jest.fn().mockReturnValue(jest.fn());
+
+  const context = {
+    initialState: {},
+    saveState: jest.fn(),
+    setPreviewTime: jest.fn(),
+    seekPlayback: jest.fn(),
+    subscribe,
+    unsubscribeAll: jest.fn(),
+    updatePanelSettingsEditor: jest.fn(),
+    unstable_subscribeMessageRange: subscribeMessageRange,
+    watch: jest.fn(),
+    onRender: undefined,
+  } as unknown as PanelExtensionContext;
+
+  const utils = render(<MapPanel context={context} />);
+
+  const emitRender = (renderState: RenderState) => {
+    act(() => {
+      context.onRender?.(renderState, () => {});
+    });
+  };
+
+  return { subscribe, subscribeMessageRange, emitRender, ...utils };
+}
+
+/** Names of the GeoJSON features handed to leaflet, in the order they were drawn. */
+function drawnFeatureNames(): string[] {
+  return mockGeoJSON.mock.calls.map(
+    (call) => (call[0] as { properties?: { name?: string } }).properties?.name ?? "",
+  );
+}
+
+describe("MapPanel", () => {
+  beforeEach(() => {
+    mockGeoJSON.mockClear();
+  });
+
+  it("should not range subscribe to GeoJSON topics", () => {
+    // GIVEN a panel showing one location fix topic and one GeoJSON topic
+    const { subscribe, subscribeMessageRange, emitRender } = setup();
+
+    // WHEN the topic list arrives
+    emitRender({ topics: [NAV_TOPIC, GEO_TOPIC] });
+
+    // THEN only the location fix topic is accumulated over the whole recording, because ranging
+    // over GeoJSON would draw every historical and not-yet-reached message at once (#1243).
+    const rangedTopics = subscribeMessageRange.mock.calls.map(
+      (call) => (call[0] as { topic: string }).topic,
+    );
+    expect(rangedTopics).toEqual([NAV_TOPIC.name]);
+
+    // ...while both topics are still subscribed for the current frame
+    const subscribed = (subscribe.mock.calls.at(-1)?.[0] as { topic: string }[] | undefined)?.map(
+      (subscription) => subscription.topic,
+    );
+    expect(subscribed).toEqual([NAV_TOPIC.name, GEO_TOPIC.name]);
+  });
+
+  it("should draw only the newest GeoJSON message of a frame", () => {
+    // GIVEN a panel with a GeoJSON topic
+    const { emitRender } = setup();
+    emitRender({ topics: [GEO_TOPIC] });
+    mockGeoJSON.mockClear();
+
+    // WHEN a frame carries several messages on that topic
+    emitRender({
+      currentFrame: [geoJsonMessage("old", 1), geoJsonMessage("newer", 2), geoJsonMessage("newest", 3)],
+    });
+
+    // THEN only the last one is drawn, since each message replaces the previous one
+    expect(drawnFeatureNames()).toEqual(["newest"]);
+  });
+
+  it("should replace the drawn GeoJSON when a newer message arrives", () => {
+    // GIVEN a panel that has drawn a GeoJSON message
+    const { emitRender } = setup();
+    emitRender({ topics: [GEO_TOPIC] });
+    emitRender({ currentFrame: [geoJsonMessage("first", 1)] });
+    mockGeoJSON.mockClear();
+
+    // WHEN a later message arrives on the same topic
+    emitRender({ currentFrame: [geoJsonMessage("second", 2)] });
+
+    // THEN only the newer one is drawn
+    expect(drawnFeatureNames()).toEqual(["second"]);
+  });
+
+  it("should not draw GeoJSON collected by the range subscription", async () => {
+    // GIVEN a panel with both kinds of topic
+    const { subscribeMessageRange, emitRender } = setup();
+    emitRender({ topics: [NAV_TOPIC, GEO_TOPIC] });
+    mockGeoJSON.mockClear();
+
+    // WHEN the range subscription for the location fix topic yields a batch that also happens to
+    // contain GeoJSON messages
+    const subscribeArgs = subscribeMessageRange.mock.calls[0]![0] as {
+      onNewRangeIterator: (iterator: AsyncIterable<MessageEvent[]>) => Promise<void>;
+    };
+    await act(async () => {
+      await subscribeArgs.onNewRangeIterator(
+        (async function* () {
+          yield [navMessage(1), geoJsonMessage("historical", 1)];
+        })(),
+      );
+    });
+
+    // THEN nothing from the historical range is drawn as GeoJSON
+    expect(drawnFeatureNames()).toEqual([]);
+  });
+});

--- a/packages/suite-base/src/panels/Map/MapPanel.tsx
+++ b/packages/suite-base/src/panels/Map/MapPanel.tsx
@@ -43,6 +43,8 @@ import {
   GeoJsonMessage,
   hasFix,
   isGeoJSONMessage,
+  isGeoJSONSchema,
+  isNavSatFixMessage,
   isSupportedSchema,
   isValidMapMessage,
   parseGeoJSON,
@@ -106,8 +108,10 @@ function MapPanel(props: MapPanelProps): React.JSX.Element {
   const [allMapMessages, setAllMapMessages] = useState<MapPanelMessage[]>([]);
   const [currentMapMessages, setCurrentMapMessages] = useState<MapPanelMessage[]>([]);
 
-  const [allGeoMessages, allNavMessages] = useMemo(
-    () => _.partition(allMapMessages, isGeoJSONMessage),
+  // Only location fixes are accumulated over the whole recording (see the range subscription
+  // below), so everything collected here contributes to the travelled track.
+  const allNavMessages = useMemo(
+    () => allMapMessages.filter(isNavSatFixMessage),
     [allMapMessages],
   );
 
@@ -309,6 +313,14 @@ function MapPanel(props: MapPanelProps): React.JSX.Element {
     const unsubscriptions: (() => void)[] = [];
     for (const topic of eligibleTopics) {
       if (config.disabledTopics.includes(topic.name)) {
+        continue;
+      }
+      // The range subscription feeds the "all frames" layer, which exists to draw the travelled
+      // track from every location fix in the recording. A GeoJSON message is instead a
+      // self-contained scene that the next message replaces, so it is rendered from the current
+      // frame only. Ranging over it would overlay every past *and* not-yet-reached message on the
+      // map at once - and keep them all in memory - so those topics are skipped here.
+      if (isGeoJSONSchema(topic.schemaName)) {
         continue;
       }
       const unsubscribe = context.unstable_subscribeMessageRange({
@@ -546,23 +558,8 @@ function MapPanel(props: MapPanelProps): React.JSX.Element {
 
       // Push this layer to the back so it renders under the current messages.
       pointLayer.bringToBack();
-
-      allGeoMessages
-        .filter((message) => message.topic === topic)
-        .forEach((message) => {
-          addGeoJsonMessage(message, topicLayer.allFrames);
-        });
     }
-  }, [
-    addGeoJsonMessage,
-    allGeoMessages,
-    allNavMessages,
-    currentMap,
-    filterBounds,
-    onClick,
-    onHover,
-    topicLayers,
-  ]);
+  }, [allNavMessages, currentMap, filterBounds, onClick, onHover, topicLayers]);
 
   // create a filtered marker layer for the current nav messages
   // this effect is added after the allNavMessages so the layer appears above
@@ -606,11 +603,12 @@ function MapPanel(props: MapPanelProps): React.JSX.Element {
     const geoByTopic = _.groupBy(currentGeoMessages, (msg) => msg.topic);
     for (const [topic, messages] of Object.entries(geoByTopic)) {
       const topicLayer = topicLayers.get(topic);
-      if (topicLayer) {
+      // Each GeoJSON message supersedes the previous one, so when a frame carries several of them
+      // only the newest is drawn instead of stacking them all on top of each other.
+      const latestMessage = _.last(messages);
+      if (topicLayer && latestMessage) {
         topicLayer.currentFrame.clearLayers();
-        for (const message of messages) {
-          addGeoJsonMessage(message, topicLayer.currentFrame);
-        }
+        addGeoJsonMessage(latestMessage, topicLayer.currentFrame);
       }
     }
   }, [

--- a/packages/suite-base/src/panels/Map/MapPanel.tsx
+++ b/packages/suite-base/src/panels/Map/MapPanel.tsx
@@ -738,7 +738,6 @@ function MapPanel(props: MapPanelProps): React.JSX.Element {
             visibility: center ? "visible" : "hidden",
           }}
         />
-        x
       </Stack>
     </ThemeProvider>
   );

--- a/packages/suite-base/src/panels/Map/support.ts
+++ b/packages/suite-base/src/panels/Map/support.ts
@@ -31,14 +31,29 @@ export function hasFix(ev: MessageEvent<NavSatFixMsg>): boolean {
   }
 }
 
-export function isGeoJSONMessage(msgEvent: MessageEvent): msgEvent is GeoJsonMessage {
-  const datatype = msgEvent.schemaName;
+/**
+ * @returns true if the schema name identifies a GeoJSON message
+ */
+export function isGeoJSONSchema(schemaName: string): boolean {
   return (
-    datatype === "foxglove_msgs/GeoJSON" ||
-    datatype === "foxglove_msgs/msg/GeoJSON" ||
-    datatype === "foxglove::GeoJSON" ||
-    datatype === "foxglove.GeoJSON"
+    schemaName === "foxglove_msgs/GeoJSON" ||
+    schemaName === "foxglove_msgs/msg/GeoJSON" ||
+    schemaName === "foxglove::GeoJSON" ||
+    schemaName === "foxglove.GeoJSON"
   );
+}
+
+export function isGeoJSONMessage(msgEvent: MessageEvent): msgEvent is GeoJsonMessage {
+  return isGeoJSONSchema(msgEvent.schemaName);
+}
+
+/**
+ * Within the set of messages this panel accepts, anything that is not GeoJSON is a location fix.
+ */
+export function isNavSatFixMessage(
+  msgEvent: MapPanelMessage,
+): msgEvent is MessageEvent<NavSatFixMsg> {
+  return !isGeoJSONMessage(msgEvent);
 }
 
 /**


### PR DESCRIPTION
## User-Facing Changes

The Map panel now shows only the GeoJSON message current at the playhead, instead of every GeoJSON message in the recording drawn on top of one another.

## Description

Fixes #1243.

Since the experimental message range subscription landed in v1.25, the Map panel accumulates every message of the recording into its "all frames" layer. That is correct for location fixes — the accumulated set is what draws the travelled track — but a GeoJSON message is a self-contained scene that the next message supersedes. The panel ended up drawing every past *and* not-yet-reached GeoJSON message stacked on the map, and retaining them all for the lifetime of the subscription, which makes a dynamically published route unreadable.

GeoJSON topics are no longer ranged over. They keep their regular subscription for the current frame, where seek backfill supplies the message current at the playhead, and a frame carrying several of them now draws only the newest.

A second commit removes a stray bare `x` text node in the panel body that was painted over the map — introduced accidentally in 46aaf5f, no purpose.

Side note for anyone reading this alongside #1251: dropping these per-topic range subscriptions also removes a couple of cursors from any layout containing a Map panel. It is not a fix for that issue, just one fewer contributor.

## Checklist

- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Map travel tracks now include only navigation-fix data, preventing GeoJSON messages from being displayed incorrectly.
  * Map overlays now show only the latest GeoJSON message for each topic.
  * GeoJSON updates received through GPS subscriptions are no longer drawn on the map.
  * Removed an extraneous visual artifact from the map panel.

* **Tests**
  * Added coverage for map subscriptions, GeoJSON rendering, travel tracks, and the initial empty state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->