### PR TITLE
Feat/tsp 3095/additional panels

### DIFF
--- a/packages/suite-base/src/panels/BlackboxShared/canvas.ts
+++ b/packages/suite-base/src/panels/BlackboxShared/canvas.ts
@@ -1,0 +1,150 @@
+export interface Bounds {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
+export type Project = (x: number, y: number) => [number, number];
+
+export function boundsOf(points: readonly { x: number; y: number }[]): Bounds | undefined {
+  if (points.length === 0) {
+    return undefined;
+  }
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const p of points) {
+    if (p.x < minX) {
+      minX = p.x;
+    }
+    if (p.x > maxX) {
+      maxX = p.x;
+    }
+    if (p.y < minY) {
+      minY = p.y;
+    }
+    if (p.y > maxY) {
+      maxY = p.y;
+    }
+  }
+  return { minX, maxX, minY, maxY };
+}
+
+export function padBounds(b: Bounds, pad: number): Bounds {
+  return { minX: b.minX - pad, maxX: b.maxX + pad, minY: b.minY - pad, maxY: b.maxY + pad };
+}
+
+export function atLeastExtent(b: Bounds, extent: number): Bounds {
+  const result = { ...b };
+  if (result.maxX - result.minX < extent) {
+    const cx = (result.minX + result.maxX) / 2;
+    result.minX = cx - extent / 2;
+    result.maxX = cx + extent / 2;
+  }
+  if (result.maxY - result.minY < extent) {
+    const cy = (result.minY + result.maxY) / 2;
+    result.minY = cy - extent / 2;
+    result.maxY = cy + extent / 2;
+  }
+  return result;
+}
+
+// Fit-to-box uniform scale (preserves aspect ratio) with a flipped Y axis (world +Y is up,
+// canvas +Y is down) so drawing code can work in plain world coordinates.
+export function makeProjector(
+  bounds: Bounds,
+  width: number,
+  height: number,
+  pad = 28,
+): { toPx: Project; scale: number } {
+  const spanX = Math.max(bounds.maxX - bounds.minX, 1e-6);
+  const spanY = Math.max(bounds.maxY - bounds.minY, 1e-6);
+  const scale = Math.min((width - 2 * pad) / spanX, (height - 2 * pad) / spanY);
+  const offsetX = pad + (width - 2 * pad - spanX * scale) / 2;
+  const offsetY = pad + (height - 2 * pad - spanY * scale) / 2;
+  const toPx: Project = (x, y) => [
+    offsetX + (x - bounds.minX) * scale,
+    height - (offsetY + (y - bounds.minY) * scale),
+  ];
+  return { toPx, scale };
+}
+
+export function setupCanvas(
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+): CanvasRenderingContext2D | undefined {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return undefined;
+  }
+  canvas.width = width;
+  canvas.height = height;
+  ctx.clearRect(0, 0, width, height);
+  return ctx;
+}
+
+// 10-point (5-pointed) star, alternating outer `radius` / inner `radius / 2.3`, first point
+// straight up.
+export function drawStar(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  radius: number,
+  fill: string,
+  stroke: string,
+): void {
+  ctx.beginPath();
+  for (let i = 0; i < 10; i++) {
+    const angle = (Math.PI / 5) * i - Math.PI / 2;
+    const r = i % 2 === 0 ? radius : radius / 2.3;
+    const px = cx + r * Math.cos(angle);
+    const py = cy + r * Math.sin(angle);
+    if (i === 0) {
+      ctx.moveTo(px, py);
+    } else {
+      ctx.lineTo(px, py);
+    }
+  }
+  ctx.closePath();
+  ctx.fillStyle = fill;
+  ctx.fill();
+  ctx.strokeStyle = stroke;
+  ctx.lineWidth = 1;
+  ctx.stroke();
+}
+
+// Shaft + a triangular head formed by rotating back along the shaft direction by +/-30 degrees.
+export function drawArrow(
+  ctx: CanvasRenderingContext2D,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  color: string,
+): void {
+  const angle = Math.atan2(y2 - y1, x2 - x1);
+  const head = 8;
+  ctx.strokeStyle = color;
+  ctx.fillStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x2, y2);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.moveTo(x2, y2);
+  ctx.lineTo(
+    x2 - head * Math.cos(angle - Math.PI / 6),
+    y2 - head * Math.sin(angle - Math.PI / 6),
+  );
+  ctx.lineTo(
+    x2 - head * Math.cos(angle + Math.PI / 6),
+    y2 - head * Math.sin(angle + Math.PI / 6),
+  );
+  ctx.closePath();
+  ctx.fill();
+}

--- a/packages/suite-base/src/panels/BlackboxShared/colormap.ts
+++ b/packages/suite-base/src/panels/BlackboxShared/colormap.ts
@@ -1,0 +1,51 @@
+type RGB = [number, number, number];
+type Stop = [number, RGB];
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function ramp(stops: Stop[], value: number): string {
+  for (let i = 1; i < stops.length; i++) {
+    const [p1, c1] = stops[i - 1]!;
+    const [p2, c2] = stops[i]!;
+    if (value <= p2) {
+      const span = p2 - p1;
+      const t = (value - p1) / (span === 0 ? 1 : span);
+      const r = Math.round(lerp(c1[0], c2[0], t));
+      const g = Math.round(lerp(c1[1], c2[1], t));
+      const b = Math.round(lerp(c1[2], c2[2], t));
+      return `rgb(${r}, ${g}, ${b})`;
+    }
+  }
+  const [, lastColor] = stops[stops.length - 1]!;
+  return `rgb(${lastColor[0]}, ${lastColor[1]}, ${lastColor[2]})`;
+}
+
+const TERRAIN: Stop[] = [
+  [0, [44, 60, 140]],
+  [0.4, [60, 150, 120]],
+  [0.6, [120, 170, 90]],
+  [0.75, [160, 130, 70]],
+  [0.9, [200, 180, 150]],
+  [1, [245, 245, 245]],
+];
+
+const SPEED: Stop[] = [
+  [0, [13, 8, 135]],
+  [0.5, [156, 23, 158]],
+  [0.75, [237, 121, 83]],
+  [1, [240, 249, 33]],
+];
+
+export function heightColor(z: number, vmin = -1.2, vmax = 1.2): string {
+  return ramp(TERRAIN, clamp01((z - vmin) / (vmax - vmin)));
+}
+
+export function speedColor(speed: number, vmax = 1.8): string {
+  return ramp(SPEED, clamp01(Math.abs(speed) / vmax));
+}

