### PR TITLE
fix: make layout userNodes optional in validation

### DIFF
--- a/packages/suite-base/src/context/CurrentLayoutContext/actions.ts
+++ b/packages/suite-base/src/context/CurrentLayoutContext/actions.ts
@@ -33,7 +33,11 @@ export type LayoutData = {
   layout?: MosaicNode<string>;
   globalVariables: GlobalVariables;
   playbackConfig: PlaybackConfig;
-  userNodes: UserScripts;
+  /**
+   * User scripts (a.k.a. user nodes). Optional: a layout with no user scripts may omit this field,
+   * in which case consumers treat it as an empty object.
+   */
+  userNodes?: UserScripts;
   /** @deprecated renamed to configById */
   savedProps?: SavedProps;
   /**

--- a/packages/suite-base/src/context/CurrentLayoutContext/actions.ts
+++ b/packages/suite-base/src/context/CurrentLayoutContext/actions.ts
@@ -33,10 +33,6 @@ export type LayoutData = {
   layout?: MosaicNode<string>;
   globalVariables: GlobalVariables;
   playbackConfig: PlaybackConfig;
-  /**
-   * User scripts (a.k.a. user nodes). Optional: a layout with no user scripts may omit this field,
-   * in which case consumers treat it as an empty object.
-   */
   userNodes?: UserScripts;
   /** @deprecated renamed to configById */
   savedProps?: SavedProps;

--- a/packages/suite-base/src/util/layout.test.ts
+++ b/packages/suite-base/src/util/layout.test.ts
@@ -692,7 +692,6 @@ describe("layout", () => {
     it.each([
       "configById",
       "globalVariables",
-      "userNodes",
     ] as const)("throws when required object field %s is missing", (field) => {
       // Given a layout missing a required object field
       const data = validData();
@@ -701,6 +700,25 @@ describe("layout", () => {
       // When validating it
       // Then it throws referencing that field
       expect(() => validateLayoutData(data)).toThrow(`missing or invalid "${field}"`);
+    });
+
+    it("accepts a layout that omits userNodes", () => {
+      // Given a valid layout without a userNodes field
+      const data = validData();
+      delete data.userNodes;
+
+      // When validating it
+      // Then it is accepted
+      expect(validateLayoutData(data)).toBe(data);
+    });
+
+    it("throws when userNodes is present but not an object", () => {
+      // Given a layout whose userNodes field is not an object
+      const data = { ...validData(), userNodes: [] };
+
+      // When validating it
+      // Then it throws
+      expect(() => validateLayoutData(data)).toThrow('invalid "userNodes"');
     });
 
     it("throws when playbackConfig is missing", () => {
@@ -747,7 +765,7 @@ describe("layout", () => {
       // When validating it
       // Then all invalid fields are reported
       expect(() => validateLayoutData(data)).toThrow(
-        'missing or invalid fields: "configById", "userNodes", "playbackConfig"',
+        'missing or invalid fields: "configById", "playbackConfig"',
       );
     });
   });

--- a/packages/suite-base/src/util/layout.test.ts
+++ b/packages/suite-base/src/util/layout.test.ts
@@ -721,6 +721,15 @@ describe("layout", () => {
       expect(() => validateLayoutData(data)).toThrow('invalid "userNodes"');
     });
 
+    it("throws when userNodes is null", () => {
+      // Given a layout whose userNodes field is explicitly null
+      const data = { ...validData(), userNodes: null };
+
+      // When validating it
+      // Then it throws
+      expect(() => validateLayoutData(data)).toThrow('invalid "userNodes"');
+    });
+
     it("throws when playbackConfig is missing", () => {
       // Given a layout without playbackConfig
       const data = validData();

--- a/packages/suite-base/src/util/layout.ts
+++ b/packages/suite-base/src/util/layout.ts
@@ -596,7 +596,6 @@ export function validateLayoutData(data: unknown): LayoutData {
     errors.push(`missing or invalid fields: ${quotedFields}`);
   }
 
-  // userNodes is optional; validate its type whenever the field is present (rejecting null).
   if ("userNodes" in data && !isPlainObject(data.userNodes)) {
     errors.push(`invalid "userNodes"`);
   }

--- a/packages/suite-base/src/util/layout.ts
+++ b/packages/suite-base/src/util/layout.ts
@@ -583,7 +583,7 @@ export function validateLayoutData(data: unknown): LayoutData {
     throw new Error("expected an object");
   }
 
-  const missingFields = ["configById", "globalVariables", "userNodes"].filter(
+  const missingFields = ["configById", "globalVariables"].filter(
     (field) => !isPlainObject(data[field]),
   );
   if (!isPlainObject(data.playbackConfig) || typeof data.playbackConfig.speed !== "number") {
@@ -594,6 +594,11 @@ export function validateLayoutData(data: unknown): LayoutData {
   } else if (missingFields.length > 1) {
     const quotedFields = missingFields.map((field) => `"${field}"`).join(", ");
     errors.push(`missing or invalid fields: ${quotedFields}`);
+  }
+
+  // userNodes is optional; only its type is validated when present.
+  if (data.userNodes != undefined && !isPlainObject(data.userNodes)) {
+    errors.push(`invalid "userNodes"`);
   }
 
   if (data.layout != undefined && typeof data.layout !== "string" && !isPlainObject(data.layout)) {

--- a/packages/suite-base/src/util/layout.ts
+++ b/packages/suite-base/src/util/layout.ts
@@ -596,8 +596,8 @@ export function validateLayoutData(data: unknown): LayoutData {
     errors.push(`missing or invalid fields: ${quotedFields}`);
   }
 
-  // userNodes is optional; only its type is validated when present.
-  if (data.userNodes != undefined && !isPlainObject(data.userNodes)) {
+  // userNodes is optional; validate its type whenever the field is present (rejecting null).
+  if ("userNodes" in data && !isPlainObject(data.userNodes)) {
     errors.push(`invalid "userNodes"`);
   }
 


### PR DESCRIPTION
## User-Facing Changes

Layouts that don't define user scripts (`userNodes`) can now be imported instead of being rejected with `missing or invalid "userNodes"`.

## Description

`userNodes` only stores User Script panel scripts and is optional at runtime (already defaulted to empty via `?? EMPTY_USER_NODES` in PlayerManager and UserScriptEditor). The type declared it required, which made `validateLayoutData` reject valid layouts.

This makes `LayoutData.userNodes` optional and relaxes the validator to only check the field's type when present.

### How to test

- Import a layout JSON that has no `userNodes` field; it now imports successfully.
- Importing a layout where `userNodes` is present but not an object still fails with `invalid "userNodes"`.
- Updated `packages/suite-base/src/util/layout.test.ts`.
- `layout.test.ts` (47/47) and `reducers.test.tsx` (41/41) pass.

Validation run:

```sh
yarn test --runTestsByPath packages/suite-base/src/util/layout.test.ts packages/suite-base/src/providers/CurrentLayoutProvider/reducers.test.tsx --runInBand
```

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Layouts can now omit user script data when no user scripts are present.
  * Layout validation continues to reject invalid user script data when provided.
  * Improved validation error reporting for invalid layout content.

* **Tests**
  * Updated layout validation coverage for optional user script data and invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->