### PR TITLE
fix: bound worker memory for large multi-MCAP sessions to prevent OOM

### DIFF
--- a/packages/suite-base/src/dataSources/McapLocalDataSourceFactory.test.ts
+++ b/packages/suite-base/src/dataSources/McapLocalDataSourceFactory.test.ts
@@ -94,6 +94,28 @@ describe("McapLocalDataSourceFactory", () => {
     expect(player).toBeInstanceOf(IterablePlayer);
   });
 
+  it("should pass configured hydration overrides into initArgs", () => {
+    const files = [buildMcapFile(), buildMcapFile()];
+    const { args } = setup({ files });
+    factory = new McapLocalDataSourceFactory({
+      maxHydratedSources: 3,
+      maxHydratedBytes: 1234,
+      initConcurrency: 2,
+    });
+
+    factory.initialize(args);
+
+    expect(WorkerSerializedIterableSource).toHaveBeenCalledWith({
+      initWorker: expect.any(Function),
+      initArgs: {
+        files,
+        maxHydratedSources: 3,
+        maxHydratedBytes: 1234,
+        initConcurrency: 2,
+      },
+    });
+  });
+
   it("should return undefined when no files are provided", () => {
     const { args } = setup({ files: undefined });
 

--- a/packages/suite-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/suite-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -12,17 +12,29 @@ import {
 } from "@lichtblick/suite-base/context/PlayerSelectionContext";
 import { IterablePlayer } from "@lichtblick/suite-base/players/IterablePlayer";
 import { WorkerSerializedIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource";
+import {
+  MultiFileHydrationOverrides,
+  addMultiFileHydrationOverrides,
+} from "@lichtblick/suite-base/players/IterablePlayer/shared/multiFileHydrationOptions";
 import { expandVideoSeekBackfill } from "@lichtblick/suite-base/players/IterablePlayer/videoSeekBackfill";
 import { Player } from "@lichtblick/suite-base/players/types";
 import { mergeMultipleFileNames } from "@lichtblick/suite-base/util/mergeMultipleFileName";
 
 class McapLocalDataSourceFactory implements IDataSourceFactory {
+  private readonly multiFileHydrationOverrides?: MultiFileHydrationOverrides;
+
   public id = "mcap-local-file";
   public type: IDataSourceFactory["type"] = "file";
   public displayName = "MCAP";
   public iconName: IDataSourceFactory["iconName"] = "OpenFile";
   public supportedFileTypes = [AllowedFileExtensions.MCAP];
   public supportsMultiFile = true;
+
+  // Optional pass-through for future multi-file hydration tuning experiments. Omitted by default
+  // so existing behavior remains unchanged until a caller explicitly opts in.
+  public constructor(multiFileHydrationOverrides?: MultiFileHydrationOverrides) {
+    this.multiFileHydrationOverrides = multiFileHydrationOverrides;
+  }
 
   public initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
     const files = args.files ?? [];
@@ -44,7 +56,7 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
           ),
         );
       },
-      initArgs: { files },
+      initArgs: addMultiFileHydrationOverrides({ files }, this.multiFileHydrationOverrides),
     });
 
     return new IterablePlayer({

--- a/packages/suite-base/src/dataSources/RemoteDataSourceFactory.test.tsx
+++ b/packages/suite-base/src/dataSources/RemoteDataSourceFactory.test.tsx
@@ -9,7 +9,7 @@ import { WorkerSerializedIterableSource } from "@lichtblick/suite-base/players/I
 import { expandVideoSeekBackfill } from "@lichtblick/suite-base/players/IterablePlayer/videoSeekBackfill";
 import { PlayerMetricsCollectorInterface } from "@lichtblick/suite-base/players/types";
 
-import RemoteDataSourceFactory, { checkExtensionMatch } from "./RemoteDataSourceFactory";
+import RemoteDataSourceFactory from "./RemoteDataSourceFactory";
 
 jest.mock("@lichtblick/suite-base/players/IterablePlayer", () => ({
   IterablePlayer: jest.fn(),
@@ -28,32 +28,28 @@ function setupArgs(params?: Record<string, string | undefined>): DataSourceFacto
 }
 
 describe("checkExtensionMatch", () => {
+  let factory: RemoteDataSourceFactory;
+
+  beforeEach(() => {
+    factory = new RemoteDataSourceFactory();
+  });
+
   it("should return the extension if the comparing extension is undefined", () => {
-    const mockExtenstion = ".mcap";
+    const result = (factory as any).checkExtensionMatch(".mcap");
 
-    const result = checkExtensionMatch(mockExtenstion);
-
-    expect(result).toBe(mockExtenstion);
+    expect(result).toBe(".mcap");
   });
 
   it("should return the extension when the comparator and comparing extensions are equal", () => {
-    const mockExtenstion = ".mcap";
-    const comparatorExtension = ".mcap";
+    const result = (factory as any).checkExtensionMatch(".mcap", ".mcap");
 
-    const result = checkExtensionMatch(mockExtenstion, comparatorExtension);
-
-    expect(result).toBe(mockExtenstion);
+    expect(result).toBe(".mcap");
   });
 
   it("should throw an error if the comparator and comparing extensions are different", () => {
-    const mockExtenstion = ".mcap";
-    const comparatorExtension = ".bag";
-
-    const result = () => {
-      checkExtensionMatch(mockExtenstion, comparatorExtension);
-    };
-
-    expect(result).toThrow("All sources need to be from the same type");
+    expect(() => (factory as any).checkExtensionMatch(".mcap", ".bag")).toThrow(
+      "All sources need to be from the same type",
+    );
   });
 });
 
@@ -138,6 +134,29 @@ describe("RemoteDataSourceFactory", () => {
     });
 
     expect(result).toBe(mockPlayer);
+  });
+
+  it("should pass configured hydration overrides into multi-url initArgs", () => {
+    factory = new RemoteDataSourceFactory({
+      maxHydratedSources: 4,
+      maxHydratedBytes: 5678,
+      initConcurrency: 3,
+    });
+    const mockArgs = setupArgs({
+      url: "https://example.com/test1.mcap,https://example.com/test2.mcap",
+    });
+
+    factory.initialize(mockArgs);
+
+    expect(WorkerSerializedIterableSource).toHaveBeenCalledWith({
+      initWorker: expect.any(Function),
+      initArgs: {
+        urls: ["https://example.com/test1.mcap", "https://example.com/test2.mcap"],
+        maxHydratedSources: 4,
+        maxHydratedBytes: 5678,
+        initConcurrency: 3,
+      },
+    });
   });
 
   it("should return undefined if args.params.url is undefined", () => {

--- a/packages/suite-base/src/dataSources/RemoteDataSourceFactory.tsx
+++ b/packages/suite-base/src/dataSources/RemoteDataSourceFactory.tsx
@@ -14,6 +14,10 @@ import {
 } from "@lichtblick/suite-base/context/PlayerSelectionContext";
 import { IterablePlayer } from "@lichtblick/suite-base/players/IterablePlayer";
 import { WorkerSerializedIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSource";
+import {
+  MultiFileHydrationOverrides,
+  addMultiFileHydrationOverrides,
+} from "@lichtblick/suite-base/players/IterablePlayer/shared/multiFileHydrationOptions";
 import { expandVideoSeekBackfill } from "@lichtblick/suite-base/players/IterablePlayer/videoSeekBackfill";
 import { Player } from "@lichtblick/suite-base/players/types";
 
@@ -43,14 +47,9 @@ const fileTypesAllowed: AllowedFileExtensions[] = [
   AllowedFileExtensions.MCAP,
 ];
 
-export function checkExtensionMatch(fileExtension: string, previousExtension?: string): string {
-  if (previousExtension != undefined && previousExtension !== fileExtension) {
-    throw new Error("All sources need to be from the same type");
-  }
-  return fileExtension;
-}
-
 class RemoteDataSourceFactory implements IDataSourceFactory {
+  private readonly multiFileHydrationOverrides?: MultiFileHydrationOverrides;
+
   public id = "remote-file";
 
   // The remote file feature use to be handled by two separate factories with these IDs.
@@ -90,6 +89,12 @@ class RemoteDataSourceFactory implements IDataSourceFactory {
 
   public warning = "Loading large files over HTTP can be slow";
 
+  // Optional pass-through for future multi-file hydration tuning experiments. Omitted by default
+  // so existing behavior remains unchanged until a caller explicitly opts in.
+  public constructor(multiFileHydrationOverrides?: MultiFileHydrationOverrides) {
+    this.multiFileHydrationOverrides = multiFileHydrationOverrides;
+  }
+
   public initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
     if (args.params?.url == undefined) {
       return;
@@ -101,12 +106,15 @@ class RemoteDataSourceFactory implements IDataSourceFactory {
 
     urls.forEach((url) => {
       extension = path.extname(new URL(url).pathname);
-      nextExtension = checkExtensionMatch(extension, nextExtension);
+      nextExtension = this.checkExtensionMatch(extension, nextExtension);
     });
 
     const initWorker = initWorkers[extension]!;
 
-    const initArgs = urls.length === 1 ? { url: urls[0] } : { urls };
+    const initArgs =
+      urls.length === 1
+        ? { url: urls[0] }
+        : addMultiFileHydrationOverrides({ urls }, this.multiFileHydrationOverrides);
     const source = new WorkerSerializedIterableSource({ initWorker, initArgs });
 
     return new IterablePlayer({
@@ -121,6 +129,13 @@ class RemoteDataSourceFactory implements IDataSourceFactory {
       // A no-op for non-video (e.g. .bag) sources.
       expandBackfill: expandVideoSeekBackfill,
     });
+  }
+
+  private checkExtensionMatch(fileExtension: string, previousExtension?: string): string {
+    if (previousExtension != undefined && previousExtension !== fileExtension) {
+      throw new Error("All sources need to be from the same type");
+    }
+    return fileExtension;
   }
 
   #validateUrl(newValue: string): Error | undefined {

--- a/packages/suite-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IIterableSource.ts
@@ -208,6 +208,13 @@ export interface IIterableSource<MessageType = unknown> {
    * method when the source will no longer be used.
    */
   terminate?: () => Promise<void>;
+
+  /**
+   * Optional method a data source can implement to warm itself up before it becomes the active
+   * source (e.g. hydrate a pooled reader ahead of playback reaching it). Failures should be
+   * treated as non-fatal by callers; the source can still hydrate on demand later.
+   */
+  prewarm?: () => Promise<void>;
 }
 
 export type IterableSourceInitializeArgs = {

--- a/packages/suite-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IIterableSource.ts
@@ -107,17 +107,9 @@ export type GetBackfillMessagesArgs = {
   abortSignal?: AbortSignal;
 };
 
-// IMessageCursor describes an interface for message cursors. Message cursors are a similar concept
-// to javascript generators but provide a method for reading a batch of messages rather than one
-// message.
-//
-// Motivation: When using webworkers, read calls are invoked via an RPC interface. For large
-// datasets (many hundred thousand) messages, preloading the data (i.e. to plot a signal) would
-// result in several hundred thousand RPC calls. The overhead of making these calls add up and
-// negatively impact the preloading experience.
-//
-// Providing an interface which allows callers to read a batch of messages significantly (4x speedup
-// on an 700k message dataset on M1 Pro) reduces the RPC call overhead.
+// IMessageCursor is similar to a JavaScript generator, but it can return message batches.
+// For worker/RPC-backed sources this avoids one round-trip per message when preloading large
+// datasets and substantially reduces overhead.
 export interface IMessageCursor<MessageType = unknown> {
   /**
    * Read the next message from the cursor. Return a result or undefined if the cursor is done
@@ -168,13 +160,9 @@ export interface IIterableSource<MessageType = unknown> {
    * The iterator produces IteratorResults from the source. The IteratorResults should be in log
    * time order.
    *
-   * Returning an AsyncIterator rather than AsyncIterable communicates that the returned iterator
-   * cannot be used directly in a `for-await-of` loop. This forces the IterablePlayer implementation
-   * to use the `.next()` API, rather than `for-await-of` which would implicitly call the iterator's
-   * `return()` method when breaking out of the loop and prevent the iterator from being used in
-   * more than one loop. This means the IIterableSource implementations can use a simple async
-   * generator function, and a `finally` block to do any necessary cleanup tasks when the request
-   * finishes or is canceled.
+   * Returning an AsyncIterator rather than something intended for `for-await-of` forces callers to
+   * use `.next()`. That avoids implicit `return()` calls when a loop exits, so implementations can
+   * rely on generator `finally` cleanup only when the request actually finishes or is canceled.
    */
   messageIterator(
     args: Immutable<MessageIteratorArgs>,
@@ -222,6 +210,12 @@ export type IterableSourceInitializeArgs = {
   url?: string;
   files?: File[];
   urls?: string[];
+  // Optional overrides for multi-file hydration tuning (see MultiSourceHydrationOptions in
+  // players/IterablePlayer/shared/types.ts). Only meaningful when `files`/`urls` has more than
+  // one entry. When omitted, MultiIterableSource's internal defaults apply.
+  maxHydratedSources?: number;
+  maxHydratedBytes?: number;
+  initConcurrency?: number;
   params?: Record<string, string | undefined>;
 
   api?: {

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
@@ -372,7 +372,7 @@ describe("McapIterableSource", () => {
         const topic = "/pooled_topic";
         const mcapData = await buildIndexedMcapWithTopic(topic, [1_000_000_000n]);
         mockRemoteFileReadableWith(mcapData);
-        const pool = new HydratedSourcePool(1);
+        const pool = new HydratedSourcePool({ maxCount: 1 });
         const sourceA = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
         const sourceB = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
 
@@ -410,7 +410,7 @@ describe("McapIterableSource", () => {
           8_000_000_000n,
         ]);
         mockRemoteFileReadableWith(mcapData);
-        const pool = new HydratedSourcePool(1);
+        const pool = new HydratedSourcePool({ maxCount: 1 });
         const sourceA = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
         const sourceB = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
 
@@ -429,7 +429,7 @@ describe("McapIterableSource", () => {
         // Given two indexed MCAPs sharing a pool with capacity 2
         const mcapData = await buildIndexedMcapWithTopic("/n_topic", [1_000_000_000n]);
         mockRemoteFileReadableWith(mcapData);
-        const pool = new HydratedSourcePool(2);
+        const pool = new HydratedSourcePool({ maxCount: 2 });
         const sourceA = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
         const sourceB = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
 
@@ -449,7 +449,7 @@ describe("McapIterableSource", () => {
         // Given a pooled url source whose inner is owned by the pool
         const mcapData = await buildIndexedMcapWithTopic("/term_topic", [1_000_000_000n]);
         mockRemoteFileReadableWith(mcapData);
-        const pool = new HydratedSourcePool(4);
+        const pool = new HydratedSourcePool({ maxCount: 4 });
         const source = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
         await source.initialize();
 
@@ -468,7 +468,7 @@ describe("McapIterableSource", () => {
       const topic = `/${BasicBuilder.string()}`;
       const fileA = await createMcapFile({ withMessage: true, topic });
       const fileB = await createMcapFile({ withMessage: true, topic });
-      const pool = new HydratedSourcePool(1);
+      const pool = new HydratedSourcePool({ maxCount: 1 });
       const sourceA = new McapIterableSource({ type: "file", file: fileA, pool });
       const sourceB = new McapIterableSource({ type: "file", file: fileB, pool });
 
@@ -497,7 +497,7 @@ describe("McapIterableSource", () => {
       const topic = `/${BasicBuilder.string()}`;
       const fileA = await createMcapFile({ withMessage: true, topic });
       const fileB = await createMcapFile({ withMessage: true, topic });
-      const pool = new HydratedSourcePool(2);
+      const pool = new HydratedSourcePool({ maxCount: 2 });
       const sourceA = new McapIterableSource({ type: "file", file: fileA, pool });
       const sourceB = new McapIterableSource({ type: "file", file: fileB, pool });
 

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
@@ -88,6 +88,7 @@ describe("McapIterableSource", () => {
   beforeEach(() => {
     // Reset and setup mock to return actual decompression handlers
     mockLoadDecompressHandlers.mockReset();
+    MockRemoteFileReadable.mockReset();
     mockLoadDecompressHandlers.mockImplementation(() =>
       jest.requireActual("@lichtblick/mcap-support").loadDecompressHandlers(),
     );
@@ -151,9 +152,21 @@ describe("McapIterableSource", () => {
     const urlIndexedMcap = "https://example.com/data.mcap";
     const urlUnindexedMcap = "https://example.com/unindexed.mcap";
 
-    function mockRemoteFileReadableWith(mcapData: Uint8Array): void {
-      MockRemoteFileReadable.mockImplementation(() => {
-        return {
+    type MockRemoteReadable = {
+      open: jest.Mock<Promise<void>, []>;
+      close: jest.Mock<void, []>;
+      size: jest.Mock<Promise<bigint>, []>;
+      read: jest.Mock<Promise<Uint8Array>, [bigint, bigint]>;
+    };
+
+    function mockRemoteFileReadableWith(
+      mcapDataOrByUrl: Uint8Array | Record<string, Uint8Array>,
+    ): Map<string, MockRemoteReadable[]> {
+      const instancesByUrl = new Map<string, MockRemoteReadable[]>();
+      MockRemoteFileReadable.mockImplementation((url: string) => {
+        const mcapData =
+          mcapDataOrByUrl instanceof Uint8Array ? mcapDataOrByUrl : mcapDataOrByUrl[url]!;
+        const instance: MockRemoteReadable = {
           open: jest.fn().mockResolvedValue(undefined),
           close: jest.fn(),
           size: jest.fn().mockResolvedValue(BigInt(mcapData.byteLength)),
@@ -164,8 +177,13 @@ describe("McapIterableSource", () => {
               Number(size),
             );
           }),
-        } as unknown as RemoteFileReadable;
+        };
+        const instances = instancesByUrl.get(url) ?? [];
+        instances.push(instance);
+        instancesByUrl.set(url, instances);
+        return instance as unknown as RemoteFileReadable;
       });
+      return instancesByUrl;
     }
 
     async function buildIndexedMcap(
@@ -248,6 +266,27 @@ describe("McapIterableSource", () => {
         cacheSizeInBytes,
         readAheadEnabled,
       });
+    });
+
+    it("should forward readAheadBufferBytes to RemoteFileReadable when provided", async () => {
+      // Given an indexed MCAP served via URL with a bounded read-ahead override
+      const mcapData = await buildIndexedMcap([{ logTime: 1_000_000_000n }]);
+      mockRemoteFileReadableWith(mcapData);
+      const readAheadBufferBytes = 2 * 1024 * 1024;
+
+      // When initializing a McapIterableSource with URL type
+      const source = new McapIterableSource({
+        type: "url",
+        url: urlIndexedMcap,
+        readAheadBufferBytes,
+      });
+      await source.initialize();
+
+      // Then RemoteFileReadable should receive the bounded read-ahead override
+      expect(MockRemoteFileReadable).toHaveBeenCalledWith(
+        urlIndexedMcap,
+        expect.objectContaining({ readAheadBufferBytes }),
+      );
     });
 
     it("should delegate getStart and getEnd to the underlying indexed source", async () => {
@@ -367,40 +406,110 @@ describe("McapIterableSource", () => {
         return tempBuffer.get();
       }
 
-      it("keeps only the pool capacity resident and re-hydrates an evicted pooled source on iterate", async () => {
+      it("reuses the same RemoteFileReadable across eviction while re-running indexed initialization on re-hydration", async () => {
         // Given two indexed MCAPs served via URL that share a capacity-1 pool
         const topic = "/pooled_topic";
+        const urlIndexedMcapA = "https://example.com/data-a.mcap";
+        const urlIndexedMcapB = "https://example.com/data-b.mcap";
         const mcapData = await buildIndexedMcapWithTopic(topic, [1_000_000_000n]);
-        mockRemoteFileReadableWith(mcapData);
+        const readableInstancesByUrl = mockRemoteFileReadableWith({
+          [urlIndexedMcapA]: mcapData,
+          [urlIndexedMcapB]: mcapData,
+        });
         const pool = new HydratedSourcePool({ maxCount: 1 });
-        const sourceA = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
-        const sourceB = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
+        const sourceA = new McapIterableSource({ type: "url", url: urlIndexedMcapA, pool });
+        const sourceB = new McapIterableSource({ type: "url", url: urlIndexedMcapB, pool });
+        const readerInitializeSpy = jest.spyOn(McapIndexedReader, "Initialize");
 
-        // When initializing both sources
+        // When initializing A and iterating it while still resident
+        await sourceA.initialize();
+        const initialIterator = sourceA.messageIterator({
+          topics: new Map([[topic, PlayerBuilder.subscribePayload({ topic })]]),
+        });
+        const initialResult = await initialIterator.next();
+        await initialIterator.next();
+
+        // Then A created exactly one remote readable and one indexed reader so far
+        expect(initialResult.value).toMatchObject({ type: "message-event" });
+        const sourceAReadable = readableInstancesByUrl.get(urlIndexedMcapA)?.[0];
+        expect(sourceAReadable).toBeDefined();
+        expect(sourceAReadable?.open).toHaveBeenCalledTimes(1);
+        expect(
+          readerInitializeSpy.mock.calls.filter(([arg]) => arg.readable === sourceAReadable),
+        ).toHaveLength(1);
+
+        // When B initializes, A is evicted, and A is iterated again after eviction
+        await sourceB.initialize();
+        expect(pool.size).toBe(1);
+        expect(sourceAReadable?.close).not.toHaveBeenCalled();
+        const constructorCallsAfterEviction = MockRemoteFileReadable.mock.calls.length;
+
+        const rehydratedIterator = sourceA.messageIterator({
+          topics: new Map([[topic, PlayerBuilder.subscribePayload({ topic })]]),
+        });
+        const rehydratedResult = await rehydratedIterator.next();
+        await rehydratedIterator.next();
+
+        // Then A reuses its original RemoteFileReadable instead of opening a new connection, while
+        // still rebuilding the indexed reader/parsing state after re-hydration.
+        expect(rehydratedResult.value).toMatchObject({ type: "message-event" });
+        expect(MockRemoteFileReadable.mock.calls).toHaveLength(constructorCallsAfterEviction);
+        expect(sourceAReadable?.open).toHaveBeenCalledTimes(1);
+        expect(
+          readerInitializeSpy.mock.calls.filter(([arg]) => arg.readable === sourceAReadable),
+        ).toHaveLength(2);
+      });
+
+      it("recreates a url-backed RemoteFileReadable after a fatal indexed re-hydration failure", async () => {
+        // Given two indexed MCAPs served via URL that share a capacity-1 pool
+        const topic = "/retry_topic";
+        const urlIndexedMcapA = "https://example.com/retry-a.mcap";
+        const urlIndexedMcapB = "https://example.com/retry-b.mcap";
+        const mcapData = await buildIndexedMcapWithTopic(topic, [1_000_000_000n]);
+        const readableInstancesByUrl = mockRemoteFileReadableWith({
+          [urlIndexedMcapA]: mcapData,
+          [urlIndexedMcapB]: mcapData,
+        });
+        const pool = new HydratedSourcePool({ maxCount: 1 });
+        const sourceA = new McapIterableSource({ type: "url", url: urlIndexedMcapA, pool });
+        const sourceB = new McapIterableSource({ type: "url", url: urlIndexedMcapB, pool });
+        const realInitialize = McapIndexedReader.Initialize.bind(McapIndexedReader);
+        let failRehydrateForReadable: MockRemoteReadable | undefined;
+        const fatalError = new Error("fatal indexed init");
+        jest.spyOn(McapIndexedReader, "Initialize").mockImplementation(async (args) => {
+          if (args.readable === failRehydrateForReadable) {
+            failRehydrateForReadable = undefined;
+            throw fatalError;
+          }
+          return await realInitialize(args);
+        });
+
         await sourceA.initialize();
         await sourceB.initialize();
 
-        // Then only one reader stays resident: B was admitted last, so A is evicted+closed
-        expect(pool.size).toBe(1);
-        const firstReadable = MockRemoteFileReadable.mock.results[0]!.value as unknown as {
-          close: jest.Mock;
-        };
-        expect(firstReadable.close).toHaveBeenCalledTimes(1);
+        const firstReadable = readableInstancesByUrl.get(urlIndexedMcapA)?.[0];
+        expect(firstReadable).toBeDefined();
+        failRehydrateForReadable = firstReadable;
 
-        const constructorCallsAfterInit = MockRemoteFileReadable.mock.calls.length;
-
-        // When iterating the evicted source A
-        const iterator = sourceA.messageIterator({
+        const failingIterator = sourceA.messageIterator({
           topics: new Map([[topic, PlayerBuilder.subscribePayload({ topic })]]),
         });
-        const result = await iterator.next();
+        await expect(failingIterator.next()).rejects.toThrow(fatalError);
+        expect(firstReadable?.close).toHaveBeenCalledTimes(1);
 
-        // Then it re-hydrates (opens a fresh reader) and still yields the message event
-        expect(result.value).toMatchObject({ type: "message-event" });
-        expect(MockRemoteFileReadable.mock.calls.length).toBeGreaterThan(constructorCallsAfterInit);
+        const constructorCallsAfterFailure = MockRemoteFileReadable.mock.calls.length;
+        const recoveredIterator = sourceA.messageIterator({
+          topics: new Map([[topic, PlayerBuilder.subscribePayload({ topic })]]),
+        });
+        const recoveredResult = await recoveredIterator.next();
+        await recoveredIterator.next();
 
-        // Drain to trigger release() in the iterator's finally block
-        await iterator.next();
+        const secondReadable = readableInstancesByUrl.get(urlIndexedMcapA)?.[1];
+        expect(recoveredResult.value).toMatchObject({ type: "message-event" });
+        expect(MockRemoteFileReadable.mock.calls).toHaveLength(constructorCallsAfterFailure + 1);
+        expect(secondReadable).toBeDefined();
+        expect(secondReadable).not.toBe(firstReadable);
+        expect(secondReadable?.open).toHaveBeenCalledTimes(1);
       });
 
       it("returns cached getStart/getEnd for an evicted pooled source without re-hydrating", async () => {
@@ -445,19 +554,35 @@ describe("McapIterableSource", () => {
         expect(firstReadable.close).not.toHaveBeenCalled();
       });
 
-      it("terminate() on a pooled source resolves and leaves pool teardown to the owner", async () => {
+      it("terminate() closes the persistent readable once while leaving pool teardown to the owner", async () => {
         // Given a pooled url source whose inner is owned by the pool
         const mcapData = await buildIndexedMcapWithTopic("/term_topic", [1_000_000_000n]);
-        mockRemoteFileReadableWith(mcapData);
+        const readableInstancesByUrl = mockRemoteFileReadableWith(mcapData);
         const pool = new HydratedSourcePool({ maxCount: 4 });
         const source = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
         await source.initialize();
+        const readable = readableInstancesByUrl.get(urlIndexedMcap)?.[0];
 
-        // When terminating the source
+        // When terminating the source twice
+        await expect(source.terminate()).resolves.toBeUndefined();
         await expect(source.terminate()).resolves.toBeUndefined();
 
-        // Then the pool entry is untouched (the pool owner tears it down)
+        // Then the session-persistent readable is closed exactly once and the pool entry remains
+        // owned by the pool.
+        expect(readable?.close).toHaveBeenCalledTimes(1);
         expect(pool.size).toBe(1);
+      });
+
+      it("terminate() is a no-op when no persistent readable was ever created", async () => {
+        // Given a pooled url source that was never initialized
+        const source = new McapIterableSource({
+          type: "url",
+          url: urlIndexedMcap,
+          pool: new HydratedSourcePool({ maxCount: 1 }),
+        });
+
+        // When / Then
+        await expect(source.terminate()).resolves.toBeUndefined();
       });
     });
   });
@@ -587,7 +712,7 @@ describe("McapIterableSource", () => {
       expect(result.topics).toEqual([]);
     });
 
-    it("falls back to unindexed reader when indexed reader initialization fails", async () => {
+    it("surfaces a real initialization error instead of silently falling back to unindexed (operational failure, not a genuinely unindexed file)", async () => {
       // Given
       const file = await createMcapFile({ withMessage: true });
       const source = new McapIterableSource({ type: "file", file });
@@ -597,15 +722,28 @@ describe("McapIterableSource", () => {
         .mockRejectedValue(new Error("Corrupt MCAP file"));
       const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
 
+      // When / Then
+      await expect(source.initialize()).rejects.toThrow("Corrupt MCAP file");
+      expect(initializeSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(new Error("Corrupt MCAP file"));
+    });
+
+    it("still falls back to unindexed reader when Initialize throws the genuine 'File is not indexed' error", async () => {
+      // Given
+      const file = await createMcapFile({ withMessage: true });
+      const source = new McapIterableSource({ type: "file", file });
+
+      jest
+        .spyOn(McapIndexedReader, "Initialize")
+        .mockRejectedValue(new Error("File is not indexed [library=test]"));
+
       // When
       const result = await source.initialize();
 
-      // Then
+      // Then — genuinely unindexed (per the real @mcap/core error signal) still falls back safely
       expect(result).toBeDefined();
       expect(result.topics).toHaveLength(1);
       expect(result.topics[0]?.name).toBe("/test");
-      expect(initializeSpy).toHaveBeenCalledTimes(1);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(new Error("Corrupt MCAP file"));
     });
   });
 

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
@@ -619,9 +619,9 @@ describe("McapIterableSource", () => {
 
       // When iterating messageIterator before initialize
       // Then it should throw (the async generator body runs on first next())
-      await expect(
-        source.messageIterator({ topics: new Map() }).next(),
-      ).rejects.toThrow("Invariant: uninitialized");
+      await expect(source.messageIterator({ topics: new Map() }).next()).rejects.toThrow(
+        "Invariant: uninitialized",
+      );
     });
 
     it("should return an iterator from the underlying source after initialization", async () => {

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
@@ -422,7 +422,7 @@ describe("McapIterableSource", () => {
         // Then getStart/getEnd return the cached range without opening a new reader
         expect(sourceA.getStart()).toEqual({ sec: 2, nsec: 0 });
         expect(sourceA.getEnd()).toEqual({ sec: 8, nsec: 0 });
-        expect(MockRemoteFileReadable.mock.calls.length).toBe(constructorCallsAfterInit);
+        expect(MockRemoteFileReadable.mock.calls).toHaveLength(constructorCallsAfterInit);
       });
 
       it("keeps every pooled source resident when N <= pool capacity", async () => {

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
@@ -15,6 +15,7 @@ import { BasicBuilder } from "@lichtblick/test-builders";
 
 import { McapIterableSource } from "./McapIterableSource";
 import { RemoteFileReadable } from "./RemoteFileReadable";
+import { HydratedSourcePool } from "../shared/HydratedSourcePool";
 
 jest.mock("./RemoteFileReadable");
 
@@ -154,6 +155,7 @@ describe("McapIterableSource", () => {
       MockRemoteFileReadable.mockImplementation(() => {
         return {
           open: jest.fn().mockResolvedValue(undefined),
+          close: jest.fn(),
           size: jest.fn().mockResolvedValue(BigInt(mcapData.byteLength)),
           read: jest.fn().mockImplementation(async (offset: bigint, size: bigint) => {
             return new Uint8Array(
@@ -330,6 +332,182 @@ describe("McapIterableSource", () => {
         `Remote file is missing Content-Length header. <${urlUnindexedMcap}>`,
       );
     });
+
+    describe("with a bounded HydratedSourcePool", () => {
+      // Build an indexed MCAP with a known topic and valid json encoding so init.topics is
+      // populated and messages can be subscribed/iterated by name.
+      async function buildIndexedMcapWithTopic(
+        topic: string,
+        logTimes: bigint[],
+      ): Promise<Uint8Array> {
+        const tempBuffer = new TempBuffer();
+        const writer = new McapWriter({ writable: tempBuffer, startChannelId: 1 });
+        await writer.start({ library: "", profile: "" });
+        const schemaId = await writer.registerSchema({
+          name: "test_schema",
+          encoding: "jsonschema",
+          data: new TextEncoder().encode(JSON.stringify({ type: "object" })),
+        });
+        await writer.registerChannel({
+          messageEncoding: "json",
+          schemaId,
+          metadata: new Map(),
+          topic,
+        });
+        for (let i = 0; i < logTimes.length; i++) {
+          await writer.addMessage({
+            channelId: 1,
+            data: new TextEncoder().encode("{}"),
+            logTime: logTimes[i]!,
+            publishTime: 0n,
+            sequence: i + 1,
+          });
+        }
+        await writer.end();
+        return tempBuffer.get();
+      }
+
+      it("keeps only the pool capacity resident and re-hydrates an evicted pooled source on iterate", async () => {
+        // Given two indexed MCAPs served via URL that share a capacity-1 pool
+        const topic = "/pooled_topic";
+        const mcapData = await buildIndexedMcapWithTopic(topic, [1_000_000_000n]);
+        mockRemoteFileReadableWith(mcapData);
+        const pool = new HydratedSourcePool(1);
+        const sourceA = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
+        const sourceB = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
+
+        // When initializing both sources
+        await sourceA.initialize();
+        await sourceB.initialize();
+
+        // Then only one reader stays resident: B was admitted last, so A is evicted+closed
+        expect(pool.size).toBe(1);
+        const firstReadable = MockRemoteFileReadable.mock.results[0]!.value as unknown as {
+          close: jest.Mock;
+        };
+        expect(firstReadable.close).toHaveBeenCalledTimes(1);
+
+        const constructorCallsAfterInit = MockRemoteFileReadable.mock.calls.length;
+
+        // When iterating the evicted source A
+        const iterator = sourceA.messageIterator({
+          topics: new Map([[topic, PlayerBuilder.subscribePayload({ topic })]]),
+        });
+        const result = await iterator.next();
+
+        // Then it re-hydrates (opens a fresh reader) and still yields the message event
+        expect(result.value).toMatchObject({ type: "message-event" });
+        expect(MockRemoteFileReadable.mock.calls.length).toBeGreaterThan(constructorCallsAfterInit);
+
+        // Drain to trigger release() in the iterator's finally block
+        await iterator.next();
+      });
+
+      it("returns cached getStart/getEnd for an evicted pooled source without re-hydrating", async () => {
+        // Given two indexed MCAPs (message range 2s–8s) sharing a capacity-1 pool
+        const mcapData = await buildIndexedMcapWithTopic("/range_topic", [
+          2_000_000_000n,
+          8_000_000_000n,
+        ]);
+        mockRemoteFileReadableWith(mcapData);
+        const pool = new HydratedSourcePool(1);
+        const sourceA = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
+        const sourceB = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
+
+        // When initializing both, so A is evicted by B
+        await sourceA.initialize();
+        await sourceB.initialize();
+        const constructorCallsAfterInit = MockRemoteFileReadable.mock.calls.length;
+
+        // Then getStart/getEnd return the cached range without opening a new reader
+        expect(sourceA.getStart()).toEqual({ sec: 2, nsec: 0 });
+        expect(sourceA.getEnd()).toEqual({ sec: 8, nsec: 0 });
+        expect(MockRemoteFileReadable.mock.calls.length).toBe(constructorCallsAfterInit);
+      });
+
+      it("keeps every pooled source resident when N <= pool capacity", async () => {
+        // Given two indexed MCAPs sharing a pool with capacity 2
+        const mcapData = await buildIndexedMcapWithTopic("/n_topic", [1_000_000_000n]);
+        mockRemoteFileReadableWith(mcapData);
+        const pool = new HydratedSourcePool(2);
+        const sourceA = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
+        const sourceB = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
+
+        // When initializing both
+        await sourceA.initialize();
+        await sourceB.initialize();
+
+        // Then both stay resident and nothing is evicted (no re-open needed later)
+        expect(pool.size).toBe(2);
+        const firstReadable = MockRemoteFileReadable.mock.results[0]!.value as unknown as {
+          close: jest.Mock;
+        };
+        expect(firstReadable.close).not.toHaveBeenCalled();
+      });
+
+      it("terminate() on a pooled source resolves and leaves pool teardown to the owner", async () => {
+        // Given a pooled url source whose inner is owned by the pool
+        const mcapData = await buildIndexedMcapWithTopic("/term_topic", [1_000_000_000n]);
+        mockRemoteFileReadableWith(mcapData);
+        const pool = new HydratedSourcePool(4);
+        const source = new McapIterableSource({ type: "url", url: urlIndexedMcap, pool });
+        await source.initialize();
+
+        // When terminating the source
+        await expect(source.terminate()).resolves.toBeUndefined();
+
+        // Then the pool entry is untouched (the pool owner tears it down)
+        expect(pool.size).toBe(1);
+      });
+    });
+  });
+
+  describe("When source type is file with a bounded HydratedSourcePool", () => {
+    it("admits file sources to the pool and re-hydrates an evicted source on iterate", async () => {
+      // Given two indexed MCAP file blobs that share a capacity-1 pool
+      const topic = `/${BasicBuilder.string()}`;
+      const fileA = await createMcapFile({ withMessage: true, topic });
+      const fileB = await createMcapFile({ withMessage: true, topic });
+      const pool = new HydratedSourcePool(1);
+      const sourceA = new McapIterableSource({ type: "file", file: fileA, pool });
+      const sourceB = new McapIterableSource({ type: "file", file: fileB, pool });
+
+      // When initializing both sources
+      await sourceA.initialize();
+      await sourceB.initialize();
+
+      // Then only one inner stays resident: B was admitted last, so A was evicted
+      expect(pool.size).toBe(1);
+
+      // When iterating the evicted source A
+      const iterator = sourceA.messageIterator({
+        topics: new Map([[topic, PlayerBuilder.subscribePayload({ topic })]]),
+      });
+      const result = await iterator.next();
+
+      // Then it re-hydrates (re-opens the blob reader) and still yields the message event
+      expect(result.value).toMatchObject({ type: "message-event" });
+
+      // Drain to trigger release() in the iterator's finally block
+      await iterator.next();
+    });
+
+    it("keeps every file source resident when N <= pool capacity", async () => {
+      // Given two indexed MCAP file blobs sharing a pool with capacity 2
+      const topic = `/${BasicBuilder.string()}`;
+      const fileA = await createMcapFile({ withMessage: true, topic });
+      const fileB = await createMcapFile({ withMessage: true, topic });
+      const pool = new HydratedSourcePool(2);
+      const sourceA = new McapIterableSource({ type: "file", file: fileA, pool });
+      const sourceB = new McapIterableSource({ type: "file", file: fileB, pool });
+
+      // When initializing both
+      await sourceA.initialize();
+      await sourceB.initialize();
+
+      // Then both stay resident and nothing is evicted
+      expect(pool.size).toBe(2);
+    });
   });
 
   describe("tryCreateIndexedReader", () => {
@@ -432,18 +610,18 @@ describe("McapIterableSource", () => {
   });
 
   describe("messageIterator", () => {
-    it("should throw when source has not been initialized", () => {
+    it("should throw when source has not been initialized", async () => {
       // Given a source that has not been initialized
       const source = new McapIterableSource({
         type: "file",
         file: new Blob([]) as unknown as globalThis.Blob,
       });
 
-      // When calling messageIterator before initialize
-      // Then it should throw
-      expect(() => source.messageIterator({ topics: new Map() })).toThrow(
-        "Invariant: uninitialized",
-      );
+      // When iterating messageIterator before initialize
+      // Then it should throw (the async generator body runs on first next())
+      await expect(
+        source.messageIterator({ topics: new Map() }).next(),
+      ).rejects.toThrow("Invariant: uninitialized");
     });
 
     it("should return an iterator from the underlying source after initialization", async () => {

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -23,12 +23,25 @@ import {
   GetBackfillMessagesArgs,
   ISerializedIterableSource,
 } from "../IIterableSource";
+import { HydratedSourcePool, SourceHydrator } from "../shared/HydratedSourcePool";
 
 const log = Log.getLogger(__filename);
 
 type McapSource =
-  | { type: "file"; file: Blob }
-  | { type: "url"; url: string; cacheSizeInBytes?: number; readAheadEnabled?: boolean };
+  | { type: "file"; file: Blob; pool?: HydratedSourcePool }
+  | {
+      type: "url";
+      url: string;
+      cacheSizeInBytes?: number;
+      readAheadEnabled?: boolean;
+      pool?: HydratedSourcePool;
+    };
+
+type HydratedInner = {
+  inner: ISerializedIterableSource;
+  // Present only for remote sources so the connection/cache can be closed on eviction.
+  readable?: RemoteFileReadable;
+};
 
 /**
  * Create a McapIndexedReader if it will be possible to do an indexed read. If the file is not
@@ -53,7 +66,12 @@ async function tryCreateIndexedReader(
 
 export class McapIterableSource implements ISerializedIterableSource {
   #source: McapSource;
-  #sourceImpl: ISerializedIterableSource | undefined;
+  // Eagerly-retained inner: used for local blobs, unindexed streams, and unpooled sources.
+  #eagerInner: ISerializedIterableSource | undefined;
+  // Set when this source is managed by a bounded LRU pool (re-hydrated on demand).
+  #pool: HydratedSourcePool | undefined;
+  #start?: Time;
+  #end?: Time;
 
   public readonly sourceType = "serialized";
 
@@ -61,7 +79,13 @@ export class McapIterableSource implements ISerializedIterableSource {
     this.#source = source;
   }
 
-  public async initialize(): Promise<Initialization> {
+  // Build a fresh inner source (open readable + reader). Returns the readable for remote sources so
+  // the caller can close its connection/cache when releasing.
+  async #openInner(): Promise<{
+    inner: ISerializedIterableSource;
+    readable?: RemoteFileReadable;
+    indexed: boolean;
+  }> {
     const source = this.#source;
 
     // Preload decompression handlers before starting any MCAP operations.
@@ -80,14 +104,15 @@ export class McapIterableSource implements ISerializedIterableSource {
         const readable = new BlobReadable(source.file);
         const reader = await tryCreateIndexedReader(readable, decompressHandlers);
         if (reader) {
-          this.#sourceImpl = new McapIndexedIterableSource(reader);
-        } else {
-          this.#sourceImpl = new McapUnindexedIterableSource({
+          return { inner: new McapIndexedIterableSource(reader), indexed: true };
+        }
+        return {
+          inner: new McapUnindexedIterableSource({
             size: source.file.size,
             stream: source.file.stream(),
-          });
-        }
-        break;
+          }),
+          indexed: false,
+        };
       }
       case "url": {
         const readable = new RemoteFileReadable(source.url, {
@@ -97,54 +122,103 @@ export class McapIterableSource implements ISerializedIterableSource {
         await readable.open();
         const reader = await tryCreateIndexedReader(readable, decompressHandlers);
         if (reader) {
-          this.#sourceImpl = new McapIndexedIterableSource(reader);
-        } else {
-          const response = await fetch(source.url);
-          if (!response.body) {
-            throw new Error(`Unable to stream remote file. <${source.url}>`);
-          }
-          const size = response.headers.get("content-length");
-          if (size == undefined) {
-            throw new Error(`Remote file is missing Content-Length header. <${source.url}>`);
-          }
-
-          this.#sourceImpl = new McapUnindexedIterableSource({
-            size: parseInt(size),
-            stream: response.body,
-          });
+          return { inner: new McapIndexedIterableSource(reader), readable, indexed: true };
         }
-        break;
+        // Unindexed remote fallback: single-pass streaming read of the whole file.
+        readable.close();
+        const response = await fetch(source.url);
+        if (!response.body) {
+          throw new Error(`Unable to stream remote file. <${source.url}>`);
+        }
+        const size = response.headers.get("content-length");
+        if (size == undefined) {
+          throw new Error(`Remote file is missing Content-Length header. <${source.url}>`);
+        }
+        return {
+          inner: new McapUnindexedIterableSource({ size: parseInt(size), stream: response.body }),
+          indexed: false,
+        };
       }
     }
-
-    return await this.#sourceImpl.initialize();
   }
 
-  public messageIterator(
+  // Pool hydrator: builds a ready-to-iterate indexed inner (channels parsed) plus its readable so
+  // it can be closed on eviction.
+  readonly #hydrator: SourceHydrator<HydratedInner> = {
+    open: async () => {
+      const { inner, readable } = await this.#openInner();
+      await inner.initialize();
+      return { inner, readable };
+    },
+    close: async ({ readable }) => {
+      readable?.close();
+    },
+  };
+
+  public async initialize(): Promise<Initialization> {
+    const opened = await this.#openInner();
+    const init = await opened.inner.initialize();
+    this.#start = init.start;
+    this.#end = init.end;
+
+    const pool = this.#source.pool;
+    if (pool && opened.indexed) {
+      this.#pool = pool;
+      // Seed the pool with the already-hydrated inner (no redundant open). May be evicted+closed
+      // immediately if the pool is already at capacity.
+      await pool.admit(this, this.#hydrator, { inner: opened.inner, readable: opened.readable });
+    } else {
+      this.#eagerInner = opened.inner;
+    }
+    return init;
+  }
+
+  public async *messageIterator(
     opt: MessageIteratorArgs,
   ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
-    if (!this.#sourceImpl) {
-      throw new Error("Invariant: uninitialized");
+    if (!this.#pool) {
+      if (!this.#eagerInner) {
+        throw new Error("Invariant: uninitialized");
+      }
+      yield* this.#eagerInner.messageIterator(opt);
+      return;
     }
-
-    return this.#sourceImpl.messageIterator(opt);
+    const { inner } = await this.#pool.acquire(this, this.#hydrator);
+    try {
+      yield* inner.messageIterator(opt);
+    } finally {
+      this.#pool.release(this);
+    }
   }
 
   public async getBackfillMessages(
     args: GetBackfillMessagesArgs,
   ): Promise<MessageEvent<Uint8Array>[]> {
-    if (!this.#sourceImpl) {
-      throw new Error("Invariant: uninitialized");
+    if (!this.#pool) {
+      if (!this.#eagerInner) {
+        throw new Error("Invariant: uninitialized");
+      }
+      return await this.#eagerInner.getBackfillMessages(args);
     }
-
-    return await this.#sourceImpl.getBackfillMessages(args);
+    const { inner } = await this.#pool.acquire(this, this.#hydrator);
+    try {
+      return await inner.getBackfillMessages(args);
+    } finally {
+      this.#pool.release(this);
+    }
   }
 
   public getStart(): Time | undefined {
-    return this.#sourceImpl!.getStart!();
+    return this.#start;
   }
 
   public getEnd(): Time | undefined {
-    return this.#sourceImpl!.getEnd!();
+    return this.#end;
+  }
+
+  public async terminate(): Promise<void> {
+    // Pooled inners are torn down by the pool (owned by MultiIterableSource); only release an
+    // eagerly-retained inner here.
+    await this.#eagerInner?.terminate?.();
   }
 }

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -14,7 +14,12 @@ import { MessageEvent } from "@lichtblick/suite-base/players/types";
 
 import { BlobReadable } from "./BlobReadable";
 import { McapIndexedIterableSource } from "./McapIndexedIterableSource";
-import type { HydratedInner, IndexedReaderResult, McapSource } from "./McapIterableSource.types";
+import type {
+  HydratedInner,
+  IndexedReaderResult,
+  McapSource,
+  OpenedInner,
+} from "./McapIterableSource.types";
 import { McapUnindexedIterableSource } from "./McapUnindexedIterableSource";
 import { RemoteFileReadable } from "./RemoteFileReadable";
 import { READER_BASE_BYTES, estimateReaderWeightBytes } from "./readerWeight";
@@ -89,99 +94,110 @@ export class McapIterableSource implements ISerializedIterableSource {
   }
 
   // Build a fresh inner source. Returns the readable for remote sources so it can be closed later.
-  async #openInner(): Promise<{
-    inner: ISerializedIterableSource;
-    readable?: RemoteFileReadable;
-    indexed: boolean;
-    weightBytes: number;
-  }> {
+  async #openInner(): Promise<OpenedInner> {
     const source = this.#source;
 
     // Preload decompression handlers so WASM is ready before any read that needs it.
     const decompressHandlers = await loadDecompressHandlers();
 
     switch (source.type) {
-      case "file": {
-        // Ensure the file is readable before proceeding (will throw in the event of a permission
-        // error). Workaround for the fact that `file.stream().getReader()` returns a generic
-        // "network error" in the event of a permission error.
-        await source.file.slice(0, 1).arrayBuffer();
-
-        const readable = new BlobReadable(source.file);
-        const result = await tryCreateIndexedReader(readable, decompressHandlers);
-        if (result.status === "failed") {
-          // A real initialization failure (not "unindexed") must not be masked by the eager,
-          // unbounded streaming fallback — surface it so the caller sees an actual error.
-          throw result.error;
-        }
-        if (result.status === "indexed") {
-          return {
-            inner: new McapIndexedIterableSource(result.reader),
-            indexed: true,
-            weightBytes: estimateReaderWeightBytes(result.reader),
-          };
-        }
-        return {
-          inner: new McapUnindexedIterableSource({
-            size: source.file.size,
-            stream: source.file.stream(),
-          }),
-          indexed: false,
-          weightBytes: READER_BASE_BYTES,
-        };
-      }
-      case "url": {
-        let readable = this.#persistentReadable;
-        if (!readable) {
-          readable = new RemoteFileReadable(source.url, {
-            cacheSizeInBytes: source.cacheSizeInBytes,
-            readAheadEnabled: source.readAheadEnabled,
-            ...(source.readAheadBufferBytes != undefined
-              ? { readAheadBufferBytes: source.readAheadBufferBytes }
-              : {}),
-          });
-          await readable.open();
-          this.#persistentReadable = readable;
-        }
-        const result = await tryCreateIndexedReader(readable, decompressHandlers);
-        if (result.status === "failed") {
-          // A real initialization failure (not "unindexed") must not be masked by re-fetching the
-          // whole file via the eager, unbounded streaming fallback — surface the actual error.
-          readable.close();
-          this.#persistentReadable = undefined;
-          throw result.error;
-        }
-        if (result.status === "indexed") {
-          return {
-            inner: new McapIndexedIterableSource(result.reader),
-            readable,
-            indexed: true,
-            weightBytes: estimateReaderWeightBytes(result.reader),
-          };
-        }
-        // Unindexed remote fallback: single-pass streaming read of the whole file. This path
-        // bypasses the pool entirely and never re-hydrates, so there is no benefit in keeping the
-        // indexed-init probe connection/cache alive.
-        readable.close();
-        this.#persistentReadable = undefined;
-        const response = await fetch(source.url);
-        if (!response.body) {
-          throw new Error(`Unable to stream remote file. <${source.url}>`);
-        }
-        const size = response.headers.get("content-length");
-        if (size == undefined) {
-          throw new Error(`Remote file is missing Content-Length header. <${source.url}>`);
-        }
-        return {
-          inner: new McapUnindexedIterableSource({
-            size: Number.parseInt(size, 10),
-            stream: response.body,
-          }),
-          indexed: false,
-          weightBytes: READER_BASE_BYTES,
-        };
-      }
+      case "file":
+        return await this.#openFileSource(source, decompressHandlers);
+      case "url":
+        return await this.#openUrlSource(source, decompressHandlers);
     }
+  }
+
+  async #openFileSource(
+    source: Extract<McapSource, { type: "file" }>,
+    decompressHandlers: McapTypes.DecompressHandlers,
+  ): Promise<OpenedInner> {
+    // Ensure the file is readable before proceeding (will throw in the event of a permission
+    // error). Workaround for the fact that `file.stream().getReader()` returns a generic
+    // "network error" in the event of a permission error.
+    await source.file.slice(0, 1).arrayBuffer();
+
+    const readable = new BlobReadable(source.file);
+    const result = await tryCreateIndexedReader(readable, decompressHandlers);
+    if (result.status === "failed") {
+      // A real initialization failure (not "unindexed") must not be masked by the eager,
+      // unbounded streaming fallback — surface it so the caller sees an actual error.
+      throw result.error;
+    }
+    if (result.status === "indexed") {
+      return {
+        inner: new McapIndexedIterableSource(result.reader),
+        indexed: true,
+        weightBytes: estimateReaderWeightBytes(result.reader),
+      };
+    }
+    return {
+      inner: new McapUnindexedIterableSource({
+        size: source.file.size,
+        stream: source.file.stream(),
+      }),
+      indexed: false,
+      weightBytes: READER_BASE_BYTES,
+    };
+  }
+
+  async #openUrlSource(
+    source: Extract<McapSource, { type: "url" }>,
+    decompressHandlers: McapTypes.DecompressHandlers,
+  ): Promise<OpenedInner> {
+    let readable = this.#persistentReadable;
+    if (!readable) {
+      readable = new RemoteFileReadable(source.url, {
+        cacheSizeInBytes: source.cacheSizeInBytes,
+        readAheadEnabled: source.readAheadEnabled,
+        ...(source.readAheadBufferBytes != undefined
+          ? { readAheadBufferBytes: source.readAheadBufferBytes }
+          : {}),
+      });
+      await readable.open();
+      this.#persistentReadable = readable;
+    }
+    const result = await tryCreateIndexedReader(readable, decompressHandlers);
+    if (result.status === "failed") {
+      // A real initialization failure (not "unindexed") must not be masked by re-fetching the
+      // whole file via the eager, unbounded streaming fallback — surface the actual error.
+      readable.close();
+      this.#persistentReadable = undefined;
+      throw result.error;
+    }
+    if (result.status === "indexed") {
+      return {
+        inner: new McapIndexedIterableSource(result.reader),
+        readable,
+        indexed: true,
+        weightBytes: estimateReaderWeightBytes(result.reader),
+      };
+    }
+    // Unindexed remote fallback: single-pass streaming read of the whole file. This path
+    // bypasses the pool entirely and never re-hydrates, so there is no benefit in keeping the
+    // indexed-init probe connection/cache alive.
+    readable.close();
+    this.#persistentReadable = undefined;
+    return await this.#openUnindexedUrlFallback(source.url);
+  }
+
+  async #openUnindexedUrlFallback(url: string): Promise<OpenedInner> {
+    const response = await fetch(url);
+    if (!response.body) {
+      throw new Error(`Unable to stream remote file. <${url}>`);
+    }
+    const size = response.headers.get("content-length");
+    if (size == undefined) {
+      throw new Error(`Remote file is missing Content-Length header. <${url}>`);
+    }
+    return {
+      inner: new McapUnindexedIterableSource({
+        size: Number.parseInt(size, 10),
+        stream: response.body,
+      }),
+      indexed: false,
+      weightBytes: READER_BASE_BYTES,
+    };
   }
 
   // Pool hydrator: builds a ready-to-iterate indexed inner (channels parsed). The underlying

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -27,6 +27,22 @@ import { HydratedSourcePool, SourceHydrator } from "../shared/HydratedSourcePool
 
 const log = Log.getLogger(__filename);
 
+// Heuristic per-reader resident-memory weights (bytes) used by the pool's byte budget. Absolute
+// values are approximate; the RELATIVE weighting (heavier index/more channels => evicted sooner)
+// is what matters. Calibrate against real datasets before loosening pool defaults.
+const READER_BASE_BYTES = 2 * 1024 * 1024; // fixed reader/deserializer overhead
+const BYTES_PER_CHUNK_INDEX = 512; // per chunk-index entry retained by McapIndexedReader
+const BYTES_PER_CHANNEL = 16 * 1024; // parsed schema + per-channel deserializer
+
+function estimateReaderWeightBytes(reader: McapIndexedReader, cacheBytes: number): number {
+  return (
+    READER_BASE_BYTES +
+    reader.chunkIndexes.length * BYTES_PER_CHUNK_INDEX +
+    reader.channelsById.size * BYTES_PER_CHANNEL +
+    cacheBytes
+  );
+}
+
 type McapSource =
   | { type: "file"; file: Blob; pool?: HydratedSourcePool }
   | {
@@ -41,6 +57,8 @@ type HydratedInner = {
   inner: ISerializedIterableSource;
   // Present only for remote sources so the connection/cache can be closed on eviction.
   readable?: RemoteFileReadable;
+  // Estimated resident bytes, fed to the pool's byte budget.
+  weightBytes: number;
 };
 
 /**
@@ -85,6 +103,7 @@ export class McapIterableSource implements ISerializedIterableSource {
     inner: ISerializedIterableSource;
     readable?: RemoteFileReadable;
     indexed: boolean;
+    weightBytes: number;
   }> {
     const source = this.#source;
 
@@ -104,7 +123,11 @@ export class McapIterableSource implements ISerializedIterableSource {
         const readable = new BlobReadable(source.file);
         const reader = await tryCreateIndexedReader(readable, decompressHandlers);
         if (reader) {
-          return { inner: new McapIndexedIterableSource(reader), indexed: true };
+          return {
+            inner: new McapIndexedIterableSource(reader),
+            indexed: true,
+            weightBytes: estimateReaderWeightBytes(reader, 0),
+          };
         }
         return {
           inner: new McapUnindexedIterableSource({
@@ -112,6 +135,7 @@ export class McapIterableSource implements ISerializedIterableSource {
             stream: source.file.stream(),
           }),
           indexed: false,
+          weightBytes: READER_BASE_BYTES,
         };
       }
       case "url": {
@@ -122,7 +146,12 @@ export class McapIterableSource implements ISerializedIterableSource {
         await readable.open();
         const reader = await tryCreateIndexedReader(readable, decompressHandlers);
         if (reader) {
-          return { inner: new McapIndexedIterableSource(reader), readable, indexed: true };
+          return {
+            inner: new McapIndexedIterableSource(reader),
+            readable,
+            indexed: true,
+            weightBytes: estimateReaderWeightBytes(reader, source.cacheSizeInBytes ?? 0),
+          };
         }
         // Unindexed remote fallback: single-pass streaming read of the whole file.
         readable.close();
@@ -137,6 +166,7 @@ export class McapIterableSource implements ISerializedIterableSource {
         return {
           inner: new McapUnindexedIterableSource({ size: parseInt(size), stream: response.body }),
           indexed: false,
+          weightBytes: READER_BASE_BYTES,
         };
       }
     }
@@ -146,13 +176,14 @@ export class McapIterableSource implements ISerializedIterableSource {
   // it can be closed on eviction.
   readonly #hydrator: SourceHydrator<HydratedInner> = {
     open: async () => {
-      const { inner, readable } = await this.#openInner();
+      const { inner, readable, weightBytes } = await this.#openInner();
       await inner.initialize();
-      return { inner, readable };
+      return { inner, readable, weightBytes };
     },
     close: async ({ readable }) => {
       readable?.close();
     },
+    weigh: ({ weightBytes }) => weightBytes,
   };
 
   public async initialize(): Promise<Initialization> {
@@ -166,8 +197,15 @@ export class McapIterableSource implements ISerializedIterableSource {
       this.#pool = pool;
       // Seed the pool with the already-hydrated inner (no redundant open). May be evicted+closed
       // immediately if the pool is already at capacity.
-      await pool.admit(this, this.#hydrator, { inner: opened.inner, readable: opened.readable });
+      await pool.admit(this, this.#hydrator, {
+        inner: opened.inner,
+        readable: opened.readable,
+        weightBytes: opened.weightBytes,
+      });
     } else {
+      // Unindexed (and unpooled) sources are retained eagerly for the whole session and are NOT
+      // bounded by the pool. A session of many large unindexed MCAPs can therefore grow unbounded;
+      // pooling them is non-trivial because re-hydration would re-stream the entire file.
       this.#eagerInner = opened.inner;
     }
     return init;
@@ -176,6 +214,9 @@ export class McapIterableSource implements ISerializedIterableSource {
   public async *messageIterator(
     opt: MessageIteratorArgs,
   ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
+    // NOTE: this is an async generator, so the "uninitialized" invariant below throws on the first
+    // .next() call, not when messageIterator() is invoked. Callers that expect a synchronous throw
+    // (mergeSequentialIterators calls .next(), so it surfaces there) should account for this.
     if (!this.#pool) {
       if (!this.#eagerInner) {
         throw new Error("Invariant: uninitialized");
@@ -214,6 +255,17 @@ export class McapIterableSource implements ISerializedIterableSource {
 
   public getEnd(): Time | undefined {
     return this.#end;
+  }
+
+  // Best-effort warm-up (I1): re-hydrate this source into the pool and immediately release it, so
+  // it becomes resident (and most-recently-used) without holding a pin. No-op for unpooled sources.
+  // Used to keep the earliest-by-start sources warm ahead of playback starting at t=0.
+  public async prewarm(): Promise<void> {
+    if (!this.#pool) {
+      return;
+    }
+    await this.#pool.acquire(this, this.#hydrator);
+    this.#pool.release(this);
   }
 
   public async terminate(): Promise<void> {

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -55,9 +55,7 @@ type McapSource =
 
 type HydratedInner = {
   inner: ISerializedIterableSource;
-  // Present only for remote sources so the connection/cache can be closed on eviction.
   readable?: RemoteFileReadable;
-  // Estimated resident bytes, fed to the pool's byte budget.
   weightBytes: number;
 };
 
@@ -97,8 +95,7 @@ export class McapIterableSource implements ISerializedIterableSource {
     this.#source = source;
   }
 
-  // Build a fresh inner source (open readable + reader). Returns the readable for remote sources so
-  // the caller can close its connection/cache when releasing.
+  // Build a fresh inner source. Returns the readable for remote sources so it can be closed later.
   async #openInner(): Promise<{
     inner: ISerializedIterableSource;
     readable?: RemoteFileReadable;
@@ -107,10 +104,7 @@ export class McapIterableSource implements ISerializedIterableSource {
   }> {
     const source = this.#source;
 
-    // Preload decompression handlers before starting any MCAP operations.
-    // This ensures WASM modules are fully loaded before the reader attempts any operations
-    // that might need decompression. Under network congestion, WASM modules can be slow
-    // to download/initialize. Without preloading, message reading could fail when handlers aren't ready yet.
+    // Preload decompression handlers so WASM is ready before any read that needs it.
     const decompressHandlers = await loadDecompressHandlers();
 
     switch (source.type) {
@@ -164,7 +158,10 @@ export class McapIterableSource implements ISerializedIterableSource {
           throw new Error(`Remote file is missing Content-Length header. <${source.url}>`);
         }
         return {
-          inner: new McapUnindexedIterableSource({ size: parseInt(size), stream: response.body }),
+          inner: new McapUnindexedIterableSource({
+            size: Number.parseInt(size, 10),
+            stream: response.body,
+          }),
           indexed: false,
           weightBytes: READER_BASE_BYTES,
         };
@@ -257,9 +254,8 @@ export class McapIterableSource implements ISerializedIterableSource {
     return this.#end;
   }
 
-  // Best-effort warm-up (I1): re-hydrate this source into the pool and immediately release it, so
-  // it becomes resident (and most-recently-used) without holding a pin. No-op for unpooled sources.
-  // Used to keep the earliest-by-start sources warm ahead of playback starting at t=0.
+  // Warm this source into the pool (resident + most-recently-used) without holding a pin, so the
+  // earliest-by-start sources are ready before playback begins. No-op for unpooled sources.
   public async prewarm(): Promise<void> {
     if (!this.#pool) {
       return;

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -14,11 +14,7 @@ import { MessageEvent } from "@lichtblick/suite-base/players/types";
 
 import { BlobReadable } from "./BlobReadable";
 import { McapIndexedIterableSource } from "./McapIndexedIterableSource";
-import type {
-  HydratedInner,
-  IndexedReaderResult,
-  McapSource,
-} from "./McapIterableSource.types";
+import type { HydratedInner, IndexedReaderResult, McapSource } from "./McapIterableSource.types";
 import { McapUnindexedIterableSource } from "./McapUnindexedIterableSource";
 import { RemoteFileReadable } from "./RemoteFileReadable";
 import { READER_BASE_BYTES, estimateReaderWeightBytes } from "./readerWeight";
@@ -47,7 +43,10 @@ async function tryCreateIndexedReader(
 ): Promise<IndexedReaderResult> {
   let reader: McapIndexedReader;
   try {
-    reader = await McapIndexedReader.Initialize({ readable, decompressHandlers });
+    reader = await McapIndexedReader.Initialize({
+      readable,
+      decompressHandlers,
+    });
   } catch (err: unknown) {
     const error = err instanceof Error ? err : new Error(String(err));
     // @mcap/core throws exactly this message (plus a " [library=...]" suffix) when the file has

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -16,6 +16,7 @@ import { BlobReadable } from "./BlobReadable";
 import { McapIndexedIterableSource } from "./McapIndexedIterableSource";
 import { McapUnindexedIterableSource } from "./McapUnindexedIterableSource";
 import { RemoteFileReadable } from "./RemoteFileReadable";
+import { READER_BASE_BYTES, estimateReaderWeightBytes } from "./readerWeight";
 import {
   IteratorResult,
   Initialization,
@@ -26,22 +27,6 @@ import {
 import { HydratedSourcePool, SourceHydrator } from "../shared/HydratedSourcePool";
 
 const log = Log.getLogger(__filename);
-
-// Heuristic per-reader resident-memory weights (bytes) used by the pool's byte budget. Absolute
-// values are approximate; the RELATIVE weighting (heavier index/more channels => evicted sooner)
-// is what matters. Calibrate against real datasets before loosening pool defaults.
-const READER_BASE_BYTES = 2 * 1024 * 1024; // fixed reader/deserializer overhead
-const BYTES_PER_CHUNK_INDEX = 512; // per chunk-index entry retained by McapIndexedReader
-const BYTES_PER_CHANNEL = 16 * 1024; // parsed schema + per-channel deserializer
-
-function estimateReaderWeightBytes(reader: McapIndexedReader, cacheBytes: number): number {
-  return (
-    READER_BASE_BYTES +
-    reader.chunkIndexes.length * BYTES_PER_CHUNK_INDEX +
-    reader.channelsById.size * BYTES_PER_CHANNEL +
-    cacheBytes
-  );
-}
 
 type McapSource =
   | { type: "file"; file: Blob; pool?: HydratedSourcePool }

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -14,6 +14,11 @@ import { MessageEvent } from "@lichtblick/suite-base/players/types";
 
 import { BlobReadable } from "./BlobReadable";
 import { McapIndexedIterableSource } from "./McapIndexedIterableSource";
+import type {
+  HydratedInner,
+  IndexedReaderResult,
+  McapSource,
+} from "./McapIterableSource.types";
 import { McapUnindexedIterableSource } from "./McapUnindexedIterableSource";
 import { RemoteFileReadable } from "./RemoteFileReadable";
 import { READER_BASE_BYTES, estimateReaderWeightBytes } from "./readerWeight";
@@ -28,41 +33,39 @@ import { HydratedSourcePool, SourceHydrator } from "../shared/HydratedSourcePool
 
 const log = Log.getLogger(__filename);
 
-type McapSource =
-  | { type: "file"; file: Blob; pool?: HydratedSourcePool }
-  | {
-      type: "url";
-      url: string;
-      cacheSizeInBytes?: number;
-      readAheadEnabled?: boolean;
-      pool?: HydratedSourcePool;
-    };
-
-type HydratedInner = {
-  inner: ISerializedIterableSource;
-  readable?: RemoteFileReadable;
-  weightBytes: number;
-};
-
 /**
- * Create a McapIndexedReader if it will be possible to do an indexed read. If the file is not
- * indexed or is empty, returns undefined.
+ * Create a McapIndexedReader if it will be possible to do an indexed read. Distinguishes a
+ * genuinely unindexed/empty file (safe, expected fallback to streaming read) from an operational
+ * failure while attempting indexed initialization (e.g. a network/range-read error from the
+ * underlying `readable`, or a malformed/corrupt index) — the latter must NOT be silently treated
+ * as "unindexed", since that would mask a real error behind an unbounded, unpooled eager-streaming
+ * fallback (see `#eagerInner`).
  */
 async function tryCreateIndexedReader(
   readable: McapTypes.IReadable,
   decompressHandlers: McapTypes.DecompressHandlers,
-): Promise<McapIndexedReader | undefined> {
+): Promise<IndexedReaderResult> {
+  let reader: McapIndexedReader;
   try {
-    const reader = await McapIndexedReader.Initialize({ readable, decompressHandlers });
-
-    if (reader.chunkIndexes.length === 0 || reader.channelsById.size === 0) {
-      return undefined;
-    }
-    return reader;
+    reader = await McapIndexedReader.Initialize({ readable, decompressHandlers });
   } catch (err: unknown) {
-    log.error(err);
-    return undefined;
+    const error = err instanceof Error ? err : new Error(String(err));
+    // @mcap/core throws exactly this message (plus a " [library=...]" suffix) when the file has
+    // no summary section at all (footer.summaryStart === 0n) — a genuinely unindexed file, not an
+    // operational failure. Any other message indicates a malformed file or an I/O error bubbling
+    // up from `readable` and must be surfaced as a real failure, not silently swallowed.
+    if (error.message.includes("File is not indexed")) {
+      return { status: "unindexed" };
+    }
+    log.error(error);
+    return { status: "failed", error };
   }
+
+  if (reader.chunkIndexes.length === 0 || reader.channelsById.size === 0) {
+    // Parsed successfully but genuinely has no index data (e.g. an empty recording).
+    return { status: "unindexed" };
+  }
+  return { status: "indexed", reader };
 }
 
 export class McapIterableSource implements ISerializedIterableSource {
@@ -73,6 +76,12 @@ export class McapIterableSource implements ISerializedIterableSource {
   #pool: HydratedSourcePool | undefined;
   #start?: Time;
   #end?: Time;
+  // Session-persistent remote connection + byte cache for `type: "url"` indexed sources.
+  // Created once (on first hydration) and reused across every subsequent re-hydration, so pool
+  // eviction only discards the heavyweight indexed-reader/parsed-channel state. Closed only in
+  // terminate(). Undefined for "file" sources and for remote sources that fail indexed init or
+  // fall back to eager unindexed streaming.
+  #persistentReadable: RemoteFileReadable | undefined;
 
   public readonly sourceType = "serialized";
 
@@ -100,12 +109,17 @@ export class McapIterableSource implements ISerializedIterableSource {
         await source.file.slice(0, 1).arrayBuffer();
 
         const readable = new BlobReadable(source.file);
-        const reader = await tryCreateIndexedReader(readable, decompressHandlers);
-        if (reader) {
+        const result = await tryCreateIndexedReader(readable, decompressHandlers);
+        if (result.status === "failed") {
+          // A real initialization failure (not "unindexed") must not be masked by the eager,
+          // unbounded streaming fallback — surface it so the caller sees an actual error.
+          throw result.error;
+        }
+        if (result.status === "indexed") {
           return {
-            inner: new McapIndexedIterableSource(reader),
+            inner: new McapIndexedIterableSource(result.reader),
             indexed: true,
-            weightBytes: estimateReaderWeightBytes(reader, 0),
+            weightBytes: estimateReaderWeightBytes(result.reader),
           };
         }
         return {
@@ -118,22 +132,39 @@ export class McapIterableSource implements ISerializedIterableSource {
         };
       }
       case "url": {
-        const readable = new RemoteFileReadable(source.url, {
-          cacheSizeInBytes: source.cacheSizeInBytes,
-          readAheadEnabled: source.readAheadEnabled,
-        });
-        await readable.open();
-        const reader = await tryCreateIndexedReader(readable, decompressHandlers);
-        if (reader) {
+        let readable = this.#persistentReadable;
+        if (!readable) {
+          readable = new RemoteFileReadable(source.url, {
+            cacheSizeInBytes: source.cacheSizeInBytes,
+            readAheadEnabled: source.readAheadEnabled,
+            ...(source.readAheadBufferBytes != undefined
+              ? { readAheadBufferBytes: source.readAheadBufferBytes }
+              : {}),
+          });
+          await readable.open();
+          this.#persistentReadable = readable;
+        }
+        const result = await tryCreateIndexedReader(readable, decompressHandlers);
+        if (result.status === "failed") {
+          // A real initialization failure (not "unindexed") must not be masked by re-fetching the
+          // whole file via the eager, unbounded streaming fallback — surface the actual error.
+          readable.close();
+          this.#persistentReadable = undefined;
+          throw result.error;
+        }
+        if (result.status === "indexed") {
           return {
-            inner: new McapIndexedIterableSource(reader),
+            inner: new McapIndexedIterableSource(result.reader),
             readable,
             indexed: true,
-            weightBytes: estimateReaderWeightBytes(reader, source.cacheSizeInBytes ?? 0),
+            weightBytes: estimateReaderWeightBytes(result.reader),
           };
         }
-        // Unindexed remote fallback: single-pass streaming read of the whole file.
+        // Unindexed remote fallback: single-pass streaming read of the whole file. This path
+        // bypasses the pool entirely and never re-hydrates, so there is no benefit in keeping the
+        // indexed-init probe connection/cache alive.
         readable.close();
+        this.#persistentReadable = undefined;
         const response = await fetch(source.url);
         if (!response.body) {
           throw new Error(`Unable to stream remote file. <${source.url}>`);
@@ -154,16 +185,19 @@ export class McapIterableSource implements ISerializedIterableSource {
     }
   }
 
-  // Pool hydrator: builds a ready-to-iterate indexed inner (channels parsed) plus its readable so
-  // it can be closed on eviction.
+  // Pool hydrator: builds a ready-to-iterate indexed inner (channels parsed). The underlying
+  // remote readable/connection is session-persistent and intentionally survives pool eviction.
   readonly #hydrator: SourceHydrator<HydratedInner> = {
     open: async () => {
       const { inner, readable, weightBytes } = await this.#openInner();
       await inner.initialize();
       return { inner, readable, weightBytes };
     },
-    close: async ({ readable }) => {
-      readable?.close();
+    close: async (_value) => {
+      // The underlying RemoteFileReadable/connection is session-persistent (see
+      // #persistentReadable) and is intentionally NOT closed here. Eviction only discards the
+      // heavyweight indexed-reader/parsed-channel structures, which are rebuilt on the next
+      // acquire() from the already-open, already-cached remote source.
     },
     weigh: ({ weightBytes }) => weightBytes,
   };
@@ -253,5 +287,9 @@ export class McapIterableSource implements ISerializedIterableSource {
     // Pooled inners are torn down by the pool (owned by MultiIterableSource); only release an
     // eagerly-retained inner here.
     await this.#eagerInner?.terminate?.();
+    // The pool's hydrator.close() intentionally does not close this — it is session-persistent
+    // (see #persistentReadable) and is only closed when the whole source is torn down.
+    this.#persistentReadable?.close();
+    this.#persistentReadable = undefined;
   }
 }

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.types.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.types.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import type { McapIndexedReader } from "@mcap/core";
+
+import type { ISerializedIterableSource } from "../IIterableSource";
+import type { RemoteFileReadable } from "./RemoteFileReadable";
+import type { HydratedSourcePool } from "../shared/HydratedSourcePool";
+
+export type McapSource =
+  | { type: "file"; file: Blob; pool?: HydratedSourcePool }
+  | {
+      type: "url";
+      url: string;
+      cacheSizeInBytes?: number;
+      readAheadEnabled?: boolean;
+      readAheadBufferBytes?: number;
+      pool?: HydratedSourcePool;
+    };
+
+export type HydratedInner = {
+  inner: ISerializedIterableSource;
+  readable?: RemoteFileReadable;
+  weightBytes: number;
+};
+
+export type IndexedReaderResult =
+  | { status: "indexed"; reader: McapIndexedReader }
+  | { status: "unindexed" }
+  | { status: "failed"; error: Error };

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.types.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSource.types.ts
@@ -32,3 +32,10 @@ export type IndexedReaderResult =
   | { status: "indexed"; reader: McapIndexedReader }
   | { status: "unindexed" }
   | { status: "failed"; error: Error };
+
+export type OpenedInner = {
+  inner: ISerializedIterableSource;
+  readable?: RemoteFileReadable;
+  indexed: boolean;
+  weightBytes: number;
+};

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.test.ts
@@ -50,6 +50,33 @@ describe("initialize", () => {
     expect(result).toBeInstanceOf(WorkerSerializedIterableSourceWorker);
   });
 
+  it("should pass hydration overrides through for multiple files", () => {
+    const filename1 = `${BasicBuilder.string()}.mcap`;
+    const filename2 = `${BasicBuilder.string()}.mcap`;
+    const files = [new File(["data"], filename1), new File(["data"], filename2)];
+
+    const result = initialize({
+      files,
+      maxHydratedSources: 3,
+      maxHydratedBytes: 1234,
+      initConcurrency: 2,
+    });
+
+    expect(MultiIterableSource).toHaveBeenCalledWith(
+      {
+        type: "files",
+        files,
+        maxHydratedSources: 3,
+        maxHydratedBytes: 1234,
+        initConcurrency: 2,
+      },
+      McapIterableSource,
+    );
+    expect(WorkerSerializedIterableSourceWorker).toHaveBeenCalled();
+    expect(Comlink.proxy).toHaveBeenCalled();
+    expect(result).toBeInstanceOf(WorkerSerializedIterableSourceWorker);
+  });
+
   it("should initialize with a single URL", () => {
     const url = `http://${BasicBuilder.string()}.com/${BasicBuilder.string()}.mcap`;
 
@@ -70,6 +97,34 @@ describe("initialize", () => {
     const result = initialize({ urls });
 
     expect(MultiIterableSource).toHaveBeenCalledWith({ type: "urls", urls }, McapIterableSource);
+    expect(WorkerSerializedIterableSourceWorker).toHaveBeenCalled();
+    expect(Comlink.proxy).toHaveBeenCalled();
+    expect(result).toBeInstanceOf(WorkerSerializedIterableSourceWorker);
+  });
+
+  it("should pass hydration overrides through for multiple URLs", () => {
+    const urls = [
+      `http://${BasicBuilder.string()}.com/${BasicBuilder.string()}.mcap`,
+      `http://${BasicBuilder.string()}.com/${BasicBuilder.string()}.mcap`,
+    ];
+
+    const result = initialize({
+      urls,
+      maxHydratedSources: 4,
+      maxHydratedBytes: 5678,
+      initConcurrency: 3,
+    });
+
+    expect(MultiIterableSource).toHaveBeenCalledWith(
+      {
+        type: "urls",
+        urls,
+        maxHydratedSources: 4,
+        maxHydratedBytes: 5678,
+        initConcurrency: 3,
+      },
+      McapIterableSource,
+    );
     expect(WorkerSerializedIterableSourceWorker).toHaveBeenCalled();
     expect(Comlink.proxy).toHaveBeenCalled();
     expect(result).toBeInstanceOf(WorkerSerializedIterableSourceWorker);

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.ts
@@ -9,6 +9,7 @@ import * as Comlink from "@lichtblick/comlink";
 import { IterableSourceInitializeArgs } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import { WorkerSerializedIterableSourceWorker } from "@lichtblick/suite-base/players/IterablePlayer/WorkerSerializedIterableSourceWorker";
 import { MultiIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/shared/MultiIterableSource";
+import { pickDefinedHydrationOverrides } from "@lichtblick/suite-base/players/IterablePlayer/shared/multiFileHydrationOptions";
 
 import { McapIterableSource } from "./McapIterableSource";
 
@@ -21,7 +22,7 @@ export function initialize(
     return Comlink.proxy(wrapped);
   } else if (args.files) {
     const source = new MultiIterableSource(
-      { type: "files", files: args.files },
+      { type: "files", files: args.files, ...pickDefinedHydrationOverrides(args) },
       McapIterableSource,
     );
     const wrapped = new WorkerSerializedIterableSourceWorker(source);
@@ -31,7 +32,10 @@ export function initialize(
     const wrapped = new WorkerSerializedIterableSourceWorker(source);
     return Comlink.proxy(wrapped);
   } else if (args.urls) {
-    const source = new MultiIterableSource({ type: "urls", urls: args.urls }, McapIterableSource);
+    const source = new MultiIterableSource(
+      { type: "urls", urls: args.urls, ...pickDefinedHydrationOverrides(args) },
+      McapIterableSource,
+    );
     const wrapped = new WorkerSerializedIterableSourceWorker(source);
     return Comlink.proxy(wrapped);
   }

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.test.ts
@@ -7,12 +7,14 @@ import { RemoteFileReadable } from "./RemoteFileReadable";
 const mockOpen = jest.fn().mockResolvedValue(undefined);
 const mockSize = jest.fn().mockReturnValue(1024);
 const mockRead = jest.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+const mockClose = jest.fn();
 
 jest.mock("@lichtblick/suite-base/util/CachedFilelike", () => {
   return jest.fn().mockImplementation(() => ({
     open: mockOpen,
     size: mockSize,
     read: mockRead,
+    close: mockClose,
   }));
 });
 
@@ -104,6 +106,19 @@ describe("RemoteFileReadable", () => {
       await expect(reader.read(BigInt(Number.MAX_SAFE_INTEGER), BigInt(1))).rejects.toThrow(
         "Read too large",
       );
+    });
+  });
+
+  describe("close", () => {
+    it("should delegate to CachedFilelike.close()", () => {
+      // Given a RemoteFileReadable instance
+      const reader = new RemoteFileReadable(testUrl);
+
+      // When calling close
+      reader.close();
+
+      // Then it should delegate to the internal CachedFilelike
+      expect(mockClose).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.test.ts
@@ -56,6 +56,19 @@ describe("RemoteFileReadable", () => {
         expect.objectContaining({ cacheSizeInBytes: customSize }),
       );
     });
+
+    it("should pass through readAheadBufferBytes when provided", () => {
+      // Given a URL with a bounded read-ahead buffer override
+      const readAheadBufferBytes = 2 * 1024 * 1024;
+
+      // When creating a RemoteFileReadable
+      new RemoteFileReadable(testUrl, { readAheadBufferBytes });
+
+      // Then CachedFilelike should receive the same bounded read-ahead override
+      expect(CachedFilelike).toHaveBeenCalledWith(
+        expect.objectContaining({ readAheadBufferBytes }),
+      );
+    });
   });
 
   describe("open", () => {

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
@@ -53,4 +53,8 @@ export class RemoteFileReadable {
   public async read(offset: bigint, size: bigint): Promise<Uint8Array> {
     return await this.#batchingReadable.read(offset, size);
   }
+
+  public close(): void {
+    this.#remoteReader.close();
+  }
 }

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
@@ -11,13 +11,9 @@ import BrowserHttpReader from "@lichtblick/suite-base/util/BrowserHttpReader";
 import CachedFilelike from "@lichtblick/suite-base/util/CachedFilelike";
 
 import { BatchingReadable } from "./BatchingReadable";
+import type { RemoteFileReadableOptions } from "./RemoteFileReadable.types";
 
 const DEFAULT_CACHE_SIZE_BYTES = 1024 * 1024 * 500; // 500MiB
-
-type RemoteFileReadableOptions = {
-  cacheSizeInBytes?: number;
-  readAheadEnabled?: boolean;
-};
 
 export class RemoteFileReadable {
   readonly #remoteReader: CachedFilelike;
@@ -29,6 +25,7 @@ export class RemoteFileReadable {
       fileReader,
       cacheSizeInBytes: options?.cacheSizeInBytes ?? DEFAULT_CACHE_SIZE_BYTES,
       readAheadEnabled: options?.readAheadEnabled,
+      readAheadBufferBytes: options?.readAheadBufferBytes,
     });
 
     const inner: McapTypes.IReadable = {

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.types.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.types.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export type RemoteFileReadableOptions = {
+  cacheSizeInBytes?: number;
+  readAheadEnabled?: boolean;
+  readAheadBufferBytes?: number;
+};

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/readerWeight.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/readerWeight.test.ts
@@ -5,34 +5,54 @@ import { McapIndexedReader } from "@mcap/core";
 
 import { READER_BASE_BYTES, estimateReaderWeightBytes } from "./readerWeight";
 
-function makeReader(chunkIndexCount: number, channelCount: number): McapIndexedReader {
+function makeReader(
+  chunkIndexCount: number,
+  channelCount: number,
+  messageIndexEntriesPerChunk = 0,
+): McapIndexedReader {
   return {
-    chunkIndexes: Array.from({ length: chunkIndexCount }, () => ({})),
+    chunkIndexes: Array.from({ length: chunkIndexCount }, () => ({
+      messageIndexOffsets: new Map(
+        Array.from({ length: messageIndexEntriesPerChunk }, (_, i) => [i, 0n]),
+      ),
+    })),
     channelsById: new Map(Array.from({ length: channelCount }, (_, i) => [i, {}])),
   } as unknown as McapIndexedReader;
 }
 
 describe("estimateReaderWeightBytes", () => {
   it("returns the base weight for a reader with no chunks or channels", () => {
-    // GIVEN: a reader with no chunk indexes or channels and no cache bytes.
+    // GIVEN: a reader with no chunk indexes or channels.
     const reader = makeReader(0, 0);
 
     // WHEN: estimating its weight.
-    const weight = estimateReaderWeightBytes(reader, 0);
+    const weight = estimateReaderWeightBytes(reader);
 
     // THEN: only the fixed base overhead is counted.
     expect(weight).toBe(READER_BASE_BYTES);
   });
 
   it("scales with chunk index count", () => {
-    // GIVEN: a reader with 10 chunk indexes.
+    // GIVEN: a reader with 10 chunk indexes and no per-chunk message-index entries.
     const reader = makeReader(10, 0);
 
     // WHEN: estimating its weight.
-    const weight = estimateReaderWeightBytes(reader, 0);
+    const weight = estimateReaderWeightBytes(reader);
 
-    // THEN: the weight includes the per-chunk-index contribution.
-    expect(weight).toBe(READER_BASE_BYTES + 10 * 512);
+    // THEN: the weight includes the per-chunk-index base contribution.
+    expect(weight).toBe(READER_BASE_BYTES + 10 * 128);
+  });
+
+  it("scales with per-chunk messageIndexOffsets entries (dominant real cost for many-channel files)", () => {
+    // GIVEN: a reader with 10 chunk indexes, each covering 20 channels (200 total map entries).
+    const reader = makeReader(10, 0, 20);
+
+    // WHEN: estimating its weight.
+    const weight = estimateReaderWeightBytes(reader);
+
+    // THEN: the weight includes the per-chunk-index base PLUS the per-message-index-entry cost,
+    // which scales with chunkCount × channelsPerChunk, not chunk count alone.
+    expect(weight).toBe(READER_BASE_BYTES + 10 * 128 + 10 * 20 * 64);
   });
 
   it("scales with channel count", () => {
@@ -40,20 +60,20 @@ describe("estimateReaderWeightBytes", () => {
     const reader = makeReader(0, 5);
 
     // WHEN: estimating its weight.
-    const weight = estimateReaderWeightBytes(reader, 0);
+    const weight = estimateReaderWeightBytes(reader);
 
     // THEN: the weight includes the per-channel contribution.
     expect(weight).toBe(READER_BASE_BYTES + 5 * 16 * 1024);
   });
 
-  it("adds the provided cache bytes on top of the base weight", () => {
-    // GIVEN: a reader with no chunks/channels and a non-zero cache budget.
-    const reader = makeReader(0, 0);
+  it("combines chunk, message-index, and channel contributions without any external cache budget", () => {
+    // GIVEN: a reader with 2 chunk indexes, 3 message-index entries per chunk, and 4 channels.
+    const reader = makeReader(2, 4, 3);
 
-    // WHEN: estimating its weight with 1024 cache bytes.
-    const weight = estimateReaderWeightBytes(reader, 1024);
+    // WHEN: estimating its weight.
+    const weight = estimateReaderWeightBytes(reader);
 
-    // THEN: the cache bytes are added on top of the base weight.
-    expect(weight).toBe(READER_BASE_BYTES + 1024);
+    // THEN: only the evictable indexed-reader structures contribute to the pool weight.
+    expect(weight).toBe(READER_BASE_BYTES + 2 * 128 + 2 * 3 * 64 + 4 * 16 * 1024);
   });
 });

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/readerWeight.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/readerWeight.test.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { McapIndexedReader } from "@mcap/core";
+
+import { READER_BASE_BYTES, estimateReaderWeightBytes } from "./readerWeight";
+
+function makeReader(chunkIndexCount: number, channelCount: number): McapIndexedReader {
+  return {
+    chunkIndexes: Array.from({ length: chunkIndexCount }, () => ({})),
+    channelsById: new Map(Array.from({ length: channelCount }, (_, i) => [i, {}])),
+  } as unknown as McapIndexedReader;
+}
+
+describe("estimateReaderWeightBytes", () => {
+  it("returns the base weight for a reader with no chunks or channels", () => {
+    // GIVEN: a reader with no chunk indexes or channels and no cache bytes.
+    const reader = makeReader(0, 0);
+
+    // WHEN: estimating its weight.
+    const weight = estimateReaderWeightBytes(reader, 0);
+
+    // THEN: only the fixed base overhead is counted.
+    expect(weight).toBe(READER_BASE_BYTES);
+  });
+
+  it("scales with chunk index count", () => {
+    // GIVEN: a reader with 10 chunk indexes.
+    const reader = makeReader(10, 0);
+
+    // WHEN: estimating its weight.
+    const weight = estimateReaderWeightBytes(reader, 0);
+
+    // THEN: the weight includes the per-chunk-index contribution.
+    expect(weight).toBe(READER_BASE_BYTES + 10 * 512);
+  });
+
+  it("scales with channel count", () => {
+    // GIVEN: a reader with 5 channels.
+    const reader = makeReader(0, 5);
+
+    // WHEN: estimating its weight.
+    const weight = estimateReaderWeightBytes(reader, 0);
+
+    // THEN: the weight includes the per-channel contribution.
+    expect(weight).toBe(READER_BASE_BYTES + 5 * 16 * 1024);
+  });
+
+  it("adds the provided cache bytes on top of the base weight", () => {
+    // GIVEN: a reader with no chunks/channels and a non-zero cache budget.
+    const reader = makeReader(0, 0);
+
+    // WHEN: estimating its weight with 1024 cache bytes.
+    const weight = estimateReaderWeightBytes(reader, 1024);
+
+    // THEN: the cache bytes are added on top of the base weight.
+    expect(weight).toBe(READER_BASE_BYTES + 1024);
+  });
+});

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/readerWeight.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/readerWeight.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { McapIndexedReader } from "@mcap/core";
+
+// Heuristic per-reader resident-memory weights (bytes) used by the pool's byte budget. Absolute
+// values are approximate; the RELATIVE weighting (heavier index/more channels => evicted sooner)
+// is what matters. Calibrate against real datasets before loosening pool defaults.
+export const READER_BASE_BYTES = 2 * 1024 * 1024; // fixed reader/deserializer overhead
+const BYTES_PER_CHUNK_INDEX = 512; // per chunk-index entry retained by McapIndexedReader
+const BYTES_PER_CHANNEL = 16 * 1024; // parsed schema + per-channel deserializer
+
+export function estimateReaderWeightBytes(reader: McapIndexedReader, cacheBytes: number): number {
+  return (
+    READER_BASE_BYTES +
+    reader.chunkIndexes.length * BYTES_PER_CHUNK_INDEX +
+    reader.channelsById.size * BYTES_PER_CHANNEL +
+    cacheBytes
+  );
+}

--- a/packages/suite-base/src/players/IterablePlayer/Mcap/readerWeight.ts
+++ b/packages/suite-base/src/players/IterablePlayer/Mcap/readerWeight.ts
@@ -7,14 +7,26 @@ import { McapIndexedReader } from "@mcap/core";
 // values are approximate; the RELATIVE weighting (heavier index/more channels => evicted sooner)
 // is what matters. Calibrate against real datasets before loosening pool defaults.
 export const READER_BASE_BYTES = 2 * 1024 * 1024; // fixed reader/deserializer overhead
-const BYTES_PER_CHUNK_INDEX = 512; // per chunk-index entry retained by McapIndexedReader
+// Fixed scalar fields of one ChunkIndex entry (offsets, lengths, times, compression string).
+const BYTES_PER_CHUNK_INDEX_BASE = 128;
+// One entry in a ChunkIndex's `messageIndexOffsets: Map<number, bigint>` — one entry per channel
+// PRESENT IN THAT CHUNK. This dominates real resident memory far more than a chunk index's own
+// fixed fields: total cost scales with chunkCount × channelsPerChunk, not chunk count alone. A
+// prior flat per-chunk-index estimate ignored this entirely, which was the single largest known
+// contributor to underestimating real per-file memory (an internal report observed ~150 MiB
+// resident for a ~611-channel file against a ~26-30 MiB estimate from the old formula).
+const BYTES_PER_MESSAGE_INDEX_ENTRY = 64;
 const BYTES_PER_CHANNEL = 16 * 1024; // parsed schema + per-channel deserializer
 
-export function estimateReaderWeightBytes(reader: McapIndexedReader, cacheBytes: number): number {
+export function estimateReaderWeightBytes(reader: McapIndexedReader): number {
+  let messageIndexEntries = 0;
+  for (const chunkIndex of reader.chunkIndexes) {
+    messageIndexEntries += chunkIndex.messageIndexOffsets.size;
+  }
   return (
     READER_BASE_BYTES +
-    reader.chunkIndexes.length * BYTES_PER_CHUNK_INDEX +
-    reader.channelsById.size * BYTES_PER_CHANNEL +
-    cacheBytes
+    reader.chunkIndexes.length * BYTES_PER_CHUNK_INDEX_BASE +
+    messageIndexEntries * BYTES_PER_MESSAGE_INDEX_ENTRY +
+    reader.channelsById.size * BYTES_PER_CHANNEL
   );
 }

--- a/packages/suite-base/src/players/IterablePlayer/WorkerSerializedIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/WorkerSerializedIterableSource.test.ts
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { ComlinkWrap } from "@lichtblick/den/worker";
+
+import { WorkerSerializedIterableSource } from "./WorkerSerializedIterableSource";
+
+jest.mock("@lichtblick/den/worker", () => ({
+  ComlinkWrap: jest.fn(),
+}));
+
+const mockComlinkWrap = ComlinkWrap as jest.MockedFunction<typeof ComlinkWrap>;
+
+function makeMockRemote(overrides: { terminate?: jest.Mock } = {}) {
+  return {
+    initialize: jest.fn().mockResolvedValue({ topics: [] }),
+    terminate: overrides.terminate ?? jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeSource(): WorkerSerializedIterableSource {
+  return new WorkerSerializedIterableSource({
+    initWorker: () => ({}) as unknown as Worker,
+    initArgs: {},
+  });
+}
+
+describe("WorkerSerializedIterableSource", () => {
+  beforeEach(() => {
+    mockComlinkWrap.mockReset();
+  });
+
+  it("still disposes the worker when the remote's terminate() rejects", async () => {
+    // GIVEN: an initialized source whose worker-side terminate() rejects.
+    const dispose = jest.fn();
+    const remote = makeMockRemote({ terminate: jest.fn().mockRejectedValue(new Error("boom")) });
+    mockComlinkWrap.mockReturnValueOnce({
+      remote: jest.fn().mockResolvedValue(remote) as any,
+      dispose,
+    });
+    const source = makeSource();
+    await source.initialize();
+
+    // WHEN/THEN: terminate() rejects with the same error...
+    await expect(source.terminate()).rejects.toThrow("boom");
+
+    // ...but the worker is still disposed.
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a concurrent initialize() worker get disposed or cleared by an in-flight terminate()", async () => {
+    // GIVEN: a first initialized worker whose terminate() call is left pending.
+    const dispose1 = jest.fn();
+    let resolveTerminate1: () => void = () => {};
+    const terminate1Promise = new Promise<void>((resolve) => {
+      resolveTerminate1 = resolve;
+    });
+    const remote1 = makeMockRemote({ terminate: jest.fn().mockReturnValue(terminate1Promise) });
+    mockComlinkWrap.mockReturnValueOnce({
+      remote: jest.fn().mockResolvedValue(remote1) as any,
+      dispose: dispose1,
+    });
+    const source = makeSource();
+    await source.initialize();
+
+    // WHEN: terminate() is started but not yet resolved...
+    const firstTerminate = source.terminate();
+
+    // ...and, before it resolves, initialize() is called again, producing a second worker.
+    const dispose2 = jest.fn();
+    const remote2 = makeMockRemote();
+    mockComlinkWrap.mockReturnValueOnce({
+      remote: jest.fn().mockResolvedValue(remote2) as any,
+      dispose: dispose2,
+    });
+    await source.initialize();
+
+    // Let the first terminate()'s remote.terminate() resolve.
+    resolveTerminate1();
+    await firstTerminate;
+
+    // THEN: only the worker captured by the first terminate() call was disposed; the second
+    // (newer) worker from the concurrent initialize() was left untouched.
+    expect(dispose1).toHaveBeenCalledTimes(1);
+    expect(dispose2).not.toHaveBeenCalled();
+
+    // AND: the source still targets the second (newer) worker — a subsequent terminate() operates
+    // on it, proving it wasn't cleared by the earlier in-flight terminate().
+    await source.terminate();
+    expect(remote2.terminate).toHaveBeenCalledTimes(1);
+    expect(dispose2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/suite-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
@@ -137,6 +137,10 @@ export class WorkerSerializedIterableSource implements ISerializedIterableSource
   }
 
   public async terminate(): Promise<void> {
+    // Give the worker-side source (e.g. MultiIterableSource's pool) a chance to release pooled
+    // readers/streams gracefully before the worker is hard-killed below.
+    await this.#sourceWorkerRemote?.terminate();
+
     this.#disposeRemote?.();
     // shouldn't normally have to do this, but if `initialize` is called after again we don't want
     // to reuse the old remote

--- a/packages/suite-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
@@ -137,14 +137,21 @@ export class WorkerSerializedIterableSource implements ISerializedIterableSource
   }
 
   public async terminate(): Promise<void> {
-    // Give the worker-side source (e.g. MultiIterableSource's pool) a chance to release pooled
-    // readers/streams gracefully before the worker is hard-killed below.
-    await this.#sourceWorkerRemote?.terminate();
-
-    this.#disposeRemote?.();
-    // shouldn't normally have to do this, but if `initialize` is called after again we don't want
-    // to reuse the old remote
-    this.#disposeRemote = undefined;
+    // Capture and clear this call's endpoint immediately: a concurrent initialize() call may
+    // replace #sourceWorkerRemote/#disposeRemote with a newer worker while this terminate() is
+    // still awaiting below, and that newer worker must not be touched or disposed by this call.
+    const remote = this.#sourceWorkerRemote;
+    const disposeRemote = this.#disposeRemote;
     this.#sourceWorkerRemote = undefined;
+    this.#disposeRemote = undefined;
+
+    try {
+      // Give the worker-side source (e.g. MultiIterableSource's pool) a chance to release pooled
+      // readers/streams gracefully before the worker is hard-killed below.
+      await remote?.terminate();
+    } finally {
+      // Always dispose the captured worker, even if its graceful terminate() rejected.
+      disposeRemote?.();
+    }
   }
 }

--- a/packages/suite-base/src/players/IterablePlayer/WorkerSerializedIterableSourceWorker.ts
+++ b/packages/suite-base/src/players/IterablePlayer/WorkerSerializedIterableSourceWorker.ts
@@ -62,6 +62,10 @@ export class WorkerSerializedIterableSourceWorker implements ISerializedIterable
     const cursor = new ComlinkTransferIteratorCursor(new IteratorCursor<Uint8Array>(iter, abort));
     return Comlink.proxy(cursor);
   }
+
+  public async terminate(): Promise<void> {
+    await this.#source.terminate?.();
+  }
 }
 
 Comlink.transferHandlers.set("abortsignal", abortSignalTransferHandler);

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
@@ -172,10 +172,7 @@ describe("HydratedSourcePool", () => {
     const pool = new HydratedSourcePool(2);
     const token = {};
     const hydrator = {
-      open: jest
-        .fn()
-        .mockRejectedValueOnce(new Error("boom"))
-        .mockResolvedValueOnce("recovered"),
+      open: jest.fn().mockRejectedValueOnce(new Error("boom")).mockResolvedValueOnce("recovered"),
       close: jest.fn().mockResolvedValue(undefined),
     };
 

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
@@ -295,6 +295,25 @@ describe("HydratedSourcePool", () => {
       expect(hydratorB.close).not.toHaveBeenCalled();
     });
 
+    it("clamps minResident to maxCount so the count cap is still enforced", async () => {
+      // GIVEN: a pool whose configured minResident (5) exceeds its count cap (1).
+      const pool = new HydratedSourcePool({ maxCount: 1, minResident: 5 });
+      const tokenA = {};
+      const tokenB = {};
+      const hydratorA = makeHydrator("A");
+      const hydratorB = makeHydrator("B");
+
+      // WHEN: two unpinned entries are hydrated and released.
+      await pool.acquire(tokenA, hydratorA);
+      pool.release(tokenA);
+      await pool.acquire(tokenB, hydratorB);
+      pool.release(tokenB);
+
+      // THEN: the count cap (1) is enforced rather than the unclamped minResident (5).
+      expect(pool.size).toBe(1);
+      expect(hydratorA.close).toHaveBeenCalledTimes(1);
+    });
+
     it("keeps a single entry heavier than the whole budget", async () => {
       // GIVEN: a pool with a byte budget smaller than one entry.
       const pool = new HydratedSourcePool({ maxBytes: 5 });

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
@@ -5,14 +5,28 @@ import { HydratedSourcePool, SourceHydrator } from "./HydratedSourcePool";
 
 // Build a hydrator whose open() yields a distinct value and whose open/close are jest spies so
 // tests can assert on hydration and eviction.
-function makeHydrator(value: unknown): SourceHydrator<unknown> & {
+function makeHydrator(
+  value: unknown,
+  weight?: number,
+): SourceHydrator<unknown> & {
   open: jest.Mock;
   close: jest.Mock;
+  weigh?: jest.Mock;
 } {
-  return {
+  const hydrator: SourceHydrator<unknown> & {
+    open: jest.Mock;
+    close: jest.Mock;
+    weigh?: jest.Mock;
+  } = {
     open: jest.fn().mockResolvedValue(value),
     close: jest.fn().mockResolvedValue(undefined),
   };
+
+  if (weight != undefined) {
+    hydrator.weigh = jest.fn().mockReturnValue(weight);
+  }
+
+  return hydrator;
 }
 
 describe("HydratedSourcePool", () => {
@@ -188,5 +202,117 @@ describe("HydratedSourcePool", () => {
     expect(hydrator.open).toHaveBeenCalledTimes(2);
 
     pool.release(token);
+  });
+
+  describe("weighted budget", () => {
+    it("evicts by byte budget while keeping heavy entries count low", async () => {
+      // GIVEN: a pool with a 100-byte budget and entries weighing 60 bytes each.
+      const pool = new HydratedSourcePool({ maxBytes: 100 });
+      const tokenA = {};
+      const tokenB = {};
+      const hydratorA = makeHydrator("A", 60);
+      const hydratorB = makeHydrator("B", 60);
+
+      await pool.acquire(tokenA, hydratorA);
+      pool.release(tokenA);
+
+      // WHEN: a second entry pushes total resident bytes over budget.
+      await pool.acquire(tokenB, hydratorB);
+      pool.release(tokenB);
+
+      // THEN: the least-recently-used heavy entry is evicted.
+      expect(hydratorA.close).toHaveBeenCalledTimes(1);
+      expect(hydratorB.close).not.toHaveBeenCalled();
+      expect(pool.size).toBe(1);
+    });
+
+    it("keeps more small entries than a flat count would (weight below budget)", async () => {
+      // GIVEN: a pool with enough byte and count budget for five small entries.
+      const pool = new HydratedSourcePool({ maxBytes: 1000, maxCount: 100 });
+      const tokens = [{}, {}, {}, {}, {}];
+      const hydrators = tokens.map((_, index) => makeHydrator(`value-${index}`, 10));
+
+      // WHEN: five small entries are hydrated and released.
+      for (const [index, token] of tokens.entries()) {
+        await pool.acquire(token, hydrators[index]!);
+        pool.release(token);
+      }
+
+      // THEN: all entries remain resident and none are closed.
+      expect(pool.size).toBe(5);
+      for (const hydrator of hydrators) {
+        expect(hydrator.close).not.toHaveBeenCalled();
+      }
+    });
+
+    it("never evicts below minResident", async () => {
+      // GIVEN: a pool whose byte budget is lower than two resident entries.
+      const pool = new HydratedSourcePool({ maxBytes: 1, minResident: 2 });
+      const tokenA = {};
+      const tokenB = {};
+      const hydratorA = makeHydrator("A", 10);
+      const hydratorB = makeHydrator("B", 10);
+
+      // WHEN: two overweight entries are hydrated and released.
+      await pool.acquire(tokenA, hydratorA);
+      pool.release(tokenA);
+      await pool.acquire(tokenB, hydratorB);
+      pool.release(tokenB);
+
+      // THEN: the minResident floor keeps both entries resident.
+      expect(pool.size).toBe(2);
+      expect(hydratorA.close).not.toHaveBeenCalled();
+      expect(hydratorB.close).not.toHaveBeenCalled();
+    });
+
+    it("keeps a single entry heavier than the whole budget", async () => {
+      // GIVEN: a pool with a byte budget smaller than one entry.
+      const pool = new HydratedSourcePool({ maxBytes: 5 });
+      const token = {};
+      const hydrator = makeHydrator("heavy", 100);
+
+      // WHEN: an entry heavier than the whole budget is hydrated and released.
+      await pool.acquire(token, hydrator);
+      pool.release(token);
+
+      // THEN: the default minResident floor keeps it resident.
+      expect(pool.size).toBe(1);
+      expect(hydrator.close).not.toHaveBeenCalled();
+    });
+  });
+
+  it("concurrent acquire of a failing open does not leak a pin", async () => {
+    // GIVEN: a pool and a hydrator whose shared open rejects for concurrent acquires.
+    const pool = new HydratedSourcePool({ maxBytes: 1000, maxCount: 2 });
+    const failingToken = {};
+    const failingHydrator: SourceHydrator<unknown> & {
+      open: jest.Mock;
+      close: jest.Mock;
+    } = {
+      open: jest.fn().mockRejectedValue(new Error("boom")),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+
+    // WHEN: the same token is acquired twice concurrently.
+    const firstAcquire = pool.acquire(failingToken, failingHydrator);
+    const secondAcquire = pool.acquire(failingToken, failingHydrator);
+    const results = await Promise.allSettled([firstAcquire, secondAcquire]);
+
+    // THEN: both acquires reject and the failed entry is removed.
+    for (const result of results) {
+      expect(result.status).toBe("rejected");
+    }
+    expect(pool.size).toBe(0);
+
+    // WHEN: a different token is acquired after the failure.
+    const goodToken = {};
+    const goodHydrator = makeHydrator("good", 10);
+    const value = await pool.acquire(goodToken, goodHydrator);
+
+    // THEN: the later acquire succeeds without any phantom pin or budget leak.
+    expect(value).toBe("good");
+    expect(pool.size).toBe(1);
+
+    pool.release(goodToken);
   });
 });

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { HydratedSourcePool, SourceHydrator } from "./HydratedSourcePool";
+
+// Build a hydrator whose open() yields a distinct value and whose open/close are jest spies so
+// tests can assert on hydration and eviction.
+function makeHydrator(value: unknown): SourceHydrator<unknown> & {
+  open: jest.Mock;
+  close: jest.Mock;
+} {
+  return {
+    open: jest.fn().mockResolvedValue(value),
+    close: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("HydratedSourcePool", () => {
+  it("reuses an admitted value without calling open again", async () => {
+    // GIVEN: a pool seeded with an already-hydrated value.
+    const pool = new HydratedSourcePool(4);
+    const token = {};
+    const hydrator = makeHydrator("seed-value");
+    await pool.admit(token, hydrator, "seed-value");
+
+    // WHEN: acquiring the same token.
+    const value = await pool.acquire(token, hydrator);
+
+    // THEN: the seeded value is returned and open() is never called.
+    expect(value).toBe("seed-value");
+    expect(hydrator.open).not.toHaveBeenCalled();
+
+    pool.release(token);
+  });
+
+  it("hydrates via open() when not resident and allows eviction after release", async () => {
+    // GIVEN: an empty pool and a token that has not been hydrated.
+    const pool = new HydratedSourcePool(1);
+    const tokenA = {};
+    const hydratorA = makeHydrator("A");
+
+    // WHEN: acquiring the token.
+    const value = await pool.acquire(tokenA, hydratorA);
+
+    // THEN: open() is invoked and its value is returned; the entry stays pinned.
+    expect(value).toBe("A");
+    expect(hydratorA.open).toHaveBeenCalledTimes(1);
+    expect(pool.size).toBe(1);
+
+    // WHEN: releasing and acquiring a second token that pushes over capacity.
+    pool.release(tokenA);
+    const tokenB = {};
+    const hydratorB = makeHydrator("B");
+    await pool.acquire(tokenB, hydratorB);
+
+    // THEN: the now-unpinned first entry is evicted (closed).
+    expect(hydratorA.close).toHaveBeenCalledTimes(1);
+    expect(pool.size).toBe(1);
+
+    pool.release(tokenB);
+  });
+
+  it("enforces capacity by closing the least-recently-used unpinned entry", async () => {
+    // GIVEN: a pool with capacity 2.
+    const pool = new HydratedSourcePool(2);
+    const tokenA = {};
+    const tokenB = {};
+    const tokenC = {};
+    const hydratorA = makeHydrator("A");
+    const hydratorB = makeHydrator("B");
+    const hydratorC = makeHydrator("C");
+
+    // WHEN: admitting/acquiring three distinct unpinned tokens.
+    await pool.admit(tokenA, hydratorA, "A");
+    await pool.admit(tokenB, hydratorB, "B");
+    await pool.acquire(tokenC, hydratorC);
+    pool.release(tokenC);
+
+    // THEN: the least-recently-used token (A) is evicted and size stays within capacity.
+    expect(hydratorA.close).toHaveBeenCalledTimes(1);
+    expect(hydratorB.close).not.toHaveBeenCalled();
+    expect(hydratorC.close).not.toHaveBeenCalled();
+    expect(pool.size).toBeLessThanOrEqual(2);
+  });
+
+  it("never evicts a pinned entry even when over capacity", async () => {
+    // GIVEN: a pool with capacity 2.
+    const pool = new HydratedSourcePool(2);
+    const tokenA = {};
+    const tokenB = {};
+    const tokenC = {};
+    const hydratorA = makeHydrator("A");
+    const hydratorB = makeHydrator("B");
+    const hydratorC = makeHydrator("C");
+
+    // WHEN: acquiring three tokens without releasing any of them.
+    await pool.acquire(tokenA, hydratorA);
+    await pool.acquire(tokenB, hydratorB);
+    await pool.acquire(tokenC, hydratorC);
+
+    // THEN: all three stay resident (pool exceeds capacity) and none are closed.
+    expect(pool.size).toBe(3);
+    expect(hydratorA.close).not.toHaveBeenCalled();
+    expect(hydratorB.close).not.toHaveBeenCalled();
+    expect(hydratorC.close).not.toHaveBeenCalled();
+
+    // WHEN: releasing the least-recently-used token (A), a subsequent acquire triggers eviction.
+    pool.release(tokenA);
+    const tokenD = {};
+    const hydratorD = makeHydrator("D");
+    await pool.acquire(tokenD, hydratorD);
+
+    // THEN: the now-unpinned LRU entry (A) is evicted.
+    expect(hydratorA.close).toHaveBeenCalledTimes(1);
+    expect(hydratorB.close).not.toHaveBeenCalled();
+    expect(hydratorC.close).not.toHaveBeenCalled();
+
+    pool.release(tokenB);
+    pool.release(tokenC);
+    pool.release(tokenD);
+  });
+
+  it("re-hydrates via open() again after a token was evicted", async () => {
+    // GIVEN: a capacity-1 pool where an acquired token is evicted by a second acquire.
+    const pool = new HydratedSourcePool(1);
+    const tokenA = {};
+    const hydratorA = makeHydrator("A");
+
+    await pool.acquire(tokenA, hydratorA);
+    pool.release(tokenA);
+
+    const tokenB = {};
+    const hydratorB = makeHydrator("B");
+    await pool.acquire(tokenB, hydratorB);
+    pool.release(tokenB);
+
+    // THEN: token A was evicted.
+    expect(hydratorA.close).toHaveBeenCalledTimes(1);
+
+    // WHEN: acquiring the evicted token again.
+    const value = await pool.acquire(tokenA, hydratorA);
+
+    // THEN: open() runs a second time to re-hydrate.
+    expect(value).toBe("A");
+    expect(hydratorA.open).toHaveBeenCalledTimes(2);
+
+    pool.release(tokenA);
+  });
+
+  it("terminate() closes all resident entries and empties the pool", async () => {
+    // GIVEN: a pool with two resident entries.
+    const pool = new HydratedSourcePool(4);
+    const tokenA = {};
+    const tokenB = {};
+    const hydratorA = makeHydrator("A");
+    const hydratorB = makeHydrator("B");
+    await pool.admit(tokenA, hydratorA, "A");
+    await pool.acquire(tokenB, hydratorB);
+    pool.release(tokenB);
+
+    // WHEN: terminating the pool.
+    await pool.terminate();
+
+    // THEN: every entry is closed and the pool is empty.
+    expect(hydratorA.close).toHaveBeenCalledTimes(1);
+    expect(hydratorB.close).toHaveBeenCalledTimes(1);
+    expect(pool.size).toBe(0);
+  });
+
+  it("removes a broken entry on rejected open() and allows a later retry", async () => {
+    // GIVEN: a hydrator whose first open() rejects, then succeeds.
+    const pool = new HydratedSourcePool(2);
+    const token = {};
+    const hydrator = {
+      open: jest
+        .fn()
+        .mockRejectedValueOnce(new Error("boom"))
+        .mockResolvedValueOnce("recovered"),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+
+    // WHEN/THEN: the first acquire rejects and the broken entry is removed.
+    await expect(pool.acquire(token, hydrator)).rejects.toThrow("boom");
+    expect(pool.size).toBe(0);
+
+    // WHEN: acquiring again after the failure.
+    const value = await pool.acquire(token, hydrator);
+
+    // THEN: open() runs a second time and the value is returned.
+    expect(value).toBe("recovered");
+    expect(hydrator.open).toHaveBeenCalledTimes(2);
+
+    pool.release(token);
+  });
+});

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
@@ -364,4 +364,176 @@ describe("HydratedSourcePool", () => {
 
     pool.release(goodToken);
   });
+
+  it("three concurrent acquires of a failing open for the same never-before-seen token all reject cleanly", async () => {
+    // GIVEN: a token with no resident entry and a hydrator whose open() always rejects.
+    const pool = new HydratedSourcePool({ maxCount: 2 });
+    const token = {};
+    const hydrator: SourceHydrator<unknown> & { open: jest.Mock; close: jest.Mock } = {
+      open: jest.fn().mockRejectedValue(new Error("boom")),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+
+    // WHEN: a third acquire() joins the same token while the first two are still in flight
+    // (all three synchronously issued before any of them has rejected).
+    const results = await Promise.allSettled([
+      pool.acquire(token, hydrator),
+      pool.acquire(token, hydrator),
+      pool.acquire(token, hydrator),
+    ]);
+
+    // THEN: all three reject, the shared in-flight open() is reused (called once, not three
+    // times), and no phantom pin is left on the removed entry.
+    expect(results.every((result) => result.status === "rejected")).toBe(true);
+    expect(hydrator.open).toHaveBeenCalledTimes(1);
+    expect(pool.size).toBe(0);
+
+    // WHEN: the token is retried after the failure.
+    const value = await pool.acquire(token, { ...hydrator, open: jest.fn().mockResolvedValue("ok") });
+
+    // THEN: the retry succeeds normally.
+    expect(value).toBe("ok");
+    pool.release(token);
+  });
+
+  it("two concurrent successful acquires of the same never-before-seen token each hold their own pin", async () => {
+    // GIVEN: a capacity-1 pool and a token with no resident entry.
+    const pool = new HydratedSourcePool({ maxCount: 1 });
+    const tokenA = {};
+    const hydratorA = makeHydrator("A");
+
+    // WHEN: the same token is acquired twice concurrently and both resolve.
+    const [valueFromFirst, valueFromSecond] = await Promise.all([
+      pool.acquire(tokenA, hydratorA),
+      pool.acquire(tokenA, hydratorA),
+    ]);
+
+    // THEN: open() only runs once (the second caller joins the in-flight hydration) and both
+    // callers get the same value.
+    expect(valueFromFirst).toBe("A");
+    expect(valueFromSecond).toBe("A");
+    expect(hydratorA.open).toHaveBeenCalledTimes(1);
+
+    // WHEN: only one of the two pins is released, then a second token forces an eviction sweep.
+    pool.release(tokenA);
+    const tokenB = {};
+    const hydratorB = makeHydrator("B");
+    await pool.acquire(tokenB, hydratorB);
+
+    // THEN: the entry is still pinned once (the second acquire's pin), so it must NOT be evicted.
+    expect(hydratorA.close).not.toHaveBeenCalled();
+    pool.release(tokenB);
+
+    // WHEN: the second pin is also released, and eviction is triggered again.
+    pool.release(tokenA);
+    const tokenC = {};
+    const hydratorC = makeHydrator("C");
+    await pool.acquire(tokenC, hydratorC);
+
+    // THEN: pins correctly reached 0 after both releases, so the entry is now evictable.
+    expect(hydratorA.close).toHaveBeenCalledTimes(1);
+    pool.release(tokenC);
+  });
+
+  it("double-releasing a token does not make pins negative or trigger adverse eviction behavior", async () => {
+    // GIVEN: a token acquired (and released) exactly once.
+    const pool = new HydratedSourcePool({ maxCount: 2 });
+    const token = {};
+    const hydrator = makeHydrator("A");
+    await pool.acquire(token, hydrator);
+    pool.release(token);
+
+    // WHEN: releasing the same token again (more times than it was acquired).
+    pool.release(token);
+    pool.release(token);
+
+    // THEN: the entry is untouched (guarded by `if (entry.pins > 0)`) — it's simply unpinned,
+    // not closed or removed, and a later acquire still reuses it without re-opening.
+    expect(hydrator.close).not.toHaveBeenCalled();
+    expect(pool.size).toBe(1);
+    const value = await pool.acquire(token, hydrator);
+    expect(value).toBe("A");
+    expect(hydrator.open).toHaveBeenCalledTimes(1);
+    pool.release(token);
+  });
+
+  it("release() on a token with no resident entry is a harmless no-op", () => {
+    // GIVEN: an empty pool and a token that was never acquired or admitted.
+    const pool = new HydratedSourcePool({ maxCount: 2 });
+    const token = {};
+
+    // WHEN/THEN: releasing it does not throw and leaves the pool untouched.
+    expect(() => {
+      pool.release(token);
+    }).not.toThrow();
+    expect(pool.size).toBe(0);
+  });
+
+  it(
+    "documents (does not 'fix'): release()'s fire-and-forget eviction may let a synchronous " +
+      "re-acquire re-open a token before the evicted instance's close() finishes, while pool " +
+      "accounting itself stays consistent",
+    async () => {
+      // GIVEN: two tokens pinned simultaneously so the pool sits over its count cap (both
+      // unevictable while pinned) and a hydrator for A with a manually-controlled, slow close().
+      const pool = new HydratedSourcePool({ maxCount: 1 });
+      const tokenA = {};
+      let resolveClose: (() => void) | undefined;
+      const closeStarted = jest.fn();
+      const closeFinished = jest.fn();
+      const hydratorA: SourceHydrator<unknown> & { open: jest.Mock; close: jest.Mock } = {
+        open: jest.fn().mockResolvedValue("A-instance"),
+        close: jest.fn().mockImplementation(async () => {
+          closeStarted();
+          await new Promise<void>((resolve) => {
+            resolveClose = resolve;
+          });
+          closeFinished();
+        }),
+      };
+      await pool.acquire(tokenA, hydratorA);
+
+      const tokenB = {};
+      const hydratorB = makeHydrator("B");
+      await pool.acquire(tokenB, hydratorB);
+      expect(pool.size).toBe(2); // over the count cap, but both pinned so unevictable.
+
+      // WHEN: releasing A (synchronously starts, but does not await, an eviction sweep that
+      // deletes A's map entry before hydrator.close() is actually invoked) immediately followed,
+      // in the same synchronous tick, by re-acquiring A.
+      pool.release(tokenA);
+      const reacquirePromise = pool.acquire(tokenA, hydratorA);
+
+      // THEN: the re-acquire already took the "not resident" branch and called open() a second
+      // time, because the abandoned entry was synchronously removed from the map by release()'s
+      // eviction sweep before this line ran.
+      expect(hydratorA.open).toHaveBeenCalledTimes(2);
+
+      // Flush microtasks so the abandoned eviction sweep's own close() call gets a chance to
+      // start (it awaits `entry.value` first), without allowing it to finish.
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+      }
+
+      // THEN: open() (for the new instance) and close() (for the evicted instance) are both
+      // in flight at the same time for the SAME token — a real, if narrow, resource-lifecycle
+      // race inherent to the opportunistic/non-blocking eviction design.
+      expect(closeStarted).toHaveBeenCalledTimes(1);
+      expect(closeFinished).not.toHaveBeenCalled();
+
+      // This is intentionally NOT treated as a bug to fix here: the pool's own bookkeeping
+      // (pins/size) stays fully consistent throughout (the old entry was already removed from
+      // the map before the replacement was inserted, so there is no double-count or lost pin),
+      // and the only real hydrator in this codebase (McapIterableSource's) opens a brand-new
+      // RemoteFileReadable/BlobReadable instance on every open() and closes only the specific
+      // readable instance it captured in its own closure — the two overlapping instances share
+      // no mutable state, so the overlap is harmless in practice. Should a future hydrator
+      // introduce shared state between instances for the same token, it would need to guard
+      // against this itself, or this pool would need the `Acquisition<T>` handle refactor.
+      resolveClose?.();
+      await reacquirePromise;
+      pool.release(tokenB);
+      pool.release(tokenA);
+    },
+  );
 });

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
@@ -181,6 +181,36 @@ describe("HydratedSourcePool", () => {
     expect(pool.size).toBe(0);
   });
 
+  it("rejects acquire() after terminate() and does not re-hydrate", async () => {
+    // GIVEN: a terminated pool.
+    const pool = new HydratedSourcePool(2);
+    const token = {};
+    const hydrator = makeHydrator("A");
+    await pool.terminate();
+
+    // WHEN/THEN: acquiring rejects and open() is never called.
+    await expect(pool.acquire(token, hydrator)).rejects.toThrow();
+    expect(hydrator.open).not.toHaveBeenCalled();
+    expect(pool.size).toBe(0);
+  });
+
+  it("closes a duplicate admitted value without re-opening", async () => {
+    // GIVEN: a token already admitted with a value.
+    const pool = new HydratedSourcePool(2);
+    const token = {};
+    const hydrator = makeHydrator("A");
+    await pool.admit(token, hydrator, "first");
+
+    // WHEN: admitting the same token again with a new value.
+    await pool.admit(token, hydrator, "second");
+
+    // THEN: the second value is closed, open() is never called, and one entry remains.
+    expect(hydrator.close).toHaveBeenCalledTimes(1);
+    expect(hydrator.close).toHaveBeenCalledWith("second");
+    expect(hydrator.open).not.toHaveBeenCalled();
+    expect(pool.size).toBe(1);
+  });
+
   it("removes a broken entry on rejected open() and allows a later retry", async () => {
     // GIVEN: a hydrator whose first open() rejects, then succeeds.
     const pool = new HydratedSourcePool(2);

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
@@ -389,7 +389,10 @@ describe("HydratedSourcePool", () => {
     expect(pool.size).toBe(0);
 
     // WHEN: the token is retried after the failure.
-    const value = await pool.acquire(token, { ...hydrator, open: jest.fn().mockResolvedValue("ok") });
+    const value = await pool.acquire(token, {
+      ...hydrator,
+      open: jest.fn().mockResolvedValue("ok"),
+    });
 
     // THEN: the retry succeeds normally.
     expect(value).toBe("ok");

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.test.ts
@@ -32,7 +32,7 @@ function makeHydrator(
 describe("HydratedSourcePool", () => {
   it("reuses an admitted value without calling open again", async () => {
     // GIVEN: a pool seeded with an already-hydrated value.
-    const pool = new HydratedSourcePool(4);
+    const pool = new HydratedSourcePool({ maxCount: 4 });
     const token = {};
     const hydrator = makeHydrator("seed-value");
     await pool.admit(token, hydrator, "seed-value");
@@ -49,7 +49,7 @@ describe("HydratedSourcePool", () => {
 
   it("hydrates via open() when not resident and allows eviction after release", async () => {
     // GIVEN: an empty pool and a token that has not been hydrated.
-    const pool = new HydratedSourcePool(1);
+    const pool = new HydratedSourcePool({ maxCount: 1 });
     const tokenA = {};
     const hydratorA = makeHydrator("A");
 
@@ -76,7 +76,7 @@ describe("HydratedSourcePool", () => {
 
   it("enforces capacity by closing the least-recently-used unpinned entry", async () => {
     // GIVEN: a pool with capacity 2.
-    const pool = new HydratedSourcePool(2);
+    const pool = new HydratedSourcePool({ maxCount: 2 });
     const tokenA = {};
     const tokenB = {};
     const tokenC = {};
@@ -99,7 +99,7 @@ describe("HydratedSourcePool", () => {
 
   it("never evicts a pinned entry even when over capacity", async () => {
     // GIVEN: a pool with capacity 2.
-    const pool = new HydratedSourcePool(2);
+    const pool = new HydratedSourcePool({ maxCount: 2 });
     const tokenA = {};
     const tokenB = {};
     const tokenC = {};
@@ -136,7 +136,7 @@ describe("HydratedSourcePool", () => {
 
   it("re-hydrates via open() again after a token was evicted", async () => {
     // GIVEN: a capacity-1 pool where an acquired token is evicted by a second acquire.
-    const pool = new HydratedSourcePool(1);
+    const pool = new HydratedSourcePool({ maxCount: 1 });
     const tokenA = {};
     const hydratorA = makeHydrator("A");
 
@@ -163,7 +163,7 @@ describe("HydratedSourcePool", () => {
 
   it("terminate() closes all resident entries and empties the pool", async () => {
     // GIVEN: a pool with two resident entries.
-    const pool = new HydratedSourcePool(4);
+    const pool = new HydratedSourcePool({ maxCount: 4 });
     const tokenA = {};
     const tokenB = {};
     const hydratorA = makeHydrator("A");
@@ -183,7 +183,7 @@ describe("HydratedSourcePool", () => {
 
   it("rejects acquire() after terminate() and does not re-hydrate", async () => {
     // GIVEN: a terminated pool.
-    const pool = new HydratedSourcePool(2);
+    const pool = new HydratedSourcePool({ maxCount: 2 });
     const token = {};
     const hydrator = makeHydrator("A");
     await pool.terminate();
@@ -196,7 +196,7 @@ describe("HydratedSourcePool", () => {
 
   it("closes a duplicate admitted value without re-opening", async () => {
     // GIVEN: a token already admitted with a value.
-    const pool = new HydratedSourcePool(2);
+    const pool = new HydratedSourcePool({ maxCount: 2 });
     const token = {};
     const hydrator = makeHydrator("A");
     await pool.admit(token, hydrator, "first");
@@ -213,7 +213,7 @@ describe("HydratedSourcePool", () => {
 
   it("removes a broken entry on rejected open() and allows a later retry", async () => {
     // GIVEN: a hydrator whose first open() rejects, then succeeds.
-    const pool = new HydratedSourcePool(2);
+    const pool = new HydratedSourcePool({ maxCount: 2 });
     const token = {};
     const hydrator = {
       open: jest.fn().mockRejectedValueOnce(new Error("boom")).mockResolvedValueOnce("recovered"),

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
@@ -53,6 +53,7 @@ export class HydratedSourcePool {
   readonly #entries = new Map<object, Entry>();
   #totalWeight = 0;
   #overCapacityReported = false;
+  #terminated = false;
 
   public constructor(capacityOrOptions: number | HydratedSourcePoolOptions) {
     if (typeof capacityOrOptions === "number") {
@@ -80,6 +81,11 @@ export class HydratedSourcePool {
    * pool is already over budget. `hydrator.open` is used for later re-hydration after eviction.
    */
   public async admit<T>(token: object, hydrator: SourceHydrator<T>, value: T): Promise<void> {
+    if (this.#terminated) {
+      // Pool is torn down: never retain new values.
+      await hydrator.close(value);
+      return;
+    }
     const existing = this.#entries.get(token);
     if (existing) {
       // Refresh recency; keep the existing (possibly in-use) value and drop the new one.
@@ -105,9 +111,11 @@ export class HydratedSourcePool {
    * Callers MUST call release(token) exactly once per acquire, ideally in a finally block.
    */
   public async acquire<T>(token: object, hydrator: SourceHydrator<T>): Promise<T> {
+    if (this.#terminated) {
+      throw new Error("HydratedSourcePool has been terminated");
+    }
     const existing = this.#entries.get(token);
     if (existing) {
-      // Refresh recency (LRU) and pin.
       this.#entries.delete(token);
       this.#entries.set(token, existing);
       existing.pins += 1;
@@ -138,10 +146,13 @@ export class HydratedSourcePool {
       );
       return value;
     } catch (err) {
-      // Hydration failed: remove the broken entry so a later acquire can retry. Its weight was
-      // never added to #totalWeight, so there is nothing to roll back.
+      // Hydration failed: remove the broken entry so a later acquire can retry. Guard on entry
+      // identity so a late rejection cannot delete a newer entry re-created for the same token.
+      // Its weight was never added to #totalWeight, so there is nothing to roll back.
       entry.pins -= 1;
-      this.#entries.delete(token);
+      if (this.#entries.get(token) === entry) {
+        this.#entries.delete(token);
+      }
       throw err;
     }
   }
@@ -163,6 +174,8 @@ export class HydratedSourcePool {
 
   /** Close and remove every entry. Use on teardown. */
   public async terminate(): Promise<void> {
+    // Mark terminal before clearing so concurrent acquire()/admit() cannot hydrate or retain.
+    this.#terminated = true;
     const entries = [...this.#entries.entries()];
     this.#entries.clear();
     this.#totalWeight = 0;

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
@@ -5,9 +5,11 @@ import Logger from "@lichtblick/log";
 
 import type { HydratedSourcePoolOptions, SourceHydrator } from "./types";
 
-// Re-exported so existing imports of these types from "./HydratedSourcePool" keep working; their
-// canonical definition now lives in shared/types.ts alongside the other shared contract types.
-export type { HydratedSourcePoolOptions, SourceHydrator };
+// Re-exported so the existing external import of this type from "./HydratedSourcePool" keeps
+// working; its canonical definition now lives in shared/types.ts. HydratedSourcePoolOptions is
+// only used internally here (constructor parameter type) — external consumers import it directly
+// from "./types".
+export type { SourceHydrator };
 
 const log = Logger.getLogger(__filename);
 

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
@@ -50,7 +50,9 @@ export class HydratedSourcePool {
         ? Math.max(1, Math.floor(options.maxCount))
         : Number.POSITIVE_INFINITY;
     this.#maxBytes = options.maxBytes ?? Number.POSITIVE_INFINITY;
-    this.#minResident = Math.max(1, Math.floor(options.minResident ?? 1));
+    // Never let the resident floor exceed the count cap (Math.min with Infinity is a no-op when
+    // maxCount is unset).
+    this.#minResident = Math.min(this.#maxCount, Math.max(1, Math.floor(options.minResident ?? 1)));
   }
 
   // eslint-disable-next-line no-restricted-syntax

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
@@ -28,8 +28,8 @@ type Entry = {
  * bound, but never below `minResident` entries and never while pinned (so the pool may temporarily
  * exceed its bounds when more than the budget's worth of sources are active at once).
  *
- * Backward compatible: `new HydratedSourcePool(n)` is a pure count cap (`maxCount=n`,
- * `maxBytes=Infinity`), and with no `weigh` hook every entry weighs 1.
+ * With no `maxBytes` set the pool is a pure count cap, and with no `weigh` hook every entry
+ * weighs 1.
  *
  * A JS Map preserves insertion order, so re-inserting an entry on access implements LRU ordering
  * (oldest first).
@@ -44,19 +44,13 @@ export class HydratedSourcePool {
   #overCapacityReported = false;
   #terminated = false;
 
-  public constructor(capacityOrOptions: number | HydratedSourcePoolOptions) {
-    if (typeof capacityOrOptions === "number") {
-      this.#maxCount = Math.max(1, Math.floor(capacityOrOptions));
-      this.#maxBytes = Number.POSITIVE_INFINITY;
-      this.#minResident = 1;
-    } else {
-      this.#maxCount =
-        capacityOrOptions.maxCount != undefined
-          ? Math.max(1, Math.floor(capacityOrOptions.maxCount))
-          : Number.POSITIVE_INFINITY;
-      this.#maxBytes = capacityOrOptions.maxBytes ?? Number.POSITIVE_INFINITY;
-      this.#minResident = Math.max(1, Math.floor(capacityOrOptions.minResident ?? 1));
-    }
+  public constructor(options: HydratedSourcePoolOptions) {
+    this.#maxCount =
+      options.maxCount != undefined
+        ? Math.max(1, Math.floor(options.maxCount))
+        : Number.POSITIVE_INFINITY;
+    this.#maxBytes = options.maxBytes ?? Number.POSITIVE_INFINITY;
+    this.#minResident = Math.max(1, Math.floor(options.minResident ?? 1));
   }
 
   // eslint-disable-next-line no-restricted-syntax

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import Logger from "@lichtblick/log";
+
+const log = Logger.getLogger(__filename);
+
+export type SourceHydrator<T> = {
+  // Create the heavyweight value (open readable, build reader, parse channels, ...).
+  open: () => Promise<T>;
+  // Release the heavyweight value (close readable/connection, drop references).
+  close: (value: T) => Promise<void>;
+};
+
+type Entry = {
+  hydrator: SourceHydrator<unknown>;
+  value: Promise<unknown>;
+  pins: number;
+};
+
+/**
+ * Bounded LRU pool of hydrated (heavyweight) sources. At most `capacity` entries are kept
+ * resident; least-recently-used *unpinned* entries are closed when the pool is over capacity.
+ * Entries currently in use are pinned via acquire()/release() and are never evicted while pinned,
+ * so the pool may temporarily exceed capacity if more than `capacity` sources are active at once.
+ *
+ * A JS Map preserves insertion order, so re-inserting an entry on access implements LRU ordering
+ * (oldest first).
+ */
+export class HydratedSourcePool {
+  readonly #capacity: number;
+  // Insertion order is LRU order: the first entry is the least-recently-used.
+  readonly #entries = new Map<object, Entry>();
+  #overCapacityReported = false;
+
+  public constructor(capacity: number) {
+    this.#capacity = Math.max(1, Math.floor(capacity));
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  public get size(): number {
+    return this.#entries.size;
+  }
+
+  /**
+   * Seed the pool with an already-hydrated value produced elsewhere (e.g. during initialization),
+   * avoiding a redundant open(). The entry starts unpinned and may be evicted immediately if the
+   * pool is already at capacity. `hydrator.open` is used for later re-hydration after eviction.
+   */
+  public async admit<T>(token: object, hydrator: SourceHydrator<T>, value: T): Promise<void> {
+    const existing = this.#entries.get(token);
+    if (existing) {
+      // Refresh recency; keep the existing (possibly in-use) value and drop the new one.
+      this.#entries.delete(token);
+      this.#entries.set(token, existing);
+      await hydrator.close(value);
+      return;
+    }
+    this.#entries.set(token, {
+      hydrator: hydrator as SourceHydrator<unknown>,
+      value: Promise.resolve(value),
+      pins: 0,
+    });
+    await this.#evictBeyondCapacity();
+  }
+
+  /**
+   * Acquire the hydrated value for `token`, hydrating via `hydrator.open()` if it is not resident.
+   * The entry is pinned until the matching release(token) call, so it cannot be evicted while used.
+   * Callers MUST call release(token) exactly once per acquire, ideally in a finally block.
+   */
+  public async acquire<T>(token: object, hydrator: SourceHydrator<T>): Promise<T> {
+    const existing = this.#entries.get(token);
+    if (existing) {
+      // Refresh recency (LRU) and pin.
+      this.#entries.delete(token);
+      this.#entries.set(token, existing);
+      existing.pins += 1;
+      return (await existing.value) as T;
+    }
+
+    const entry: Entry = {
+      hydrator: hydrator as SourceHydrator<unknown>,
+      value: hydrator.open(),
+      pins: 1,
+    };
+    this.#entries.set(token, entry);
+    try {
+      const value = (await entry.value) as T;
+      await this.#evictBeyondCapacity();
+      log.debug(`hydrated source; resident=${this.#entries.size}/${this.#capacity}`);
+      return value;
+    } catch (err) {
+      // Hydration failed: remove the broken entry so a later acquire can retry.
+      entry.pins -= 1;
+      this.#entries.delete(token);
+      throw err;
+    }
+  }
+
+  /** Release one pin previously taken by acquire(). Unpinned entries become evictable. */
+  public release(token: object): void {
+    const entry = this.#entries.get(token);
+    if (!entry) {
+      return;
+    }
+    if (entry.pins > 0) {
+      entry.pins -= 1;
+    }
+    // Opportunistically reclaim memory if we are over capacity and this entry is now evictable.
+    void this.#evictBeyondCapacity().catch((err: unknown) => {
+      log.error("HydratedSourcePool eviction failed", err);
+    });
+  }
+
+  /** Close and remove every entry. Use on teardown. */
+  public async terminate(): Promise<void> {
+    const entries = [...this.#entries.entries()];
+    this.#entries.clear();
+    await Promise.all(
+      entries.map(async ([, entry]) => {
+        try {
+          await entry.hydrator.close(await entry.value);
+        } catch (err) {
+          log.error("HydratedSourcePool terminate close failed", err);
+        }
+      }),
+    );
+  }
+
+  // Close least-recently-used unpinned entries until at or below capacity, or until only pinned
+  // entries remain (in which case the pool temporarily exceeds capacity).
+  async #evictBeyondCapacity(): Promise<void> {
+    while (this.#entries.size > this.#capacity) {
+      let evictKey: object | undefined;
+      for (const [key, entry] of this.#entries) {
+        if (entry.pins === 0) {
+          evictKey = key;
+          break;
+        }
+      }
+      if (evictKey == undefined) {
+        return; // All remaining entries are pinned/in-use.
+      }
+      if (!this.#overCapacityReported) {
+        this.#overCapacityReported = true;
+        log.info(
+          `HydratedSourcePool over capacity: capping resident sources at ${this.#capacity} and re-opening others on demand.`,
+        );
+      }
+      const entry = this.#entries.get(evictKey)!;
+      // Delete before awaiting close so concurrent evictions never target the same entry twice.
+      this.#entries.delete(evictKey);
+      try {
+        await entry.hydrator.close(await entry.value);
+      } catch (err) {
+        log.error("HydratedSourcePool evict close failed", err);
+      }
+      log.debug(`evicted LRU source; resident=${this.#entries.size}/${this.#capacity}`);
+    }
+  }
+}

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
@@ -3,17 +3,13 @@
 
 import Logger from "@lichtblick/log";
 
-const log = Logger.getLogger(__filename);
+import type { HydratedSourcePoolOptions, SourceHydrator } from "./types";
 
-export type SourceHydrator<T> = {
-  // Create the heavyweight value (open readable, build reader, parse channels, ...).
-  open: () => Promise<T>;
-  // Release the heavyweight value (close readable/connection, drop references).
-  close: (value: T) => Promise<void>;
-  // Optional estimated resident memory (bytes) of the hydrated value, used by the byte budget.
-  // When omitted, every entry weighs 1 so the pool behaves as a pure count cap.
-  weigh?: (value: T) => number;
-};
+// Re-exported so existing imports of these types from "./HydratedSourcePool" keep working; their
+// canonical definition now lives in shared/types.ts alongside the other shared contract types.
+export type { HydratedSourcePoolOptions, SourceHydrator };
+
+const log = Logger.getLogger(__filename);
 
 type Entry = {
   hydrator: SourceHydrator<unknown>;
@@ -21,15 +17,6 @@ type Entry = {
   pins: number;
   // Estimated resident bytes for this entry. 0 until the value resolves (for acquire()).
   weight: number;
-};
-
-export type HydratedSourcePoolOptions = {
-  // Primary limiter: evict LRU unpinned entries while total estimated bytes exceeds this.
-  maxBytes?: number;
-  // Safety cap on resident entry count (bounds open connections/readers regardless of weight).
-  maxCount?: number;
-  // Never evict below this many entries (default 1), even when over the byte/count budget.
-  minResident?: number;
 };
 
 /**

--- a/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts
@@ -10,31 +10,63 @@ export type SourceHydrator<T> = {
   open: () => Promise<T>;
   // Release the heavyweight value (close readable/connection, drop references).
   close: (value: T) => Promise<void>;
+  // Optional estimated resident memory (bytes) of the hydrated value, used by the byte budget.
+  // When omitted, every entry weighs 1 so the pool behaves as a pure count cap.
+  weigh?: (value: T) => number;
 };
 
 type Entry = {
   hydrator: SourceHydrator<unknown>;
   value: Promise<unknown>;
   pins: number;
+  // Estimated resident bytes for this entry. 0 until the value resolves (for acquire()).
+  weight: number;
+};
+
+export type HydratedSourcePoolOptions = {
+  // Primary limiter: evict LRU unpinned entries while total estimated bytes exceeds this.
+  maxBytes?: number;
+  // Safety cap on resident entry count (bounds open connections/readers regardless of weight).
+  maxCount?: number;
+  // Never evict below this many entries (default 1), even when over the byte/count budget.
+  minResident?: number;
 };
 
 /**
- * Bounded LRU pool of hydrated (heavyweight) sources. At most `capacity` entries are kept
- * resident; least-recently-used *unpinned* entries are closed when the pool is over capacity.
- * Entries currently in use are pinned via acquire()/release() and are never evicted while pinned,
- * so the pool may temporarily exceed capacity if more than `capacity` sources are active at once.
+ * Bounded LRU pool of hydrated (heavyweight) sources. Residency is bounded by a hybrid budget:
+ * a primary byte budget (`maxBytes`, via each entry's estimated `weight`) and a safety count cap
+ * (`maxCount`). Least-recently-used *unpinned* entries are closed when the pool is over either
+ * bound, but never below `minResident` entries and never while pinned (so the pool may temporarily
+ * exceed its bounds when more than the budget's worth of sources are active at once).
+ *
+ * Backward compatible: `new HydratedSourcePool(n)` is a pure count cap (`maxCount=n`,
+ * `maxBytes=Infinity`), and with no `weigh` hook every entry weighs 1.
  *
  * A JS Map preserves insertion order, so re-inserting an entry on access implements LRU ordering
  * (oldest first).
  */
 export class HydratedSourcePool {
-  readonly #capacity: number;
+  readonly #maxBytes: number;
+  readonly #maxCount: number;
+  readonly #minResident: number;
   // Insertion order is LRU order: the first entry is the least-recently-used.
   readonly #entries = new Map<object, Entry>();
+  #totalWeight = 0;
   #overCapacityReported = false;
 
-  public constructor(capacity: number) {
-    this.#capacity = Math.max(1, Math.floor(capacity));
+  public constructor(capacityOrOptions: number | HydratedSourcePoolOptions) {
+    if (typeof capacityOrOptions === "number") {
+      this.#maxCount = Math.max(1, Math.floor(capacityOrOptions));
+      this.#maxBytes = Number.POSITIVE_INFINITY;
+      this.#minResident = 1;
+    } else {
+      this.#maxCount =
+        capacityOrOptions.maxCount != undefined
+          ? Math.max(1, Math.floor(capacityOrOptions.maxCount))
+          : Number.POSITIVE_INFINITY;
+      this.#maxBytes = capacityOrOptions.maxBytes ?? Number.POSITIVE_INFINITY;
+      this.#minResident = Math.max(1, Math.floor(capacityOrOptions.minResident ?? 1));
+    }
   }
 
   // eslint-disable-next-line no-restricted-syntax
@@ -45,7 +77,7 @@ export class HydratedSourcePool {
   /**
    * Seed the pool with an already-hydrated value produced elsewhere (e.g. during initialization),
    * avoiding a redundant open(). The entry starts unpinned and may be evicted immediately if the
-   * pool is already at capacity. `hydrator.open` is used for later re-hydration after eviction.
+   * pool is already over budget. `hydrator.open` is used for later re-hydration after eviction.
    */
   public async admit<T>(token: object, hydrator: SourceHydrator<T>, value: T): Promise<void> {
     const existing = this.#entries.get(token);
@@ -56,11 +88,14 @@ export class HydratedSourcePool {
       await hydrator.close(value);
       return;
     }
+    const weight = Math.max(0, hydrator.weigh?.(value) ?? 1);
     this.#entries.set(token, {
       hydrator: hydrator as SourceHydrator<unknown>,
       value: Promise.resolve(value),
       pins: 0,
+      weight,
     });
+    this.#totalWeight += weight;
     await this.#evictBeyondCapacity();
   }
 
@@ -76,22 +111,35 @@ export class HydratedSourcePool {
       this.#entries.delete(token);
       this.#entries.set(token, existing);
       existing.pins += 1;
-      return (await existing.value) as T;
+      try {
+        return (await existing.value) as T;
+      } catch (err) {
+        // A co-pending open() rejected: drop the pin we just added so the (already removed by the
+        // hydrating caller) entry does not leak a phantom pin.
+        existing.pins -= 1;
+        throw err;
+      }
     }
 
     const entry: Entry = {
       hydrator: hydrator as SourceHydrator<unknown>,
       value: hydrator.open(),
       pins: 1,
+      weight: 0,
     };
     this.#entries.set(token, entry);
     try {
       const value = (await entry.value) as T;
+      entry.weight = Math.max(0, hydrator.weigh?.(value) ?? 1);
+      this.#totalWeight += entry.weight;
       await this.#evictBeyondCapacity();
-      log.debug(`hydrated source; resident=${this.#entries.size}/${this.#capacity}`);
+      log.debug(
+        `hydrated source; resident=${this.#entries.size}/${this.#maxCount} bytes=${this.#totalWeight}/${this.#maxBytes}`,
+      );
       return value;
     } catch (err) {
-      // Hydration failed: remove the broken entry so a later acquire can retry.
+      // Hydration failed: remove the broken entry so a later acquire can retry. Its weight was
+      // never added to #totalWeight, so there is nothing to roll back.
       entry.pins -= 1;
       this.#entries.delete(token);
       throw err;
@@ -107,7 +155,7 @@ export class HydratedSourcePool {
     if (entry.pins > 0) {
       entry.pins -= 1;
     }
-    // Opportunistically reclaim memory if we are over capacity and this entry is now evictable.
+    // Opportunistically reclaim memory if we are over budget and this entry is now evictable.
     void this.#evictBeyondCapacity().catch((err: unknown) => {
       log.error("HydratedSourcePool eviction failed", err);
     });
@@ -117,6 +165,7 @@ export class HydratedSourcePool {
   public async terminate(): Promise<void> {
     const entries = [...this.#entries.entries()];
     this.#entries.clear();
+    this.#totalWeight = 0;
     await Promise.all(
       entries.map(async ([, entry]) => {
         try {
@@ -128,10 +177,18 @@ export class HydratedSourcePool {
     );
   }
 
-  // Close least-recently-used unpinned entries until at or below capacity, or until only pinned
-  // entries remain (in which case the pool temporarily exceeds capacity).
+  // True when the pool exceeds either bound and may shed a least-recently-used unpinned entry.
+  #isOverCapacity(): boolean {
+    if (this.#entries.size <= this.#minResident) {
+      return false;
+    }
+    return this.#entries.size > this.#maxCount || this.#totalWeight > this.#maxBytes;
+  }
+
+  // Close least-recently-used unpinned entries until within budget, `minResident` is reached, or
+  // only pinned entries remain (in which case the pool temporarily exceeds its bounds).
   async #evictBeyondCapacity(): Promise<void> {
-    while (this.#entries.size > this.#capacity) {
+    while (this.#isOverCapacity()) {
       let evictKey: object | undefined;
       for (const [key, entry] of this.#entries) {
         if (entry.pins === 0) {
@@ -145,18 +202,19 @@ export class HydratedSourcePool {
       if (!this.#overCapacityReported) {
         this.#overCapacityReported = true;
         log.info(
-          `HydratedSourcePool over capacity: capping resident sources at ${this.#capacity} and re-opening others on demand.`,
+          `HydratedSourcePool over capacity: capping resident sources (maxCount=${this.#maxCount}, maxBytes=${this.#maxBytes}) and re-opening others on demand.`,
         );
       }
       const entry = this.#entries.get(evictKey)!;
       // Delete before awaiting close so concurrent evictions never target the same entry twice.
       this.#entries.delete(evictKey);
+      this.#totalWeight -= entry.weight;
       try {
         await entry.hydrator.close(await entry.value);
       } catch (err) {
         log.error("HydratedSourcePool evict close failed", err);
       }
-      log.debug(`evicted LRU source; resident=${this.#entries.size}/${this.#capacity}`);
+      log.debug(`evicted LRU source; resident=${this.#entries.size}/${this.#maxCount}`);
     }
   }
 }

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
@@ -5,9 +5,11 @@ import { MessageEvent, TopicSelection } from "@lichtblick/suite-base/players/typ
 import InitializationSourceBuilder from "@lichtblick/suite-base/testing/builders/InitializationSourceBuilder";
 import MessageEventBuilder from "@lichtblick/suite-base/testing/builders/MessageEventBuilder";
 import RosTimeBuilder from "@lichtblick/suite-base/testing/builders/RosTimeBuilder";
+import delay from "@lichtblick/suite-base/util/delay";
 import { BasicBuilder } from "@lichtblick/test-builders";
 
 import { IIterableSource, Initialization } from "../IIterableSource";
+import { HydratedSourcePool } from "./HydratedSourcePool";
 import { MultiIterableSource } from "./MultiIterableSource";
 import { MultiSource } from "./types";
 
@@ -65,10 +67,12 @@ describe("MultiIterableSource", () => {
       expect(mockSourceConstructor).toHaveBeenNthCalledWith(1, {
         type: "file",
         file: file1,
+        pool: expect.any(HydratedSourcePool),
       });
       expect(mockSourceConstructor).toHaveBeenNthCalledWith(2, {
         type: "file",
         file: file2,
+        pool: expect.any(HydratedSourcePool),
       });
       expect(initializations).toHaveLength(2);
     });
@@ -91,12 +95,14 @@ describe("MultiIterableSource", () => {
         url: url1,
         cacheSizeInBytes: expect.any(Number),
         readAheadEnabled: false,
+        pool: expect.any(HydratedSourcePool),
       });
       expect(mockSourceConstructor).toHaveBeenNthCalledWith(2, {
         type: "url",
         url: url2,
         cacheSizeInBytes: expect.any(Number),
         readAheadEnabled: false,
+        pool: expect.any(HydratedSourcePool),
       });
       expect(initializations).toHaveLength(2);
     });
@@ -173,6 +179,115 @@ describe("MultiIterableSource", () => {
 
       // THEN: the explicit value overrides the single-url default of true.
       expect(mockSourceConstructor.mock.calls[0]![0].readAheadEnabled).toBe(false);
+    });
+    it("should bound default initialization concurrency for url sources", async () => {
+      // GIVEN: more URL sources than the default remote initialization concurrency.
+      const urls = Array.from({ length: 8 }, () => BasicBuilder.string());
+      let inFlight = 0;
+      let maxInFlight = 0;
+      mockSourceConstructor.mockImplementation(
+        () =>
+          ({
+            initialize: jest.fn().mockImplementation(async () => {
+              inFlight++;
+              maxInFlight = Math.max(maxInFlight, inFlight);
+              await delay(1);
+              inFlight--;
+              return InitializationSourceBuilder.initialization();
+            }),
+            messageIterator: jest.fn().mockResolvedValue({ done: true, value: undefined }),
+            getBackfillMessages: jest.fn().mockResolvedValue([]),
+            getStart: jest.fn().mockReturnValue(RosTimeBuilder.time()),
+            getEnd: jest.fn().mockReturnValue(RosTimeBuilder.time()),
+          }) as jest.Mocked<IIterableSource>,
+      );
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN: initializing all remote sources.
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: no more than four sources initialize concurrently.
+      expect(maxInFlight).toBeLessThanOrEqual(4);
+      expect(mockSourceConstructor).toHaveBeenCalledTimes(urls.length);
+    });
+    it("should bound default initialization concurrency for file sources", async () => {
+      // GIVEN: more file sources than the default initialization concurrency.
+      const files = Array.from({ length: 8 }, () => new Blob([BasicBuilder.string()]));
+      let inFlight = 0;
+      let maxInFlight = 0;
+      mockSourceConstructor.mockImplementation(
+        () =>
+          ({
+            initialize: jest.fn().mockImplementation(async () => {
+              inFlight++;
+              maxInFlight = Math.max(maxInFlight, inFlight);
+              await delay(1);
+              inFlight--;
+              return InitializationSourceBuilder.initialization();
+            }),
+            messageIterator: jest.fn().mockResolvedValue({ done: true, value: undefined }),
+            getBackfillMessages: jest.fn().mockResolvedValue([]),
+            getStart: jest.fn().mockReturnValue(RosTimeBuilder.time()),
+            getEnd: jest.fn().mockReturnValue(RosTimeBuilder.time()),
+          }) as jest.Mocked<IIterableSource>,
+      );
+      const multiSource = new MultiIterableSource(
+        {
+          type: "files",
+          files,
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN: initializing all file sources.
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: no more than the default of four sources initialize concurrently.
+      expect(maxInFlight).toBeLessThanOrEqual(4);
+      expect(mockSourceConstructor).toHaveBeenCalledTimes(files.length);
+    });
+    it("should respect explicit initialization concurrency for url sources", async () => {
+      // GIVEN: a URL source with an explicit lower initialization concurrency.
+      const urls = Array.from({ length: 6 }, () => BasicBuilder.string());
+      let inFlight = 0;
+      let maxInFlight = 0;
+      mockSourceConstructor.mockImplementation(
+        () =>
+          ({
+            initialize: jest.fn().mockImplementation(async () => {
+              inFlight++;
+              maxInFlight = Math.max(maxInFlight, inFlight);
+              await delay(1);
+              inFlight--;
+              return InitializationSourceBuilder.initialization();
+            }),
+            messageIterator: jest.fn().mockResolvedValue({ done: true, value: undefined }),
+            getBackfillMessages: jest.fn().mockResolvedValue([]),
+            getStart: jest.fn().mockReturnValue(RosTimeBuilder.time()),
+            getEnd: jest.fn().mockReturnValue(RosTimeBuilder.time()),
+          }) as jest.Mocked<IIterableSource>,
+      );
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+          initConcurrency: 2,
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN: initializing all remote sources.
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: the explicit concurrency override is enforced.
+      expect(maxInFlight).toBeLessThanOrEqual(2);
+      expect(mockSourceConstructor).toHaveBeenCalledTimes(urls.length);
     });
     it("should allocate equal cache split when few sources do not trigger the minimum floor", async () => {
       // GIVEN: 2 URL sources with the default 500 MiB total cache budget.
@@ -493,6 +608,93 @@ describe("MultiIterableSource", () => {
       const sources = multiSource["sourceImpl"];
       expect(sources[0]).toBe(sourceWithoutStart);
       expect(sources[1]).toBe(sourceWithStart);
+    });
+  });
+
+  describe("HydratedSourcePool wiring", () => {
+    it("should create a single shared pool and pass it to every url source", async () => {
+      // GIVEN: a multi-url source with three URLs.
+      const urls = [BasicBuilder.string(), BasicBuilder.string(), BasicBuilder.string()];
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: every source receives the same pool instance.
+      const pool = mockSourceConstructor.mock.calls[0]![0].pool;
+      expect(pool).toBeInstanceOf(HydratedSourcePool);
+      expect(mockSourceConstructor.mock.calls[1]![0].pool).toBe(pool);
+      expect(mockSourceConstructor.mock.calls[2]![0].pool).toBe(pool);
+    });
+
+    it("should create a single shared pool and pass it to every file source", async () => {
+      // GIVEN: a multi-file source with three files.
+      const multiSource = new MultiIterableSource(
+        { type: "files", files: [new Blob(), new Blob(), new Blob()] },
+        mockSourceConstructor,
+      );
+
+      // WHEN
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: every file source receives the same pool instance.
+      const pool = mockSourceConstructor.mock.calls[0]![0].pool;
+      expect(pool).toBeInstanceOf(HydratedSourcePool);
+      expect(mockSourceConstructor.mock.calls[1]![0].pool).toBe(pool);
+      expect(mockSourceConstructor.mock.calls[2]![0].pool).toBe(pool);
+    });
+
+    it("should honor a maxHydratedSources override without crashing", async () => {
+      // GIVEN: a multi-url source with an explicit maxHydratedSources of 1.
+      const urls = [BasicBuilder.string(), BasicBuilder.string(), BasicBuilder.string()];
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+          maxHydratedSources: 1,
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN: initializing all remote sources.
+      const result = await multiSource.initialize();
+
+      // THEN: a pool is still created and shared, and a merged initialization is returned.
+      expect(mockSourceConstructor.mock.calls[0]![0].pool).toBeInstanceOf(HydratedSourcePool);
+      expect(result.start).toBeDefined();
+      expect(result.end).toBeDefined();
+    });
+
+    it("should terminate all sources and tear down the pool", async () => {
+      // GIVEN: url sources whose terminate is observable.
+      const terminateSpy = jest.fn().mockResolvedValue(undefined);
+      mockSourceConstructor.mockImplementation(() => ({
+        initialize: jest.fn().mockResolvedValue(InitializationSourceBuilder.initialization()),
+        messageIterator: jest.fn().mockResolvedValue({ done: true, value: undefined }),
+        getBackfillMessages: jest.fn().mockResolvedValue([]),
+        getStart: jest.fn().mockReturnValue(RosTimeBuilder.time()),
+        getEnd: jest.fn().mockReturnValue(RosTimeBuilder.time()),
+        terminate: terminateSpy,
+      }));
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls: [BasicBuilder.string(), BasicBuilder.string()],
+        },
+        mockSourceConstructor,
+      );
+      await multiSource.initialize();
+
+      // WHEN: terminating the multi-source.
+      // THEN: it resolves and every source's terminate is called.
+      await expect(multiSource.terminate()).resolves.toBeUndefined();
+      expect(terminateSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
@@ -8,10 +8,12 @@ import RosTimeBuilder from "@lichtblick/suite-base/testing/builders/RosTimeBuild
 import delay from "@lichtblick/suite-base/util/delay";
 import { BasicBuilder } from "@lichtblick/test-builders";
 
-import { IIterableSource, Initialization } from "../IIterableSource";
-import { HydratedSourcePool } from "./HydratedSourcePool";
+import { IIterableSource, Initialization, ISerializedIterableSource } from "../IIterableSource";
+import { HydratedSourcePool, SourceHydrator } from "./HydratedSourcePool";
 import { MultiIterableSource } from "./MultiIterableSource";
 import { MultiSource } from "./types";
+
+const DEFAULT_READ_AHEAD_BUFFER_BYTES = 1024 * 1024 * 2;
 
 // Capture log.warn so individual tests can assert on it.
 // Variables whose names start with "mock" are hoisted by babel-jest alongside jest.mock(),
@@ -119,19 +121,21 @@ describe("MultiIterableSource", () => {
         type: "url",
         url: url1,
         cacheSizeInBytes: expect.any(Number),
-        readAheadEnabled: false,
+        readAheadEnabled: true,
+        readAheadBufferBytes: DEFAULT_READ_AHEAD_BUFFER_BYTES,
         pool: expect.any(HydratedSourcePool),
       });
       expect(mockSourceConstructor).toHaveBeenNthCalledWith(2, {
         type: "url",
         url: url2,
         cacheSizeInBytes: expect.any(Number),
-        readAheadEnabled: false,
+        readAheadEnabled: true,
+        readAheadBufferBytes: DEFAULT_READ_AHEAD_BUFFER_BYTES,
         pool: expect.any(HydratedSourcePool),
       });
       expect(initializations).toHaveLength(2);
     });
-    it("should disable read-ahead by default for multi-url sources", async () => {
+    it("should enable read-ahead by default for multi-url sources", async () => {
       // GIVEN: a multi-url source with three URLs.
       const urls = [BasicBuilder.string(), BasicBuilder.string(), BasicBuilder.string()];
       const multiSource = new MultiIterableSource(
@@ -145,10 +149,10 @@ describe("MultiIterableSource", () => {
       // WHEN
       await multiSource["loadMultipleSources"]();
 
-      // THEN: each constructed source opts out of speculative read-ahead.
-      expect(mockSourceConstructor.mock.calls[0]![0].readAheadEnabled).toBe(false);
-      expect(mockSourceConstructor.mock.calls[1]![0].readAheadEnabled).toBe(false);
-      expect(mockSourceConstructor.mock.calls[2]![0].readAheadEnabled).toBe(false);
+      // THEN: each constructed source keeps bounded speculative read-ahead enabled.
+      expect(mockSourceConstructor.mock.calls[0]![0].readAheadEnabled).toBe(true);
+      expect(mockSourceConstructor.mock.calls[1]![0].readAheadEnabled).toBe(true);
+      expect(mockSourceConstructor.mock.calls[2]![0].readAheadEnabled).toBe(true);
     });
     it("should enable read-ahead by default for a single-url source", async () => {
       // GIVEN: a single-url source.
@@ -167,6 +171,69 @@ describe("MultiIterableSource", () => {
       // THEN: the constructed source keeps legacy read-ahead behavior.
       expect(mockSourceConstructor.mock.calls[0]![0].readAheadEnabled).toBe(true);
     });
+    it("should cap default multi-url readAheadBufferBytes at 2 MiB when per-source cache is larger", async () => {
+      // GIVEN: a multi-url source whose per-source cache is far above 8 MiB.
+      const urls = [BasicBuilder.string(), BasicBuilder.string(), BasicBuilder.string()];
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: each source receives the 2 MiB default cap instead of a larger quarter-cache value.
+      expect(mockSourceConstructor.mock.calls[0]![0].readAheadBufferBytes).toBe(
+        DEFAULT_READ_AHEAD_BUFFER_BYTES,
+      );
+      expect(mockSourceConstructor.mock.calls[1]![0].readAheadBufferBytes).toBe(
+        DEFAULT_READ_AHEAD_BUFFER_BYTES,
+      );
+      expect(mockSourceConstructor.mock.calls[2]![0].readAheadBufferBytes).toBe(
+        DEFAULT_READ_AHEAD_BUFFER_BYTES,
+      );
+    });
+    it("should bound default multi-url readAheadBufferBytes to one quarter of per-source cache when smaller than 2 MiB", async () => {
+      // GIVEN: a multi-url source whose per-source cache works out to 4 MiB.
+      const urls = [BasicBuilder.string(), BasicBuilder.string(), BasicBuilder.string()];
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+          totalCacheSizeInBytes: 1024 * 1024 * 12,
+          minCachePerSourceBytes: 1024 * 1024,
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: the bounded read-ahead uses floor(perSourceCache / 4) = 1 MiB.
+      expect(mockSourceConstructor.mock.calls[0]![0].readAheadBufferBytes).toBe(1024 * 1024);
+      expect(mockSourceConstructor.mock.calls[1]![0].readAheadBufferBytes).toBe(1024 * 1024);
+      expect(mockSourceConstructor.mock.calls[2]![0].readAheadBufferBytes).toBe(1024 * 1024);
+    });
+    it("should leave single-url readAheadBufferBytes undefined to preserve legacy single-file behavior", async () => {
+      // GIVEN: a single-url source.
+      const urls = [BasicBuilder.string()];
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+        },
+        mockSourceConstructor,
+      );
+
+      // WHEN
+      await multiSource["loadMultipleSources"]();
+
+      // THEN: the downstream source falls back to getNewConnection's legacy 50 MiB default.
+      expect(mockSourceConstructor.mock.calls[0]![0].readAheadBufferBytes).toBeUndefined();
+    });
     it("should respect an explicit readAheadEnabled override for multi-url sources", async () => {
       // GIVEN: a multi-url source that explicitly opts into read-ahead.
       const urls = [BasicBuilder.string(), BasicBuilder.string(), BasicBuilder.string()];
@@ -182,7 +249,7 @@ describe("MultiIterableSource", () => {
       // WHEN
       await multiSource["loadMultipleSources"]();
 
-      // THEN: the explicit value overrides the multi-url default of false.
+      // THEN: the explicit value is preserved.
       expect(mockSourceConstructor.mock.calls[0]![0].readAheadEnabled).toBe(true);
       expect(mockSourceConstructor.mock.calls[1]![0].readAheadEnabled).toBe(true);
       expect(mockSourceConstructor.mock.calls[2]![0].readAheadEnabled).toBe(true);
@@ -588,6 +655,103 @@ describe("MultiIterableSource", () => {
       expect(sources[0]).toBe(sourceWithoutStart);
       expect(sources[1]).toBe(sourceWithStart);
     });
+  });
+
+  describe("prewarm stress coverage", () => {
+    it(
+      "resolves initialize after prewarming earliest sources that were evicted during multi-url initialization",
+      async () => {
+        // GIVEN: many URL sources sharing the real bounded HydratedSourcePool so the earliest
+        // initialized sources must be evicted before initialize() finishes.
+        const urls = Array.from({ length: 20 }, (_, index) => `https://example.com/${index}.mcap`);
+        const openCounts = new Map<string, number>();
+        const prewarmCounts = new Map<string, number>();
+
+        type TestResidentValue = { url: string };
+        type TestSourceArgs = { type: "url"; url: string; pool: HydratedSourcePool };
+
+        class TestPooledSource implements ISerializedIterableSource {
+          public readonly sourceType = "serialized";
+          #url: string;
+          #pool: HydratedSourcePool;
+          #start = RosTimeBuilder.time();
+          #end = RosTimeBuilder.time();
+
+          public constructor(args: TestSourceArgs) {
+            this.#url = args.url;
+            this.#pool = args.pool;
+          }
+
+          readonly #hydrator: SourceHydrator<TestResidentValue> = {
+            open: async () => {
+              const index = Number.parseInt(this.#url.split("/").at(-1)!.replace(".mcap", ""), 10);
+              openCounts.set(this.#url, (openCounts.get(this.#url) ?? 0) + 1);
+              await delay(index);
+              return { url: this.#url };
+            },
+            close: async (_value) => {
+              await Promise.resolve();
+            },
+          };
+
+          public async initialize(): Promise<Initialization> {
+            const index = Number.parseInt(this.#url.split("/").at(-1)!.replace(".mcap", ""), 10);
+            const value = await this.#hydrator.open();
+            const initialization = InitializationSourceBuilder.initialization({
+              start: RosTimeBuilder.time({ sec: index, nsec: 0 }),
+              end: RosTimeBuilder.time({ sec: index + 1, nsec: 0 }),
+            });
+            this.#start = initialization.start;
+            this.#end = initialization.end;
+            await this.#pool.admit(this, this.#hydrator, value);
+            return initialization;
+          }
+
+          public async *messageIterator(): AsyncIterableIterator<Readonly<never>> {
+            yield* [];
+          }
+
+          public async getBackfillMessages() {
+            return [];
+          }
+
+          public getStart() {
+            return this.#start;
+          }
+
+          public getEnd() {
+            return this.#end;
+          }
+
+          public async prewarm(): Promise<void> {
+            prewarmCounts.set(this.#url, (prewarmCounts.get(this.#url) ?? 0) + 1);
+            await this.#pool.acquire(this, this.#hydrator);
+            this.#pool.release(this);
+          }
+        }
+
+        const multiSource = new MultiIterableSource(
+          {
+            type: "urls",
+            urls,
+          },
+          TestPooledSource,
+        );
+
+        // WHEN: the real top-level initialize() sorts and prewarms the earliest sources.
+        await expect(multiSource.initialize()).resolves.toBeDefined();
+
+        // THEN: the three earliest-by-start sources were prewarmed exactly once and had to
+        // re-acquire from the real pool after their first initialized residency was evicted.
+        expect(prewarmCounts.get(urls[0]!)).toBe(1);
+        expect(prewarmCounts.get(urls[1]!)).toBe(1);
+        expect(prewarmCounts.get(urls[2]!)).toBe(1);
+        expect(openCounts.get(urls[0]!)).toBe(2);
+        expect(openCounts.get(urls[1]!)).toBe(2);
+        expect(openCounts.get(urls[2]!)).toBe(2);
+      },
+      5000,
+    );
   });
 
   describe("HydratedSourcePool wiring", () => {

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
@@ -29,6 +29,31 @@ jest.mock("@lichtblick/log", () => ({
   })),
 }));
 
+// Shared source-constructor mock that tracks concurrent initialize() calls so tests can assert on
+// the effective initialization concurrency.
+function trackInitConcurrency(): {
+  implementation: () => jest.Mocked<IIterableSource>;
+  getMaxInFlight: () => number;
+} {
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const implementation = () =>
+    ({
+      initialize: jest.fn().mockImplementation(async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await delay(1);
+        inFlight--;
+        return InitializationSourceBuilder.initialization();
+      }),
+      messageIterator: jest.fn().mockResolvedValue({ done: true, value: undefined }),
+      getBackfillMessages: jest.fn().mockResolvedValue([]),
+      getStart: jest.fn().mockReturnValue(RosTimeBuilder.time()),
+      getEnd: jest.fn().mockReturnValue(RosTimeBuilder.time()),
+    }) as jest.Mocked<IIterableSource>;
+  return { implementation, getMaxInFlight: () => maxInFlight };
+}
+
 describe("MultiIterableSource", () => {
   let mockSourceConstructor: jest.Mock;
   let dataSource: MultiSource;
@@ -183,24 +208,8 @@ describe("MultiIterableSource", () => {
     it("should bound default initialization concurrency for url sources", async () => {
       // GIVEN: more URL sources than the default remote initialization concurrency.
       const urls = Array.from({ length: 8 }, () => BasicBuilder.string());
-      let inFlight = 0;
-      let maxInFlight = 0;
-      mockSourceConstructor.mockImplementation(
-        () =>
-          ({
-            initialize: jest.fn().mockImplementation(async () => {
-              inFlight++;
-              maxInFlight = Math.max(maxInFlight, inFlight);
-              await delay(1);
-              inFlight--;
-              return InitializationSourceBuilder.initialization();
-            }),
-            messageIterator: jest.fn().mockResolvedValue({ done: true, value: undefined }),
-            getBackfillMessages: jest.fn().mockResolvedValue([]),
-            getStart: jest.fn().mockReturnValue(RosTimeBuilder.time()),
-            getEnd: jest.fn().mockReturnValue(RosTimeBuilder.time()),
-          }) as jest.Mocked<IIterableSource>,
-      );
+      const { implementation, getMaxInFlight } = trackInitConcurrency();
+      mockSourceConstructor.mockImplementation(implementation);
       const multiSource = new MultiIterableSource(
         {
           type: "urls",
@@ -212,31 +221,16 @@ describe("MultiIterableSource", () => {
       // WHEN: initializing all remote sources.
       await multiSource["loadMultipleSources"]();
 
-      // THEN: no more than four sources initialize concurrently.
-      expect(maxInFlight).toBeLessThanOrEqual(4);
+      // THEN: initialization runs concurrently but no more than four at a time.
+      expect(getMaxInFlight()).toBeGreaterThan(1);
+      expect(getMaxInFlight()).toBeLessThanOrEqual(4);
       expect(mockSourceConstructor).toHaveBeenCalledTimes(urls.length);
     });
     it("should bound default initialization concurrency for file sources", async () => {
       // GIVEN: more file sources than the default initialization concurrency.
       const files = Array.from({ length: 8 }, () => new Blob([BasicBuilder.string()]));
-      let inFlight = 0;
-      let maxInFlight = 0;
-      mockSourceConstructor.mockImplementation(
-        () =>
-          ({
-            initialize: jest.fn().mockImplementation(async () => {
-              inFlight++;
-              maxInFlight = Math.max(maxInFlight, inFlight);
-              await delay(1);
-              inFlight--;
-              return InitializationSourceBuilder.initialization();
-            }),
-            messageIterator: jest.fn().mockResolvedValue({ done: true, value: undefined }),
-            getBackfillMessages: jest.fn().mockResolvedValue([]),
-            getStart: jest.fn().mockReturnValue(RosTimeBuilder.time()),
-            getEnd: jest.fn().mockReturnValue(RosTimeBuilder.time()),
-          }) as jest.Mocked<IIterableSource>,
-      );
+      const { implementation, getMaxInFlight } = trackInitConcurrency();
+      mockSourceConstructor.mockImplementation(implementation);
       const multiSource = new MultiIterableSource(
         {
           type: "files",
@@ -248,31 +242,16 @@ describe("MultiIterableSource", () => {
       // WHEN: initializing all file sources.
       await multiSource["loadMultipleSources"]();
 
-      // THEN: no more than the default of four sources initialize concurrently.
-      expect(maxInFlight).toBeLessThanOrEqual(4);
+      // THEN: initialization runs concurrently but no more than the default of four at a time.
+      expect(getMaxInFlight()).toBeGreaterThan(1);
+      expect(getMaxInFlight()).toBeLessThanOrEqual(4);
       expect(mockSourceConstructor).toHaveBeenCalledTimes(files.length);
     });
     it("should respect explicit initialization concurrency for url sources", async () => {
       // GIVEN: a URL source with an explicit lower initialization concurrency.
       const urls = Array.from({ length: 6 }, () => BasicBuilder.string());
-      let inFlight = 0;
-      let maxInFlight = 0;
-      mockSourceConstructor.mockImplementation(
-        () =>
-          ({
-            initialize: jest.fn().mockImplementation(async () => {
-              inFlight++;
-              maxInFlight = Math.max(maxInFlight, inFlight);
-              await delay(1);
-              inFlight--;
-              return InitializationSourceBuilder.initialization();
-            }),
-            messageIterator: jest.fn().mockResolvedValue({ done: true, value: undefined }),
-            getBackfillMessages: jest.fn().mockResolvedValue([]),
-            getStart: jest.fn().mockReturnValue(RosTimeBuilder.time()),
-            getEnd: jest.fn().mockReturnValue(RosTimeBuilder.time()),
-          }) as jest.Mocked<IIterableSource>,
-      );
+      const { implementation, getMaxInFlight } = trackInitConcurrency();
+      mockSourceConstructor.mockImplementation(implementation);
       const multiSource = new MultiIterableSource(
         {
           type: "urls",
@@ -286,7 +265,7 @@ describe("MultiIterableSource", () => {
       await multiSource["loadMultipleSources"]();
 
       // THEN: the explicit concurrency override is enforced.
-      expect(maxInFlight).toBeLessThanOrEqual(2);
+      expect(getMaxInFlight()).toBeLessThanOrEqual(2);
       expect(mockSourceConstructor).toHaveBeenCalledTimes(urls.length);
     });
     it("should allocate equal cache split when few sources do not trigger the minimum floor", async () => {
@@ -691,10 +670,18 @@ describe("MultiIterableSource", () => {
       );
       await multiSource.initialize();
 
+      // Spy on the shared pool captured from the first source construction.
+      const pool = mockSourceConstructor.mock.calls[0]![0].pool as HydratedSourcePool;
+      const poolTerminateSpy = jest.spyOn(pool, "terminate");
+
       // WHEN: terminating the multi-source.
-      // THEN: it resolves and every source's terminate is called.
+      // THEN: it resolves, every source's terminate is called, and the pool is torn down after.
       await expect(multiSource.terminate()).resolves.toBeUndefined();
       expect(terminateSpy).toHaveBeenCalledTimes(2);
+      expect(poolTerminateSpy).toHaveBeenCalledTimes(1);
+      expect(terminateSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+        poolTerminateSpy.mock.invocationCallOrder[0]!,
+      );
     });
   });
 });

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.test.ts
@@ -658,100 +658,96 @@ describe("MultiIterableSource", () => {
   });
 
   describe("prewarm stress coverage", () => {
-    it(
-      "resolves initialize after prewarming earliest sources that were evicted during multi-url initialization",
-      async () => {
-        // GIVEN: many URL sources sharing the real bounded HydratedSourcePool so the earliest
-        // initialized sources must be evicted before initialize() finishes.
-        const urls = Array.from({ length: 20 }, (_, index) => `https://example.com/${index}.mcap`);
-        const openCounts = new Map<string, number>();
-        const prewarmCounts = new Map<string, number>();
+    it("resolves initialize after prewarming earliest sources that were evicted during multi-url initialization", async () => {
+      // GIVEN: many URL sources sharing the real bounded HydratedSourcePool so the earliest
+      // initialized sources must be evicted before initialize() finishes.
+      const urls = Array.from({ length: 20 }, (_, index) => `https://example.com/${index}.mcap`);
+      const openCounts = new Map<string, number>();
+      const prewarmCounts = new Map<string, number>();
 
-        type TestResidentValue = { url: string };
-        type TestSourceArgs = { type: "url"; url: string; pool: HydratedSourcePool };
+      type TestResidentValue = { url: string };
+      type TestSourceArgs = { type: "url"; url: string; pool: HydratedSourcePool };
 
-        class TestPooledSource implements ISerializedIterableSource {
-          public readonly sourceType = "serialized";
-          #url: string;
-          #pool: HydratedSourcePool;
-          #start = RosTimeBuilder.time();
-          #end = RosTimeBuilder.time();
+      class TestPooledSource implements ISerializedIterableSource {
+        public readonly sourceType = "serialized";
+        #url: string;
+        #pool: HydratedSourcePool;
+        #start = RosTimeBuilder.time();
+        #end = RosTimeBuilder.time();
 
-          public constructor(args: TestSourceArgs) {
-            this.#url = args.url;
-            this.#pool = args.pool;
-          }
-
-          readonly #hydrator: SourceHydrator<TestResidentValue> = {
-            open: async () => {
-              const index = Number.parseInt(this.#url.split("/").at(-1)!.replace(".mcap", ""), 10);
-              openCounts.set(this.#url, (openCounts.get(this.#url) ?? 0) + 1);
-              await delay(index);
-              return { url: this.#url };
-            },
-            close: async (_value) => {
-              await Promise.resolve();
-            },
-          };
-
-          public async initialize(): Promise<Initialization> {
-            const index = Number.parseInt(this.#url.split("/").at(-1)!.replace(".mcap", ""), 10);
-            const value = await this.#hydrator.open();
-            const initialization = InitializationSourceBuilder.initialization({
-              start: RosTimeBuilder.time({ sec: index, nsec: 0 }),
-              end: RosTimeBuilder.time({ sec: index + 1, nsec: 0 }),
-            });
-            this.#start = initialization.start;
-            this.#end = initialization.end;
-            await this.#pool.admit(this, this.#hydrator, value);
-            return initialization;
-          }
-
-          public async *messageIterator(): AsyncIterableIterator<Readonly<never>> {
-            yield* [];
-          }
-
-          public async getBackfillMessages() {
-            return [];
-          }
-
-          public getStart() {
-            return this.#start;
-          }
-
-          public getEnd() {
-            return this.#end;
-          }
-
-          public async prewarm(): Promise<void> {
-            prewarmCounts.set(this.#url, (prewarmCounts.get(this.#url) ?? 0) + 1);
-            await this.#pool.acquire(this, this.#hydrator);
-            this.#pool.release(this);
-          }
+        public constructor(args: TestSourceArgs) {
+          this.#url = args.url;
+          this.#pool = args.pool;
         }
 
-        const multiSource = new MultiIterableSource(
-          {
-            type: "urls",
-            urls,
+        readonly #hydrator: SourceHydrator<TestResidentValue> = {
+          open: async () => {
+            const index = Number.parseInt(this.#url.split("/").at(-1)!.replace(".mcap", ""), 10);
+            openCounts.set(this.#url, (openCounts.get(this.#url) ?? 0) + 1);
+            await delay(index);
+            return { url: this.#url };
           },
-          TestPooledSource,
-        );
+          close: async (_value) => {
+            await Promise.resolve();
+          },
+        };
 
-        // WHEN: the real top-level initialize() sorts and prewarms the earliest sources.
-        await expect(multiSource.initialize()).resolves.toBeDefined();
+        public async initialize(): Promise<Initialization> {
+          const index = Number.parseInt(this.#url.split("/").at(-1)!.replace(".mcap", ""), 10);
+          const value = await this.#hydrator.open();
+          const initialization = InitializationSourceBuilder.initialization({
+            start: RosTimeBuilder.time({ sec: index, nsec: 0 }),
+            end: RosTimeBuilder.time({ sec: index + 1, nsec: 0 }),
+          });
+          this.#start = initialization.start;
+          this.#end = initialization.end;
+          await this.#pool.admit(this, this.#hydrator, value);
+          return initialization;
+        }
 
-        // THEN: the three earliest-by-start sources were prewarmed exactly once and had to
-        // re-acquire from the real pool after their first initialized residency was evicted.
-        expect(prewarmCounts.get(urls[0]!)).toBe(1);
-        expect(prewarmCounts.get(urls[1]!)).toBe(1);
-        expect(prewarmCounts.get(urls[2]!)).toBe(1);
-        expect(openCounts.get(urls[0]!)).toBe(2);
-        expect(openCounts.get(urls[1]!)).toBe(2);
-        expect(openCounts.get(urls[2]!)).toBe(2);
-      },
-      5000,
-    );
+        public async *messageIterator(): AsyncIterableIterator<Readonly<never>> {
+          yield* [];
+        }
+
+        public async getBackfillMessages() {
+          return [];
+        }
+
+        public getStart() {
+          return this.#start;
+        }
+
+        public getEnd() {
+          return this.#end;
+        }
+
+        public async prewarm(): Promise<void> {
+          prewarmCounts.set(this.#url, (prewarmCounts.get(this.#url) ?? 0) + 1);
+          await this.#pool.acquire(this, this.#hydrator);
+          this.#pool.release(this);
+        }
+      }
+
+      const multiSource = new MultiIterableSource(
+        {
+          type: "urls",
+          urls,
+        },
+        TestPooledSource,
+      );
+
+      // WHEN: the real top-level initialize() sorts and prewarms the earliest sources.
+      await expect(multiSource.initialize()).resolves.toBeDefined();
+
+      // THEN: the three earliest-by-start sources were prewarmed exactly once and had to
+      // re-acquire from the real pool after their first initialized residency was evicted.
+      expect(prewarmCounts.get(urls[0]!)).toBe(1);
+      expect(prewarmCounts.get(urls[1]!)).toBe(1);
+      expect(prewarmCounts.get(urls[2]!)).toBe(1);
+      expect(openCounts.get(urls[0]!)).toBe(2);
+      expect(openCounts.get(urls[1]!)).toBe(2);
+      expect(openCounts.get(urls[2]!)).toBe(2);
+    }, 5000);
   });
 
   describe("HydratedSourcePool wiring", () => {

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
@@ -46,17 +46,14 @@ const DEFAULT_CACHE_TOTAL_BYTES = 1024 * 1024 * 500; // 500 MiB
 // the budget into slices smaller than one summary/index read and crash.
 const MIN_CACHE_PER_SOURCE_BYTES = 1024 * 1024 * 10; // 10 MiB
 
-// Bounds the initial request burst and transient memory from concurrent MCAP summary reads.
+// Defaults for the optional MultiSourceHydrationOptions overrides (see shared/types.ts for the
+// rationale behind each knob). Heuristic; tune against real datasets.
 const DEFAULT_INIT_CONCURRENCY = 4;
-
-// Count-cap safety for heavyweight per-file readers; the byte budget is primary.
 const DEFAULT_MAX_HYDRATED_SOURCES = 12;
-
-// Primary byte budget for resident heavyweight readers; the pool evicts LRU readers once estimated
-// resident bytes exceed this. Heuristic — tune against real datasets.
 const DEFAULT_MAX_HYDRATED_BYTES = 1024 * 1024 * 512; // 512 MiB
 
-// Small dedicated prewarm limit: enough for t=0 playback, not a large open/request burst.
+// Earliest-by-start sources to prewarm for t=0 playback. Not part of MultiSourceHydrationOptions:
+// intentionally fixed and small to avoid a large open/request burst.
 const PREWARM_EARLIEST_COUNT = 3;
 
 export class MultiIterableSource<T extends ISerializedIterableSource, P>

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
+import { Semaphore } from "async-mutex";
+
 import Logger from "@lichtblick/log";
 import { compare } from "@lichtblick/rostime";
 import {
@@ -33,6 +35,7 @@ import {
   GetBackfillMessagesArgs,
   ISerializedIterableSource,
 } from "../IIterableSource";
+import { HydratedSourcePool } from "./HydratedSourcePool";
 
 const log = Logger.getLogger(__filename);
 
@@ -45,6 +48,13 @@ const DEFAULT_CACHE_TOTAL_BYTES = 1024 * 1024 * 500; // 500 MiB
 // single metadata read, causing CachedFilelike to throw "Requested more data than cache size".
 const MIN_CACHE_PER_SOURCE_BYTES = 1024 * 1024 * 10; // 10 MiB
 
+// Default number of remote sources initialized concurrently. Bounds the initial request burst and the transient memory spike from concurrent MCAP summary reads.
+const DEFAULT_INIT_CONCURRENCY = 4;
+
+// Default number of heavyweight per-file readers kept resident at once for remote multi-file
+// sessions. Bounds worker memory; sources beyond this are re-opened on demand.
+const DEFAULT_MAX_HYDRATED_SOURCES = 8;
+
 export class MultiIterableSource<T extends ISerializedIterableSource, P>
   implements ISerializedIterableSource
 {
@@ -52,6 +62,7 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
   private SourceConstructor: IterableSourceConstructor<T, P>;
   private dataSource: MultiSource;
   private sourceImpl: IIterableSource<Uint8Array>[] = [];
+  #pool: HydratedSourcePool | undefined;
 
   public constructor(dataSource: MultiSource, SourceConstructor: IterableSourceConstructor<T, P>) {
     this.dataSource = dataSource;
@@ -63,8 +74,10 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
 
     let sources: IIterableSource<Uint8Array>[];
     if (type === "files") {
+      const maxHydrated = this.dataSource.maxHydratedSources ?? DEFAULT_MAX_HYDRATED_SOURCES;
+      this.#pool = new HydratedSourcePool(maxHydrated);
       sources = this.dataSource.files.map(
-        (file) => new this.SourceConstructor({ type: "file", file } as P),
+        (file) => new this.SourceConstructor({ type: "file", file, pool: this.#pool } as P),
       );
     } else {
       // Distribute total cache budget across remote sources with a minimum floor per source.
@@ -90,6 +103,9 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
       const readAheadEnabled: boolean =
         this.dataSource.readAheadEnabled ?? this.dataSource.urls.length === 1;
 
+      const maxHydrated = this.dataSource.maxHydratedSources ?? DEFAULT_MAX_HYDRATED_SOURCES;
+      this.#pool = new HydratedSourcePool(maxHydrated);
+
       sources = this.dataSource.urls.map(
         (url) =>
           new this.SourceConstructor({
@@ -97,17 +113,33 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
             url,
             cacheSizeInBytes: perSourceCache,
             readAheadEnabled,
+            pool: this.#pool,
           } as P),
       );
     }
 
     this.sourceImpl.push(...sources);
 
-    const initializations: Initialization[] = await Promise.all(
-      sources.map(async (source) => await source.initialize()),
-    );
+    // Both local blobs and remote urls are bounded: parsing many MCAP channel schemas concurrently
+    // produces a large transient memory spike (a dominant contributor to worker OOM in big
+    // multi-file sessions).
+    const concurrency = this.dataSource.initConcurrency ?? DEFAULT_INIT_CONCURRENCY;
 
-    return initializations;
+    return await this.initializeSources(sources, concurrency);
+  }
+
+  private async initializeSources(
+    sources: IIterableSource<Uint8Array>[],
+    concurrency: number,
+  ): Promise<Initialization[]> {
+    const semaphore = new Semaphore(Math.max(1, concurrency));
+    // Promise.all preserves input order regardless of settle order, so the returned
+    // initializations stay aligned with `sources`.
+    return await Promise.all(
+      sources.map(
+        async (source) => await semaphore.runExclusive(async () => await source.initialize()),
+      ),
+    );
   }
 
   public async initialize(): Promise<Initialization> {
@@ -176,6 +208,11 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
     }
 
     return backfillMessages;
+  }
+
+  public async terminate(): Promise<void> {
+    await Promise.all(this.sourceImpl.map(async (source) => await source.terminate?.()));
+    await this.#pool?.terminate();
   }
 
   private mergeInitializations(initializations: Initialization[]): Initialization {

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
@@ -173,9 +173,8 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
     }
     const warmCount = Math.min(PREWARM_EARLIEST_COUNT, this.sourceImpl.length);
     for (let index = warmCount - 1; index >= 0; index--) {
-      const source = this.sourceImpl[index] as { prewarm?: () => Promise<void> };
       try {
-        await source.prewarm?.();
+        await this.sourceImpl[index]?.prewarm?.();
       } catch (err) {
         log.debug("prewarmEarliestSources: source prewarm failed", err);
       }

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
@@ -42,24 +42,22 @@ const log = Logger.getLogger(__filename);
 // Default total cache budget for remote sources (500 MiB — same as single-file default).
 const DEFAULT_CACHE_TOTAL_BYTES = 1024 * 1024 * 500; // 500 MiB
 
-// Minimum cache allocated per remote source to prevent crashes when reading MCAP metadata.
-// The MCAP summary section (chunk indexes, schema records, etc.) can be several MiB in size.
-// Without a floor, a linear split across 300+ files produces cache slices smaller than a
-// single metadata read, causing CachedFilelike to throw "Requested more data than cache size".
+// Minimum per-source cache for MCAP metadata reads; without a floor, hundreds of files can split
+// the budget into slices smaller than one summary/index read and crash.
 const MIN_CACHE_PER_SOURCE_BYTES = 1024 * 1024 * 10; // 10 MiB
 
-// Default number of remote sources initialized concurrently. Bounds the initial request burst and the transient memory spike from concurrent MCAP summary reads.
+// Bounds the initial request burst and transient memory from concurrent MCAP summary reads.
 const DEFAULT_INIT_CONCURRENCY = 4;
 
-// Default count-cap safety for heavyweight per-file readers kept resident at once. The byte
-// budget is primary; this was raised from 8 to allow more small-file residents.
+// Count-cap safety for heavyweight per-file readers; the byte budget is primary.
 const DEFAULT_MAX_HYDRATED_SOURCES = 12;
 
-// Default primary byte budget for resident heavyweight readers in a multi-file session. The pool
-// evicts least-recently-used readers once estimated resident bytes exceed this. Heuristic; tune
-// against real datasets (see calibration task). Kept conservative so worker memory stays well
-// under the browser tab limit even if per-reader weight is under-estimated.
+// Primary byte budget for resident heavyweight readers; the pool evicts LRU readers once estimated
+// resident bytes exceed this. Heuristic — tune against real datasets.
 const DEFAULT_MAX_HYDRATED_BYTES = 1024 * 1024 * 512; // 512 MiB
+
+// Small dedicated prewarm limit: enough for t=0 playback, not a large open/request burst.
+const PREWARM_EARLIEST_COUNT = 3;
 
 export class MultiIterableSource<T extends ISerializedIterableSource, P>
   implements ISerializedIterableSource
@@ -69,7 +67,6 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
   private dataSource: MultiSource;
   private sourceImpl: IIterableSource<Uint8Array>[] = [];
   #pool: HydratedSourcePool | undefined;
-  #maxHydratedSources: number = DEFAULT_MAX_HYDRATED_SOURCES;
 
   public constructor(dataSource: MultiSource, SourceConstructor: IterableSourceConstructor<T, P>) {
     this.dataSource = dataSource;
@@ -79,15 +76,16 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
   private async loadMultipleSources(): Promise<Initialization[]> {
     const { type } = this.dataSource;
 
+    // Construct one bounded reader pool before branching; files and URLs use the same overrides.
+    const maxHydratedCount = this.dataSource.maxHydratedSources ?? DEFAULT_MAX_HYDRATED_SOURCES;
+    const maxHydratedBytes = this.dataSource.maxHydratedBytes ?? DEFAULT_MAX_HYDRATED_BYTES;
+    this.#pool = new HydratedSourcePool({
+      maxBytes: maxHydratedBytes,
+      maxCount: maxHydratedCount,
+    });
+
     let sources: IIterableSource<Uint8Array>[];
     if (type === "files") {
-      const maxHydratedCount = this.dataSource.maxHydratedSources ?? DEFAULT_MAX_HYDRATED_SOURCES;
-      const maxHydratedBytes = this.dataSource.maxHydratedBytes ?? DEFAULT_MAX_HYDRATED_BYTES;
-      this.#maxHydratedSources = maxHydratedCount;
-      this.#pool = new HydratedSourcePool({
-        maxBytes: maxHydratedBytes,
-        maxCount: maxHydratedCount,
-      });
       sources = this.dataSource.files.map(
         (file) => new this.SourceConstructor({ type: "file", file, pool: this.#pool } as P),
       );
@@ -115,14 +113,6 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
       const readAheadEnabled: boolean =
         this.dataSource.readAheadEnabled ?? this.dataSource.urls.length === 1;
 
-      const maxHydratedCount = this.dataSource.maxHydratedSources ?? DEFAULT_MAX_HYDRATED_SOURCES;
-      const maxHydratedBytes = this.dataSource.maxHydratedBytes ?? DEFAULT_MAX_HYDRATED_BYTES;
-      this.#maxHydratedSources = maxHydratedCount;
-      this.#pool = new HydratedSourcePool({
-        maxBytes: maxHydratedBytes,
-        maxCount: maxHydratedCount,
-      });
-
       sources = this.dataSource.urls.map(
         (url) =>
           new this.SourceConstructor({
@@ -137,9 +127,8 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
 
     this.sourceImpl.push(...sources);
 
-    // Both local blobs and remote urls are bounded: parsing many MCAP channel schemas concurrently
-    // produces a large transient memory spike (a dominant contributor to worker OOM in big
-    // multi-file sessions).
+    // Bound local and remote initialization: concurrent MCAP summary parsing can spike worker
+    // memory in large multi-file sessions.
     const concurrency = this.dataSource.initConcurrency ?? DEFAULT_INIT_CONCURRENCY;
 
     return await this.initializeSources(sources, concurrency);
@@ -149,7 +138,10 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
     sources: IIterableSource<Uint8Array>[],
     concurrency: number,
   ): Promise<Initialization[]> {
-    const semaphore = new Semaphore(Math.max(1, concurrency));
+    // Normalize overrides to a positive integer permit count.
+    const floored = Math.floor(concurrency);
+    const permits = Number.isFinite(floored) && floored >= 1 ? floored : 1;
+    const semaphore = new Semaphore(permits);
     // Promise.all preserves input order regardless of settle order, so the returned
     // initializations stay aligned with `sources`.
     return await Promise.all(
@@ -170,22 +162,19 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
       return compare(aStart, bStart);
     });
 
-    // I1: warm the earliest-by-start sources so playback beginning at t=0 does not stall
-    // re-hydrating them. Best-effort and bounded by the pool's count cap.
+    // Warm earliest sources so t=0 playback does not stall re-hydrating them.
     await this.#prewarmEarliestSources();
 
     return resultInit;
   }
 
-  // Touch the earliest-by-start sources in DESCENDING start order so the earliest end up
-  // most-recently-used in the pool (least likely to be evicted before playback reaches them).
-  // sourceImpl is sorted ascending by start time before this runs. Errors are non-fatal: a source
-  // that fails to prewarm will simply be hydrated on demand later.
+  // Touch earliest sources in descending start order so the earliest become most-recently-used.
+  // Prewarm failures are non-fatal; the source will hydrate on demand later.
   async #prewarmEarliestSources(): Promise<void> {
     if (!this.#pool) {
       return;
     }
-    const warmCount = Math.min(this.#maxHydratedSources, this.sourceImpl.length);
+    const warmCount = Math.min(PREWARM_EARLIEST_COUNT, this.sourceImpl.length);
     for (let index = warmCount - 1; index >= 0; index--) {
       const source = this.sourceImpl[index] as { prewarm?: () => Promise<void> };
       try {
@@ -204,9 +193,8 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
     // with specific start/end it avoids triggering HTTP requests to irrelevant files.
     const relevantSources = filterSourcesByTimeRange(this.sourceImpl, opt.start, opt.end);
 
-    // Use lazy sequential merge: iterators for later sources are only started
-    // when the current playback time reaches their start time, avoiding
-    // concurrent HTTP byte-range requests to all remote MCAP files at once.
+    // Start later iterators only when playback reaches their start time, avoiding concurrent
+    // byte-range requests to all remote MCAP files.
     yield* mergeSequentialIterators(relevantSources, opt);
   }
   public async getBackfillMessages(
@@ -216,14 +204,9 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
     // This avoids triggering HTTP requests to MCAP files that start after the requested time.
     const relevantSources = filterSourcesForBackfill(this.sourceImpl, args.time);
 
-    // Query sources nearest to the backfill time first and stop as soon as every requested topic
-    // has a value. `sourceImpl` (and therefore `relevantSources`) is sorted ascending by start
-    // time, so we iterate in reverse to begin with the source covering the seek target.
-    //
-    // Without this short-circuit, every preceding source would independently read its last chunk
-    // for the requested topics — a large redundant download. For example, a forward seek across
-    // many small remote MCAPs fetched ~one chunk per preceding file even though only the
-    // nearest source(s) hold the winning "latest message before time" values.
+    // Iterate in reverse (sources are sorted ascending by start) so we begin at the source covering
+    // the seek target and stop once every topic has a value. Without this short-circuit each
+    // preceding source would redundantly read its last chunk for the requested topics.
     const backfillMessages: MessageEvent<Uint8Array>[] = [];
     const missingTopics = new Map(args.topics);
 
@@ -251,8 +234,24 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
   }
 
   public async terminate(): Promise<void> {
-    await Promise.all(this.sourceImpl.map(async (source) => await source.terminate?.()));
-    await this.#pool?.terminate();
+    try {
+      // Attempt every source terminate; one rejection must not skip the others or the pool teardown.
+      const results = await Promise.allSettled(
+        this.sourceImpl.map(async (source) => await source.terminate?.()),
+      );
+      const rejected = results.filter(
+        (result): result is PromiseRejectedResult => result.status === "rejected",
+      );
+      if (rejected.length > 0) {
+        for (const failure of rejected) {
+          log.error("MultiIterableSource source terminate failed", failure.reason);
+        }
+        throw rejected[0]!.reason;
+      }
+    } finally {
+      // Always tear down the pool, even if a source failed to terminate.
+      await this.#pool?.terminate();
+    }
   }
 
   private mergeInitializations(initializations: Initialization[]): Initialization {
@@ -280,7 +279,6 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
       resultInit.topicStats = mergeTopicStats(resultInit.topicStats, init.topicStats);
       resultInit.metadata = mergeMetadata(resultInit.metadata, init.metadata);
       resultInit.alerts.push(...init.alerts);
-      // These methos validate and add to avoid lopp through all topics and datatypes once again
       validateAndAddNewDatatypes(resultInit, init);
       validateAndAddNewTopics(resultInit, init);
     }

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
@@ -51,9 +51,15 @@ const MIN_CACHE_PER_SOURCE_BYTES = 1024 * 1024 * 10; // 10 MiB
 // Default number of remote sources initialized concurrently. Bounds the initial request burst and the transient memory spike from concurrent MCAP summary reads.
 const DEFAULT_INIT_CONCURRENCY = 4;
 
-// Default number of heavyweight per-file readers kept resident at once for remote multi-file
-// sessions. Bounds worker memory; sources beyond this are re-opened on demand.
-const DEFAULT_MAX_HYDRATED_SOURCES = 8;
+// Default count-cap safety for heavyweight per-file readers kept resident at once. The byte
+// budget is primary; this was raised from 8 to allow more small-file residents.
+const DEFAULT_MAX_HYDRATED_SOURCES = 12;
+
+// Default primary byte budget for resident heavyweight readers in a multi-file session. The pool
+// evicts least-recently-used readers once estimated resident bytes exceed this. Heuristic; tune
+// against real datasets (see calibration task). Kept conservative so worker memory stays well
+// under the browser tab limit even if per-reader weight is under-estimated.
+const DEFAULT_MAX_HYDRATED_BYTES = 1024 * 1024 * 512; // 512 MiB
 
 export class MultiIterableSource<T extends ISerializedIterableSource, P>
   implements ISerializedIterableSource
@@ -63,6 +69,7 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
   private dataSource: MultiSource;
   private sourceImpl: IIterableSource<Uint8Array>[] = [];
   #pool: HydratedSourcePool | undefined;
+  #maxHydratedSources: number = DEFAULT_MAX_HYDRATED_SOURCES;
 
   public constructor(dataSource: MultiSource, SourceConstructor: IterableSourceConstructor<T, P>) {
     this.dataSource = dataSource;
@@ -74,8 +81,13 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
 
     let sources: IIterableSource<Uint8Array>[];
     if (type === "files") {
-      const maxHydrated = this.dataSource.maxHydratedSources ?? DEFAULT_MAX_HYDRATED_SOURCES;
-      this.#pool = new HydratedSourcePool(maxHydrated);
+      const maxHydratedCount = this.dataSource.maxHydratedSources ?? DEFAULT_MAX_HYDRATED_SOURCES;
+      const maxHydratedBytes = this.dataSource.maxHydratedBytes ?? DEFAULT_MAX_HYDRATED_BYTES;
+      this.#maxHydratedSources = maxHydratedCount;
+      this.#pool = new HydratedSourcePool({
+        maxBytes: maxHydratedBytes,
+        maxCount: maxHydratedCount,
+      });
       sources = this.dataSource.files.map(
         (file) => new this.SourceConstructor({ type: "file", file, pool: this.#pool } as P),
       );
@@ -103,8 +115,13 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
       const readAheadEnabled: boolean =
         this.dataSource.readAheadEnabled ?? this.dataSource.urls.length === 1;
 
-      const maxHydrated = this.dataSource.maxHydratedSources ?? DEFAULT_MAX_HYDRATED_SOURCES;
-      this.#pool = new HydratedSourcePool(maxHydrated);
+      const maxHydratedCount = this.dataSource.maxHydratedSources ?? DEFAULT_MAX_HYDRATED_SOURCES;
+      const maxHydratedBytes = this.dataSource.maxHydratedBytes ?? DEFAULT_MAX_HYDRATED_BYTES;
+      this.#maxHydratedSources = maxHydratedCount;
+      this.#pool = new HydratedSourcePool({
+        maxBytes: maxHydratedBytes,
+        maxCount: maxHydratedCount,
+      });
 
       sources = this.dataSource.urls.map(
         (url) =>
@@ -153,7 +170,30 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
       return compare(aStart, bStart);
     });
 
+    // I1: warm the earliest-by-start sources so playback beginning at t=0 does not stall
+    // re-hydrating them. Best-effort and bounded by the pool's count cap.
+    await this.#prewarmEarliestSources();
+
     return resultInit;
+  }
+
+  // Touch the earliest-by-start sources in DESCENDING start order so the earliest end up
+  // most-recently-used in the pool (least likely to be evicted before playback reaches them).
+  // sourceImpl is sorted ascending by start time before this runs. Errors are non-fatal: a source
+  // that fails to prewarm will simply be hydrated on demand later.
+  async #prewarmEarliestSources(): Promise<void> {
+    if (!this.#pool) {
+      return;
+    }
+    const warmCount = Math.min(this.#maxHydratedSources, this.sourceImpl.length);
+    for (let index = warmCount - 1; index >= 0; index--) {
+      const source = this.sourceImpl[index] as { prewarm?: () => Promise<void> };
+      try {
+        await source.prewarm?.();
+      } catch (err) {
+        log.debug("prewarmEarliestSources: source prewarm failed", err);
+      }
+    }
   }
 
   public async *messageIterator(

--- a/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts
@@ -39,17 +39,24 @@ import { HydratedSourcePool } from "./HydratedSourcePool";
 
 const log = Logger.getLogger(__filename);
 
-// Default total cache budget for remote sources (500 MiB — same as single-file default).
+// Default total cache budget for remote sources, matching the single-file default.
 const DEFAULT_CACHE_TOTAL_BYTES = 1024 * 1024 * 500; // 500 MiB
 
-// Minimum per-source cache for MCAP metadata reads; without a floor, hundreds of files can split
-// the budget into slices smaller than one summary/index read and crash.
+// Floor per-source cache so large fan-out sessions still fit at least one MCAP summary/index read.
 const MIN_CACHE_PER_SOURCE_BYTES = 1024 * 1024 * 10; // 10 MiB
+
+// Small bounded multi-file read-ahead that coalesces sequential remote reads without outrunning
+// the per-source cache budget.
+const DEFAULT_READ_AHEAD_BUFFER_BYTES = 1024 * 1024 * 2; // 2 MiB
 
 // Defaults for the optional MultiSourceHydrationOptions overrides (see shared/types.ts for the
 // rationale behind each knob). Heuristic; tune against real datasets.
 const DEFAULT_INIT_CONCURRENCY = 4;
-const DEFAULT_MAX_HYDRATED_SOURCES = 12;
+// Raising the resident-reader budget made multi-file OOMs worse because evicted sources must fully
+// rebuild their reader, cache, and parsed channels on re-hydration.
+// Keep the smaller defaults until eviction can preserve the cheap per-source connection/cache
+// while only dropping heavyweight reader state.
+const DEFAULT_MAX_HYDRATED_SOURCES = 4;
 const DEFAULT_MAX_HYDRATED_BYTES = 1024 * 1024 * 512; // 512 MiB
 
 // Earliest-by-start sources to prewarm for t=0 playback. Not part of MultiSourceHydrationOptions:
@@ -87,9 +94,8 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
         (file) => new this.SourceConstructor({ type: "file", file, pool: this.#pool } as P),
       );
     } else {
-      // Distribute total cache budget across remote sources with a minimum floor per source.
-      // A pure linear split (totalCache / n) can produce a per-source budget smaller than a
-      // single MCAP metadata read when n > ~300, causing a crash in CachedFilelike.
+      // Split remote cache budget across sources, but keep a floor so large fan-out sessions do
+      // not drop below a single MCAP metadata read and crash CachedFilelike.
       const totalCache: number = this.dataSource.totalCacheSizeInBytes ?? DEFAULT_CACHE_TOTAL_BYTES;
       const minPerSource: number =
         this.dataSource.minCachePerSourceBytes ?? MIN_CACHE_PER_SOURCE_BYTES;
@@ -104,11 +110,15 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
         );
       }
 
-      // Default to lazy loading for multi-file remote sessions: with many small MCAPs the
-      // speculative whole-file read-ahead would download every file up-front. A single-file
-      // session keeps the legacy read-ahead behaviour. Callers may override explicitly.
-      const readAheadEnabled: boolean =
-        this.dataSource.readAheadEnabled ?? this.dataSource.urls.length === 1;
+      // Keep read-ahead enabled by default so sequential remote reads still coalesce into fewer
+      // requests, but pair it with a small bounded buffer to stay within the per-source cache.
+      // Callers can still opt out with readAheadEnabled: false.
+      const readAheadEnabled: boolean = this.dataSource.readAheadEnabled ?? true;
+      const readAheadBufferBytes: number | undefined =
+        this.dataSource.readAheadBufferBytes ??
+        (numSources > 1
+          ? Math.min(DEFAULT_READ_AHEAD_BUFFER_BYTES, Math.floor(perSourceCache / 4))
+          : undefined);
 
       sources = this.dataSource.urls.map(
         (url) =>
@@ -117,6 +127,7 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
             url,
             cacheSizeInBytes: perSourceCache,
             readAheadEnabled,
+            readAheadBufferBytes,
             pool: this.#pool,
           } as P),
       );
@@ -184,9 +195,8 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
   public async *messageIterator(
     opt: MessageIteratorArgs,
   ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
-    // Filter sources to only those overlapping the requested time range.
-    // For full-range playback this still includes all sources, but for block loading
-    // with specific start/end it avoids triggering HTTP requests to irrelevant files.
+    // Restrict iteration to sources overlapping the requested time range to avoid irrelevant
+    // remote reads during block loading.
     const relevantSources = filterSourcesByTimeRange(this.sourceImpl, opt.start, opt.end);
 
     // Start later iterators only when playback reaches their start time, avoiding concurrent
@@ -197,12 +207,10 @@ export class MultiIterableSource<T extends ISerializedIterableSource, P>
     args: GetBackfillMessagesArgs,
   ): Promise<MessageEvent<Uint8Array>[]> {
     // Only consider sources that could contain messages at or before the backfill time.
-    // This avoids triggering HTTP requests to MCAP files that start after the requested time.
     const relevantSources = filterSourcesForBackfill(this.sourceImpl, args.time);
 
-    // Iterate in reverse (sources are sorted ascending by start) so we begin at the source covering
-    // the seek target and stop once every topic has a value. Without this short-circuit each
-    // preceding source would redundantly read its last chunk for the requested topics.
+    // Iterate newest-first so we start near the seek target and stop once every topic has a value,
+    // avoiding redundant reads from earlier sources.
     const backfillMessages: MessageEvent<Uint8Array>[] = [];
     const missingTopics = new Map(args.topics);
 

--- a/packages/suite-base/src/players/IterablePlayer/shared/multiFileHydrationOptions.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/multiFileHydrationOptions.test.ts
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import {
+  addMultiFileHydrationOverrides,
+  pickDefinedHydrationOverrides,
+} from "./multiFileHydrationOptions";
+
+describe("multiFileHydrationOptions", () => {
+  describe("addMultiFileHydrationOverrides", () => {
+    it("returns initArgs unchanged when overrides are undefined", () => {
+      // GIVEN: base init args with no override object.
+      const initArgs = { files: [new File(["data"], "first.mcap")] };
+
+      // WHEN: applying undefined overrides.
+      const result = addMultiFileHydrationOverrides(initArgs, undefined);
+
+      // THEN: the original init args object is returned unchanged.
+      expect(result).toBe(initArgs);
+    });
+
+    it("merges a single defined override field", () => {
+      // GIVEN: base init args and one defined override.
+      const initArgs = { urls: ["https://example.com/first.mcap"] };
+
+      // WHEN: applying the override.
+      const result = addMultiFileHydrationOverrides(initArgs, {
+        maxHydratedSources: 3,
+      });
+
+      // THEN: only the defined field is merged into the result.
+      expect(result).toEqual({
+        urls: ["https://example.com/first.mcap"],
+        maxHydratedSources: 3,
+      });
+    });
+
+    it("merges all defined override fields", () => {
+      // GIVEN: base init args and all override fields defined.
+      const initArgs = { files: [new File(["data"], "first.mcap")] };
+
+      // WHEN: applying the overrides.
+      const result = addMultiFileHydrationOverrides(initArgs, {
+        maxHydratedSources: 4,
+        maxHydratedBytes: 5678,
+        initConcurrency: 2,
+      });
+
+      // THEN: every defined override field is merged into the result.
+      expect(result).toEqual({
+        files: [initArgs.files[0]],
+        maxHydratedSources: 4,
+        maxHydratedBytes: 5678,
+        initConcurrency: 2,
+      });
+    });
+
+    it("does not add undefined override fields or overwrite existing values with undefined", () => {
+      // GIVEN: init args that already include hydration fields.
+      const initArgs = {
+        urls: ["https://example.com/first.mcap"],
+        maxHydratedSources: 9,
+        initConcurrency: 5,
+      };
+
+      // WHEN: applying an override object with mixed defined and undefined values.
+      const result = addMultiFileHydrationOverrides(initArgs, {
+        maxHydratedSources: undefined,
+        maxHydratedBytes: 1234,
+        initConcurrency: undefined,
+      });
+
+      // THEN: only the defined override is applied and existing values remain intact.
+      expect(result).toEqual({
+        urls: ["https://example.com/first.mcap"],
+        maxHydratedSources: 9,
+        maxHydratedBytes: 1234,
+        initConcurrency: 5,
+      });
+    });
+  });
+
+  describe("pickDefinedHydrationOverrides", () => {
+    it("returns only the defined hydration fields", () => {
+      // GIVEN: a mixed hydration override object.
+      const overrides = {
+        maxHydratedSources: 4,
+        maxHydratedBytes: undefined,
+        initConcurrency: 2,
+      };
+
+      // WHEN: picking defined fields.
+      const result = pickDefinedHydrationOverrides(overrides);
+
+      // THEN: only the defined fields are returned.
+      expect(result).toEqual({
+        maxHydratedSources: 4,
+        initConcurrency: 2,
+      });
+    });
+  });
+});

--- a/packages/suite-base/src/players/IterablePlayer/shared/multiFileHydrationOptions.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/multiFileHydrationOptions.ts
@@ -17,9 +17,7 @@ export function pickDefinedHydrationOverrides(
     ...(source.maxHydratedSources != undefined
       ? { maxHydratedSources: source.maxHydratedSources }
       : {}),
-    ...(source.maxHydratedBytes != undefined
-      ? { maxHydratedBytes: source.maxHydratedBytes }
-      : {}),
+    ...(source.maxHydratedBytes != undefined ? { maxHydratedBytes: source.maxHydratedBytes } : {}),
     ...(source.initConcurrency != undefined ? { initConcurrency: source.initConcurrency } : {}),
   };
 }

--- a/packages/suite-base/src/players/IterablePlayer/shared/multiFileHydrationOptions.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/multiFileHydrationOptions.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { IterableSourceInitializeArgs } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
+
+// Shared multi-file hydration overrides passed through to MultiIterableSource.
+export type MultiFileHydrationOverrides = Pick<
+  IterableSourceInitializeArgs,
+  "maxHydratedSources" | "maxHydratedBytes" | "initConcurrency"
+>;
+
+// Pick only the hydration overrides that are explicitly defined.
+export function pickDefinedHydrationOverrides(
+  source: MultiFileHydrationOverrides,
+): Partial<MultiFileHydrationOverrides> {
+  return {
+    ...(source.maxHydratedSources != undefined
+      ? { maxHydratedSources: source.maxHydratedSources }
+      : {}),
+    ...(source.maxHydratedBytes != undefined
+      ? { maxHydratedBytes: source.maxHydratedBytes }
+      : {}),
+    ...(source.initConcurrency != undefined ? { initConcurrency: source.initConcurrency } : {}),
+  };
+}
+
+// Merge defined multi-file hydration overrides on top of existing init args.
+export function addMultiFileHydrationOverrides<T extends object>(
+  initArgs: T,
+  overrides?: MultiFileHydrationOverrides,
+): T & Partial<MultiFileHydrationOverrides> {
+  if (overrides == undefined) {
+    return initArgs;
+  }
+
+  return {
+    ...initArgs,
+    ...pickDefinedHydrationOverrides(overrides),
+  };
+}

--- a/packages/suite-base/src/players/IterablePlayer/shared/types.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/types.ts
@@ -8,21 +8,27 @@ import {
   IteratorResult,
 } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 
+// Shared memory/concurrency overrides for a multi-file session. All optional; internal defaults
+// apply when unset.
+type MultiSourceHydrationOptions = {
+  // Primary byte budget for resident heavyweight readers (worker memory). Overrides the internal
+  // default when set. `maxHydratedSources` remains a count-cap safety on top of this.
+  maxHydratedBytes?: number;
+  // Maximum number of heavyweight per-file readers kept resident at once. Bounds worker memory for
+  // large multi-file sessions; sources beyond this are re-opened on demand.
+  maxHydratedSources?: number;
+  // Maximum number of sources initialized concurrently. Bounds the transient memory spike from
+  // concurrently parsing many MCAP channel schemas (and, for remote sources, the initial request
+  // burst from concurrent MCAP summary reads).
+  initConcurrency?: number;
+};
+
 export type MultiSource =
-  | {
+  | ({
       type: "files";
       files: Blob[];
-      // Primary byte budget for resident heavyweight readers (worker memory). Overrides the
-      // internal default when set. `maxHydratedSources` remains a count-cap safety on top of this.
-      maxHydratedBytes?: number;
-      // Maximum number of heavyweight per-file readers kept resident at once. Bounds worker memory
-      // for large multi-file sessions; sources beyond this are re-opened on demand.
-      maxHydratedSources?: number;
-      // Maximum number of sources initialized concurrently. Bounds the transient memory spike from
-      // concurrently parsing many MCAP channel schemas.
-      initConcurrency?: number;
-    }
-  | {
+    } & MultiSourceHydrationOptions)
+  | ({
       type: "urls";
       urls: string[];
       totalCacheSizeInBytes?: number;
@@ -30,17 +36,7 @@ export type MultiSource =
       // When false (default for multi-file), each remote source downloads lazily without
       // speculative read-ahead. When true, legacy whole-file read-ahead is used.
       readAheadEnabled?: boolean;
-      // Maximum number of remote sources initialized concurrently. Bounds the initial request
-      // burst and the transient memory spike from concurrent MCAP summary reads. Defaults to a
-      // small value for multi-file remote sessions.
-      initConcurrency?: number;
-      // Primary byte budget for resident heavyweight readers (worker memory). Overrides the
-      // internal default when set. `maxHydratedSources` remains a count-cap safety on top of this.
-      maxHydratedBytes?: number;
-      // Maximum number of heavyweight per-file readers kept resident at once. Bounds worker memory
-      // for large multi-file remote sessions; sources beyond this are re-opened on demand.
-      maxHydratedSources?: number;
-    };
+    } & MultiSourceHydrationOptions);
 
 export type IterableSourceConstructor<T extends IIterableSource, P> = new (args: P) => T;
 

--- a/packages/suite-base/src/players/IterablePlayer/shared/types.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/types.ts
@@ -9,7 +9,16 @@ import {
 } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 
 export type MultiSource =
-  | { type: "files"; files: Blob[] }
+  | {
+      type: "files";
+      files: Blob[];
+      // Maximum number of heavyweight per-file readers kept resident at once. Bounds worker memory
+      // for large multi-file sessions; sources beyond this are re-opened on demand.
+      maxHydratedSources?: number;
+      // Maximum number of sources initialized concurrently. Bounds the transient memory spike from
+      // concurrently parsing many MCAP channel schemas.
+      initConcurrency?: number;
+    }
   | {
       type: "urls";
       urls: string[];
@@ -18,6 +27,13 @@ export type MultiSource =
       // When false (default for multi-file), each remote source downloads lazily without
       // speculative read-ahead. When true, legacy whole-file read-ahead is used.
       readAheadEnabled?: boolean;
+      // Maximum number of remote sources initialized concurrently. Bounds the initial request
+      // burst and the transient memory spike from concurrent MCAP summary reads. Defaults to a
+      // small value for multi-file remote sessions.
+      initConcurrency?: number;
+      // Maximum number of heavyweight per-file readers kept resident at once. Bounds worker memory
+      // for large multi-file remote sessions; sources beyond this are re-opened on demand.
+      maxHydratedSources?: number;
     };
 
 export type IterableSourceConstructor<T extends IIterableSource, P> = new (args: P) => T;

--- a/packages/suite-base/src/players/IterablePlayer/shared/types.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/types.ts
@@ -53,9 +53,15 @@ export type MultiSource =
       urls: string[];
       totalCacheSizeInBytes?: number;
       minCachePerSourceBytes?: number;
-      // When false (default for multi-file), each remote source downloads lazily without
-      // speculative read-ahead. When true, legacy whole-file read-ahead is used.
+      // When false, each remote source downloads only exact requested ranges with no speculative
+      // read-ahead. When omitted, MultiIterableSource now defaults to read-ahead enabled and uses
+      // readAheadBufferBytes to keep multi-file sessions safely bounded.
       readAheadEnabled?: boolean;
+      // Bounds the speculative read-ahead extension (bytes) used when readAheadEnabled is true.
+      // When omitted, MultiIterableSource derives a safe multi-file value from the per-source
+      // cache budget, while single-file sessions keep the legacy 50 MiB default from
+      // getNewConnection.ts.
+      readAheadBufferBytes?: number;
     } & MultiSourceHydrationOptions);
 
 export type IterableSourceConstructor<T extends IIterableSource, P> = new (args: P) => T;

--- a/packages/suite-base/src/players/IterablePlayer/shared/types.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/types.ts
@@ -8,6 +8,26 @@ import {
   IteratorResult,
 } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 
+// Contract a caller supplies to HydratedSourcePool for a hydrated (heavyweight) value.
+export type SourceHydrator<T> = {
+  // Create the heavyweight value (open readable, build reader, parse channels, ...).
+  open: () => Promise<T>;
+  // Release the heavyweight value (close readable/connection, drop references).
+  close: (value: T) => Promise<void>;
+  // Optional estimated resident memory (bytes) of the hydrated value, used by the byte budget.
+  // When omitted, every entry weighs 1 so the pool behaves as a pure count cap.
+  weigh?: (value: T) => number;
+};
+
+export type HydratedSourcePoolOptions = {
+  // Primary limiter: evict LRU unpinned entries while total estimated bytes exceeds this.
+  maxBytes?: number;
+  // Safety cap on resident entry count (bounds open connections/readers regardless of weight).
+  maxCount?: number;
+  // Never evict below this many entries (default 1), even when over the byte/count budget.
+  minResident?: number;
+};
+
 // Shared memory/concurrency overrides for a multi-file session. All optional; internal defaults
 // apply when unset.
 type MultiSourceHydrationOptions = {

--- a/packages/suite-base/src/players/IterablePlayer/shared/types.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/types.ts
@@ -12,6 +12,9 @@ export type MultiSource =
   | {
       type: "files";
       files: Blob[];
+      // Primary byte budget for resident heavyweight readers (worker memory). Overrides the
+      // internal default when set. `maxHydratedSources` remains a count-cap safety on top of this.
+      maxHydratedBytes?: number;
       // Maximum number of heavyweight per-file readers kept resident at once. Bounds worker memory
       // for large multi-file sessions; sources beyond this are re-opened on demand.
       maxHydratedSources?: number;
@@ -31,6 +34,9 @@ export type MultiSource =
       // burst and the transient memory spike from concurrent MCAP summary reads. Defaults to a
       // small value for multi-file remote sessions.
       initConcurrency?: number;
+      // Primary byte budget for resident heavyweight readers (worker memory). Overrides the
+      // internal default when set. `maxHydratedSources` remains a count-cap safety on top of this.
+      maxHydratedBytes?: number;
       // Maximum number of heavyweight per-file readers kept resident at once. Bounds worker memory
       // for large multi-file remote sessions; sources beyond this are re-opened on demand.
       maxHydratedSources?: number;

--- a/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.test.ts
@@ -41,6 +41,36 @@ function makeMockSource(
   } as unknown as IIterableSource<Uint8Array>;
 }
 
+function makeMockSourceWithReturn(
+  start: Time,
+  end: Time,
+  messages: IteratorResult<Uint8Array>[],
+  returnFn: jest.Mock,
+): IIterableSource<Uint8Array> {
+  return {
+    sourceType: "serialized",
+    initialize: jest.fn(),
+    getBackfillMessages: jest.fn(),
+    getStart: () => start,
+    getEnd: () => end,
+    messageIterator: jest.fn().mockImplementation(() => {
+      let index = 0;
+      return {
+        next: async () => {
+          if (index < messages.length) {
+            return { value: messages[index++], done: false };
+          }
+          return { value: undefined, done: true };
+        },
+        return: returnFn.mockResolvedValue({ value: undefined, done: true }),
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
+    }),
+  } as unknown as IIterableSource<Uint8Array>;
+}
+
 describe("mergeSequentialIterators", () => {
   const defaultArgs: MessageIteratorArgs = {
     topics: new Map([["topic", { topic: "topic" }]]),
@@ -248,36 +278,6 @@ describe("mergeSequentialIterators", () => {
   it("cleans up active iterators when consumer breaks early", async () => {
     const returnFns = [jest.fn(), jest.fn(), jest.fn()];
 
-    function makeMockSourceWithReturn(
-      start: Time,
-      end: Time,
-      messages: IteratorResult<Uint8Array>[],
-      returnFn: jest.Mock,
-    ): IIterableSource<Uint8Array> {
-      return {
-        sourceType: "serialized",
-        initialize: jest.fn(),
-        getBackfillMessages: jest.fn(),
-        getStart: () => start,
-        getEnd: () => end,
-        messageIterator: jest.fn().mockImplementation(() => {
-          let index = 0;
-          return {
-            next: async () => {
-              if (index < messages.length) {
-                return { value: messages[index++], done: false };
-              }
-              return { value: undefined, done: true };
-            },
-            return: returnFn.mockResolvedValue({ value: undefined, done: true }),
-            [Symbol.asyncIterator]() {
-              return this;
-            },
-          };
-        }),
-      } as unknown as IIterableSource<Uint8Array>;
-    }
-
     // All three sources overlap at time 0, so all will be activated initially
     const source1 = makeMockSourceWithReturn(
       { sec: 0, nsec: 0 },
@@ -311,6 +311,54 @@ describe("mergeSequentialIterators", () => {
     // All active iterators that still had remaining data should have .return() called
     const totalReturnCalls = returnFns.reduce((sum, fn) => sum + fn.mock.calls.length, 0);
     expect(totalReturnCalls).toBeGreaterThan(0);
+  });
+
+  it("calls return() on the currently-yielded iterator when cancelled mid-yield (not just heap-resident ones)", async () => {
+    const returnFns = [jest.fn(), jest.fn(), jest.fn()];
+
+    // All three sources overlap at time 0, so all will be activated initially.
+    const source1 = makeMockSourceWithReturn(
+      { sec: 0, nsec: 0 },
+      { sec: 10, nsec: 0 },
+      [makeMessageEvent("topic", 1), makeMessageEvent("topic", 5), makeMessageEvent("topic", 9)],
+      returnFns[0]!,
+    );
+    const source2 = makeMockSourceWithReturn(
+      { sec: 0, nsec: 0 },
+      { sec: 10, nsec: 0 },
+      [makeMessageEvent("topic", 2), makeMessageEvent("topic", 6)],
+      returnFns[1]!,
+    );
+    const source3 = makeMockSourceWithReturn(
+      { sec: 0, nsec: 0 },
+      { sec: 10, nsec: 0 },
+      [makeMessageEvent("topic", 3), makeMessageEvent("topic", 7)],
+      returnFns[2]!,
+    );
+
+    const results: IteratorResult[] = [];
+    for await (const msg of mergeSequentialIterators([source1, source2, source3], defaultArgs)) {
+      results.push(msg);
+      // Break after consuming only 2 messages. The first popped/yielded value is source1's
+      // sec=1 message; resuming after that yield advances source1 (now sec=5, re-pushed into
+      // the heap) and pops source2's sec=2 message for the second yield. Cancellation happens
+      // while suspended at THAT yield, so source2's iterator was popped from the heap and not
+      // yet put back — it must still be cleaned up in `finally`.
+      if (results.length >= 2) {
+        break;
+      }
+    }
+
+    expect(results).toHaveLength(2);
+    // source2's iterator was mid-yield (popped, not yet re-pushed) at cancellation time — it
+    // must still be closed by the finally block, not skipped just because it's absent from heap.
+    expect(returnFns[1]).toHaveBeenCalledTimes(1);
+    // source1's iterator was re-pushed into the heap before the second yield, so it remains
+    // heap-resident at cancellation and should already be cleaned up.
+    expect(returnFns[0]).toHaveBeenCalledTimes(1);
+    // source3 was activated eagerly (all three sources overlap at time 0) and remains
+    // heap-resident, untouched, at cancellation.
+    expect(returnFns[2]).toHaveBeenCalledTimes(1);
   });
 
   it("only activates the source containing queryStart on seek (skips earlier sources)", async () => {

--- a/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.ts
@@ -15,14 +15,8 @@ import {
 } from "@lichtblick/suite-base/players/IterablePlayer/shared/types";
 
 /**
- * A lazy sequential iterator that only activates source iterators when the current
- * playback time reaches (or is near) that source's time range.
- *
- * This avoids starting HTTP byte-range requests for all remote MCAP files simultaneously.
- * Instead, only the source(s) covering the current time window are actively read from.
- *
- * Sources are sorted by start time. When the current yield time approaches a source's
- * start time, that source's iterator is initialized and added to the merge heap.
+ * Lazily merges sources in start-time order, activating each iterator only when playback reaches
+ * that source's time range. This avoids starting remote reads for every file at once.
  */
 export async function* mergeSequentialIterators<T extends IteratorResult>(
   sources: IIterableSource[],
@@ -43,26 +37,32 @@ export async function* mergeSequentialIterators<T extends IteratorResult>(
     }
   }
 
-  // Sort by start time
   sourcesWithTime.sort((a, b) => compare(a.startTime, b.startTime));
 
   const heap = new Heap<SequentialIteratorMergeOptions<T>>(
     (a, b) => getTime(a.value) - getTime(b.value),
   );
 
-  /**
-   * Activate a source's iterator and push its first value onto the heap.
-   * Returns true if the source produced a value, false if it was empty.
-   */
+  // Tracks every iterator that has been activated (messageIterator() called and not yet
+  // exhausted). Unlike the heap, this includes the iterator whose value is currently being
+  // yielded (removed from the heap by `pop()` before `yield`), so cancellation while suspended
+  // at that yield can still clean it up in `finally`.
+  const activeIterators = new Set<AsyncIterableIterator<Readonly<IteratorResult>>>();
+
+  /** Activate a source iterator and push its first value onto the heap if present. */
   async function activateSource(source: IIterableSource): Promise<void> {
     const iterator = source.messageIterator(args);
+    activeIterators.add(iterator);
     const result = await iterator.next();
     if (!(result.done ?? false)) {
       heap.push({ value: result.value as T, iterator });
+    } else {
+      // Exhausted immediately (empty source): nothing left to clean up.
+      activeIterators.delete(iterator);
     }
   }
 
-  // Initialize sources that don't have time info (must be started eagerly)
+  // Start sources without time info eagerly.
   for (const source of sourcesWithoutTime) {
     await activateSource(source);
   }
@@ -70,25 +70,18 @@ export async function* mergeSequentialIterators<T extends IteratorResult>(
   // Index into the sorted sourcesWithTime array tracking the next source to potentially activate
   let nextSourceIndex = 0;
 
-  /**
-   * Activate the next pending source from sourcesWithTime and advance the index.
-   */
+  /** Activate the next pending timed source. */
   async function activateNextSource(): Promise<void> {
     await activateSource(sourcesWithTime[nextSourceIndex]!.source);
     nextSourceIndex++;
   }
 
-  // Activate sources whose start time is at or before the query start time.
-  // When no query start is provided, activate only the first source (the earliest by startTime)
-  // to avoid starting HTTP requests for all files simultaneously.
-  //
-  // When a query start IS provided (e.g. after a seek), only activate sources whose time range
-  // [startTime, endTime] actually contains the queryStart. Sources that end before queryStart
-  // are skipped entirely — they cannot contain relevant data at the seek position.
-  // This avoids activating all preceding sources when seeking to the end of the timeline.
+  // On seek, start only sources whose range can contain queryStart; otherwise start just the
+  // earliest source. Additional sources are activated lazily as playback reaches them so we do
+  // not open remote reads for every file up front.
   const queryStart = args.start;
   if (queryStart != undefined) {
-    // Skip sources that end before queryStart (they can't contain messages at the seek point)
+    // Skip sources that end before queryStart.
     while (nextSourceIndex < sourcesWithTime.length) {
       const sourceInfo = sourcesWithTime[nextSourceIndex]!;
       if (compare(sourceInfo.endTime, queryStart) >= 0) {
@@ -96,7 +89,7 @@ export async function* mergeSequentialIterators<T extends IteratorResult>(
       }
       nextSourceIndex++;
     }
-    // Activate sources that contain queryStart (startTime <= queryStart)
+    // Activate sources that contain queryStart.
     while (nextSourceIndex < sourcesWithTime.length) {
       const sourceInfo = sourcesWithTime[nextSourceIndex]!;
       if (compare(sourceInfo.startTime, queryStart) > 0) {
@@ -105,7 +98,7 @@ export async function* mergeSequentialIterators<T extends IteratorResult>(
       await activateNextSource();
     }
   } else {
-    // No query start — activate only the first source
+    // No query start: activate only the first source.
     if (nextSourceIndex < sourcesWithTime.length) {
       await activateNextSource();
     }
@@ -122,8 +115,7 @@ export async function* mergeSequentialIterators<T extends IteratorResult>(
       const node = heap.pop()!;
       const currentTimeMs = getTime(node.value);
 
-      // Before yielding, check if any pending sources should be activated.
-      // Activate sources whose startTime is <= the current message time.
+      // Activate any pending sources whose startTime is <= the current message time.
       while (nextSourceIndex < sourcesWithTime.length) {
         const sourceInfo = sourcesWithTime[nextSourceIndex]!;
         if (toMillis(sourceInfo.startTime) > currentTimeMs) {
@@ -137,18 +129,24 @@ export async function* mergeSequentialIterators<T extends IteratorResult>(
       const nextResult = await node.iterator.next();
       if (!(nextResult.done ?? false)) {
         heap.push({ value: nextResult.value as T, iterator: node.iterator });
-      } else if (heap.isEmpty() && nextSourceIndex < sourcesWithTime.length) {
-        // Current heap is exhausted but there are still pending sources.
-        // Activate the next source to continue yielding.
-        await activateNextSource();
+      } else {
+        activeIterators.delete(node.iterator);
+        if (heap.isEmpty() && nextSourceIndex < sourcesWithTime.length) {
+          // Heap is empty but timed sources remain; activate the next one.
+          await activateNextSource();
+        }
       }
     }
   } finally {
-    // Close all active iterators to release resources (e.g. HTTP connections)
-    // when the consumer breaks early or the generator is discarded.
-    for (const node of heap.toArray()) {
-      await node.iterator.return?.();
-    }
+    // Close every iterator that is still active — this includes any left in the heap AND the
+    // one whose value was mid-yield when the consumer cancelled (that node was already popped
+    // from the heap by `pop()` before `yield`, so it would otherwise be skipped here, leaking
+    // any resources it holds open — e.g. a pinned HydratedSourcePool entry in McapIterableSource).
+    await Promise.allSettled(
+      [...activeIterators].map(async (iterator) => {
+        await iterator.return?.();
+      }),
+    );
   }
 }
 

--- a/packages/suite-base/src/util/BrowserHttpReader.ts
+++ b/packages/suite-base/src/util/BrowserHttpReader.ts
@@ -14,7 +14,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { FileReader, FileStream } from "@lichtblick/suite-base/util/CachedFilelike";
+import type { FileReader, FileStream } from "@lichtblick/suite-base/util/CachedFilelike.types";
 import FetchReader from "@lichtblick/suite-base/util/FetchReader";
 import isDesktopApp from "@lichtblick/suite-base/util/isDesktopApp";
 

--- a/packages/suite-base/src/util/CachedFilelike.test.ts
+++ b/packages/suite-base/src/util/CachedFilelike.test.ts
@@ -110,21 +110,23 @@ describe("CachedFilelike", () => {
     it("bounds speculative fetch length with readAheadBufferBytes", async () => {
       // GIVEN: a large remote-like file with a small cache budget and a much smaller read-ahead cap.
       const readAheadBufferBytes = 2 * 1024 * 1024;
-      const fetch = jest.fn((_offset: number, length: number): FileStream => ({
-        on: (
-          type: "data" | "error" | "end",
-          callback: ((_: Uint8Array) => void) & ((_: Error) => void) & (() => void),
-        ) => {
-          if (type === "data") {
-            setTimeout(() => {
-              callback(new Uint8Array(length));
-            }, 0);
-          }
-        },
-        destroy() {
-          // no-op
-        },
-      }));
+      const fetch = jest.fn(
+        (_offset: number, length: number): FileStream => ({
+          on: (
+            type: "data" | "error" | "end",
+            callback: ((_: Uint8Array) => void) & ((_: Error) => void) & (() => void),
+          ) => {
+            if (type === "data") {
+              setTimeout(() => {
+                callback(new Uint8Array(length));
+              }, 0);
+            }
+          },
+          destroy() {
+            // no-op
+          },
+        }),
+      );
       const fileReader: FileReader = {
         open: async () => ({ size: 100 * 1024 * 1024 }),
         fetch,
@@ -143,12 +145,11 @@ describe("CachedFilelike", () => {
       expect(fetch).toHaveBeenNthCalledWith(1, 0, readAheadBufferBytes);
     });
 
-    it(
-      "resolves a later overlapping read instead of hanging when a small read-ahead buffer trails cached bytes",
-      async () => {
-        // GIVEN: a file where an earlier 2 MiB speculative fetch is still in flight when a later
-        // 4 MiB read arrives, matching the production hang scenario exposed by a 2 MiB buffer.
-        const fetch = jest.fn((_offset: number, length: number): FileStream => ({
+    it("resolves a later overlapping read instead of hanging when a small read-ahead buffer trails cached bytes", async () => {
+      // GIVEN: a file where an earlier 2 MiB speculative fetch is still in flight when a later
+      // 4 MiB read arrives, matching the production hang scenario exposed by a 2 MiB buffer.
+      const fetch = jest.fn(
+        (_offset: number, length: number): FileStream => ({
           on: (
             type: "data" | "error" | "end",
             callback: ((_: Uint8Array) => void) & ((_: Error) => void) & (() => void),
@@ -162,36 +163,35 @@ describe("CachedFilelike", () => {
           destroy() {
             // no-op
           },
-        }));
-        const fileReader: FileReader = {
-          open: async () => ({ size: 8 * MEBIBYTE }),
-          fetch,
-        };
-        const cachedFileReader = new CachedFilelike({
-          fileReader,
-          cacheSizeInBytes: 6 * MEBIBYTE,
-          readAheadBufferBytes: 2 * MEBIBYTE,
-          log,
-        });
+        }),
+      );
+      const fileReader: FileReader = {
+        open: async () => ({ size: 8 * MEBIBYTE }),
+        fetch,
+      };
+      const cachedFileReader = new CachedFilelike({
+        fileReader,
+        cacheSizeInBytes: 6 * MEBIBYTE,
+        readAheadBufferBytes: 2 * MEBIBYTE,
+        log,
+      });
 
-        const firstReadPromise = cachedFileReader.read(0, 1);
-        await delay(10);
-        expect(fetch).toHaveBeenCalledTimes(1);
+      const firstReadPromise = cachedFileReader.read(0, 1);
+      await delay(10);
+      expect(fetch).toHaveBeenCalledTimes(1);
 
-        // WHEN: a larger overlapping read needs bytes beyond the already cached 2 MiB prefix.
-        const secondReadPromise = cachedFileReader.read(0, 4 * MEBIBYTE);
+      // WHEN: a larger overlapping read needs bytes beyond the already cached 2 MiB prefix.
+      const secondReadPromise = cachedFileReader.read(0, 4 * MEBIBYTE);
 
-        // THEN: the second fetch makes forward progress by requesting the missing 2 MiB tail
-        // instead of issuing a degenerate 2 MiB-2 MiB range and hanging forever.
-        await expect(firstReadPromise).resolves.toEqual(new Uint8Array([0]));
-        await expect(secondReadPromise).resolves.toEqual(new Uint8Array(4 * MEBIBYTE));
-        expect(fetch.mock.calls.slice(0, 2)).toEqual([
-          [0, 2 * MEBIBYTE],
-          [2 * MEBIBYTE, 2 * MEBIBYTE],
-        ]);
-      },
-      2000,
-    );
+      // THEN: the second fetch makes forward progress by requesting the missing 2 MiB tail
+      // instead of issuing a degenerate 2 MiB-2 MiB range and hanging forever.
+      await expect(firstReadPromise).resolves.toEqual(new Uint8Array([0]));
+      await expect(secondReadPromise).resolves.toEqual(new Uint8Array(4 * MEBIBYTE));
+      expect(fetch.mock.calls.slice(0, 2)).toEqual([
+        [0, 2 * MEBIBYTE],
+        [2 * MEBIBYTE, 2 * MEBIBYTE],
+      ]);
+    }, 2000);
 
     it("ignores a degenerate zero-width idle connection instead of fetching it", async () => {
       jest.resetModules();
@@ -330,11 +330,10 @@ describe("CachedFilelike", () => {
       await expect(cachedFileReader.read(1, 0)).resolves.toEqual(new Uint8Array([]));
     });
 
-    it(
-      "rejects instead of hanging when a cached connection ends before the requested range is fully downloaded",
-      async () => {
-        // GIVEN: a cached read whose underlying stream ends early twice in a row.
-        const fetch = jest.fn((_offset: number, length: number): FileStream => ({
+    it("rejects instead of hanging when a cached connection ends before the requested range is fully downloaded", async () => {
+      // GIVEN: a cached read whose underlying stream ends early twice in a row.
+      const fetch = jest.fn(
+        (_offset: number, length: number): FileStream => ({
           on: (
             type: "data" | "error" | "end",
             callback: ((_: Uint8Array) => void) & ((_: Error) => void) & (() => void),
@@ -353,26 +352,23 @@ describe("CachedFilelike", () => {
           destroy() {
             // no-op
           },
-        }));
-        const fileReader: FileReader = {
-          open: async () => ({ size: 100 }),
-          fetch,
-        };
-        const cachedFileReader = new CachedFilelike({
-          fileReader,
-          readAheadEnabled: false,
-          log,
-        });
+        }),
+      );
+      const fileReader: FileReader = {
+        open: async () => ({ size: 100 }),
+        fetch,
+      };
+      const cachedFileReader = new CachedFilelike({
+        fileReader,
+        readAheadEnabled: false,
+        log,
+      });
 
-        // WHEN / THEN: the read rejects after the early EOF retry path rather than staying
-        // pending forever with no further network activity.
-        await expect(cachedFileReader.read(0, 10)).rejects.toThrow(
-          /ended before download completed/,
-        );
-        expect(fetch).toHaveBeenCalledTimes(2);
-      },
-      1000,
-    );
+      // WHEN / THEN: the read rejects after the early EOF retry path rather than staying
+      // pending forever with no further network activity.
+      await expect(cachedFileReader.read(0, 10)).rejects.toThrow(/ended before download completed/);
+      expect(fetch).toHaveBeenCalledTimes(2);
+    }, 1000);
   });
 
   describe("#close", () => {

--- a/packages/suite-base/src/util/CachedFilelike.test.ts
+++ b/packages/suite-base/src/util/CachedFilelike.test.ts
@@ -36,7 +36,10 @@ class InMemoryFileReader implements FileReader {
       );
     }
     return {
-      on: (type: "data" | "error", callback: ((_: Uint8Array) => void) & ((_: Error) => void)) => {
+      on: (
+        type: "data" | "error" | "end",
+        callback: ((_: Uint8Array) => void) & ((_: Error) => void) & (() => void),
+      ) => {
         if (type === "data") {
           setTimeout(() => {
             callback(this.#buffer.slice(offset, offset + length));
@@ -132,8 +135,8 @@ describe("CachedFilelike", () => {
       jest.spyOn(fileReader, "fetch").mockImplementation(() => {
         return {
           on: (
-            type: "data" | "error",
-            callback: ((_: Uint8Array) => void) & ((_: Error) => void),
+            type: "data" | "error" | "end",
+            callback: ((_: Uint8Array) => void) & ((_: Error) => void) & (() => void),
           ) => {
             if (type === "error") {
               interval = setInterval(() => {
@@ -161,8 +164,8 @@ describe("CachedFilelike", () => {
       const mockFetch = jest.spyOn(fileReader, "fetch").mockImplementation(() => {
         return {
           on: (
-            type: "data" | "error",
-            callback: ((_: Uint8Array) => void) & ((_: Error) => void),
+            type: "data" | "error" | "end",
+            callback: ((_: Uint8Array) => void) & ((_: Error) => void) & (() => void),
           ) => {
             if (type === "data") {
               dataCallback = callback;

--- a/packages/suite-base/src/util/CachedFilelike.test.ts
+++ b/packages/suite-base/src/util/CachedFilelike.test.ts
@@ -252,5 +252,29 @@ describe("CachedFilelike", () => {
       // THEN: the pending read rejects with the closed error.
       await expect(readPromise).rejects.toThrow("CachedFilelike is closed");
     });
+
+    it("rejects an oversized uncached read when closed", async () => {
+      // GIVEN: a small cache and a fetch that never delivers data, so an oversized (uncached)
+      // read stays pending.
+      const fileReader = new InMemoryFileReader(new Uint8Array(100));
+      jest.spyOn(fileReader, "fetch").mockImplementation(() => ({
+        on: () => {
+          // Never emits "data", "end", or "error", leaving the uncached read pending.
+        },
+        destroy() {
+          // no-op
+        },
+      }));
+      const cachedFileReader = new CachedFilelike({ fileReader, cacheSizeInBytes: 10, log });
+      await cachedFileReader.open();
+
+      // WHEN: an oversized read (larger than the cache budget) is started, then the reader closes.
+      const readPromise = cachedFileReader.read(0, 50);
+      await delay(10);
+      cachedFileReader.close();
+
+      // THEN: the oversized uncached read settles by rejecting with the closed error.
+      await expect(readPromise).rejects.toThrow("CachedFilelike is closed");
+    });
   });
 });

--- a/packages/suite-base/src/util/CachedFilelike.test.ts
+++ b/packages/suite-base/src/util/CachedFilelike.test.ts
@@ -101,17 +101,28 @@ describe("CachedFilelike", () => {
       expect(fetch).toHaveBeenCalledWith(0, 10);
     });
 
-    it("throws a clear error when a single read exceeds the cache size", () => {
+    it("reads the exact range uncached when a single read exceeds the cache size", async () => {
       // GIVEN: a source allocated a small cache (mirrors a many-file remote session where each
       // source receives only the 10 MiB minimum floor) backed by a larger file.
-      const fileReader = new InMemoryFileReader(new Uint8Array(100));
+      const sourceData = Uint8Array.from({ length: 100 }, (_, index) => index);
+      const fileReader = new InMemoryFileReader(sourceData);
       const cachedFileReader = new CachedFilelike({ fileReader, cacheSizeInBytes: 10, log });
 
-      // WHEN/THEN: a chunk read larger than the cache fails fast with an explicit, actionable
-      // message instead of silently truncating or mis-reading.
-      expect(() => {
-        void cachedFileReader.read(0, 20);
-      }).toThrow("Requested more data than cache size: 20 > 10");
+      // WHEN: a chunk read is larger than the cache.
+      const result = await cachedFileReader.read(0, 20);
+
+      // THEN: the exact bytes are returned via the uncached path.
+      expect(result).toEqual(sourceData.slice(0, 20));
+    });
+
+    it("rejects when an uncached read exceeds the file size", async () => {
+      // GIVEN: a small file and a cache smaller than the requested read.
+      const fileReader = new InMemoryFileReader(new Uint8Array(10));
+      const cachedFileReader = new CachedFilelike({ fileReader, cacheSizeInBytes: 5, log });
+
+      // WHEN/THEN: an oversized read that extends past EOF still rejects with the normal
+      // out-of-bounds error.
+      await expect(cachedFileReader.read(0, 1000)).rejects.toThrow("CachedFilelike#read past size");
     });
 
     it("returns an error in the callback if the FileReader keeps returning errors", async () => {
@@ -191,6 +202,55 @@ describe("CachedFilelike", () => {
       const fileReader = new InMemoryFileReader(new Uint8Array([0, 1, 2, 3]));
       const cachedFileReader = new CachedFilelike({ fileReader, log });
       await expect(cachedFileReader.read(1, 0)).resolves.toEqual(new Uint8Array([]));
+    });
+  });
+
+  describe("#close", () => {
+    it("rejects reads after close()", async () => {
+      // GIVEN: an opened reader.
+      const fileReader = new InMemoryFileReader(new Uint8Array([0, 1, 2, 3]));
+      const cachedFileReader = new CachedFilelike({ fileReader, log });
+      await cachedFileReader.open();
+
+      // WHEN: the reader is closed.
+      cachedFileReader.close();
+
+      // THEN: subsequent reads reject with the closed error.
+      await expect(cachedFileReader.read(0, 2)).rejects.toThrow("CachedFilelike is closed");
+    });
+
+    it("is idempotent when called twice", () => {
+      // GIVEN: a reader.
+      const fileReader = new InMemoryFileReader(new Uint8Array([0, 1, 2, 3]));
+      const cachedFileReader = new CachedFilelike({ fileReader, log });
+
+      // WHEN/THEN: closing twice does not throw.
+      expect(() => {
+        cachedFileReader.close();
+        cachedFileReader.close();
+      }).not.toThrow();
+    });
+
+    it("rejects an in-flight pending read request", async () => {
+      // GIVEN: a file reader whose fetch never delivers data, so the read stays pending.
+      const fileReader = new InMemoryFileReader(new Uint8Array([0, 1, 2, 3]));
+      jest.spyOn(fileReader, "fetch").mockImplementation(() => ({
+        on: () => {
+          // Never emits "data" or "error", leaving the read request pending.
+        },
+        destroy() {
+          // no-op
+        },
+      }));
+      const cachedFileReader = new CachedFilelike({ fileReader, log });
+
+      // WHEN: a read is started (and stays pending) and then the reader is closed.
+      const readPromise = cachedFileReader.read(0, 2);
+      await delay(10);
+      cachedFileReader.close();
+
+      // THEN: the pending read rejects with the closed error.
+      await expect(readPromise).rejects.toThrow("CachedFilelike is closed");
     });
   });
 });

--- a/packages/suite-base/src/util/CachedFilelike.test.ts
+++ b/packages/suite-base/src/util/CachedFilelike.test.ts
@@ -16,7 +16,10 @@
 
 import delay from "@lichtblick/suite-base/util/delay";
 
-import CachedFilelike, { FileReader, FileStream } from "./CachedFilelike";
+import CachedFilelike from "./CachedFilelike";
+import type { FileReader, FileStream } from "./CachedFilelike.types";
+
+const MEBIBYTE = 1024 * 1024;
 
 class InMemoryFileReader implements FileReader {
   #buffer: Uint8Array;
@@ -102,6 +105,126 @@ describe("CachedFilelike", () => {
       // THEN: no speculative whole-file or look-ahead fetch is made.
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(fetch).toHaveBeenCalledWith(0, 10);
+    });
+
+    it("bounds speculative fetch length with readAheadBufferBytes", async () => {
+      // GIVEN: a large remote-like file with a small cache budget and a much smaller read-ahead cap.
+      const readAheadBufferBytes = 2 * 1024 * 1024;
+      const fetch = jest.fn((_offset: number, length: number): FileStream => ({
+        on: (
+          type: "data" | "error" | "end",
+          callback: ((_: Uint8Array) => void) & ((_: Error) => void) & (() => void),
+        ) => {
+          if (type === "data") {
+            setTimeout(() => {
+              callback(new Uint8Array(length));
+            }, 0);
+          }
+        },
+        destroy() {
+          // no-op
+        },
+      }));
+      const fileReader: FileReader = {
+        open: async () => ({ size: 100 * 1024 * 1024 }),
+        fetch,
+      };
+      const cachedFileReader = new CachedFilelike({
+        fileReader,
+        cacheSizeInBytes: 10 * 1024 * 1024,
+        readAheadBufferBytes,
+        log,
+      });
+
+      // WHEN: reading a small initial range.
+      await expect(cachedFileReader.read(0, 1024)).resolves.toEqual(new Uint8Array(1024));
+
+      // THEN: the initial underlying fetch uses the bounded read-ahead size instead of 50 MiB.
+      expect(fetch).toHaveBeenNthCalledWith(1, 0, readAheadBufferBytes);
+    });
+
+    it(
+      "resolves a later overlapping read instead of hanging when a small read-ahead buffer trails cached bytes",
+      async () => {
+        // GIVEN: a file where an earlier 2 MiB speculative fetch is still in flight when a later
+        // 4 MiB read arrives, matching the production hang scenario exposed by a 2 MiB buffer.
+        const fetch = jest.fn((_offset: number, length: number): FileStream => ({
+          on: (
+            type: "data" | "error" | "end",
+            callback: ((_: Uint8Array) => void) & ((_: Error) => void) & (() => void),
+          ) => {
+            if (type === "data") {
+              setTimeout(() => {
+                callback(new Uint8Array(length));
+              }, 25);
+            }
+          },
+          destroy() {
+            // no-op
+          },
+        }));
+        const fileReader: FileReader = {
+          open: async () => ({ size: 8 * MEBIBYTE }),
+          fetch,
+        };
+        const cachedFileReader = new CachedFilelike({
+          fileReader,
+          cacheSizeInBytes: 6 * MEBIBYTE,
+          readAheadBufferBytes: 2 * MEBIBYTE,
+          log,
+        });
+
+        const firstReadPromise = cachedFileReader.read(0, 1);
+        await delay(10);
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        // WHEN: a larger overlapping read needs bytes beyond the already cached 2 MiB prefix.
+        const secondReadPromise = cachedFileReader.read(0, 4 * MEBIBYTE);
+
+        // THEN: the second fetch makes forward progress by requesting the missing 2 MiB tail
+        // instead of issuing a degenerate 2 MiB-2 MiB range and hanging forever.
+        await expect(firstReadPromise).resolves.toEqual(new Uint8Array([0]));
+        await expect(secondReadPromise).resolves.toEqual(new Uint8Array(4 * MEBIBYTE));
+        expect(fetch.mock.calls.slice(0, 2)).toEqual([
+          [0, 2 * MEBIBYTE],
+          [2 * MEBIBYTE, 2 * MEBIBYTE],
+        ]);
+      },
+      2000,
+    );
+
+    it("ignores a degenerate zero-width idle connection instead of fetching it", async () => {
+      jest.resetModules();
+      const getNewConnection = jest
+        .fn()
+        .mockReturnValueOnce({ start: 0, end: 4 })
+        .mockReturnValueOnce({ start: 4, end: 4 })
+        .mockReturnValue(undefined);
+      jest.doMock("./getNewConnection", () => ({
+        getNewConnection,
+      }));
+      const { default: MockedCachedFilelike } = await import("./CachedFilelike");
+
+      const fileReader = new InMemoryFileReader(new Uint8Array([0, 1, 2, 3]));
+      const fetch = jest.spyOn(fileReader, "fetch");
+      const debug = jest.fn();
+      const cachedFileReader = new MockedCachedFilelike({
+        fileReader,
+        log: { ...log, debug },
+      });
+
+      try {
+        await expect(cachedFileReader.read(0, 4)).resolves.toEqual(new Uint8Array([0, 1, 2, 3]));
+        await delay(10);
+
+        expect(getNewConnection).toHaveBeenCalledTimes(2);
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledWith(0, 4);
+        expect(debug).toHaveBeenCalledWith(expect.stringContaining("Ignoring degenerate"));
+      } finally {
+        jest.dontMock("./getNewConnection");
+        jest.resetModules();
+      }
     });
 
     it("reads the exact range uncached when a single read exceeds the cache size", async () => {
@@ -206,6 +329,50 @@ describe("CachedFilelike", () => {
       const cachedFileReader = new CachedFilelike({ fileReader, log });
       await expect(cachedFileReader.read(1, 0)).resolves.toEqual(new Uint8Array([]));
     });
+
+    it(
+      "rejects instead of hanging when a cached connection ends before the requested range is fully downloaded",
+      async () => {
+        // GIVEN: a cached read whose underlying stream ends early twice in a row.
+        const fetch = jest.fn((_offset: number, length: number): FileStream => ({
+          on: (
+            type: "data" | "error" | "end",
+            callback: ((_: Uint8Array) => void) & ((_: Error) => void) & (() => void),
+          ) => {
+            if (type === "data" && length > 1) {
+              setTimeout(() => {
+                callback(new Uint8Array(length - 1));
+              }, 0);
+            }
+            if (type === "end") {
+              setTimeout(() => {
+                callback();
+              }, 1);
+            }
+          },
+          destroy() {
+            // no-op
+          },
+        }));
+        const fileReader: FileReader = {
+          open: async () => ({ size: 100 }),
+          fetch,
+        };
+        const cachedFileReader = new CachedFilelike({
+          fileReader,
+          readAheadEnabled: false,
+          log,
+        });
+
+        // WHEN / THEN: the read rejects after the early EOF retry path rather than staying
+        // pending forever with no further network activity.
+        await expect(cachedFileReader.read(0, 10)).rejects.toThrow(
+          /ended before download completed/,
+        );
+        expect(fetch).toHaveBeenCalledTimes(2);
+      },
+      1000,
+    );
   });
 
   describe("#close", () => {

--- a/packages/suite-base/src/util/CachedFilelike.test.ts
+++ b/packages/suite-base/src/util/CachedFilelike.test.ts
@@ -279,5 +279,49 @@ describe("CachedFilelike", () => {
       // THEN: the oversized uncached read settles by rejecting with the closed error.
       await expect(readPromise).rejects.toThrow("CachedFilelike is closed");
     });
+
+    it("destroys the active connection when two quick stream errors trigger the fatal close path", async () => {
+      // GIVEN: a read that reconnects once and then hits the fatal double-error close path.
+      const fileReader = new InMemoryFileReader(new Uint8Array([0, 1, 2, 3]));
+      const streams: Array<{ destroy: jest.Mock; error?: (_error: Error) => void }> = [];
+      jest.spyOn(fileReader, "fetch").mockImplementation(() => {
+        const stream = { destroy: jest.fn() };
+        streams.push(stream);
+        return {
+          on: (
+            type: "data" | "error" | "end",
+            callback: ((_: Uint8Array) => void) & ((_: Error) => void) & (() => void),
+          ) => {
+            if (type === "error") {
+              streams[streams.length - 1]!.error = callback;
+            }
+          },
+          destroy: stream.destroy,
+        };
+      });
+      let now = 1_000;
+      const dateNow = jest.spyOn(Date, "now").mockImplementation(() => now);
+      const cachedFileReader = new CachedFilelike({ fileReader, log });
+
+      try {
+        // WHEN: two connection errors happen within the fatal 100ms window.
+        const readPromise = cachedFileReader.read(0, 2);
+        await delay(10);
+
+        now = 1_010;
+        streams[0]!.error?.(new Error("transient"));
+        await delay(10);
+
+        now = 1_050;
+        const fatalError = new Error("fatal");
+        streams[1]!.error?.(fatalError);
+
+        // THEN: the read rejects, and the active connection is destroyed as part of full cleanup.
+        await expect(readPromise).rejects.toThrow("fatal");
+        expect(streams[1]!.destroy).toHaveBeenCalledTimes(1);
+      } finally {
+        dateNow.mockRestore();
+      }
+    });
   });
 });

--- a/packages/suite-base/src/util/CachedFilelike.ts
+++ b/packages/suite-base/src/util/CachedFilelike.ts
@@ -53,6 +53,7 @@ import { Range } from "./ranges";
 export type FileStream = {
   on<T>(event: "data", listener: (chunk: T) => void): void;
   on(event: "error", listener: (err: Error) => void): void;
+  on(event: "end", listener: () => void): void;
   destroy: () => void;
 };
 export interface FileReader {
@@ -82,6 +83,8 @@ export default class CachedFilelike implements Filelike {
   #virtualBuffer: VirtualLRUBuffer;
   #log: ILogger;
   #closed: boolean = false;
+  // In-flight uncached reads, tracked so close() can destroy streams and reject promises.
+  readonly #activeUncachedReads = new Set<{ cancel: (err: Error) => void }>();
   // eslint-disable-next-line @lichtblick/no-boolean-parameters
   #keepReconnectingCallback?: (reconnecting: boolean) => void;
 
@@ -192,9 +195,7 @@ export default class CachedFilelike implements Filelike {
     });
   }
 
-  // Close the reader: abort any in-flight download, reject pending reads, and release cached
-  // blocks so a lazily-released remote source frees its memory promptly. Idempotent and terminal —
-  // the instance must not be reused after close().
+  // Terminal close: abort downloads, reject pending reads, and release cache blocks promptly.
   public close(): void {
     if (this.#closed) {
       return;
@@ -209,7 +210,10 @@ export default class CachedFilelike implements Filelike {
       request.reject(closedError);
     }
     this.#readRequests = [];
-    // Release cached blocks held by the VirtualLRUBuffer.
+    // Reject in-flight uncached reads (copy first: cancel() mutates the set).
+    for (const active of [...this.#activeUncachedReads]) {
+      active.cancel(new Error("CachedFilelike is closed"));
+    }
     this.#virtualBuffer = new VirtualLRUBuffer({ size: 0 });
   }
 
@@ -228,24 +232,60 @@ export default class CachedFilelike implements Filelike {
     return await new Promise<Uint8Array>((resolve, reject) => {
       const result = new Uint8Array(length);
       let bytesRead = 0;
+      let settled = false;
       const stream = this.#fileReader.fetch(range.start, length);
 
-      stream.on("error", (error: Error) => {
+      // Registered so close() can destroy the stream and reject this read.
+      const active: { cancel: (err: Error) => void } = { cancel: () => {} };
+      const finish = (action: () => void): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.#activeUncachedReads.delete(active);
         stream.destroy();
-        reject(error);
+        action();
+      };
+      active.cancel = (err: Error) => {
+        finish(() => {
+          reject(err);
+        });
+      };
+      this.#activeUncachedReads.add(active);
+
+      stream.on("error", (error: Error) => {
+        finish(() => {
+          reject(error);
+        });
+      });
+
+      // A stream that ends before `length` bytes were received must reject, not hang forever.
+      stream.on("end", () => {
+        finish(() => {
+          reject(
+            new Error(
+              `CachedFilelike#readUncached stream ended after ${bytesRead}/${length} bytes`,
+            ),
+          );
+        });
       });
 
       stream.on("data", (chunk: Uint8Array) => {
+        if (settled) {
+          return;
+        }
         if (bytesRead + chunk.byteLength > length) {
-          stream.destroy();
-          reject(new Error("CachedFilelike#readUncached received more data than requested"));
+          finish(() => {
+            reject(new Error("CachedFilelike#readUncached received more data than requested"));
+          });
           return;
         }
         result.set(chunk, bytesRead);
         bytesRead += chunk.byteLength;
         if (bytesRead === length) {
-          stream.destroy();
-          resolve(result);
+          finish(() => {
+            resolve(result);
+          });
         }
       });
     });

--- a/packages/suite-base/src/util/CachedFilelike.ts
+++ b/packages/suite-base/src/util/CachedFilelike.ts
@@ -153,6 +153,9 @@ export default class CachedFilelike implements Filelike {
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   public read(offset: number, length: number): Promise<Uint8Array> {
+    if (this.#closed) {
+      return Promise.reject(new Error("CachedFilelike is closed"));
+    }
     if (length === 0) {
       return Promise.resolve(new Uint8Array());
     }
@@ -163,7 +166,11 @@ export default class CachedFilelike implements Filelike {
       throw new Error("CachedFilelike#read invalid input");
     }
     if (length > this.#cacheSizeInBytes) {
-      throw new Error(`Requested more data than cache size: ${length} > ${this.#cacheSizeInBytes}`);
+      // A single read larger than the LRU cache budget (e.g. an MCAP summary/index section that
+      // exceeds a small per-source cache slice in a many-file remote session) cannot be served
+      // through the VirtualLRUBuffer. Rather than failing, fetch the exact range directly without
+      // caching. Memory stays transient and the cache budget is unchanged.
+      return this.#readUncached(range);
     }
 
     // Potentially performance-sensitive; await can be expensive
@@ -182,6 +189,65 @@ export default class CachedFilelike implements Filelike {
         .catch((err: unknown) => {
           reject(err instanceof Error ? err : new Error(String(err)));
         });
+    });
+  }
+
+  // Close the reader: abort any in-flight download, reject pending reads, and release cached
+  // blocks so a lazily-released remote source frees its memory promptly. Idempotent and terminal —
+  // the instance must not be reused after close().
+  public close(): void {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    if (this.#currentConnection) {
+      this.#currentConnection.stream.destroy();
+      this.#currentConnection = undefined;
+    }
+    const closedError = new Error("CachedFilelike is closed");
+    for (const request of this.#readRequests) {
+      request.reject(closedError);
+    }
+    this.#readRequests = [];
+    // Release cached blocks held by the VirtualLRUBuffer.
+    this.#virtualBuffer = new VirtualLRUBuffer({ size: 0 });
+  }
+
+  // Reads a byte range directly from the underlying file reader without caching. Used for single
+  // reads larger than the LRU cache budget, which cannot be represented in the VirtualLRUBuffer.
+  async #readUncached(range: Range): Promise<Uint8Array> {
+    await this.open();
+    if (this.#closed) {
+      throw new Error("CachedFilelike is closed");
+    }
+    if (range.end > this.size()) {
+      throw new Error(`CachedFilelike#read past size`);
+    }
+
+    const length = range.end - range.start;
+    return await new Promise<Uint8Array>((resolve, reject) => {
+      const result = new Uint8Array(length);
+      let bytesRead = 0;
+      const stream = this.#fileReader.fetch(range.start, length);
+
+      stream.on("error", (error: Error) => {
+        stream.destroy();
+        reject(error);
+      });
+
+      stream.on("data", (chunk: Uint8Array) => {
+        if (bytesRead + chunk.byteLength > length) {
+          stream.destroy();
+          reject(new Error("CachedFilelike#readUncached received more data than requested"));
+          return;
+        }
+        result.set(chunk, bytesRead);
+        bytesRead += chunk.byteLength;
+        if (bytesRead === length) {
+          stream.destroy();
+          resolve(result);
+        }
+      });
     });
   }
 

--- a/packages/suite-base/src/util/CachedFilelike.ts
+++ b/packages/suite-base/src/util/CachedFilelike.ts
@@ -197,6 +197,15 @@ export default class CachedFilelike implements Filelike {
 
   // Terminal close: abort downloads, reject pending reads, and release cache blocks promptly.
   public close(): void {
+    this.#closeWithError(new Error("CachedFilelike is closed"));
+  }
+
+  // Shared terminal-close logic used by close() and the fatal double-error path in
+  // #setConnection, so neither can forget to destroy the active connection, reject/cancel pending
+  // reads, or release cached memory. Safe to iterate #activeUncachedReads directly: cancel() is
+  // synchronous and only removes the entry currently being visited, which for...of over a Set
+  // permits.
+  #closeWithError(error: Error): void {
     if (this.#closed) {
       return;
     }
@@ -205,15 +214,6 @@ export default class CachedFilelike implements Filelike {
       this.#currentConnection.stream.destroy();
       this.#currentConnection = undefined;
     }
-    this.#rejectPendingReads(new Error("CachedFilelike is closed"));
-    this.#virtualBuffer = new VirtualLRUBuffer({ size: 0 });
-  }
-
-  // Reject all queued read requests and cancel all in-flight uncached reads with `error`. Shared
-  // by close() and the fatal-error path in #setConnection so neither can forget to release the
-  // other's tracked state. Safe to iterate #activeUncachedReads directly: cancel() is synchronous
-  // and only removes the entry currently being visited, which for...of over a Set permits.
-  #rejectPendingReads(error: Error): void {
     for (const request of this.#readRequests) {
       request.reject(error);
     }
@@ -221,6 +221,7 @@ export default class CachedFilelike implements Filelike {
     for (const active of this.#activeUncachedReads) {
       active.cancel(error);
     }
+    this.#virtualBuffer = new VirtualLRUBuffer({ size: 0 });
   }
 
   // Reads a byte range directly from the underlying file reader without caching. Used for single
@@ -376,8 +377,7 @@ export default class CachedFilelike implements Filelike {
             )} threw another error; closing: ${error.toString()}`,
           );
 
-          this.#closed = true;
-          this.#rejectPendingReads(error);
+          this.#closeWithError(error);
           return;
         }
       }

--- a/packages/suite-base/src/util/CachedFilelike.ts
+++ b/packages/suite-base/src/util/CachedFilelike.ts
@@ -205,17 +205,22 @@ export default class CachedFilelike implements Filelike {
       this.#currentConnection.stream.destroy();
       this.#currentConnection = undefined;
     }
-    const closedError = new Error("CachedFilelike is closed");
+    this.#rejectPendingReads(new Error("CachedFilelike is closed"));
+    this.#virtualBuffer = new VirtualLRUBuffer({ size: 0 });
+  }
+
+  // Reject all queued read requests and cancel all in-flight uncached reads with `error`. Shared
+  // by close() and the fatal-error path in #setConnection so neither can forget to release the
+  // other's tracked state. Safe to iterate #activeUncachedReads directly: cancel() is synchronous
+  // and only removes the entry currently being visited, which for...of over a Set permits.
+  #rejectPendingReads(error: Error): void {
     for (const request of this.#readRequests) {
-      request.reject(closedError);
+      request.reject(error);
     }
     this.#readRequests = [];
-    // Reject in-flight uncached reads. Safe to iterate the Set directly: cancel() is synchronous
-    // and only removes the entry currently being visited, which for...of over a Set permits.
     for (const active of this.#activeUncachedReads) {
-      active.cancel(new Error("CachedFilelike is closed"));
+      active.cancel(error);
     }
-    this.#virtualBuffer = new VirtualLRUBuffer({ size: 0 });
   }
 
   // Reads a byte range directly from the underlying file reader without caching. Used for single
@@ -372,9 +377,7 @@ export default class CachedFilelike implements Filelike {
           );
 
           this.#closed = true;
-          for (const request of this.#readRequests) {
-            request.reject(error);
-          }
+          this.#rejectPendingReads(error);
           return;
         }
       }

--- a/packages/suite-base/src/util/CachedFilelike.ts
+++ b/packages/suite-base/src/util/CachedFilelike.ts
@@ -18,48 +18,14 @@ import * as _ from "lodash-es";
 import Logger from "@lichtblick/log";
 import { Filelike } from "@lichtblick/rosbag";
 
+import type { FileReader, FileStream, ILogger } from "./CachedFilelike.types";
 import VirtualLRUBuffer from "./VirtualLRUBuffer";
 import { getNewConnection } from "./getNewConnection";
 import { Range } from "./ranges";
 
-// CachedFilelike is a `Filelike` that attempts to do as much caching of the file in memory as
-// possible. It takes in 3 named arguments to its constructor:
-// - fileReader: a `FileReader` instance (defined below). This essentially does the streamed
-//     fetching of ranges from our file.
-// - cacheSizeInBytes (optional): how many bytes we're allowed to cache. Defaults to infinite
-//     caching (meaning that the cache will be as big as the file size). `cacheSizeInBytes` also
-//     becomes the largest range of data that can be requested.
-// - logFn (optional): a log function. Useful for logging in a particular format. Defaults to
-//     `console.log`.
-// - keepReconnectingCallback (optional): if set, we assume that we want to keep retrying on connection
-//     error, in which case the callback gets called with an update on whether we are currently
-//     reconnecting. This is useful when the connection is expected to be spotty, e.g. when
-//     running this code in a browser instead of on a server. If omitted, we will retry for a short
-//     amount of time and then reject read requests.
-//
-// Under the hood this uses a `VirtualLRUBuffer`, which represents the entire file in memory, even
-// though only parts of it may actually be stored in memory. It also manages evicting least recently
-// used blocks from memory.
-//
-// We keep a list of byte ranges that have been requested, and their associated callbacks. Typically
-// there will be only one such requested range at the time, as usually we need to parse some data
-// first before we can read more. We keep one stream from the `fileReader` open at a time, and we
-// serve the requested byte ranges in order.
-//
-// If there are currently no requested byte ranges, we try to intelligently load as much data as
-// possible into memory, with a preference given to ranges immediately following the last requested
-// byte range. If the cache spans the entire file size, we try to download the entire file.
-
-export type FileStream = {
-  on<T>(event: "data", listener: (chunk: T) => void): void;
-  on(event: "error", listener: (err: Error) => void): void;
-  on(event: "end", listener: () => void): void;
-  destroy: () => void;
-};
-export interface FileReader {
-  open(): Promise<{ size: number }>;
-  fetch(offset: number, length: number): FileStream;
-}
+// CachedFilelike is a streamed Filelike backed by a VirtualLRUBuffer.
+// It serves requested byte ranges from an in-memory LRU cache, keeps at most one underlying fetch
+// active, and optionally uses bounded read-ahead/reconnect behavior for remote readers.
 
 const LOGGING_INTERVAL_IN_BYTES = 1024 * 1024 * 300; // Log every 300MiB to avoid cluttering the logs too much.
 const CACHE_BLOCK_SIZE = 1024 * 1024 * 10; // 10MiB blocks.
@@ -68,17 +34,11 @@ const CLOSE_ENOUGH_BYTES_TO_NOT_START_NEW_CONNECTION = 1024 * 1024 * 5;
 
 const log = Logger.getLogger(__filename);
 
-interface ILogger {
-  debug(..._args: unknown[]): void;
-  info(..._args: unknown[]): void;
-  warn(..._args: unknown[]): void;
-  error(..._args: unknown[]): void;
-}
-
 export default class CachedFilelike implements Filelike {
   #fileReader: FileReader;
   #cacheSizeInBytes: number = Infinity;
   readonly #readAheadEnabled: boolean = true;
+  readonly #readAheadBufferBytes: number | undefined;
   #fileSize?: number;
   #virtualBuffer: VirtualLRUBuffer;
   #log: ILogger;
@@ -110,6 +70,7 @@ export default class CachedFilelike implements Filelike {
     fileReader: FileReader;
     cacheSizeInBytes?: number;
     readAheadEnabled?: boolean;
+    readAheadBufferBytes?: number;
     log?: ILogger;
     // eslint-disable-next-line @lichtblick/no-boolean-parameters
     keepReconnectingCallback?: (reconnecting: boolean) => void;
@@ -117,6 +78,7 @@ export default class CachedFilelike implements Filelike {
     this.#fileReader = options.fileReader;
     this.#cacheSizeInBytes = options.cacheSizeInBytes ?? this.#cacheSizeInBytes;
     this.#readAheadEnabled = options.readAheadEnabled ?? this.#readAheadEnabled;
+    this.#readAheadBufferBytes = options.readAheadBufferBytes;
     this.#keepReconnectingCallback = options.keepReconnectingCallback;
     this.#log = options.log ?? log;
     this.#virtualBuffer = new VirtualLRUBuffer({ size: 0 });
@@ -200,11 +162,9 @@ export default class CachedFilelike implements Filelike {
     this.#closeWithError(new Error("CachedFilelike is closed"));
   }
 
-  // Shared terminal-close logic used by close() and the fatal double-error path in
-  // #setConnection, so neither can forget to destroy the active connection, reject/cancel pending
-  // reads, or release cached memory. Safe to iterate #activeUncachedReads directly: cancel() is
-  // synchronous and only removes the entry currently being visited, which for...of over a Set
-  // permits.
+  // Shared terminal-close path for close() and fatal connection errors. Iterating
+  // #activeUncachedReads is safe because cancel() is synchronous and only removes the current Set
+  // entry.
   #closeWithError(error: Error): void {
     if (this.#closed) {
       return;
@@ -304,7 +264,6 @@ export default class CachedFilelike implements Filelike {
       return;
     }
 
-    // First, see if there are any read requests that we can resolve now.
     this.#readRequests = this.#readRequests.filter(({ range, resolve }) => {
       if (!this.#virtualBuffer.hasData(range.start, range.end)) {
         return true;
@@ -319,7 +278,6 @@ export default class CachedFilelike implements Filelike {
 
     const size = this.size();
 
-    // Then see if we need to set a new connection based on the new connection and read requests state.
     const newConnection = getNewConnection({
       currentRemainingRange: this.#currentConnection
         ? this.#currentConnection.remainingRange
@@ -331,6 +289,7 @@ export default class CachedFilelike implements Filelike {
       fileSize: size,
       continueDownloadingThreshold: CLOSE_ENOUGH_BYTES_TO_NOT_START_NEW_CONNECTION,
       readAheadEnabled: this.#readAheadEnabled,
+      readAheadBufferBytes: this.#readAheadBufferBytes,
     });
     if (newConnection) {
       this.#setConnection(newConnection);
@@ -339,10 +298,16 @@ export default class CachedFilelike implements Filelike {
 
   // Replace the current connection with a new one, spanning a certain range.
   #setConnection(range: Range): void {
+    if (range.end <= range.start) {
+      // Prevent an invalid/inverted HTTP Range header (for example "bytes=100-99") and the 416
+      // response it would trigger; keep this defense-in-depth even though getNewConnection guards it.
+      this.#log.debug(`Ignoring degenerate zero-width connection range @ ${rangeToString(range)}`);
+      return;
+    }
+
     this.#log.debug(`Setting new connection @ ${rangeToString(range)}`);
 
     if (this.#currentConnection) {
-      // Destroy the current connection if there is one.
       const currentConnection = this.#currentConnection;
       currentConnection.stream.destroy();
       this.#log.debug(
@@ -350,50 +315,18 @@ export default class CachedFilelike implements Filelike {
       );
     }
 
-    // Start the stream, and update the current connection state.
     const stream = this.#fileReader.fetch(range.start, range.end - range.start);
     this.#currentConnection = { stream, remainingRange: range };
 
     stream.on("error", (error: Error) => {
-      const currentConnection = this.#currentConnection;
-      if (stream !== currentConnection?.stream) {
-        return; // Ignore errors from old streams.
-      }
-
-      if (this.#keepReconnectingCallback) {
-        // If this callback is set, just keep retrying.
-        if (this.#lastErrorTime == undefined) {
-          // And if this is the first error, let the callback know.
-          this.#keepReconnectingCallback(true);
-        }
-      } else {
-        // Otherwise, if we get two errors in a short timespan (100ms) then there is probably a
-        // serious error, we resolve all remaining callbacks with errors and close out.
-        const lastErrorTime = this.#lastErrorTime;
-        if (lastErrorTime != undefined && Date.now() - lastErrorTime < 100) {
-          this.#log.error(
-            `Connection @ ${rangeToString(
-              range,
-            )} threw another error; closing: ${error.toString()}`,
-          );
-
-          this.#closeWithError(error);
-          return;
-        }
-      }
-
-      // When we encounter an error there is usually a bad connection or timeout or so, so just
-      // mark the current connection as destroyed, and try again.
-      this.#log.info(
-        `Connection @ ${rangeToString(range)} threw error; trying to continue: ${error.toString()}`,
-      );
-      this.#lastErrorTime = Date.now();
-      currentConnection.stream.destroy();
-      this.#currentConnection = undefined;
-      this.#updateState();
+      this.#handleConnectionInterrupted({
+        stream,
+        range,
+        error,
+        reason: "threw error",
+      });
     });
 
-    // Handle the data stream.
     const startTime = Date.now();
     let bytesRead = 0;
     let lastReportedBytesRead = 0;
@@ -412,7 +345,6 @@ export default class CachedFilelike implements Filelike {
         }
       }
 
-      // Copy the data into the VirtualLRUBuffer.
       this.#virtualBuffer.copyFrom(Buffer.from(chunk), currentConnection.remainingRange.start);
       bytesRead += chunk.byteLength;
 
@@ -436,20 +368,84 @@ export default class CachedFilelike implements Filelike {
         stream.destroy();
         this.#currentConnection = undefined;
       } else {
-        // Otherwise, update `remainingRange`.
         this.#currentConnection = {
           stream,
           remainingRange: { start: range.start + bytesRead, end: range.end },
         };
       }
 
-      // Always call `_updateState` so it can decide to create new connections, resolve callbacks, etc.
+      // Always call #updateState() so it can resolve requests and decide on the next connection.
       this.#updateState();
     });
+
+    stream.on("end", () => {
+      const currentConnection = this.#currentConnection;
+      if (stream !== currentConnection?.stream) {
+        return;
+      }
+
+      if (this.#virtualBuffer.hasData(range.start, range.end)) {
+        this.#log.info(`Connection @ ${rangeToString(currentConnection.remainingRange)} finished!`);
+        this.#currentConnection = undefined;
+        this.#updateState();
+        return;
+      }
+
+      this.#handleConnectionInterrupted({
+        stream,
+        range,
+        error: new Error(`Connection ended before download completed @ ${rangeToString(range)}`),
+        reason: "ended early",
+      });
+    });
+  }
+
+  #handleConnectionInterrupted({
+    stream,
+    range,
+    error,
+    reason,
+  }: {
+    stream: FileStream;
+    range: Range;
+    error: Error;
+    reason: string;
+  }): void {
+    const currentConnection = this.#currentConnection;
+    if (stream !== currentConnection?.stream) {
+      return;
+    }
+
+    if (this.#keepReconnectingCallback) {
+      if (this.#lastErrorTime == undefined) {
+        // And if this is the first interruption, let the callback know.
+        this.#keepReconnectingCallback(true);
+      }
+    } else {
+      // Otherwise, if we get two interruptions in a short timespan (100ms) then there is
+      // probably a serious error, we resolve all remaining callbacks with errors and close out.
+      const lastErrorTime = this.#lastErrorTime;
+      if (lastErrorTime != undefined && Date.now() - lastErrorTime < 100) {
+        this.#log.error(
+          `Connection @ ${rangeToString(range)} ${reason} again; closing: ${error.toString()}`,
+        );
+
+        this.#closeWithError(error);
+        return;
+      }
+    }
+
+    // Mark the connection interrupted and let #updateState() decide whether to retry.
+    this.#log.info(
+      `Connection @ ${rangeToString(range)} ${reason}; trying to continue: ${error.toString()}`,
+    );
+    this.#lastErrorTime = Date.now();
+    currentConnection.stream.destroy();
+    this.#currentConnection = undefined;
+    this.#updateState();
   }
 }
 
-// Some formatting functions.
 function bytesToMiB(bytes: number) {
   return _.round(bytes / 1024 / 1024, 3);
 }

--- a/packages/suite-base/src/util/CachedFilelike.ts
+++ b/packages/suite-base/src/util/CachedFilelike.ts
@@ -210,8 +210,9 @@ export default class CachedFilelike implements Filelike {
       request.reject(closedError);
     }
     this.#readRequests = [];
-    // Reject in-flight uncached reads (copy first: cancel() mutates the set).
-    for (const active of [...this.#activeUncachedReads]) {
+    // Reject in-flight uncached reads. Safe to iterate the Set directly: cancel() is synchronous
+    // and only removes the entry currently being visited, which for...of over a Set permits.
+    for (const active of this.#activeUncachedReads) {
       active.cancel(new Error("CachedFilelike is closed"));
     }
     this.#virtualBuffer = new VirtualLRUBuffer({ size: 0 });

--- a/packages/suite-base/src/util/CachedFilelike.types.ts
+++ b/packages/suite-base/src/util/CachedFilelike.types.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export type FileStream = {
+  on<T>(event: "data", listener: (chunk: T) => void): void;
+  on(event: "error", listener: (err: Error) => void): void;
+  on(event: "end", listener: () => void): void;
+  destroy: () => void;
+};
+
+export interface FileReader {
+  open(): Promise<{ size: number }>;
+  fetch(offset: number, length: number): FileStream;
+}
+
+export interface ILogger {
+  debug(..._args: unknown[]): void;
+  info(..._args: unknown[]): void;
+  warn(..._args: unknown[]): void;
+  error(..._args: unknown[]): void;
+}

--- a/packages/suite-base/src/util/getNewConnection.test.ts
+++ b/packages/suite-base/src/util/getNewConnection.test.ts
@@ -17,6 +17,7 @@
 import { getNewConnection } from "./getNewConnection";
 
 const READ_AHEAD_BUFFER_SIZE = 50 * 1024 * 1024; // 50 MB - must match the constant in getNewConnection.ts
+const MEBIBYTE = 1024 * 1024;
 
 describe("getNewConnection", () => {
   describe("when using a limited cache", () => {
@@ -188,6 +189,25 @@ describe("getNewConnection", () => {
           });
           expect(newConnection).toEqual(undefined);
         });
+
+        it("does not create a zero-width read-ahead range after reaching end of file", () => {
+          const newConnection = getNewConnection({
+            ...defaults,
+            lastResolvedCallbackEnd: 100,
+            downloadedRanges: [{ start: 0, end: 100 }],
+          });
+
+          expect(newConnection).toBeUndefined();
+        });
+
+        it("keeps a valid tail read-ahead range just before the end of file", () => {
+          const newConnection = getNewConnection({
+            ...defaults,
+            lastResolvedCallbackEnd: 99,
+          });
+
+          expect(newConnection).toEqual({ start: 99, end: 100 });
+        });
       });
     });
   });
@@ -311,6 +331,26 @@ describe("getNewConnection", () => {
           lastResolvedCallbackEnd: 30,
         });
         expect(newConnection).toEqual({ start: 30, end: 100 });
+      });
+
+      it("backfills an earlier gap at EOF when using the unlimited-cache branch", () => {
+        const newConnection = getNewConnection({
+          ...defaults,
+          lastResolvedCallbackEnd: 100,
+          downloadedRanges: [{ start: 30, end: 100 }],
+        });
+
+        expect(newConnection).toEqual({ start: 0, end: 30 });
+      });
+
+      it("does not create a zero-width read-ahead range after reaching end of file", () => {
+        const newConnection = getNewConnection({
+          ...defaults,
+          lastResolvedCallbackEnd: 100,
+          downloadedRanges: [{ start: 0, end: 100 }],
+        });
+
+        expect(newConnection).toBeUndefined();
       });
     });
   });
@@ -491,6 +531,98 @@ describe("getNewConnection", () => {
       // Both should use READ_AHEAD_BUFFER_SIZE, not maxRequestSize
       expect(connection1).toEqual({ start: 0, end: READ_AHEAD_BUFFER_SIZE });
       expect(connection2).toEqual({ start: 0, end: READ_AHEAD_BUFFER_SIZE });
+    });
+
+    it("uses a smaller explicit readAheadBufferBytes when extending a request-end read", () => {
+      // GIVEN: a large file and an explicit read-ahead buffer smaller than the legacy 50 MiB.
+      const fileSize = 200 * 1024 * 1024;
+      const readAheadBufferBytes = 2 * 1024 * 1024;
+
+      // WHEN: the requested range ends at the first missing sub-range boundary.
+      const newConnection = getNewConnection({
+        currentRemainingRange: undefined,
+        readRequestRange: { start: 8 * 1024 * 1024, end: 8 * 1024 * 1024 + 1024 },
+        downloadedRanges: [],
+        lastResolvedCallbackEnd: undefined,
+        maxRequestSize: 5 * 1024 * 1024,
+        fileSize,
+        continueDownloadingThreshold: 5,
+        readAheadBufferBytes,
+      });
+
+      // THEN: the extension uses the smaller explicit buffer instead of 50 MiB.
+      expect(newConnection).toEqual({
+        start: 8 * 1024 * 1024,
+        end: 10 * 1024 * 1024,
+      });
+    });
+
+    it("covers the full missing tail when a small explicit readAheadBufferBytes falls behind the cached prefix", () => {
+      // GIVEN: the beginning of the read request is already cached farther than the small
+      // read-ahead buffer reaches.
+      const readAheadBufferBytes = 2 * MEBIBYTE;
+      const newConnection = getNewConnection({
+        currentRemainingRange: undefined,
+        readRequestRange: { start: 0, end: 4 * MEBIBYTE },
+        downloadedRanges: [{ start: 0, end: 2 * MEBIBYTE }],
+        lastResolvedCallbackEnd: undefined,
+        maxRequestSize: 6 * MEBIBYTE,
+        fileSize: 20 * MEBIBYTE,
+        continueDownloadingThreshold: 5,
+        readAheadBufferBytes,
+      });
+
+      // THEN: the new connection still covers the missing request tail instead of collapsing to a
+      // zero-width range at 2 MiB.
+      expect(newConnection).toEqual({
+        start: 2 * MEBIBYTE,
+        end: 4 * MEBIBYTE,
+      });
+    });
+
+    it("still reads ahead past the missing tail when a large explicit readAheadBufferBytes is used", () => {
+      // GIVEN: the same partially cached request, but with the legacy large read-ahead budget.
+      const newConnection = getNewConnection({
+        currentRemainingRange: undefined,
+        readRequestRange: { start: 0, end: 4 * MEBIBYTE },
+        downloadedRanges: [{ start: 0, end: 2 * MEBIBYTE }],
+        lastResolvedCallbackEnd: undefined,
+        maxRequestSize: 60 * MEBIBYTE,
+        fileSize: 200 * MEBIBYTE,
+        continueDownloadingThreshold: 5,
+        readAheadBufferBytes: READ_AHEAD_BUFFER_SIZE,
+      });
+
+      // THEN: read-ahead still extends beyond the missing request tail when the buffer allows it.
+      expect(newConnection).toEqual({
+        start: 2 * MEBIBYTE,
+        end: READ_AHEAD_BUFFER_SIZE,
+      });
+    });
+
+    it("uses a smaller explicit readAheadBufferBytes for idle read-ahead after the last resolved request", () => {
+      // GIVEN: an idle connection that wants to read ahead from the last resolved request end.
+      const fileSize = 200 * 1024 * 1024;
+      const lastResolvedCallbackEnd = 12 * 1024 * 1024;
+      const readAheadBufferBytes = 2 * 1024 * 1024;
+
+      // WHEN: getNewConnection computes the next speculative idle range.
+      const newConnection = getNewConnection({
+        currentRemainingRange: undefined,
+        readRequestRange: undefined,
+        downloadedRanges: [],
+        lastResolvedCallbackEnd,
+        maxRequestSize: 5 * 1024 * 1024,
+        fileSize,
+        continueDownloadingThreshold: 5,
+        readAheadBufferBytes,
+      });
+
+      // THEN: the idle read-ahead range uses the smaller explicit buffer instead of 50 MiB.
+      expect(newConnection).toEqual({
+        start: lastResolvedCallbackEnd,
+        end: lastResolvedCallbackEnd + readAheadBufferBytes,
+      });
     });
   });
 });

--- a/packages/suite-base/src/util/getNewConnection.ts
+++ b/packages/suite-base/src/util/getNewConnection.ts
@@ -33,11 +33,13 @@ export function getNewConnection(options: {
   // read-ahead is performed. Used for many-small-file remote sessions to avoid fetching
   // whole files up-front. Defaults to true (legacy behaviour).
   readAheadEnabled?: boolean;
+  readAheadBufferBytes?: number;
 }): Range | undefined {
   const {
     readRequestRange,
     currentRemainingRange,
     readAheadEnabled = true,
+    readAheadBufferBytes = READ_AHEAD_BUFFER_SIZE,
     ...otherOptions
   } = options;
   if (readRequestRange) {
@@ -45,10 +47,14 @@ export function getNewConnection(options: {
       readRequestRange,
       currentRemainingRange,
       readAheadEnabled,
+      readAheadBufferBytes,
       ...otherOptions,
     });
   } else if (!currentRemainingRange && readAheadEnabled) {
-    return getNewConnectionWithoutExistingConnection(otherOptions);
+    return getNewConnectionWithoutExistingConnection({
+      ...otherOptions,
+      readAheadBufferBytes,
+    });
   }
   return undefined;
 }
@@ -61,6 +67,7 @@ function getNewConnectionWithExistingReadRequest({
   fileSize,
   continueDownloadingThreshold,
   readAheadEnabled,
+  readAheadBufferBytes,
 }: {
   currentRemainingRange?: Range;
   readRequestRange: Range;
@@ -70,6 +77,7 @@ function getNewConnectionWithExistingReadRequest({
   fileSize: number;
   continueDownloadingThreshold: number;
   readAheadEnabled: boolean;
+  readAheadBufferBytes: number;
 }): Range | undefined {
   // We have a requested range that we're trying to download.
   if (readRequestRange.end - readRequestRange.start > maxRequestSize) {
@@ -114,10 +122,14 @@ function getNewConnectionWithExistingReadRequest({
     // If we're downloading to the end of our range, do some reading ahead while we're at it.
     // Note that we might have already downloaded parts of this range, but we don't know when
     // they get evicted, so for now we just the entire range again.
-    // Use a conservative read-ahead of 50 MB to avoid downloading too much data that may not be needed
+    // Use the configured read-ahead buffer to avoid downloading too much data that may not be needed,
+    // but never shrink below the actual missing tail of the pending read request.
     return {
       ...notDownloadedRanges[0],
-      end: Math.min(readRequestRange.start + READ_AHEAD_BUFFER_SIZE, fileSize),
+      end: Math.max(
+        notDownloadedRanges[0].end,
+        Math.min(readRequestRange.start + readAheadBufferBytes, fileSize),
+      ),
     };
   }
 
@@ -130,11 +142,13 @@ function getNewConnectionWithoutExistingConnection({
   lastResolvedCallbackEnd,
   maxRequestSize,
   fileSize,
+  readAheadBufferBytes,
 }: {
   downloadedRanges: Range[];
   lastResolvedCallbackEnd?: number;
   maxRequestSize: number;
   fileSize: number;
+  readAheadBufferBytes: number;
 }): Range | undefined {
   // If we don't have any read requests, and we also don't have an active connection, then start
   // reading ahead as much data as we can!
@@ -149,12 +163,15 @@ function getNewConnectionWithoutExistingConnection({
       readAheadRange = { start: 0, end: fileSize };
     }
   } else if (lastResolvedCallbackEnd != undefined) {
+    if (lastResolvedCallbackEnd >= fileSize) {
+      return undefined;
+    }
     // Otherwise, if we have a limited cache, we want to read the data right after the last
     // read request, because usually read requests are sequential without gaps.
-    // Use a conservative read-ahead of 50 MB to avoid downloading too much data that may not be needed
+    // Use the configured read-ahead buffer to avoid downloading too much data that may not be needed.
     readAheadRange = {
       start: lastResolvedCallbackEnd,
-      end: Math.min(lastResolvedCallbackEnd + READ_AHEAD_BUFFER_SIZE, fileSize),
+      end: Math.min(lastResolvedCallbackEnd + readAheadBufferBytes, fileSize),
     };
   }
   if (readAheadRange) {


### PR DESCRIPTION
## Summary

Loading many large MCAP files (remote `ds.url` or local multi-file) grew a single `McapIterableSourceWorker` to ~4–5 GB and crashed the tab ("Aw, Snap!"). This PR bounds worker memory so large multi-file sessions (30+ files observed; target 60–100) no longer OOM.

## Root cause

`MultiIterableSource` initialized every source with unbounded concurrency and kept **all N** hydrated `McapIndexedIterableSource` readers resident for the whole session. Each reader retains the parsed protobuf channel table (~611 channels) and its buffers, so memory grew linearly with file count (~150 MB/file → ~5 GB @ 34 files). This affected both the `urls` (remote) and `files` (local) branches.

## Changes

- **Bounded init concurrency**: `initializeSources` now uses an `async-mutex` `Semaphore` (default 4) instead of `Promise.all` over all sources, for both `files` and `urls`.
- **Bounded LRU reader pool** (`HydratedSourcePool`): keeps at most K (default 8) hydrated readers resident; `acquire`/`release` pin during active iteration/backfill; least-recently-used unpinned readers are evicted and re-hydrated on demand. For N ≤ K all readers stay resident (no single-file regression); for N > K memory stays bounded.
- **Lifecycle wiring** in `McapIterableSource`: lazy `#openInner`, pool `admit` on init (reusing the init hydration, no double-open), acquire/release around `messageIterator`/`getBackfillMessages`, `terminate()`.
- **`close()` primitives**: `CachedFilelike.close()` (abort connection, reject pending reads, reset buffer, `#closed` guard in `read()`) and `RemoteFileReadable.close()` so evicted remote readers release their cache. Local `BlobReadable` eviction just drops parsed channels (cheap re-hydrate).
- New config knobs `maxHydratedSources` / `initConcurrency` on both `MultiSource` variants.
- Lightweight pool metrics logging (`resident=N/K`).

## Tradeoffs

For N > K, evicted remote readers re-read their ~14.7 MB summary on re-hydration (memory-vs-requests tradeoff, accepted). Init still parses all N files once to compute merged start/end/topics/datatypes, but bounded to `initConcurrency` at a time.

## Testing

- New suites: `HydratedSourcePool.test.ts` (pool admit/acquire/release/evict), plus updates to `MultiIterableSource`, `McapIterableSource`, `CachedFilelike`, `RemoteFileReadable` tests.
- Full IterablePlayer suite passes (242 tests); `yarn tsc --noEmit` and eslint clean.
- Validated manually: 34-file remote and 34-file local sessions no longer OOM.

## Notes

Draft: pending validation at 60–100 files and possible follow-ups (metadata-only init, tuning K, main-thread `/log` backpressure).

---

## Follow-up refinements (review items)

- **Memory-weighted pool budget (I2):** `HydratedSourcePool` uses a hybrid budget — primary byte budget (`maxBytes`, default 512 MiB) via per-reader weight estimation, plus a count-cap safety (`maxCount`, raised 8→12) and a `minResident` floor. Heavy-index files evict sooner; small files stay resident longer.
- **Earliest-by-start warm-up (I1):** after sorting sources by start time, the earliest sources are prewarmed so playback at t=0 does not stall re-hydrating them.
- **Pin-leak guard (I3):** concurrent `acquire()` of a source whose `open()` rejects no longer leaves a phantom pin.
- **Docs (I4/I5):** unindexed sources bypass the pool (retained eagerly — unbounded for many large unindexed files); `messageIterator` is an async generator so its "uninitialized" invariant throws on first `.next()`.

### Deferred (separate PRs)
- **Calibration:** the byte-budget defaults are provisional/conservative and need runtime tuning on large multi-file sessions (plan-act 34, semantic-road 20, and 150–200 file / ~10 GB projections).
- **Next OOM front (main-thread):** for 15–20 GB sessions memory pressure is expected to migrate from the worker to the renderer (BlockLoader 1 GB budget, unbounded `DeserializingIterableSource` buffers, `/log` firehose). Mapped for a follow-up PR; out of scope here.
- **Unindexed pooling** and **external budget knobs** (factories/URL params) are out of scope.

---

## Out of Scope

This PR bounds the memory of the MCAP reader **worker** (`McapIterableSourceWorker`) via `HydratedSourcePool` (byte-weighted budget + count-cap) and init concurrency. The following memory issues were **identified during this work but intentionally left out of scope** — they live in *different* processes/heaps and should be addressed in separate PRs.

> **Why OOM can still occur:** the "Aw, Snap!" crash is a per-process V8 heap limit (~2–4 GB on 64-bit Chrome), not an app-wide cap. Each Web Worker and the main renderer thread each have their **own** heap. This PR fixes the MCAP worker heap; the fronts below are separate heaps that remain unbounded.

### 1. Plot panel workers (`series.full` unbounded)
- **Where:** `panels/Plot/builders/TimestampDatasetsBuilderImpl.ts` (and `CustomDatasetsBuilderImpl.ts`).
- **Problem:** with `preloadType:"full"` (`panels/Plot/hooks/useSubscriptions.ts`), `series.full` accumulates the **whole timeline at full resolution** with fat datums (two nested `Time` objects + retained `value`/strings), with **no cap**. Only `current` (50k) and render output (5000 pts) are bounded; downsampling is read-time only, so full-res data is retained forever. `#pendingDispatch` on the main thread is also unbounded ("Chart main").
- **Symptom:** OOM with the Plot worker(s) / "Chart main" growing while the MCAP worker stays flat.
- **Future fix (separate PR):** cap/decimate `series.full` + back-pressure (Phase 1), then viewport-windowed range subscription using `IterablePlayer.getBatchIterator({start,end})` (Phase 2).

### 2. Main-thread / renderer preload front
- **Components & current limits:** `BlockLoader` cache = 1 GB (`IterablePlayer.ts` `DEFAULT_CACHE_SIZE_BYTES`), `BufferedIterableSource` = 10 s / 300 MB, `DeserializingIterableSource` = **no explicit cap**.
- **Problem at 150–200 files / 15–20 GB:** full-timeline preload deserializes everything on the main thread (LRU-evicted within 1 GB but with heavy GC churn); `/log` is ~82% of messages in these datasets (firehose); `DeserializingIterableSource` intermediate buffers are unbounded.
- **Symptom:** OOM with the **renderer** heap rising while the MCAP worker stays low/stable.
- **Future fix (separate PR):** back-pressure/caps on `DeserializingIterableSource` buffers, per-topic preload opt-out/sampling for firehose topics (e.g. `/log`), adaptive/reduced `BlockLoader` budget for large multi-file sessions, or on-demand (playhead-windowed) preload instead of whole-timeline.

### 3. Unindexed MCAP sources bypass the pool
- Unindexed sources are retained via `#eagerInner` and are **not** bounded by `HydratedSourcePool`. A session of many large unindexed files can still grow unbounded. Left as a documented follow-up.

### Also explicitly out of scope for this PR
- Any change to `BlockLoader` / `DeserializingIterableSource` / preload policy.
- External knobs (factories / URL params) for the budgets — defaults are internal only.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved handling of large MCAP files and remote sources with bounded memory usage.
  - Added smarter caching, source reuse, and on-demand rehydration during playback and backfill.
  - Added configurable limits for resident sources, memory, and initialization concurrency.
  - Added optional prewarming to improve responsiveness when accessing upcoming data.

- **Reliability**
  - Improved cleanup of remote readers and cached data during termination.
  - Large uncached reads now validate boundaries and handle interrupted or closed streams more safely.
  - Improved recovery when sources are evicted or fail to load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->