--- a/packages/suite-base/src/panels/BlackboxShared/decode.ts
+++ b/packages/suite-base/src/panels/BlackboxShared/decode.ts
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+// Mirrors the exact field paths root-cause-analyzer's RcaEvidenceExtractor.cs already navigates
+// server-side for the same evidence dataset (libs/root-cause/RootCause.Infrastructure/Services/
+// BlackBoxIngestion/Rca/RcaEvidenceExtractor.cs). Lichtblick's own CDR deserializer already turns
+// these custom ROS2 messages into plain JS objects (mcap-support's parseChannel builds the decoder
+// purely from the schema text embedded in the mcap, no hardcoded type registry) -- there is no CDR
+// parsing left to do here, only picking the same fields back out.
+
+export interface OdomSample {
+  tNs: number;
+  x: number;
+  y: number;
+  yaw: number;
+  speed: number;
+}
+
+export interface PathPoint {
+  x: number;
+  y: number;
+}
+
+export interface ZoneViolation {
+  tNs: number;
+  type: number;
+  violated: boolean;
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface LidarPoint {
+  x: number;
+  y: number;
+  z: number;
+}
+
+function toFiniteNumber(value: unknown): number | undefined {
+  const n = typeof value === "bigint" ? Number(value) : Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+// Same formula as root-cause-analyzer's Ros2Geometry.YawFromQuaternion (RcaEvidenceExtractor.cs's
+// sibling Ros2Geometry.cs), assuming a roughly level vehicle (roll/pitch ignored).
+function yawFromQuaternion(x: number, y: number, z: number, w: number): number {
+  return Math.atan2(2 * (w * z + x * y), 1 - 2 * (y * y + z * z));
+}
+
+/** nav_msgs/msg/Odometry -> {tNs, x, y, yaw, speed}. Mirrors the Topics.Odom case. */
+export function decodeOdom(message: unknown, tNs: number): OdomSample | undefined {
+  const m = message as {
+    pose?: {
+      pose?: {
+        position?: { x?: unknown; y?: unknown };
+        orientation?: { x?: unknown; y?: unknown; z?: unknown; w?: unknown };
+      };
+    };
+    twist?: { twist?: { linear?: { x?: unknown } } };
+  };
+  const x = toFiniteNumber(m.pose?.pose?.position?.x);
+  const y = toFiniteNumber(m.pose?.pose?.position?.y);
+  if (x == undefined || y == undefined) {
+    return undefined;
+  }
+  const orientation = m.pose?.pose?.orientation ?? {};
+  const yaw = yawFromQuaternion(
+    toFiniteNumber(orientation.x) ?? 0,
+    toFiniteNumber(orientation.y) ?? 0,
+    toFiniteNumber(orientation.z) ?? 0,
+    toFiniteNumber(orientation.w) ?? 0,
+  );
+  const speed = toFiniteNumber(m.twist?.twist?.linear?.x) ?? 0;
+  return { tNs, x, y, yaw, speed };
+}
+
+/** polygon_msgs/msg/Polygon2DStamped -> {x,y}[]. Mirrors the ReadPolygon helper (Topics.Hazard). */
+export function decodeHazardPolygon(message: unknown): PathPoint[] {
+  const points = (message as { polygon?: { points?: unknown[] } }).polygon?.points ?? [];
+  const result: PathPoint[] = [];
+  for (const point of points) {
+    const p = point as { x?: unknown; y?: unknown };
+    const x = toFiniteNumber(p.x);
+    const y = toFiniteNumber(p.y);
+    if (x != undefined && y != undefined) {
+      result.push({ x, y });
+    }
+  }
+  return result;
+}
+
+/** mission_msgs/msg/PathStamped -> {x,y}[]. Mirrors the ReadPlannedPath helper (Topics.PlannedPath). */
+export function decodePlannedPath(message: unknown): PathPoint[] {
+  const points = (message as { path?: { points?: unknown[] } }).path?.points ?? [];
+  const result: PathPoint[] = [];
+  for (const point of points) {
+    const p = point as { location?: { position?: { x?: unknown; y?: unknown } } };
+    const x = toFiniteNumber(p.location?.position?.x);
+    const y = toFiniteNumber(p.location?.position?.y);
+    if (x != undefined && y != undefined) {
+      result.push({ x, y });
+    }
+  }
+  return result;
+}
+
+/**
+ * mission_msgs/msg/ZoneReport -> obstacles[] flattened to {tNs, type, violated, x, y, z}[].
+ * Mirrors the Topics.ZoneReport case. Unlike the C# decoder (which has to defensively "unwrap" a
+ * {data: ...} box for ambiguous CDR-decoded scalars), Lichtblick's ROS2MessageReader already
+ * produces properly-typed primitives per the real .msg schema, so `type`/`violated` are read
+ * directly.
+ */
+export function decodeZoneViolations(message: unknown, tNs: number): ZoneViolation[] {
+  const obstacles = (message as { obstacles?: unknown[] }).obstacles ?? [];
+  const result: ZoneViolation[] = [];
+  for (const obstacle of obstacles) {
+    const o = obstacle as {
+      obstacle_location?: { x?: unknown; y?: unknown; z?: unknown };
+      type?: unknown;
+      violated?: unknown;
+    };
+    const x = toFiniteNumber(o.obstacle_location?.x);
+    const y = toFiniteNumber(o.obstacle_location?.y);
+    if (x == undefined || y == undefined) {
+      continue;
+    }
+    const z = toFiniteNumber(o.obstacle_location?.z) ?? 0;
+    result.push({
+      tNs,
+      type: Math.trunc(toFiniteNumber(o.type) ?? 0),
+      violated: Boolean(o.violated),
+      x,
+      y,
+      z,
+    });
+  }
+  return result;
+}

--- a/packages/suite-base/src/panels/BlackboxShared/frameCache.ts
+++ b/packages/suite-base/src/panels/BlackboxShared/frameCache.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MessageEvent } from "@lichtblick/suite";
+
+export interface FrameCache<T> {
+  frames?: readonly MessageEvent[];
+  items: T[];
+}
+
+/**
+ * Incrementally rebuilds a decoded-item cache from `renderState.allFrames` (the full sorted
+ * preloaded-block history for `preload: true` subscriptions). `allFrames` gets a new array
+ * reference every time more of the file streams in, and re-decoding the whole history from
+ * scratch on each of those bumps is what makes TacticalMap/LidarProfile lag heavily while a file
+ * is still loading. When the new array is an append-only extension of the previous one --
+ * verified by object identity on the last previously-seen event, the same technique these panels
+ * already use to skip re-decoding an unchanged point-cloud message, not just assumed -- only the
+ * new tail is decoded; otherwise (seek, source change, out-of-order block fill) it safely falls
+ * back to a full rebuild.
+ */
+export function updateFrameCache<T>(
+  cache: FrameCache<T>,
+  allFrames: readonly MessageEvent[],
+  topic: string,
+  decode: (event: MessageEvent) => T | readonly T[] | undefined,
+): FrameCache<T> {
+  const previousFrames = cache.frames;
+  const previousLength = previousFrames?.length ?? 0;
+  const isAppendOnly =
+    previousFrames != undefined &&
+    allFrames.length >= previousLength &&
+    (previousLength === 0 || allFrames[previousLength - 1] === previousFrames[previousLength - 1]);
+
+  const items = isAppendOnly ? cache.items.slice() : [];
+  const startIndex = isAppendOnly ? previousLength : 0;
+  for (let i = startIndex; i < allFrames.length; i++) {
+    const event = allFrames[i]!;
+    if (event.topic !== topic) {
+      continue;
+    }
+    const decoded = decode(event);
+    if (decoded == undefined) {
+      continue;
+    }
+    if (Array.isArray(decoded)) {
+      items.push(...(decoded as T[]));
+    } else {
+      items.push(decoded as T);
+    }
+  }
+
+  return { frames: allFrames, items };
+}

--- a/packages/suite-base/src/panels/BlackboxShared/geometry.test.ts
+++ b/packages/suite-base/src/panels/BlackboxShared/geometry.test.ts
@@ -1,0 +1,115 @@
+import { nearestByTime, poseAt, projectToMap, secondsFromT0 } from "./geometry";
+
+interface Sample {
+  tNs: number;
+  label: string;
+}
+
+function sample(tNs: number, label: string): Sample {
+  return { tNs, label };
+}
+
+// A brute-force linear scan mirroring the original implementation, used as an oracle to check the
+// binary-search version against a range of randomized sorted inputs.
+function linearNearestByTime<T extends { tNs: number }>(
+  samples: readonly T[],
+  tNs: number,
+): T | undefined {
+  if (samples.length === 0) {
+    return undefined;
+  }
+  let best = samples[0]!;
+  let bestDelta = Math.abs(best.tNs - tNs);
+  for (const s of samples) {
+    const delta = Math.abs(s.tNs - tNs);
+    if (delta < bestDelta) {
+      best = s;
+      bestDelta = delta;
+    }
+  }
+  return best;
+}
+
+describe("nearestByTime", () => {
+  it("returns undefined for an empty array", () => {
+    expect(nearestByTime([], 100)).toBeUndefined();
+  });
+
+  it("returns the only sample for a single-element array", () => {
+    const samples = [sample(10, "a")];
+    expect(nearestByTime(samples, 999)).toBe(samples[0]);
+    expect(nearestByTime(samples, -999)).toBe(samples[0]);
+  });
+
+  it("returns the exact match when present", () => {
+    const samples = [sample(0, "a"), sample(10, "b"), sample(20, "c")];
+    expect(nearestByTime(samples, 10)).toBe(samples[1]);
+  });
+
+  it("clamps to the first sample when the query is before the range", () => {
+    const samples = [sample(10, "a"), sample(20, "b"), sample(30, "c")];
+    expect(nearestByTime(samples, -100)).toBe(samples[0]);
+  });
+
+  it("clamps to the last sample when the query is after the range", () => {
+    const samples = [sample(10, "a"), sample(20, "b"), sample(30, "c")];
+    expect(nearestByTime(samples, 1000)).toBe(samples[2]);
+  });
+
+  it("picks the nearer neighbor between two samples", () => {
+    const samples = [sample(0, "a"), sample(100, "b")];
+    expect(nearestByTime(samples, 30)).toBe(samples[0]);
+    expect(nearestByTime(samples, 70)).toBe(samples[1]);
+  });
+
+  it("breaks exact ties in favor of the earlier sample", () => {
+    const samples = [sample(0, "a"), sample(100, "b")];
+    expect(nearestByTime(samples, 50)).toBe(samples[0]);
+  });
+
+  it("matches a brute-force linear scan across many random sorted inputs", () => {
+    for (let trial = 0; trial < 200; trial++) {
+      const length = 1 + Math.floor(Math.random() * 50);
+      const tNsValues: number[] = [];
+      let t = Math.floor(Math.random() * 1000);
+      for (let i = 0; i < length; i++) {
+        tNsValues.push(t);
+        t += Math.floor(Math.random() * 20); // strictly non-decreasing, ties allowed
+      }
+      const samples = tNsValues.map((tns, i) => sample(tns, `s${i}`));
+      const query = Math.floor(Math.random() * (t + 100)) - 50;
+
+      const expected = linearNearestByTime(samples, query);
+      const actual = nearestByTime(samples, query);
+      expect(actual?.tNs).toBe(expected?.tNs);
+    }
+  });
+});
+
+describe("poseAt", () => {
+  it("returns undefined for an empty odom list", () => {
+    expect(poseAt([], 100)).toBeUndefined();
+  });
+
+  it("returns the pose of the nearest odom sample", () => {
+    const odom = [
+      { tNs: 0, x: 1, y: 2, yaw: 0.1 },
+      { tNs: 10, x: 3, y: 4, yaw: 0.2 },
+    ];
+    expect(poseAt(odom, 9)).toEqual({ x: 3, y: 4, yaw: 0.2 });
+  });
+});
+
+describe("projectToMap", () => {
+  it("applies rotation then translation", () => {
+    const result = projectToMap({ x: 1, y: 0 }, { x: 10, y: 20, yaw: Math.PI / 2 });
+    expect(result.x).toBeCloseTo(10, 5);
+    expect(result.y).toBeCloseTo(21, 5);
+  });
+});
+
+describe("secondsFromT0", () => {
+  it("converts a nanosecond delta to seconds", () => {
+    expect(secondsFromT0(5_000_000_000, 2_000_000_000)).toBeCloseTo(3, 9);
+  });
+});

--- a/packages/suite-base/src/panels/BlackboxShared/geometry.ts
+++ b/packages/suite-base/src/panels/BlackboxShared/geometry.ts
@@ -1,0 +1,75 @@
+export interface Point2 {
+  x: number;
+  y: number;
+}
+
+export interface Pose2 {
+  x: number;
+  y: number;
+  yaw: number;
+}
+
+export function secondsFromT0(tNs: number, t0Ns: number): number {
+  return (tNs - t0Ns) / 1e9;
+}
+
+// Rigid 2D transform: rotate the vehicle-frame point by pose.yaw, then translate by pose.{x,y}.
+export function projectToMap(vehicle: Point2, pose: Pose2): Point2 {
+  const c = Math.cos(pose.yaw);
+  const s = Math.sin(pose.yaw);
+  return {
+    x: pose.x + c * vehicle.x - s * vehicle.y,
+    y: pose.y + s * vehicle.x + c * vehicle.y,
+  };
+}
+
+// No interpolation -- snaps to whichever sample's tNs is closest to the query time.
+//
+// Callers pass samples in ascending-tNs order: TacticalMap explicitly re-sorts odom after every
+// frame-cache update, and violation/other decoded lists come from `renderState.allFrames`, which
+// Lichtblick's message pipeline already guarantees is receiveTime-ordered (filtering by topic
+// preserves that order). Given sorted input, |sample.tNs - tNs| is unimodal across the array (it
+// only decreases then increases), so the global minimum sits at the binary-search insertion point
+// -- only the two neighboring samples there need checking. This runs inside TacticalMap's
+// zone-violation draw loop (once per violation, every frame), so for a preloaded clip with a large
+// odom history a linear scan there is O(violations * odom) per redraw; this is O(violations *
+// log(odom)).
+export function nearestByTime<T extends { tNs: number }>(
+  samples: readonly T[],
+  tNs: number,
+): T | undefined {
+  if (samples.length === 0) {
+    return undefined;
+  }
+
+  let lo = 0;
+  let hi = samples.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (samples[mid]!.tNs < tNs) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+
+  // `lo` is the first sample with tNs >= tNs (or the last index if every sample is earlier).
+  const candidate = samples[lo]!;
+  if (lo > 0) {
+    const prev = samples[lo - 1]!;
+    // `<=` (not `<`) so an exact tie keeps the earlier sample, matching the original linear
+    // scan's first-minimum-wins behavior.
+    if (Math.abs(prev.tNs - tNs) <= Math.abs(candidate.tNs - tNs)) {
+      return prev;
+    }
+  }
+  return candidate;
+}
+
+export function poseAt<T extends { tNs: number; x: number; y: number; yaw: number }>(
+  odom: readonly T[],
+  tNs: number,
+): Pose2 | undefined {
+  const sample = nearestByTime(odom, tNs);
+  return sample ? { x: sample.x, y: sample.y, yaw: sample.yaw } : undefined;
+}

--- a/packages/suite-base/src/panels/BlackboxShared/pointCloud.ts
+++ b/packages/suite-base/src/panels/BlackboxShared/pointCloud.ts
@@ -1,0 +1,49 @@
+// Reuses Lichtblick's own sensor_msgs/PointCloud2 field reader (the same one ThreeDeeRender's
+// point-cloud renderer and the UserScript "pointClouds" helpers use) instead of writing a second
+// binary parser -- the fork already has to solve this exact problem.
+import {
+  readPoints,
+  type sensor_msgs__PointCloud2,
+} from "@lichtblick/suite-base/players/UserScriptPlayer/transformerWorker/typescript/userUtils/pointClouds";
+
+import type { LidarPoint } from "./decode";
+
+interface MaybePointCloud2 {
+  fields?: unknown;
+  data?: unknown;
+}
+
+// Mirrors RcaPointCloudReader.Read's MaxLidarPointsPerScan cap (RootCause.Infrastructure/Services/
+// BlackBoxIngestion/Rca/RcaEvidenceExtractor.cs) -- these panels re-draw every point in the scan on
+// every onRender call (not just when the scan changes), so an uncapped cloud makes TacticalMap and
+// LidarProfile the heaviest panels in the layout on any scan with tens of thousands of points.
+const DEFAULT_MAX_POINTS = 8_000;
+
+/** sensor_msgs/msg/PointCloud2 -> {x,y,z}[], looking up field indices by name (not fixed offsets). */
+export function decodePointCloud(message: unknown, maxPoints = DEFAULT_MAX_POINTS): LidarPoint[] {
+  const maybeCloud = message as MaybePointCloud2;
+  if (!Array.isArray(maybeCloud.fields) || !(maybeCloud.data instanceof Uint8Array)) {
+    return [];
+  }
+  const cloud = message as sensor_msgs__PointCloud2;
+  const xIndex = cloud.fields.findIndex((field) => field.name === "x");
+  const yIndex = cloud.fields.findIndex((field) => field.name === "y");
+  const zIndex = cloud.fields.findIndex((field) => field.name === "z");
+  if (xIndex === -1 || yIndex === -1 || zIndex === -1) {
+    return [];
+  }
+
+  const rows = readPoints(cloud);
+  const stride = maxPoints > 0 ? Math.max(1, Math.floor(rows.length / maxPoints)) : 1;
+  const points: LidarPoint[] = [];
+  for (let i = 0; i < rows.length; i += stride) {
+    const row = rows[i]!;
+    const x = row[xIndex];
+    const y = row[yIndex];
+    const z = row[zIndex];
+    if (typeof x === "number" && typeof y === "number" && typeof z === "number") {
+      points.push({ x, y, z });
+    }
+  }
+  return points;
+}

--- a/packages/suite-base/src/panels/LidarProfile/LidarProfile.tsx
+++ b/packages/suite-base/src/panels/LidarProfile/LidarProfile.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { MessageEvent, SettingsTreeAction } from "@lichtblick/suite";
+import Stack from "@lichtblick/suite-base/components/Stack";
+import {
+  decodeHazardPolygon,
+  decodeZoneViolations,
+} from "@lichtblick/suite-base/panels/BlackboxShared/decode";
+import type { PathPoint, ZoneViolation } from "@lichtblick/suite-base/panels/BlackboxShared/decode";
+import { updateFrameCache } from "@lichtblick/suite-base/panels/BlackboxShared/frameCache";
+import { nearestByTime } from "@lichtblick/suite-base/panels/BlackboxShared/geometry";
+import { decodePointCloud } from "@lichtblick/suite-base/panels/BlackboxShared/pointCloud";
+
+import { drawProfile, drawTopDown, LidarProfileInput, LidarProfileScan } from "./draw";
+import { settingsActionReducer, useSettingsTree } from "./settings";
+import { DEFAULT_CONFIG, LidarProfileConfig, LidarProfileProps } from "./types";
+
+function eventTimeNs(event: MessageEvent): number {
+  return event.receiveTime.sec * 1e9 + event.receiveTime.nsec;
+}
+
+export function LidarProfile({ context }: LidarProfileProps): React.JSX.Element {
+  const topContainerRef = useRef<HTMLDivElement>(null);
+  const topCanvasRef = useRef<HTMLCanvasElement>(null);
+  const profileContainerRef = useRef<HTMLDivElement>(null);
+  const profileCanvasRef = useRef<HTMLCanvasElement>(null);
+  const [renderDone, setRenderDone] = useState<() => void>(() => () => {});
+  const [config, setConfig] = useState<LidarProfileConfig>(() => ({
+    ...DEFAULT_CONFIG,
+    ...(context.initialState as Partial<LidarProfileConfig>),
+  }));
+
+  const violationsCacheRef = useRef<{ frames?: readonly MessageEvent[]; violations: ZoneViolation[] }>(
+    { violations: [] },
+  );
+  const hazardPolygonRef = useRef<PathPoint[]>([]);
+  const scanCacheRef = useRef<{ message?: unknown; scan: LidarProfileScan | undefined }>({
+    scan: undefined,
+  });
+  const lastInputRef = useRef<LidarProfileInput>({
+    scan: undefined,
+    hazardPolygon: [],
+    violation: undefined,
+  });
+
+  const redraw = useCallback(() => {
+    const topCanvas = topCanvasRef.current;
+    const topContainer = topContainerRef.current;
+    if (topCanvas && topContainer) {
+      const width = Math.max(1, Math.round(topContainer.clientWidth));
+      const height = Math.max(1, Math.round(topContainer.clientHeight));
+      drawTopDown(topCanvas, width, height, lastInputRef.current);
+    }
+    const profileCanvas = profileCanvasRef.current;
+    const profileContainer = profileContainerRef.current;
+    if (profileCanvas && profileContainer) {
+      const width = Math.max(1, Math.round(profileContainer.clientWidth));
+      const height = Math.max(1, Math.round(profileContainer.clientHeight));
+      drawProfile(profileCanvas, width, height, lastInputRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    context.saveState(config);
+  }, [config, context]);
+
+  useEffect(() => {
+    context.subscribe([
+      { topic: config.zoneReportTopic, preload: true },
+      { topic: config.hazardZoneTopic, preload: false },
+      { topic: config.pointCloudTopic, preload: false },
+    ]);
+    return () => {
+      context.unsubscribeAll();
+    };
+  }, [context, config.zoneReportTopic, config.hazardZoneTopic, config.pointCloudTopic]);
+
+  useEffect(() => {
+    context.onRender = (renderState, done) => {
+      setRenderDone(() => done);
+
+      if (renderState.didSeek === true) {
+        hazardPolygonRef.current = [];
+        scanCacheRef.current = { scan: undefined };
+      }
+
+      if (renderState.allFrames && renderState.allFrames !== violationsCacheRef.current.frames) {
+        const updated = updateFrameCache<ZoneViolation>(
+          { frames: violationsCacheRef.current.frames, items: violationsCacheRef.current.violations },
+          renderState.allFrames,
+          config.zoneReportTopic,
+          (event) => decodeZoneViolations(event.message, eventTimeNs(event)),
+        );
+        violationsCacheRef.current = { frames: updated.frames, violations: updated.items };
+      }
+
+      for (const event of renderState.currentFrame ?? []) {
+        if (event.topic === config.hazardZoneTopic) {
+          hazardPolygonRef.current = decodeHazardPolygon(event.message);
+        } else if (event.topic === config.pointCloudTopic) {
+          if (scanCacheRef.current.message !== event.message) {
+            scanCacheRef.current = {
+              message: event.message,
+              scan: { tNs: eventTimeNs(event), points: decodePointCloud(event.message) },
+            };
+          }
+        }
+      }
+
+      const t0Ns = renderState.currentTime
+        ? renderState.currentTime.sec * 1e9 + renderState.currentTime.nsec
+        : undefined;
+
+      const violation =
+        t0Ns != undefined
+          ? nearestByTime(
+              violationsCacheRef.current.violations.filter((z) => z.type === 1 && z.violated),
+              t0Ns,
+            )
+          : undefined;
+
+      lastInputRef.current = {
+        scan: scanCacheRef.current.scan,
+        hazardPolygon: hazardPolygonRef.current,
+        violation,
+      };
+      redraw();
+    };
+
+    context.watch("allFrames");
+    context.watch("currentFrame");
+    context.watch("currentTime");
+    context.watch("didSeek");
+
+    return () => {
+      context.onRender = undefined;
+    };
+  }, [context, config, redraw]);
+
+  useEffect(() => {
+    const containers = [topContainerRef.current, profileContainerRef.current].filter(
+      (el): el is HTMLDivElement => el != undefined,
+    );
+    if (containers.length === 0) {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      redraw();
+    });
+    for (const container of containers) {
+      observer.observe(container);
+    }
+    return () => {
+      observer.disconnect();
+    };
+  }, [redraw]);
+
+  const settingsActionHandler = useCallback((action: SettingsTreeAction) => {
+    setConfig((prevConfig) => settingsActionReducer(prevConfig, action));
+  }, []);
+
+  const settingsTree = useSettingsTree(config);
+  useEffect(() => {
+    context.updatePanelSettingsEditor({ actionHandler: settingsActionHandler, nodes: settingsTree });
+  }, [context, settingsActionHandler, settingsTree]);
+
+  useEffect(() => {
+    renderDone();
+  }, [renderDone]);
+
+  return (
+    <Stack direction="row" flexWrap="wrap" fullHeight gap={1}>
+      <Stack style={{ flex: "1 1 320px", minWidth: 0 }}>
+        <div ref={topContainerRef} style={{ flex: "1 1 auto", minHeight: 0, position: "relative" }}>
+          <canvas ref={topCanvasRef} style={{ width: "100%", height: "100%", display: "block" }} />
+        </div>
+        <Stack padding={0.5} style={{ flex: "0 0 auto", fontSize: 12 }}>
+          Lidar scan near T0 — top-down (vehicle frame, x forward / y left)
+        </Stack>
+      </Stack>
+      <Stack style={{ flex: "1 1 320px", minWidth: 0 }}>
+        <div
+          ref={profileContainerRef}
+          style={{ flex: "1 1 auto", minHeight: 0, position: "relative" }}
+        >
+          <canvas
+            ref={profileCanvasRef}
+            style={{ width: "100%", height: "100%", display: "block" }}
+          />
+        </div>
+        <Stack padding={0.5} style={{ flex: "0 0 auto", fontSize: 12 }}>
+          Terrain height profile along the violation bearing (range vs height)
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+}

--- a/packages/suite-base/src/panels/LidarProfile/draw.ts
+++ b/packages/suite-base/src/panels/LidarProfile/draw.ts
@@ -1,0 +1,143 @@
+// Pixel-identical port of root-cause-analyzer's apps/frontend/.../blackbox/lidar-profile.tsx onto
+// canvases resized to fill the panel rather than a fixed 420x420 box.
+import { drawStar, makeProjector } from "@lichtblick/suite-base/panels/BlackboxShared/canvas";
+import { heightColor } from "@lichtblick/suite-base/panels/BlackboxShared/colormap";
+import type { LidarPoint, PathPoint, ZoneViolation } from "@lichtblick/suite-base/panels/BlackboxShared/decode";
+
+export interface LidarProfileScan {
+  tNs: number;
+  points: LidarPoint[];
+}
+
+export interface LidarProfileInput {
+  scan: LidarProfileScan | undefined;
+  hazardPolygon: PathPoint[];
+  violation: ZoneViolation | undefined;
+}
+
+function setupCanvas(
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+): CanvasRenderingContext2D | undefined {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return undefined;
+  }
+  canvas.width = width;
+  canvas.height = height;
+  ctx.fillStyle = "#0b1020";
+  ctx.fillRect(0, 0, width, height);
+  return ctx;
+}
+
+function emptyMessage(ctx: CanvasRenderingContext2D, message: string): void {
+  ctx.fillStyle = "#94a3b8";
+  ctx.font = "13px sans-serif";
+  ctx.fillText(message, 16, 24);
+}
+
+export function drawTopDown(
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+  input: LidarProfileInput,
+): void {
+  const ctx = setupCanvas(canvas, width, height);
+  if (!ctx) {
+    return;
+  }
+  const points = input.scan?.points ?? [];
+  if (points.length === 0) {
+    emptyMessage(ctx, "No lidar scan near T0.");
+    return;
+  }
+
+  const bounds = { minX: -2, maxX: 14, minY: -9, maxY: 9 };
+  const { toPx } = makeProjector(bounds, width, height);
+
+  for (const p of points) {
+    if (p.x < bounds.minX || p.x > bounds.maxX || p.y < bounds.minY || p.y > bounds.maxY) {
+      continue;
+    }
+    const [px, py] = toPx(p.x, p.y);
+    ctx.fillStyle = heightColor(p.z);
+    ctx.fillRect(px - 1, py - 1, 2, 2);
+  }
+
+  if (input.hazardPolygon.length > 2) {
+    ctx.beginPath();
+    input.hazardPolygon.forEach((p, i) => {
+      const [px, py] = toPx(p.x, p.y);
+      if (i === 0) {
+        ctx.moveTo(px, py);
+      } else {
+        ctx.lineTo(px, py);
+      }
+    });
+    ctx.closePath();
+    ctx.strokeStyle = "#f59e0b";
+    ctx.lineWidth = 2;
+    ctx.stroke();
+  }
+
+  if (input.violation) {
+    const [px, py] = toPx(input.violation.x, input.violation.y);
+    drawStar(ctx, px, py, 10, "#facc15", "#000000");
+  }
+}
+
+export function drawProfile(
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+  input: LidarProfileInput,
+): void {
+  const ctx = setupCanvas(canvas, width, height);
+  if (!ctx) {
+    return;
+  }
+  const points = input.scan?.points ?? [];
+  const violation = input.violation;
+  if (!violation || points.length === 0) {
+    emptyMessage(ctx, "No hazard-zone violation to profile.");
+    return;
+  }
+
+  const bearing = Math.atan2(violation.y, violation.x);
+  const bounds = { minX: 0, maxX: 14, minY: -2, maxY: 2 };
+  const { toPx } = makeProjector(bounds, width, height);
+
+  const [, gy] = toPx(0, 0);
+  ctx.strokeStyle = "rgba(255,255,255,0.35)";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(toPx(bounds.minX, 0)[0], gy);
+  ctx.lineTo(toPx(bounds.maxX, 0)[0], gy);
+  ctx.stroke();
+
+  const violationRange = Math.hypot(violation.x, violation.y);
+  const [vx, vy0] = toPx(violationRange, bounds.minY);
+  const [, vy1] = toPx(violationRange, bounds.maxY);
+  ctx.strokeStyle = "#facc15";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(vx, vy0);
+  ctx.lineTo(vx, vy1);
+  ctx.stroke();
+
+  for (const p of points) {
+    const range = Math.hypot(p.x, p.y);
+    if (range < 0.5 || range > bounds.maxX) {
+      continue;
+    }
+    const azimuth = Math.atan2(p.y, p.x);
+    if (Math.abs(azimuth - bearing) > 0.05) {
+      continue;
+    }
+    const z = Math.max(bounds.minY, Math.min(bounds.maxY, p.z));
+    const [px, py] = toPx(range, z);
+    ctx.fillStyle = heightColor(p.z);
+    ctx.fillRect(px - 1.5, py - 1.5, 3, 3);
+  }
+}

--- a/packages/suite-base/src/panels/LidarProfile/index.tsx
+++ b/packages/suite-base/src/panels/LidarProfile/index.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+
+import { useCrash } from "@lichtblick/hooks";
+import { PanelExtensionContext } from "@lichtblick/suite";
+import { CaptureErrorBoundary } from "@lichtblick/suite-base/components/CaptureErrorBoundary";
+import Panel from "@lichtblick/suite-base/components/Panel";
+import { PanelExtensionAdapter } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
+import { createSyncRoot } from "@lichtblick/suite-base/panels/createSyncRoot";
+import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
+import { SaveConfig } from "@lichtblick/suite-base/types/panels";
+
+import { LidarProfile } from "./LidarProfile";
+import { DEFAULT_CONFIG, LidarProfileConfig } from "./types";
+
+function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
+  return createSyncRoot(
+    <CaptureErrorBoundary onError={crash}>
+      <ThemeProvider isDark>
+        <LidarProfile context={context} />
+      </ThemeProvider>
+    </CaptureErrorBoundary>,
+    context.panelElement,
+  );
+}
+
+type LidarProfilePanelAdapterProps = {
+  config: LidarProfileConfig;
+  saveConfig: SaveConfig<LidarProfileConfig>;
+};
+
+function LidarProfilePanelAdapter({ config, saveConfig }: LidarProfilePanelAdapterProps) {
+  const crash = useCrash();
+  const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
+  return (
+    <PanelExtensionAdapter
+      config={config}
+      saveConfig={saveConfig}
+      initPanel={boundInitPanel}
+      highestSupportedConfigVersion={1}
+    />
+  );
+}
+
+export default Panel(
+  Object.assign(LidarProfilePanelAdapter, {
+    panelType: "LidarProfile",
+    defaultConfig: DEFAULT_CONFIG,
+  }),
+);

--- a/packages/suite-base/src/panels/LidarProfile/settings.ts
+++ b/packages/suite-base/src/panels/LidarProfile/settings.ts
@@ -1,0 +1,37 @@
+import { produce } from "immer";
+import * as _ from "lodash-es";
+import { useMemo } from "react";
+
+import { useShallowMemo } from "@lichtblick/hooks";
+import { SettingsTreeAction, SettingsTreeNode, SettingsTreeNodes } from "@lichtblick/suite";
+
+import { LidarProfileConfig } from "./types";
+
+export function settingsActionReducer(
+  prevConfig: LidarProfileConfig,
+  action: SettingsTreeAction,
+): LidarProfileConfig {
+  return produce(prevConfig, (draft) => {
+    if (action.action === "update" && action.payload.path[0] === "topics") {
+      _.set(draft, [action.payload.path[1]!], action.payload.value);
+    }
+  });
+}
+
+export function useSettingsTree(config: LidarProfileConfig): SettingsTreeNodes {
+  const { hazardZoneTopic, zoneReportTopic, pointCloudTopic } = config;
+
+  const topicsNode: SettingsTreeNode = useMemo(
+    () => ({
+      label: "Topics",
+      fields: {
+        hazardZoneTopic: { label: "Hazard zone", input: "string", value: hazardZoneTopic },
+        zoneReportTopic: { label: "Zone report", input: "string", value: zoneReportTopic },
+        pointCloudTopic: { label: "Lidar point cloud", input: "string", value: pointCloudTopic },
+      },
+    }),
+    [hazardZoneTopic, zoneReportTopic, pointCloudTopic],
+  );
+
+  return useShallowMemo({ topics: topicsNode });
+}

--- a/packages/suite-base/src/panels/LidarProfile/types.ts
+++ b/packages/suite-base/src/panels/LidarProfile/types.ts
@@ -1,0 +1,19 @@
+import { PanelExtensionContext } from "@lichtblick/suite";
+
+export type LidarProfileConfig = {
+  hazardZoneTopic: string;
+  zoneReportTopic: string;
+  pointCloudTopic: string;
+};
+
+// Matches the topic constants root-cause-analyzer's RcaEvidenceExtractor.cs already selects for
+// the same evidence dataset, so panels work out of the box without per-incident overrides.
+export const DEFAULT_CONFIG: LidarProfileConfig = {
+  hazardZoneTopic: "/zone/hazard",
+  zoneReportTopic: "/sentinel/zone_report",
+  pointCloudTopic: "/front_lidar/points",
+};
+
+export type LidarProfileProps = {
+  context: PanelExtensionContext;
+};

--- a/packages/suite-base/src/panels/TacticalMap/TacticalMap.test.tsx
+++ b/packages/suite-base/src/panels/TacticalMap/TacticalMap.test.tsx
@@ -1,0 +1,82 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { PanelExtensionContext } from "@lichtblick/suite";
+
+import { TacticalMap } from "./TacticalMap";
+import { DEFAULT_CONFIG } from "./types";
+
+function makeMockContext(overrides: Partial<PanelExtensionContext> = {}): PanelExtensionContext {
+  return {
+    initialState: { ...DEFAULT_CONFIG },
+    layout: { addPanel: jest.fn() },
+    onRender: undefined,
+    panelElement: document.createElement("div"),
+    saveState: jest.fn(),
+    setDefaultPanelTitle: jest.fn(),
+    setParameter: jest.fn(),
+    setPreviewTime: jest.fn(),
+    setSharedPanelState: jest.fn(),
+    setVariable: jest.fn(),
+    subscribe: jest.fn(),
+    subscribeAppSettings: jest.fn(),
+    unsubscribeAll: jest.fn(),
+    updatePanelSettingsEditor: jest.fn(),
+    watch: jest.fn(),
+    unstable_subscribeMessageRange: jest.fn(),
+    getTopicSchema: jest.fn(),
+    getSchema: jest.fn(),
+    ...overrides,
+  } as unknown as PanelExtensionContext;
+}
+
+describe("TacticalMap", () => {
+  it("renders a load button and subscribes to nothing until clicked", () => {
+    const context = makeMockContext();
+    render(<TacticalMap context={context} />);
+
+    expect(screen.getByText("Load Tactical Map")).toBeTruthy();
+    expect(context.subscribe).not.toHaveBeenCalled();
+    expect(context.watch).not.toHaveBeenCalled();
+    expect(context.onRender).toBeUndefined();
+  });
+
+  it("subscribes to topics and starts rendering once loaded", () => {
+    const context = makeMockContext();
+    render(<TacticalMap context={context} />);
+
+    fireEvent.click(screen.getByText("Load Tactical Map"));
+
+    expect(context.subscribe).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ topic: DEFAULT_CONFIG.odomTopic, preload: true }),
+        expect.objectContaining({ topic: DEFAULT_CONFIG.zoneReportTopic, preload: true }),
+        expect.objectContaining({ topic: DEFAULT_CONFIG.plannedPathTopic, preload: false }),
+        expect.objectContaining({ topic: DEFAULT_CONFIG.hazardZoneTopic, preload: false }),
+        expect.objectContaining({ topic: DEFAULT_CONFIG.pointCloudTopic, preload: false }),
+      ]),
+    );
+    expect(context.watch).toHaveBeenCalledWith("allFrames");
+    expect(context.watch).toHaveBeenCalledWith("currentFrame");
+    expect(context.onRender).toBeDefined();
+    expect(screen.queryByText("Load Tactical Map")).toBeNull();
+  });
+
+  it("unsubscribes on unmount after being loaded", () => {
+    const context = makeMockContext();
+    const { unmount } = render(<TacticalMap context={context} />);
+
+    fireEvent.click(screen.getByText("Load Tactical Map"));
+    unmount();
+
+    expect(context.unsubscribeAll).toHaveBeenCalled();
+    expect(context.onRender).toBeUndefined();
+  });
+});

