### PR TITLE
fix: render compressedDepth images instead of a broken image icon

### DIFF
--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -31,6 +31,7 @@ import { projectPixel } from "@lichtblick/suite-base/panels/ThreeDeeRender/rende
 import { RosValue } from "@lichtblick/suite-base/players/types";
 
 import { AnyImage, CompressedVideo } from "./ImageTypes";
+import { parseCompressedDepthFormat } from "./decodeCompressedDepth";
 import {
   decodeCompressedImageToBitmap,
   decodeCompressedVideoToBitmap,
@@ -666,6 +667,16 @@ export class ImageRenderable extends Renderable<ImageUserData> {
   ): Promise<ImageBitmap | ImageData> {
     if ("format" in image) {
       if (this.#codec == undefined) {
+        // `compressedDepth` images are a ROS specific container the browser cannot decode as a
+        // media type, so they are unpacked into the raw depth image they carry instead.
+        const depthFormat = parseCompressedDepthFormat(image.format);
+        if (depthFormat) {
+          return await (this.decoder ??= new WorkerImageDecoder()).decodeCompressedDepth(
+            image,
+            depthFormat,
+            this.userData.settings,
+          );
+        }
         return await decodeCompressedImageToBitmap(image, resizeWidth);
       } else {
         const frameMsg = image as CompressedVideo;

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.ts
@@ -10,6 +10,8 @@ import { RawImage } from "@foxglove/schemas";
 import * as Comlink from "@lichtblick/comlink";
 import { ComlinkWrap } from "@lichtblick/den/worker";
 
+import type { CompressedImageTypes } from "./ImageTypes";
+import type { CompressedDepthFormat } from "./decodeCompressedDepth";
 import type { RawImageOptions } from "./decodeImage";
 import { Image as RosImage } from "../../ros";
 
@@ -46,6 +48,18 @@ export class WorkerImageDecoder {
     options: Partial<RawImageOptions>,
   ): Promise<ImageData> {
     return await this.#remote.decode(image, options);
+  }
+
+  /**
+   * Copies a `compressed_depth_image_transport` image to the worker, where it is unpacked into the
+   * raw depth image it encodes and decoded. The result is transferred back to the main thread.
+   */
+  public async decodeCompressedDepth(
+    image: CompressedImageTypes,
+    format: CompressedDepthFormat,
+    options: Partial<RawImageOptions>,
+  ): Promise<ImageData> {
+    return await this.#remote.decodeCompressedDepth(image, format, options);
   }
 
   public terminate(): void {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.worker.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.worker.ts
@@ -9,6 +9,8 @@ import type { RawImage } from "@foxglove/schemas";
 
 import * as Comlink from "@lichtblick/comlink";
 
+import type { CompressedImageTypes } from "./ImageTypes";
+import { CompressedDepthFormat, decodeCompressedDepthToRawImage } from "./decodeCompressedDepth";
 import { decodeRawImage, RawImageOptions } from "./decodeImage";
 import type { Image as RosImage } from "../../ros";
 
@@ -18,7 +20,21 @@ function decode(image: RosImage | RawImage, options: Partial<RawImageOptions>): 
   return Comlink.transfer(result, [result.data.buffer]);
 }
 
+/**
+ * Unpacks a `compressed_depth_image_transport` image and decodes the raw image it contains, so
+ * both the inflate and the per-pixel conversion stay off the main thread.
+ */
+async function decodeCompressedDepth(
+  image: CompressedImageTypes,
+  format: CompressedDepthFormat,
+  options: Partial<RawImageOptions>,
+): Promise<ImageData> {
+  const rawImage = await decodeCompressedDepthToRawImage(image, format);
+  return decode(rawImage, options);
+}
+
 export const service = {
   decode,
+  decodeCompressedDepth,
 };
 Comlink.expose(service);

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeCompressedDepth.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeCompressedDepth.test.ts
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import GrayscalePngBuilder from "@lichtblick/suite-base/testing/builders/GrayscalePngBuilder";
+import RosTimeBuilder from "@lichtblick/suite-base/testing/builders/RosTimeBuilder";
+
+import { CompressedImageTypes } from "./ImageTypes";
+import {
+  decodeCompressedDepthToRawImage,
+  parseCompressedDepthFormat,
+} from "./decodeCompressedDepth";
+
+const WIDTH = 3;
+const HEIGHT = 2;
+const QUANTIZED = [0, 1000, 2500, 40000, 65535, 12345];
+
+/** Builds the 12 byte ConfigHeader that precedes the PNG payload. */
+function configHeader(depthQuantA: number, depthQuantB: number): Uint8Array {
+  const header = new Uint8Array(12);
+  const view = new DataView(header.buffer);
+  view.setInt32(0, 0, true); // compressionFormat INV_DEPTH
+  view.setFloat32(4, depthQuantA, true);
+  view.setFloat32(8, depthQuantB, true);
+  return header;
+}
+
+async function buildDepthImage({
+  format,
+  depthQuantA = 0,
+  depthQuantB = 0,
+  samples = QUANTIZED,
+  bitDepth = 16,
+}: {
+  format: string;
+  depthQuantA?: number;
+  depthQuantB?: number;
+  samples?: number[];
+  bitDepth?: 8 | 16;
+}): Promise<CompressedImageTypes> {
+  const png = await GrayscalePngBuilder.png(WIDTH, HEIGHT, bitDepth, samples);
+  const header = configHeader(depthQuantA, depthQuantB);
+  const data = new Uint8Array(header.length + png.length);
+  data.set(header);
+  data.set(png, header.length);
+  return { data, format, timestamp: RosTimeBuilder.time(), frame_id: "depth_frame" };
+}
+
+describe("parseCompressedDepthFormat", () => {
+  it.each([
+    ["16UC1; compressedDepth png", { encoding: "16UC1", codec: "png" }],
+    ["32FC1; compressedDepth png", { encoding: "32FC1", codec: "png" }],
+    ["16UC1; compressedDepth rvl", { encoding: "16UC1", codec: "rvl" }],
+    // Publishers predating the RVL support omit the codec entirely.
+    ["16UC1; compressedDepth", { encoding: "16UC1", codec: "" }],
+  ])("should parse %s", (format, expected) => {
+    expect(parseCompressedDepthFormat(format)).toEqual(expected);
+  });
+
+  it.each([
+    // Regular compressed image transport, which the browser can decode directly.
+    "bgr8; jpeg compressed bgr8",
+    "rgb8; png compressed bgr8",
+    "jpeg",
+    "png",
+    "h264",
+    "",
+  ])("should not treat %s as a compressedDepth image", (format) => {
+    expect(parseCompressedDepthFormat(format)).toBeUndefined();
+  });
+});
+
+describe("decodeCompressedDepthToRawImage", () => {
+  it("should decode a 16UC1 image into raw little-endian millimetres", async () => {
+    // GIVEN a 16UC1 compressedDepth image
+    const image = await buildDepthImage({ format: "16UC1; compressedDepth png" });
+
+    // WHEN it is decoded
+    const result = await decodeCompressedDepthToRawImage(image, {
+      encoding: "16UC1",
+      codec: "png",
+    });
+
+    // THEN it becomes a raw 16UC1 image carrying the untouched depth samples
+    expect(result.encoding).toBe("16UC1");
+    expect(result.width).toBe(WIDTH);
+    expect(result.height).toBe(HEIGHT);
+    expect(result.step).toBe(WIDTH * 2);
+    expect(result.frame_id).toBe("depth_frame");
+    // The raw image decoders read native little-endian samples.
+    const view = new DataView(result.data.buffer, result.data.byteOffset, result.data.byteLength);
+    expect(QUANTIZED.map((_, i) => view.getUint16(i * 2, true))).toEqual(QUANTIZED);
+  });
+
+  it("should undo the inverse depth quantization of a 32FC1 image", async () => {
+    // GIVEN a 32FC1 compressedDepth image with quantization parameters
+    const depthQuantA = 1000;
+    const depthQuantB = 2;
+    const image = await buildDepthImage({
+      format: "32FC1; compressedDepth png",
+      depthQuantA,
+      depthQuantB,
+    });
+
+    // WHEN it is decoded
+    const result = await decodeCompressedDepthToRawImage(image, {
+      encoding: "32FC1",
+      codec: "png",
+    });
+
+    // THEN the quantized samples are converted back to metres
+    expect(result.encoding).toBe("32FC1");
+    expect(result.step).toBe(WIDTH * 4);
+    const depths = new Float32Array(
+      result.data.buffer,
+      result.data.byteOffset,
+      WIDTH * HEIGHT,
+    );
+    // A zero sample marks a pixel the publisher could not measure.
+    expect(depths[0]).toBeNaN();
+    for (let i = 1; i < QUANTIZED.length; i++) {
+      expect(depths[i]).toBeCloseTo(depthQuantA / (QUANTIZED[i]! - depthQuantB), 4);
+    }
+  });
+
+  it("should reject the RVL codec", async () => {
+    // GIVEN an RVL encoded depth image
+    const image = await buildDepthImage({ format: "16UC1; compressedDepth rvl" });
+
+    // WHEN it is decoded THEN it is rejected with a codec specific message
+    await expect(
+      decodeCompressedDepthToRawImage(image, { encoding: "16UC1", codec: "rvl" }),
+    ).rejects.toThrow('Unsupported compressedDepth codec "rvl"');
+  });
+
+  it("should reject an unknown depth encoding", async () => {
+    // GIVEN a depth image claiming an encoding that is not a depth encoding
+    const image = await buildDepthImage({ format: "8UC1; compressedDepth png" });
+
+    // WHEN it is decoded THEN it is rejected
+    await expect(
+      decodeCompressedDepthToRawImage(image, { encoding: "8UC1", codec: "png" }),
+    ).rejects.toThrow('Unsupported compressedDepth encoding "8UC1"');
+  });
+
+  it("should reject a payload that is only a header", async () => {
+    // GIVEN a message with no PNG after the ConfigHeader
+    const image: CompressedImageTypes = {
+      data: configHeader(0, 0),
+      format: "16UC1; compressedDepth png",
+      timestamp: RosTimeBuilder.time(),
+      frame_id: "depth_frame",
+    };
+
+    // WHEN it is decoded THEN it is rejected
+    await expect(
+      decodeCompressedDepthToRawImage(image, { encoding: "16UC1", codec: "png" }),
+    ).rejects.toThrow("missing its payload");
+  });
+
+  it("should reject a payload that is not 16 bit", async () => {
+    // GIVEN a depth image whose PNG carries 8 bit samples
+    const image = await buildDepthImage({
+      format: "16UC1; compressedDepth png",
+      bitDepth: 8,
+      samples: [0, 1, 2, 3, 4, 5],
+    });
+
+    // WHEN it is decoded THEN it is rejected
+    await expect(
+      decodeCompressedDepthToRawImage(image, { encoding: "16UC1", codec: "png" }),
+    ).rejects.toThrow("expected 16");
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeCompressedDepth.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeCompressedDepth.ts
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { RawImage } from "@foxglove/schemas";
+
+import { CompressedImageTypes, getFrameIdFromImage, getTimestampFromImage } from "./ImageTypes";
+import { decodeGrayscalePng } from "./decodeGrayscalePng";
+
+/**
+ * Support for the `compressed_depth_image_transport` format, which publishes depth images as
+ * `sensor_msgs/CompressedImage` with a `format` such as `"16UC1; compressedDepth png"`.
+ *
+ * The payload is a 12 byte `ConfigHeader` followed by a single channel PNG. These are not browser
+ * decodable media types, so they have to be turned back into the raw image they encode.
+ *
+ * https://github.com/ros-perception/image_transport_plugins/blob/noetic-devel/compressed_depth_image_transport/src/codec.cpp
+ */
+
+/** sizeof(ConfigHeader): an int format enum plus two float32 quantization parameters. */
+const CONFIG_HEADER_SIZE = 12;
+
+const COMPRESSED_DEPTH_TOKEN = "compresseddepth";
+
+export type CompressedDepthFormat = {
+  /** Encoding of the image before it was compressed, e.g. `"16UC1"` or `"32FC1"`. */
+  encoding: string;
+  /** Codec of the payload. Empty when the publisher did not name one, which implies PNG. */
+  codec: string;
+};
+
+/**
+ * Parses a `sensor_msgs/CompressedImage` format string.
+ *
+ * @returns the parsed parts, or undefined if this is not a `compressedDepth` image.
+ */
+export function parseCompressedDepthFormat(format: string): CompressedDepthFormat | undefined {
+  // e.g. "16UC1; compressedDepth png", or "16UC1; compressedDepth" on older publishers.
+  const separator = format.indexOf(";");
+  if (separator < 0) {
+    return undefined;
+  }
+
+  const transport = format.slice(separator + 1).trim();
+  const [transportName, ...rest] = transport.split(/\s+/);
+  if (transportName?.toLowerCase() !== COMPRESSED_DEPTH_TOKEN) {
+    return undefined;
+  }
+
+  return {
+    encoding: format.slice(0, separator).trim(),
+    codec: rest.join(" ").toLowerCase(),
+  };
+}
+
+/**
+ * Decodes a `compressedDepth` image back into the raw image it encodes, so it can be rendered by
+ * the regular raw image path with the panel's color mode settings applied.
+ *
+ * @throws if the codec or the encoded depth encoding is not supported.
+ */
+export async function decodeCompressedDepthToRawImage(
+  image: CompressedImageTypes,
+  format: CompressedDepthFormat,
+): Promise<RawImage> {
+  // An empty codec means PNG, which is what publishers predating the RVL support emit.
+  if (format.codec !== "" && format.codec !== "png") {
+    throw new Error(
+      `Unsupported compressedDepth codec "${format.codec}", only png images can be decoded`,
+    );
+  }
+
+  const { data } = image;
+  if (data.byteLength <= CONFIG_HEADER_SIZE) {
+    throw new Error("compressedDepth image is missing its payload");
+  }
+
+  const header = new DataView(data.buffer, data.byteOffset, CONFIG_HEADER_SIZE);
+  const depthQuantA = header.getFloat32(4, true);
+  const depthQuantB = header.getFloat32(8, true);
+
+  const png = await decodeGrayscalePng(data.subarray(CONFIG_HEADER_SIZE));
+  if (png.bitDepth !== 16) {
+    throw new Error(
+      `Unsupported compressedDepth image with ${png.bitDepth} bit samples, expected 16`,
+    );
+  }
+  // PNG samples are big-endian; the raw image decoders read native little-endian data.
+  const quantized = readBigEndianUint16(png.data, png.width * png.height);
+
+  const base = {
+    timestamp: getTimestampFromImage(image),
+    frame_id: getFrameIdFromImage(image),
+    width: png.width,
+    height: png.height,
+  };
+
+  switch (format.encoding) {
+    case "16UC1":
+      // Depth is stored directly, in millimetres.
+      return {
+        ...base,
+        encoding: "16UC1",
+        step: png.width * 2,
+        data: new Uint8Array(quantized.buffer, quantized.byteOffset, quantized.byteLength),
+      };
+    case "32FC1": {
+      // The publisher quantized inverse depth into the 16 bit samples, undo that to get metres.
+      const depths = new Float32Array(quantized.length);
+      for (let i = 0; i < quantized.length; i++) {
+        const value = quantized[i]!;
+        // Zero marks a pixel the publisher could not measure.
+        depths[i] = value === 0 ? NaN : depthQuantA / (value - depthQuantB);
+      }
+      return {
+        ...base,
+        encoding: "32FC1",
+        step: png.width * 4,
+        data: new Uint8Array(depths.buffer),
+      };
+    }
+    default:
+      throw new Error(
+        `Unsupported compressedDepth encoding "${format.encoding}", expected 16UC1 or 32FC1`,
+      );
+  }
+}
+
+function readBigEndianUint16(data: Uint8Array, sampleCount: number): Uint16Array {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const samples = new Uint16Array(sampleCount);
+  for (let i = 0; i < sampleCount; i++) {
+    samples[i] = view.getUint16(i * 2, false);
+  }
+  return samples;
+}

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeGrayscalePng.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeGrayscalePng.test.ts
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import GrayscalePngBuilder from "@lichtblick/suite-base/testing/builders/GrayscalePngBuilder";
+
+import { decodeGrayscalePng } from "./decodeGrayscalePng";
+
+const WIDTH = 4;
+const HEIGHT = 3;
+// Values spread across the whole 16 bit range so any precision loss would show up.
+const SAMPLES_16 = [0, 1, 65535, 65534, 30000, 12345, 999, 40000, 65535, 0, 7, 512];
+
+describe("decodeGrayscalePng", () => {
+  it.each([0, 1, 2, 3, 4])(
+    "should round-trip 16 bit samples filtered with type %i",
+    async (filterType) => {
+      // GIVEN a 16 bit grayscale PNG encoded with the given scanline filter
+      const png = await GrayscalePngBuilder.png(WIDTH, HEIGHT, 16, SAMPLES_16, { filterType });
+
+      // WHEN it is decoded
+      const result = await decodeGrayscalePng(png);
+
+      // THEN the full precision samples come back unchanged
+      expect(result.width).toBe(WIDTH);
+      expect(result.height).toBe(HEIGHT);
+      expect(result.bitDepth).toBe(16);
+      expect(GrayscalePngBuilder.readSamples(result.data, 16, WIDTH * HEIGHT)).toEqual(SAMPLES_16);
+    },
+  );
+
+  it("should round-trip 8 bit samples", async () => {
+    // GIVEN an 8 bit grayscale PNG
+    const samples = [0, 17, 255, 128, 3, 200, 91, 42, 7, 64, 129, 250];
+    const png = await GrayscalePngBuilder.png(WIDTH, HEIGHT, 8, samples, { filterType: 4 });
+
+    // WHEN it is decoded
+    const result = await decodeGrayscalePng(png);
+
+    // THEN the samples come back unchanged
+    expect(result.bitDepth).toBe(8);
+    expect(GrayscalePngBuilder.readSamples(result.data, 8, WIDTH * HEIGHT)).toEqual(samples);
+  });
+
+  it("should join image data split over several IDAT chunks", async () => {
+    // GIVEN a PNG whose compressed stream is split over multiple IDAT chunks
+    const png = await GrayscalePngBuilder.png(WIDTH, HEIGHT, 16, SAMPLES_16, { idatChunks: 3 });
+
+    // WHEN it is decoded
+    const result = await decodeGrayscalePng(png);
+
+    // THEN the chunks are reassembled into one stream
+    expect(GrayscalePngBuilder.readSamples(result.data, 16, WIDTH * HEIGHT)).toEqual(SAMPLES_16);
+  });
+
+  it("should reject data that is not a PNG", async () => {
+    // GIVEN bytes that do not carry the PNG signature
+    const notAPng = new Uint8Array(64).fill(0x42);
+
+    // WHEN it is decoded THEN it is rejected
+    await expect(decodeGrayscalePng(notAPng)).rejects.toThrow("Not a PNG image");
+  });
+
+  it("should reject color types other than grayscale", async () => {
+    // GIVEN a PNG declaring an RGB color type
+    const png = await GrayscalePngBuilder.png(WIDTH, HEIGHT, 8, SAMPLES_16, { colorType: 2 });
+
+    // WHEN it is decoded THEN it is rejected
+    await expect(decodeGrayscalePng(png)).rejects.toThrow("Unsupported PNG color type 2");
+  });
+
+  it("should reject interlaced images", async () => {
+    // GIVEN an interlaced PNG
+    const png = await GrayscalePngBuilder.png(WIDTH, HEIGHT, 16, SAMPLES_16, { interlace: 1 });
+
+    // WHEN it is decoded THEN it is rejected
+    await expect(decodeGrayscalePng(png)).rejects.toThrow(
+      "Interlaced PNG images are not supported",
+    );
+  });
+
+  it("should reject an image without pixel data", async () => {
+    // GIVEN a PNG with no IDAT chunk
+    const png = await GrayscalePngBuilder.headerOnlyPng(1, 1);
+
+    // WHEN it is decoded THEN it is rejected
+    await expect(decodeGrayscalePng(png)).rejects.toThrow("no IDAT chunks");
+  });
+
+  it("should reject an image whose scanlines are incomplete", async () => {
+    // GIVEN a PNG whose IHDR claims more rows than the compressed data holds
+    const png = await GrayscalePngBuilder.png(WIDTH, HEIGHT, 16, SAMPLES_16);
+    // Rewrite the height in IHDR, which starts 8 (signature) + 8 (length and type) bytes in.
+    new DataView(png.buffer, png.byteOffset).setUint32(20, HEIGHT + 5);
+
+    // WHEN it is decoded THEN it is rejected
+    await expect(decodeGrayscalePng(png)).rejects.toThrow("truncated");
+  });
+});

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeGrayscalePng.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeGrayscalePng.ts
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * A minimal PNG decoder for single channel (grayscale) images.
+ *
+ * `createImageBitmap` cannot be used for depth images: the browser always hands back 8 bit RGBA
+ * samples, which would throw away half of the precision of the 16 bit values that
+ * `compressed_depth_image_transport` stores. This decoder keeps the samples intact.
+ *
+ * Only the subset of PNG that OpenCV's `imencode` produces for a single channel `Mat` is
+ * supported, which is what every ROS depth image publisher goes through.
+ */
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/** PNG color type 0, the only one this decoder handles. */
+const COLOR_TYPE_GRAYSCALE = 0;
+
+const IHDR_LENGTH = 13;
+
+export type GrayscalePng = {
+  width: number;
+  height: number;
+  bitDepth: 8 | 16;
+  /**
+   * Tightly packed sample data, `width * bitDepth / 8` bytes per row. 16 bit samples stay in the
+   * big-endian byte order that PNG mandates.
+   */
+  data: Uint8Array;
+};
+
+/**
+ * Decodes a grayscale PNG into its raw samples.
+ *
+ * @throws if the image is not a non-interlaced 8 or 16 bit grayscale PNG.
+ */
+export async function decodeGrayscalePng(png: Uint8Array): Promise<GrayscalePng> {
+  const header = readHeader(png);
+  const { width, height, bitDepth } = header;
+
+  const inflated = await inflate(concatIdat(png, header.firstChunkOffset));
+
+  const bytesPerSample = bitDepth / 8;
+  const bytesPerRow = width * bytesPerSample;
+  // Every scanline is prefixed with the filter type that was applied to it.
+  const expectedLength = (bytesPerRow + 1) * height;
+  if (inflated.length < expectedLength) {
+    throw new Error(
+      `PNG image data is truncated (expected ${expectedLength} bytes, got ${inflated.length})`,
+    );
+  }
+
+  return { width, height, bitDepth, data: unfilter(inflated, bytesPerRow, height, bytesPerSample) };
+}
+
+type PngHeader = {
+  width: number;
+  height: number;
+  bitDepth: 8 | 16;
+  /** Offset of the chunk following IHDR. */
+  firstChunkOffset: number;
+};
+
+function readHeader(png: Uint8Array): PngHeader {
+  if (png.length < PNG_SIGNATURE.length + 8 + IHDR_LENGTH) {
+    throw new Error("Not a PNG image (too short)");
+  }
+  for (const [index, byte] of PNG_SIGNATURE.entries()) {
+    if (png[index] !== byte) {
+      throw new Error("Not a PNG image (bad signature)");
+    }
+  }
+
+  const view = new DataView(png.buffer, png.byteOffset, png.byteLength);
+  // The IHDR chunk is required to be the first one, immediately after the signature.
+  const ihdrStart = PNG_SIGNATURE.length;
+  if (readChunkType(png, ihdrStart + 4) !== "IHDR") {
+    throw new Error("Invalid PNG (missing IHDR chunk)");
+  }
+  const ihdr = ihdrStart + 8;
+
+  const width = view.getUint32(ihdr);
+  const height = view.getUint32(ihdr + 4);
+  const bitDepth = view.getUint8(ihdr + 8);
+  const colorType = view.getUint8(ihdr + 9);
+  const compressionMethod = view.getUint8(ihdr + 10);
+  const filterMethod = view.getUint8(ihdr + 11);
+  const interlaceMethod = view.getUint8(ihdr + 12);
+
+  if (colorType !== COLOR_TYPE_GRAYSCALE) {
+    throw new Error(`Unsupported PNG color type ${colorType}, only grayscale is supported`);
+  }
+  if (bitDepth !== 8 && bitDepth !== 16) {
+    throw new Error(`Unsupported PNG bit depth ${bitDepth}, only 8 and 16 are supported`);
+  }
+  if (compressionMethod !== 0 || filterMethod !== 0) {
+    throw new Error("Unsupported PNG compression or filter method");
+  }
+  if (interlaceMethod !== 0) {
+    throw new Error("Interlaced PNG images are not supported");
+  }
+  if (width === 0 || height === 0) {
+    throw new Error("PNG image has zero width or height");
+  }
+
+  return { width, height, bitDepth, firstChunkOffset: ihdr + IHDR_LENGTH + 4 };
+}
+
+function readChunkType(png: Uint8Array, offset: number): string {
+  return String.fromCharCode(png[offset]!, png[offset + 1]!, png[offset + 2]!, png[offset + 3]!);
+}
+
+/** Image data may be split over any number of IDAT chunks that together form one zlib stream. */
+function concatIdat(png: Uint8Array, firstChunkOffset: number): Uint8Array {
+  const view = new DataView(png.buffer, png.byteOffset, png.byteLength);
+  const parts: Uint8Array[] = [];
+  let totalLength = 0;
+
+  // Each chunk is a 4 byte length, a 4 byte type, the payload and a 4 byte CRC.
+  let offset = firstChunkOffset;
+  while (offset + 8 <= png.length) {
+    const length = view.getUint32(offset);
+    const type = readChunkType(png, offset + 4);
+    const dataStart = offset + 8;
+    if (dataStart + length > png.length) {
+      throw new Error(`Invalid PNG (${type} chunk extends past the end of the image)`);
+    }
+    if (type === "IDAT") {
+      parts.push(png.subarray(dataStart, dataStart + length));
+      totalLength += length;
+    } else if (type === "IEND") {
+      break;
+    }
+    offset = dataStart + length + 4;
+  }
+
+  if (totalLength === 0) {
+    throw new Error("Invalid PNG (no IDAT chunks)");
+  }
+  if (parts.length === 1) {
+    return parts[0]!;
+  }
+
+  const joined = new Uint8Array(totalLength);
+  let position = 0;
+  for (const part of parts) {
+    joined.set(part, position);
+    position += part.length;
+  }
+  return joined;
+}
+
+async function inflate(data: Uint8Array): Promise<Uint8Array> {
+  // PNG stores a zlib stream, which is what the "deflate" format of DecompressionStream expects.
+  const stream = new Blob([data as BlobPart])
+    .stream()
+    .pipeThrough(new DecompressionStream("deflate"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/**
+ * Reverses the per-scanline filtering described in the PNG specification, writing the
+ * reconstructed samples into a tightly packed buffer without the filter type bytes.
+ *
+ * https://www.w3.org/TR/png-3/#9Filters
+ */
+function unfilter(
+  filtered: Uint8Array,
+  bytesPerRow: number,
+  height: number,
+  bytesPerSample: number,
+): Uint8Array {
+  const output = new Uint8Array(bytesPerRow * height);
+
+  for (let row = 0; row < height; row++) {
+    const filterType = filtered[row * (bytesPerRow + 1)]!;
+    const rowStart = row * (bytesPerRow + 1) + 1;
+    const outStart = row * bytesPerRow;
+    const prevStart = outStart - bytesPerRow;
+
+    for (let index = 0; index < bytesPerRow; index++) {
+      const raw = filtered[rowStart + index]!;
+      // `left` and `upperLeft` are the already reconstructed bytes one pixel back in the row.
+      const left = index >= bytesPerSample ? output[outStart + index - bytesPerSample]! : 0;
+      const up = row > 0 ? output[prevStart + index]! : 0;
+      const upperLeft =
+        row > 0 && index >= bytesPerSample ? output[prevStart + index - bytesPerSample]! : 0;
+
+      let value: number;
+      switch (filterType) {
+        case 0: // None
+          value = raw;
+          break;
+        case 1: // Sub
+          value = raw + left;
+          break;
+        case 2: // Up
+          value = raw + up;
+          break;
+        case 3: // Average
+          value = raw + ((left + up) >> 1);
+          break;
+        case 4: // Paeth
+          value = raw + paethPredictor(left, up, upperLeft);
+          break;
+        default:
+          throw new Error(`Unsupported PNG filter type ${filterType} on row ${row}`);
+      }
+      output[outStart + index] = value & 0xff;
+    }
+  }
+
+  return output;
+}
+
+function paethPredictor(left: number, up: number, upperLeft: number): number {
+  const estimate = left + up - upperLeft;
+  const distLeft = Math.abs(estimate - left);
+  const distUp = Math.abs(estimate - up);
+  const distUpperLeft = Math.abs(estimate - upperLeft);
+  if (distLeft <= distUp && distLeft <= distUpperLeft) {
+    return left;
+  }
+  return distUp <= distUpperLeft ? up : upperLeft;
+}

--- a/packages/suite-base/src/testing/builders/GrayscalePngBuilder.ts
+++ b/packages/suite-base/src/testing/builders/GrayscalePngBuilder.ts
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * Test scaffolding that produces single channel PNG images, the container that
+ * `compressed_depth_image_transport` wraps depth images in. Encoding them here keeps the decoder
+ * tests free of binary fixtures and lets them cover every scanline filter.
+ */
+
+const PNG_SIGNATURE = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = (c & 1) !== 0 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+export type GrayscalePngOptions = {
+  /** PNG scanline filter type (0 None, 1 Sub, 2 Up, 3 Average, 4 Paeth) applied to every row. */
+  filterType?: number;
+  /** Split the compressed stream over this many IDAT chunks. */
+  idatChunks?: number;
+  /** Overrides the IHDR color type, to build images the decoder should reject. */
+  colorType?: number;
+  /** Overrides the IHDR interlace method, to build images the decoder should reject. */
+  interlace?: number;
+};
+
+export default class GrayscalePngBuilder {
+  /** Builds a grayscale PNG holding `samples` in row-major order. */
+  public static async png(
+    width: number,
+    height: number,
+    bitDepth: 8 | 16,
+    samples: ArrayLike<number>,
+    options: GrayscalePngOptions = {},
+  ): Promise<Uint8Array> {
+    const bytesPerSample = bitDepth / 8;
+    const bytesPerRow = width * bytesPerSample;
+    const raw = new Uint8Array(bytesPerRow * height);
+    const view = new DataView(raw.buffer);
+    for (let i = 0; i < width * height; i++) {
+      if (bitDepth === 16) {
+        view.setUint16(i * 2, samples[i]!); // PNG samples are big-endian
+      } else {
+        view.setUint8(i, samples[i]!);
+      }
+    }
+
+    const filtered = filterScanlines(
+      raw,
+      bytesPerRow,
+      height,
+      bytesPerSample,
+      options.filterType ?? 0,
+    );
+    const compressed = await deflate(filtered);
+
+    const idatCount = options.idatChunks ?? 1;
+    const sliceSize = Math.ceil(compressed.length / idatCount);
+    const idats = Array.from({ length: idatCount }, (_, i) =>
+      GrayscalePngBuilder.chunk("IDAT", compressed.subarray(i * sliceSize, (i + 1) * sliceSize)),
+    );
+
+    return concat([
+      PNG_SIGNATURE,
+      GrayscalePngBuilder.chunk(
+        "IHDR",
+        ihdr(width, height, bitDepth, options.colorType ?? 0, options.interlace ?? 0),
+      ),
+      ...idats,
+      GrayscalePngBuilder.chunk("IEND", new Uint8Array()),
+    ]);
+  }
+
+  /** Builds a PNG containing only a header, i.e. one carrying no pixel data at all. */
+  public static async headerOnlyPng(width: number, height: number): Promise<Uint8Array> {
+    return concat([
+      PNG_SIGNATURE,
+      GrayscalePngBuilder.chunk("IHDR", ihdr(width, height, 16, 0, 0)),
+      GrayscalePngBuilder.chunk("IEND", new Uint8Array()),
+    ]);
+  }
+
+  /** Wraps `data` in a PNG chunk with a correct length prefix and CRC. */
+  public static chunk(type: string, data: Uint8Array): Uint8Array {
+    const out = new Uint8Array(12 + data.length);
+    const view = new DataView(out.buffer);
+    view.setUint32(0, data.length);
+    for (let i = 0; i < 4; i++) {
+      out[4 + i] = type.charCodeAt(i);
+    }
+    out.set(data, 8);
+    view.setUint32(8 + data.length, crc32(out.subarray(4, 8 + data.length)));
+    return out;
+  }
+
+  /** Reads back samples encoded by {@link GrayscalePngBuilder.png}. */
+  public static readSamples(data: Uint8Array, bitDepth: 8 | 16, count: number): number[] {
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    return Array.from({ length: count }, (_, i) =>
+      bitDepth === 16 ? view.getUint16(i * 2, false) : view.getUint8(i),
+    );
+  }
+}
+
+function ihdr(
+  width: number,
+  height: number,
+  bitDepth: number,
+  colorType: number,
+  interlace: number,
+): Uint8Array {
+  const out = new Uint8Array(13);
+  const view = new DataView(out.buffer);
+  view.setUint32(0, width);
+  view.setUint32(4, height);
+  out[8] = bitDepth;
+  out[9] = colorType;
+  out[10] = 0; // compression method
+  out[11] = 0; // filter method
+  out[12] = interlace;
+  return out;
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = CRC_TABLE[(crc ^ byte) & 0xff]! ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((sum, part) => sum + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+async function deflate(data: Uint8Array): Promise<Uint8Array> {
+  const stream = new Blob([data as BlobPart])
+    .stream()
+    .pipeThrough(new CompressionStream("deflate"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/** The inverse of the unfiltering the decoder performs. https://www.w3.org/TR/png-3/#9Filters */
+function filterScanlines(
+  raw: Uint8Array,
+  bytesPerRow: number,
+  height: number,
+  bytesPerSample: number,
+  filterType: number,
+): Uint8Array {
+  const out = new Uint8Array((bytesPerRow + 1) * height);
+  for (let row = 0; row < height; row++) {
+    const rowStart = row * bytesPerRow;
+    const prevStart = rowStart - bytesPerRow;
+    const outStart = row * (bytesPerRow + 1);
+    out[outStart] = filterType;
+
+    for (let i = 0; i < bytesPerRow; i++) {
+      const x = raw[rowStart + i]!;
+      const left = i >= bytesPerSample ? raw[rowStart + i - bytesPerSample]! : 0;
+      const up = row > 0 ? raw[prevStart + i]! : 0;
+      const upperLeft = row > 0 && i >= bytesPerSample ? raw[prevStart + i - bytesPerSample]! : 0;
+
+      let value: number;
+      switch (filterType) {
+        case 1:
+          value = x - left;
+          break;
+        case 2:
+          value = x - up;
+          break;
+        case 3:
+          value = x - ((left + up) >> 1);
+          break;
+        case 4:
+          value = x - paethPredictor(left, up, upperLeft);
+          break;
+        default:
+          value = x;
+      }
+      out[outStart + 1 + i] = value & 0xff;
+    }
+  }
+  return out;
+}
+
+function paethPredictor(left: number, up: number, upperLeft: number): number {
+  const estimate = left + up - upperLeft;
+  const distLeft = Math.abs(estimate - left);
+  const distUp = Math.abs(estimate - up);
+  const distUpperLeft = Math.abs(estimate - upperLeft);
+  if (distLeft <= distUp && distLeft <= distUpperLeft) {
+    return left;
+  }
+  return distUp <= distUpperLeft ? up : upperLeft;
+}


### PR DESCRIPTION
## User-Facing Changes

`compressedDepth` image topics now render in the Image and 3D panels, with the panel's existing depth color modes applying to them, instead of showing a broken image icon.

## Description

Fixes #1241.

`decodeCompressedImageToBitmap` builds a media type by prefixing `image/` to the message format, so a depth image became `image/16UC1; compressedDepth png` — which no browser can decode, hence the broken image icon.

Three commits:

1. **A minimal grayscale PNG decoder.** `compressed_depth_image_transport` wraps depth images in a single-channel PNG. `createImageBitmap` is not usable here: the browser always hands back 8-bit RGBA samples, throwing away half the precision of 16-bit depth values. This decoder keeps the samples intact. It handles the subset of PNG that OpenCV's `imencode` produces for a single-channel `Mat` — non-interlaced, 8- or 16-bit grayscale — which is what every ROS depth publisher goes through, and rejects anything outside that with a specific message. Inflate uses the platform `DecompressionStream`, so no new dependency.
2. **Conversion to the raw image the payload encodes.** A `compressedDepth` payload is a 12-byte `ConfigHeader` followed by the PNG, not a browser media type. Unpacking it into a raw image lets it render through the existing raw image path, so the panel's color mode settings apply exactly as they do for an uncompressed depth topic. `16UC1` carries depth directly in millimetres; `32FC1` has its inverse depth quantization undone with the parameters from the header, where a zero sample marks a pixel the publisher could not measure. The RVL codec is reported as unsupported rather than failing obscurely.
3. **Routing.** Those messages now go to the compressedDepth conversion. The work runs in the existing image decoder worker, so the inflate and per-pixel conversion stay off the main thread.

## Checklist

- [x] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying ROS `compressedDepth` images in 3D views.
  * Supports 16-bit integer and 32-bit floating-point depth formats.
  * Compressed-depth decoding now runs off the main thread for smoother rendering.

* **Tests**
  * Added coverage for depth conversion, grayscale PNG decoding, invalid payloads, and unsupported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->