--- a/packages/suite-base/src/panels/TacticalMap/TacticalMap.tsx
+++ b/packages/suite-base/src/panels/TacticalMap/TacticalMap.tsx
@@ -1,3 +1,4 @@
+import { Button, Typography } from "@mui/material";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { MessageEvent, SettingsTreeAction } from "@lichtblick/suite";
@@ -23,6 +24,8 @@ export function TacticalMap({ context }: TacticalMapProps): React.JSX.Element {
     ...DEFAULT_CONFIG,
     ...(context.initialState as Partial<TacticalMapConfig>),
   }));
+
+  const [loaded, setLoaded] = useState(false);
 
   // Decoded data is cached in refs (rather than React state) so per-frame onRender callbacks can
   // update it imperatively without triggering a React re-render for every incoming message --
@@ -63,6 +66,9 @@ export function TacticalMap({ context }: TacticalMapProps): React.JSX.Element {
   }, [config, context]);
 
   useEffect(() => {
+    if (!loaded) {
+      return undefined;
+    }
     context.subscribe([
       { topic: config.odomTopic, preload: true },
       { topic: config.zoneReportTopic, preload: true },
@@ -75,6 +81,7 @@ export function TacticalMap({ context }: TacticalMapProps): React.JSX.Element {
     };
   }, [
     context,
+    loaded,
     config.odomTopic,
     config.zoneReportTopic,
     config.plannedPathTopic,
@@ -83,6 +90,9 @@ export function TacticalMap({ context }: TacticalMapProps): React.JSX.Element {
   ]);
 
   useEffect(() => {
+    if (!loaded) {
+      return undefined;
+    }
     context.onRender = (renderState, done) => {
       setRenderDone(() => done);
 
@@ -151,12 +161,15 @@ export function TacticalMap({ context }: TacticalMapProps): React.JSX.Element {
     return () => {
       context.onRender = undefined;
     };
-  }, [context, config, redraw]);
+  }, [context, config, loaded, redraw]);
 
   useEffect(() => {
+    if (!loaded) {
+      return undefined;
+    }
     const container = containerRef.current;
     if (!container) {
-      return;
+      return undefined;
     }
     const observer = new ResizeObserver(() => {
       redraw();
@@ -165,7 +178,13 @@ export function TacticalMap({ context }: TacticalMapProps): React.JSX.Element {
     return () => {
       observer.disconnect();
     };
-  }, [redraw]);
+  }, [redraw, loaded]);
+
+  useEffect(() => {
+    if (loaded) {
+      redraw();
+    }
+  }, [loaded, redraw]);
 
   const settingsActionHandler = useCallback((action: SettingsTreeAction) => {
     setConfig((prevConfig) => settingsActionReducer(prevConfig, action));
@@ -179,6 +198,26 @@ export function TacticalMap({ context }: TacticalMapProps): React.JSX.Element {
   useEffect(() => {
     renderDone();
   }, [renderDone]);
+
+  if (!loaded) {
+    return (
+      <Stack fullHeight alignItems="center" justifyContent="center" gap={1} padding={2}>
+        <Typography variant="body2" color="text.secondary" align="center">
+          Tactical Map preloads odometry and zone-report history for the whole clip, which can be
+          heavy on long recordings.
+        </Typography>
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={() => {
+            setLoaded(true);
+          }}
+        >
+          Load Tactical Map
+        </Button>
+      </Stack>
+    );
+  }
 
   return (
     <Stack fullHeight>

--- a/packages/suite-base/src/panels/TacticalMap/TacticalMap.tsx
+++ b/packages/suite-base/src/panels/TacticalMap/TacticalMap.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { MessageEvent, SettingsTreeAction } from "@lichtblick/suite";
+import Stack from "@lichtblick/suite-base/components/Stack";
+import { decodeOdom, decodeHazardPolygon, decodePlannedPath, decodeZoneViolations } from "@lichtblick/suite-base/panels/BlackboxShared/decode";
+import type { OdomSample, PathPoint, ZoneViolation } from "@lichtblick/suite-base/panels/BlackboxShared/decode";
+import { updateFrameCache } from "@lichtblick/suite-base/panels/BlackboxShared/frameCache";
+import { decodePointCloud } from "@lichtblick/suite-base/panels/BlackboxShared/pointCloud";
+
+import { drawTacticalMap, TACTICAL_MAP_LEGEND, TacticalMapInput, TacticalMapScan } from "./draw";
+import { settingsActionReducer, useSettingsTree } from "./settings";
+import { DEFAULT_CONFIG, TacticalMapConfig, TacticalMapProps } from "./types";
+
+function eventTimeNs(event: MessageEvent): number {
+  return event.receiveTime.sec * 1e9 + event.receiveTime.nsec;
+}
+
+export function TacticalMap({ context }: TacticalMapProps): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [renderDone, setRenderDone] = useState<() => void>(() => () => {});
+  const [config, setConfig] = useState<TacticalMapConfig>(() => ({
+    ...DEFAULT_CONFIG,
+    ...(context.initialState as Partial<TacticalMapConfig>),
+  }));
+
+  // Decoded data is cached in refs (rather than React state) so per-frame onRender callbacks can
+  // update it imperatively without triggering a React re-render for every incoming message --
+  // only the canvas draw call cares about it.
+  const odomCacheRef = useRef<{ frames?: readonly MessageEvent[]; samples: OdomSample[] }>({
+    samples: [],
+  });
+  const violationsCacheRef = useRef<{ frames?: readonly MessageEvent[]; violations: ZoneViolation[] }>(
+    { violations: [] },
+  );
+  const plannedPathRef = useRef<PathPoint[]>([]);
+  const hazardPolygonRef = useRef<PathPoint[]>([]);
+  const scanCacheRef = useRef<{ message?: unknown; scan: TacticalMapScan | undefined }>({
+    scan: undefined,
+  });
+  const lastInputRef = useRef<TacticalMapInput>({
+    odom: [],
+    plannedPath: [],
+    hazardPolygon: [],
+    zoneViolations: [],
+    scan: undefined,
+    t0Ns: undefined,
+  });
+
+  const redraw = useCallback(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) {
+      return;
+    }
+    const width = Math.max(1, Math.round(container.clientWidth));
+    const height = Math.max(1, Math.round(container.clientHeight));
+    drawTacticalMap(canvas, width, height, lastInputRef.current);
+  }, []);
+
+  useEffect(() => {
+    context.saveState(config);
+  }, [config, context]);
+
+  useEffect(() => {
+    context.subscribe([
+      { topic: config.odomTopic, preload: true },
+      { topic: config.zoneReportTopic, preload: true },
+      { topic: config.plannedPathTopic, preload: false },
+      { topic: config.hazardZoneTopic, preload: false },
+      { topic: config.pointCloudTopic, preload: false },
+    ]);
+    return () => {
+      context.unsubscribeAll();
+    };
+  }, [
+    context,
+    config.odomTopic,
+    config.zoneReportTopic,
+    config.plannedPathTopic,
+    config.hazardZoneTopic,
+    config.pointCloudTopic,
+  ]);
+
+  useEffect(() => {
+    context.onRender = (renderState, done) => {
+      setRenderDone(() => done);
+
+      if (renderState.didSeek === true) {
+        plannedPathRef.current = [];
+        hazardPolygonRef.current = [];
+        scanCacheRef.current = { scan: undefined };
+      }
+
+      if (renderState.allFrames && renderState.allFrames !== odomCacheRef.current.frames) {
+        const updated = updateFrameCache(
+          { frames: odomCacheRef.current.frames, items: odomCacheRef.current.samples },
+          renderState.allFrames,
+          config.odomTopic,
+          (event) => decodeOdom(event.message, eventTimeNs(event)),
+        );
+        updated.items.sort((a, b) => a.tNs - b.tNs);
+        odomCacheRef.current = { frames: updated.frames, samples: updated.items };
+      }
+
+      if (renderState.allFrames && renderState.allFrames !== violationsCacheRef.current.frames) {
+        const updated = updateFrameCache<ZoneViolation>(
+          { frames: violationsCacheRef.current.frames, items: violationsCacheRef.current.violations },
+          renderState.allFrames,
+          config.zoneReportTopic,
+          (event) => decodeZoneViolations(event.message, eventTimeNs(event)),
+        );
+        violationsCacheRef.current = { frames: updated.frames, violations: updated.items };
+      }
+
+      for (const event of renderState.currentFrame ?? []) {
+        if (event.topic === config.plannedPathTopic) {
+          plannedPathRef.current = decodePlannedPath(event.message);
+        } else if (event.topic === config.hazardZoneTopic) {
+          hazardPolygonRef.current = decodeHazardPolygon(event.message);
+        } else if (event.topic === config.pointCloudTopic) {
+          if (scanCacheRef.current.message !== event.message) {
+            scanCacheRef.current = {
+              message: event.message,
+              scan: { tNs: eventTimeNs(event), points: decodePointCloud(event.message) },
+            };
+          }
+        }
+      }
+
+      const t0Ns = renderState.currentTime
+        ? renderState.currentTime.sec * 1e9 + renderState.currentTime.nsec
+        : undefined;
+
+      lastInputRef.current = {
+        odom: odomCacheRef.current.samples,
+        plannedPath: plannedPathRef.current,
+        hazardPolygon: hazardPolygonRef.current,
+        zoneViolations: violationsCacheRef.current.violations,
+        scan: scanCacheRef.current.scan,
+        t0Ns,
+      };
+      redraw();
+    };
+
+    context.watch("allFrames");
+    context.watch("currentFrame");
+    context.watch("currentTime");
+    context.watch("didSeek");
+
+    return () => {
+      context.onRender = undefined;
+    };
+  }, [context, config, redraw]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      redraw();
+    });
+    observer.observe(container);
+    return () => {
+      observer.disconnect();
+    };
+  }, [redraw]);
+
+  const settingsActionHandler = useCallback((action: SettingsTreeAction) => {
+    setConfig((prevConfig) => settingsActionReducer(prevConfig, action));
+  }, []);
+
+  const settingsTree = useSettingsTree(config);
+  useEffect(() => {
+    context.updatePanelSettingsEditor({ actionHandler: settingsActionHandler, nodes: settingsTree });
+  }, [context, settingsActionHandler, settingsTree]);
+
+  useEffect(() => {
+    renderDone();
+  }, [renderDone]);
+
+  return (
+    <Stack fullHeight>
+      <div ref={containerRef} style={{ flex: "1 1 auto", minHeight: 0, position: "relative" }}>
+        <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block" }} />
+      </div>
+      <Stack
+        direction="row"
+        flexWrap="wrap"
+        gap={1.5}
+        padding={0.75}
+        style={{ flex: "0 0 auto", fontSize: 12 }}
+      >
+        {TACTICAL_MAP_LEGEND.map((item) => (
+          <Stack key={item.label} direction="row" alignItems="center" gap={0.5}>
+            <span
+              style={{
+                display: "inline-block",
+                width: 10,
+                height: 10,
+                borderRadius: 2,
+                backgroundColor: item.color,
+                border: item.border === true ? "1px solid #94a3b8" : undefined,
+              }}
+            />
+            {item.label}
+          </Stack>
+        ))}
+      </Stack>
+    </Stack>
+  );
+}

--- a/packages/suite-base/src/panels/TacticalMap/draw.ts
+++ b/packages/suite-base/src/panels/TacticalMap/draw.ts
@@ -1,0 +1,211 @@
+// Pixel-identical port of root-cause-analyzer's apps/frontend/.../blackbox/tactical-map.tsx onto a
+// canvas that's resized to fill the panel rather than a fixed 760x560 box.
+import {
+  atLeastExtent,
+  Bounds,
+  boundsOf,
+  drawArrow,
+  drawStar,
+  makeProjector,
+  padBounds,
+} from "@lichtblick/suite-base/panels/BlackboxShared/canvas";
+import { heightColor, speedColor } from "@lichtblick/suite-base/panels/BlackboxShared/colormap";
+import type {
+  OdomSample,
+  PathPoint,
+  ZoneViolation,
+} from "@lichtblick/suite-base/panels/BlackboxShared/decode";
+import { nearestByTime, poseAt, projectToMap } from "@lichtblick/suite-base/panels/BlackboxShared/geometry";
+
+export interface TacticalMapScan {
+  tNs: number;
+  points: { x: number; y: number; z: number }[];
+}
+
+// The trajectory line itself is one moveTo/lineTo path regardless of point count -- cheap even at
+// full resolution. The per-sample speed-colored marker below is 3 canvas calls (beginPath/arc/fill)
+// plus a fillStyle change *per point*, redrawn on every onRender (not just when odom changes), so
+// an uncapped `/odom` history (easily thousands of samples over a preload:true window) makes this
+// panel the single heaviest one in the layout. Cap the markers the same way point clouds are capped
+// (RcaPointCloudReader.MaxLidarPointsPerScan / BlackboxShared/pointCloud.ts's DEFAULT_MAX_POINTS).
+const MAX_TRAJECTORY_MARKERS = 2_000;
+
+// `boundsOf(odom)` is an O(n) scan over the same odom history described above, but unlike the
+// trajectory it wasn't capped -- it was recomputed from scratch on every onRender call even
+// though `odom` (the array reference from TacticalMap.tsx's frame cache) only actually changes
+// when a new preloaded block arrives. Cache it by array identity so a redraw triggered by e.g. the
+// playhead advancing (odom unchanged) reuses the previous bounds instead of re-scanning the whole
+// history. WeakMap avoids retaining old odom arrays once the frame cache replaces them.
+const odomBoundsCache = new WeakMap<readonly OdomSample[], Bounds | undefined>();
+
+function cachedBoundsOf(odom: readonly OdomSample[]): Bounds | undefined {
+  if (odomBoundsCache.has(odom)) {
+    return odomBoundsCache.get(odom);
+  }
+  const bounds = boundsOf(odom);
+  odomBoundsCache.set(odom, bounds);
+  return bounds;
+}
+
+export interface TacticalMapInput {
+  odom: OdomSample[];
+  plannedPath: PathPoint[];
+  hazardPolygon: PathPoint[];
+  zoneViolations: ZoneViolation[];
+  scan: TacticalMapScan | undefined;
+  t0Ns: number | undefined;
+}
+
+export const TACTICAL_MAP_LEGEND: { color: string; label: string; border?: boolean }[] = [
+  { color: "#3c966f", label: "Lidar terrain (height)" },
+  { color: "#9c179e", label: "Trajectory (speed)" },
+  { color: "#ffffff", label: "Planned path", border: true },
+  { color: "#f59e0b", label: "Hazard zone @ T0" },
+  { color: "#ef4444", label: "Path-collision obstacle" },
+  { color: "#facc15", label: "Hazard violation (T0)" },
+];
+
+export function drawTacticalMap(
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+  input: TacticalMapInput,
+): void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return;
+  }
+  canvas.width = width;
+  canvas.height = height;
+  ctx.fillStyle = "#eef2f5";
+  ctx.fillRect(0, 0, width, height);
+
+  const { odom, plannedPath, hazardPolygon, zoneViolations, scan, t0Ns } = input;
+  const odomBounds = cachedBoundsOf(odom);
+  if (!odomBounds || t0Ns == undefined) {
+    ctx.fillStyle = "#64748b";
+    ctx.font = "14px sans-serif";
+    ctx.fillText("No odometry available for the tactical map.", 24, 32);
+    return;
+  }
+  const pose0 = poseAt(odom, t0Ns);
+  if (!pose0) {
+    ctx.fillStyle = "#64748b";
+    ctx.font = "14px sans-serif";
+    ctx.fillText("No odometry available for the tactical map.", 24, 32);
+    return;
+  }
+
+  const bounds = atLeastExtent(padBounds(odomBounds, 6), 16);
+  const { toPx } = makeProjector(bounds, width, height);
+  const inBounds = (x: number, y: number): boolean =>
+    x >= bounds.minX && x <= bounds.maxX && y >= bounds.minY && y <= bounds.maxY;
+
+  if (scan) {
+    const scanPose = poseAt(odom, scan.tNs);
+    if (scanPose) {
+      ctx.globalAlpha = 0.8;
+      for (const point of scan.points) {
+        const m = projectToMap(point, scanPose);
+        if (!inBounds(m.x, m.y)) {
+          continue;
+        }
+        const [px, py] = toPx(m.x, m.y);
+        ctx.fillStyle = heightColor(point.z);
+        ctx.fillRect(px - 1.5, py - 1.5, 3, 3);
+      }
+      ctx.globalAlpha = 1;
+    }
+  }
+
+  if (plannedPath.length > 1) {
+    ctx.beginPath();
+    plannedPath.forEach((p, i) => {
+      const [px, py] = toPx(p.x, p.y);
+      if (i === 0) {
+        ctx.moveTo(px, py);
+      } else {
+        ctx.lineTo(px, py);
+      }
+    });
+    ctx.strokeStyle = "#ffffff";
+    ctx.lineWidth = 2;
+    ctx.setLineDash([6, 4]);
+    ctx.stroke();
+    ctx.setLineDash([]);
+  }
+
+  ctx.beginPath();
+  odom.forEach((s, i) => {
+    const [px, py] = toPx(s.x, s.y);
+    if (i === 0) {
+      ctx.moveTo(px, py);
+    } else {
+      ctx.lineTo(px, py);
+    }
+  });
+  ctx.strokeStyle = "rgba(255,255,255,0.9)";
+  ctx.lineWidth = 4;
+  ctx.stroke();
+  const markerStride =
+    odom.length > 0 ? Math.max(1, Math.floor(odom.length / MAX_TRAJECTORY_MARKERS)) : 1;
+  for (let i = 0; i < odom.length; i += markerStride) {
+    const s = odom[i]!;
+    const [px, py] = toPx(s.x, s.y);
+    ctx.fillStyle = speedColor(s.speed);
+    ctx.beginPath();
+    ctx.arc(px, py, 2.5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  if (hazardPolygon.length > 2) {
+    ctx.beginPath();
+    hazardPolygon.forEach((p, i) => {
+      const m = projectToMap(p, pose0);
+      const [px, py] = toPx(m.x, m.y);
+      if (i === 0) {
+        ctx.moveTo(px, py);
+      } else {
+        ctx.lineTo(px, py);
+      }
+    });
+    ctx.closePath();
+    ctx.strokeStyle = "#f59e0b";
+    ctx.lineWidth = 2.2;
+    ctx.stroke();
+  }
+
+  for (const z of zoneViolations) {
+    if (z.type !== 0 || !z.violated) {
+      continue;
+    }
+    const pose = poseAt(odom, z.tNs);
+    if (!pose) {
+      continue;
+    }
+    const m = projectToMap({ x: z.x, y: z.y }, pose);
+    if (!inBounds(m.x, m.y)) {
+      continue;
+    }
+    const [px, py] = toPx(m.x, m.y);
+    ctx.fillStyle = "#ef4444";
+    ctx.beginPath();
+    ctx.arc(px, py, 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  const tagViolation = nearestByTime(
+    zoneViolations.filter((z) => z.type === 1 && z.violated),
+    t0Ns,
+  );
+  if (tagViolation) {
+    const pose = poseAt(odom, tagViolation.tNs) ?? pose0;
+    const m = projectToMap({ x: tagViolation.x, y: tagViolation.y }, pose);
+    const [px, py] = toPx(m.x, m.y);
+    drawStar(ctx, px, py, 10, "#facc15", "#000000");
+  }
+
+  const [hx, hy] = toPx(pose0.x, pose0.y);
+  const [hx2, hy2] = toPx(pose0.x + 2.4 * Math.cos(pose0.yaw), pose0.y + 2.4 * Math.sin(pose0.yaw));
+  drawArrow(ctx, hx, hy, hx2, hy2, "#111111");
+}

--- a/packages/suite-base/src/panels/TacticalMap/index.tsx
+++ b/packages/suite-base/src/panels/TacticalMap/index.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+
+import { useCrash } from "@lichtblick/hooks";
+import { PanelExtensionContext } from "@lichtblick/suite";
+import { CaptureErrorBoundary } from "@lichtblick/suite-base/components/CaptureErrorBoundary";
+import Panel from "@lichtblick/suite-base/components/Panel";
+import { PanelExtensionAdapter } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
+import { createSyncRoot } from "@lichtblick/suite-base/panels/createSyncRoot";
+import ThemeProvider from "@lichtblick/suite-base/theme/ThemeProvider";
+import { SaveConfig } from "@lichtblick/suite-base/types/panels";
+
+import { TacticalMap } from "./TacticalMap";
+import { DEFAULT_CONFIG, TacticalMapConfig } from "./types";
+
+function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
+  return createSyncRoot(
+    <CaptureErrorBoundary onError={crash}>
+      <ThemeProvider isDark>
+        <TacticalMap context={context} />
+      </ThemeProvider>
+    </CaptureErrorBoundary>,
+    context.panelElement,
+  );
+}
+
+type TacticalMapPanelAdapterProps = {
+  config: TacticalMapConfig;
+  saveConfig: SaveConfig<TacticalMapConfig>;
+};
+
+function TacticalMapPanelAdapter({ config, saveConfig }: TacticalMapPanelAdapterProps) {
+  const crash = useCrash();
+  const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
+  return (
+    <PanelExtensionAdapter
+      config={config}
+      saveConfig={saveConfig}
+      initPanel={boundInitPanel}
+      highestSupportedConfigVersion={1}
+    />
+  );
+}
+
+export default Panel(
+  Object.assign(TacticalMapPanelAdapter, {
+    panelType: "TacticalMap",
+    defaultConfig: DEFAULT_CONFIG,
+  }),
+);

--- a/packages/suite-base/src/panels/TacticalMap/settings.ts
+++ b/packages/suite-base/src/panels/TacticalMap/settings.ts
@@ -1,0 +1,40 @@
+import { produce } from "immer";
+import * as _ from "lodash-es";
+import { useMemo } from "react";
+
+import { useShallowMemo } from "@lichtblick/hooks";
+import { SettingsTreeAction, SettingsTreeNode, SettingsTreeNodes } from "@lichtblick/suite";
+
+import { TacticalMapConfig } from "./types";
+
+export function settingsActionReducer(
+  prevConfig: TacticalMapConfig,
+  action: SettingsTreeAction,
+): TacticalMapConfig {
+  return produce(prevConfig, (draft) => {
+    if (action.action === "update" && action.payload.path[0] === "topics") {
+      _.set(draft, [action.payload.path[1]!], action.payload.value);
+    }
+  });
+}
+
+export function useSettingsTree(config: TacticalMapConfig): SettingsTreeNodes {
+  const { odomTopic, plannedPathTopic, hazardZoneTopic, zoneReportTopic, pointCloudTopic } =
+    config;
+
+  const topicsNode: SettingsTreeNode = useMemo(
+    () => ({
+      label: "Topics",
+      fields: {
+        odomTopic: { label: "Odometry", input: "string", value: odomTopic },
+        plannedPathTopic: { label: "Planned path", input: "string", value: plannedPathTopic },
+        hazardZoneTopic: { label: "Hazard zone", input: "string", value: hazardZoneTopic },
+        zoneReportTopic: { label: "Zone report", input: "string", value: zoneReportTopic },
+        pointCloudTopic: { label: "Lidar point cloud", input: "string", value: pointCloudTopic },
+      },
+    }),
+    [odomTopic, plannedPathTopic, hazardZoneTopic, zoneReportTopic, pointCloudTopic],
+  );
+
+  return useShallowMemo({ topics: topicsNode });
+}

--- a/packages/suite-base/src/panels/TacticalMap/types.ts
+++ b/packages/suite-base/src/panels/TacticalMap/types.ts
@@ -1,0 +1,23 @@
+import { PanelExtensionContext } from "@lichtblick/suite";
+
+export type TacticalMapConfig = {
+  odomTopic: string;
+  plannedPathTopic: string;
+  hazardZoneTopic: string;
+  zoneReportTopic: string;
+  pointCloudTopic: string;
+};
+
+// Matches the topic constants root-cause-analyzer's RcaEvidenceExtractor.cs already selects for
+// the same evidence dataset, so panels work out of the box without per-incident overrides.
+export const DEFAULT_CONFIG: TacticalMapConfig = {
+  odomTopic: "/odom",
+  plannedPathTopic: "/path/planned",
+  hazardZoneTopic: "/zone/hazard",
+  zoneReportTopic: "/sentinel/zone_report",
+  pointCloudTopic: "/front_lidar/points",
+};
+
+export type TacticalMapProps = {
+  context: PanelExtensionContext;
+};

--- a/packages/suite-base/src/panels/index.ts
+++ b/packages/suite-base/src/panels/index.ts
@@ -92,6 +92,18 @@ export const getBuiltin: (t: TFunction<"panels">) => PanelInfo[] = (t) => [
     module: async () => await import("./Map"),
   },
   {
+    title: "Tactical Map",
+    type: "TacticalMap",
+    description: "Overhead trajectory, planned path, hazard zone, and lidar terrain for blackbox incidents",
+    module: async () => await import("./TacticalMap"),
+  },
+  {
+    title: "Lidar Profile",
+    type: "LidarProfile",
+    description: "Top-down and bearing-slice lidar range/height views for blackbox incidents",
+    module: async () => await import("./LidarProfile"),
+  },
+  {
     title: t("parameters"),
     type: "Parameters",
     description: t("parametersDescription"),

--- a/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.test.ts
@@ -391,6 +391,71 @@ describe("mergeSequentialIterators", () => {
     expect(jest.spyOn(source3, "messageIterator")).toHaveBeenCalledTimes(1);
   });
 
+  it("activates all overlapping sources concurrently when consumptionType is 'full'", async () => {
+    // 3 sequential MCAPs: [0-10], [10-20], [20-30]
+    const source1 = makeMockSource({ sec: 0, nsec: 0 }, { sec: 10, nsec: 0 }, [
+      makeMessageEvent("topic", 2),
+    ]);
+    const source2 = makeMockSource({ sec: 10, nsec: 0 }, { sec: 20, nsec: 0 }, [
+      makeMessageEvent("topic", 12),
+    ]);
+    const source3 = makeMockSource({ sec: 20, nsec: 0 }, { sec: 30, nsec: 0 }, [
+      makeMessageEvent("topic", 22),
+    ]);
+
+    const fullArgs: MessageIteratorArgs = { ...defaultArgs, consumptionType: "full" };
+
+    const results: IteratorResult[] = [];
+    for await (const msg of mergeSequentialIterators(
+      [source1, source2, source3],
+      fullArgs,
+    )) {
+      results.push(msg);
+    }
+
+    // All three sources are activated up front, not gated on playback time reaching them.
+    expect(source1.messageIterator).toHaveBeenCalledTimes(1);
+    expect(source2.messageIterator).toHaveBeenCalledTimes(1);
+    expect(source3.messageIterator).toHaveBeenCalledTimes(1);
+
+    // Results are still merged in time order despite concurrent activation.
+    expect(results).toHaveLength(3);
+    expect(
+      (results[0] as IteratorResult<Uint8Array> & { type: "message-event" }).msgEvent.receiveTime
+        .sec,
+    ).toBe(2);
+    expect(
+      (results[1] as IteratorResult<Uint8Array> & { type: "message-event" }).msgEvent.receiveTime
+        .sec,
+    ).toBe(12);
+    expect(
+      (results[2] as IteratorResult<Uint8Array> & { type: "message-event" }).msgEvent.receiveTime
+        .sec,
+    ).toBe(22);
+  });
+
+  it("still gates activation lazily when consumptionType is 'partial' (default)", async () => {
+    const source1 = makeMockSource({ sec: 0, nsec: 0 }, { sec: 10, nsec: 0 }, [
+      makeMessageEvent("topic", 2),
+    ]);
+    const source2 = makeMockSource({ sec: 10, nsec: 0 }, { sec: 20, nsec: 0 }, [
+      makeMessageEvent("topic", 12),
+    ]);
+
+    const partialArgs: MessageIteratorArgs = { ...defaultArgs, consumptionType: "partial" };
+
+    const results: IteratorResult[] = [];
+    for await (const msg of mergeSequentialIterators([source1, source2], partialArgs)) {
+      results.push(msg);
+      // source2 must not be activated while source1 is still being consumed.
+      if (results.length === 1) {
+        expect(source2.messageIterator).not.toHaveBeenCalled();
+      }
+    }
+
+    expect(results).toHaveLength(2);
+  });
+
   it("orders stamp results by their stamp time", async () => {
     const stampResult1: IteratorResult<Uint8Array> = {
       type: "stamp",

--- a/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.ts
@@ -78,43 +78,54 @@ export async function* mergeSequentialIterators<T extends IteratorResult>(
     nextSourceIndex++;
   }
 
-  // Activate sources whose start time is at or before the query start time.
-  // When no query start is provided, activate only the first source (the earliest by startTime)
-  // to avoid starting HTTP requests for all files simultaneously.
-  //
-  // When a query start IS provided (e.g. after a seek), only activate sources whose time range
-  // [startTime, endTime] actually contains the queryStart. Sources that end before queryStart
-  // are skipped entirely — they cannot contain relevant data at the seek position.
-  // This avoids activating all preceding sources when seeking to the end of the timeline.
-  const queryStart = args.start;
-  if (queryStart != undefined) {
-    // Skip sources that end before queryStart (they can't contain messages at the seek point)
-    while (nextSourceIndex < sourcesWithTime.length) {
-      const sourceInfo = sourcesWithTime[nextSourceIndex]!;
-      if (compare(sourceInfo.endTime, queryStart) >= 0) {
-        break;
-      }
-      nextSourceIndex++;
-    }
-    // Activate sources that contain queryStart (startTime <= queryStart)
-    while (nextSourceIndex < sourcesWithTime.length) {
-      const sourceInfo = sourcesWithTime[nextSourceIndex]!;
-      if (compare(sourceInfo.startTime, queryStart) > 0) {
-        break;
-      }
-      await activateNextSource();
-    }
+  if (args.consumptionType === "full") {
+    // "full" consumption (block preloading, batch export) reads the entire requested range in
+    // one pass — there's no "current playback time" to gate activation on, so trickling sources
+    // in one at a time only adds serial network latency for no benefit. Activate every source
+    // that overlaps the requested range concurrently instead. Playback ("partial") keeps the
+    // lazy gating below so scrubbing around a large multi-file timeline doesn't open connections
+    // to every file at once.
+    await Promise.all(sourcesWithTime.map(async (sourceInfo) => activateSource(sourceInfo.source)));
+    nextSourceIndex = sourcesWithTime.length;
   } else {
-    // No query start — activate only the first source
-    if (nextSourceIndex < sourcesWithTime.length) {
+    // Activate sources whose start time is at or before the query start time.
+    // When no query start is provided, activate only the first source (the earliest by startTime)
+    // to avoid starting HTTP requests for all files simultaneously.
+    //
+    // When a query start IS provided (e.g. after a seek), only activate sources whose time range
+    // [startTime, endTime] actually contains the queryStart. Sources that end before queryStart
+    // are skipped entirely — they cannot contain relevant data at the seek position.
+    // This avoids activating all preceding sources when seeking to the end of the timeline.
+    const queryStart = args.start;
+    if (queryStart != undefined) {
+      // Skip sources that end before queryStart (they can't contain messages at the seek point)
+      while (nextSourceIndex < sourcesWithTime.length) {
+        const sourceInfo = sourcesWithTime[nextSourceIndex]!;
+        if (compare(sourceInfo.endTime, queryStart) >= 0) {
+          break;
+        }
+        nextSourceIndex++;
+      }
+      // Activate sources that contain queryStart (startTime <= queryStart)
+      while (nextSourceIndex < sourcesWithTime.length) {
+        const sourceInfo = sourcesWithTime[nextSourceIndex]!;
+        if (compare(sourceInfo.startTime, queryStart) > 0) {
+          break;
+        }
+        await activateNextSource();
+      }
+    } else {
+      // No query start — activate only the first source
+      if (nextSourceIndex < sourcesWithTime.length) {
+        await activateNextSource();
+      }
+    }
+
+    // If the initial source(s) were empty, advance through pending sources until
+    // we find one with data or exhaust all sources.
+    while (heap.isEmpty() && nextSourceIndex < sourcesWithTime.length) {
       await activateNextSource();
     }
-  }
-
-  // If the initial source(s) were empty, advance through pending sources until
-  // we find one with data or exhaust all sources.
-  while (heap.isEmpty() && nextSourceIndex < sourcesWithTime.length) {
-    await activateNextSource();
   }
 
   try {


### PR DESCRIPTION
## User-Facing Changes

<!-- will be used as a changelog entry -->

## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tactical Map panel with synchronized lidar, trajectories, hazards, collision markers, violations, vehicle heading, and speed visualization.
  * Added Lidar Profile panel with top-down lidar views and range/elevation profiles.
  * Added configurable topic settings for both panels, with persisted configuration and timeline synchronization.
* **Bug Fixes**
  * Improved full-consumption playback so overlapping data sources activate concurrently while preserving timestamp order.
  * Improved partial playback handling for skipped, empty, and lazily loaded sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->