### PR TITLE
docs(agents): reflect HydratedSourcePool architecture from PR #1262

### DIFF
--- a/.github/agents/lb-player.agent.md
+++ b/.github/agents/lb-player.agent.md
@@ -189,6 +189,9 @@ const cancel = subscribeMessageRange({
 | `WorkerIterableSource` | Runs an `IIterableSource` in a Web Worker via Comlink |
 | `WorkerSerializedIterableSource` | Serialized variant for Worker-based sources |
 
+`IIterableSource` also exposes optional lifecycle hooks: `terminate?()` for cleanup on close, and
+`prewarm?()` to warm a source before it becomes active (used by pooled/multi-file sources; failures are non-fatal).
+
 ### IteratorResult Types
 ```typescript
 type IteratorResult =
@@ -288,6 +291,8 @@ type IteratorResult =
 - `packages/suite-base/src/players/IterablePlayer/DeserializingIterableSource.ts` — lazy deserialization + sampling
 - `packages/suite-base/src/players/IterablePlayer/BlockLoader.ts` — preloading for full subscriptions
 - `packages/suite-base/src/players/IterablePlayer/WorkerIterableSource.ts` — Worker-based source (Comlink)
+- `packages/suite-base/src/players/IterablePlayer/shared/MultiIterableSource.ts` — multi-file/multi-URL orchestration; deep dive in `@lb-remote-connection`'s knowledge base
+- `packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts` — bounded LRU pool for resident heavyweight per-file readers; deep dive in `@lb-remote-connection`'s knowledge base
 - `packages/suite-base/src/players/IterablePlayer/CachingIterableSource.ts` — block-level cache
 - `packages/suite-base/src/players/FoxgloveWebSocketPlayer/index.ts` — WebSocket player
 - `packages/suite-base/src/players/FoxgloveWebSocketPlayer/WorkerSocketAdapter.ts` — Worker WebSocket
@@ -301,6 +306,7 @@ type IteratorResult =
 - Modifying `#allTopics` identity without triggering `reset-playback-iterator` (misses new topics)
 - Calling `seekPlayback` before initialization completes (must store in `#seekTarget` for later)
 - Not clamping times to `[start, end]` range (causes source errors)
+- When `initialize()` and `terminate()` can race on shared mutable fields, `terminate()` must capture fields into locals before any `await`, clear instance fields synchronously, and run dispose/cleanup in a `finally` block so rejections do not skip cleanup or touch newer state; this pattern was established in `WorkerSerializedIterableSource.terminate()` this session, and similar sibling lifecycles (for example `WorkerIterableSource`) have not yet been audited
 - UserScriptPlayer: emitting upstream messages twice when scripts change (use empty messages array)
 
 ## Skills Reference

--- a/.github/agents/lb-remote-connection.agent.md
+++ b/.github/agents/lb-remote-connection.agent.md
@@ -54,13 +54,14 @@ IterablePlayer (state machine, tick loop)
 URLs: [url1.mcap, url2.mcap, url3.mcap]
     │
     ▼
-MultiIterableSource (500MB total cache ÷ N sources)
+MultiIterableSource (500MB total cache ÷ N, floored by MIN_CACHE_PER_SOURCE_BYTES)
     │
-    ├── McapIterableSource(url1, ~166MB cache)
-    ├── McapIterableSource(url2, ~166MB cache)
-    └── McapIterableSource(url3, ~166MB cache)
+    ├── shared HydratedSourcePool (bounds resident McapIndexedReaders by count + bytes)
+    │      ├── McapIterableSource(url1, ~166MB cache)
+    │      ├── McapIterableSource(url2, ~166MB cache)
+    │      └── McapIterableSource(url3, ~166MB cache)
     │
-    ▼ (each initialized in parallel)
+    ▼ (each initialized under bounded concurrency)
 mergeSequentialIterators (min-heap, lazy source activation)
     │
     ▼
@@ -83,6 +84,8 @@ WorkerSerializedIterableSource → BufferedIterableSource → Player
 | `IterablePlayer/Mcap/BatchingReadable.ts` | Coalesces nearby `IReadable.read()` calls into fewer, larger reads |
 | `IterablePlayer/Mcap/McapIterableSource.ts` | Factory: indexed vs streaming decision |
 | `IterablePlayer/Mcap/McapIndexedIterableSource.ts` | Random access via chunk indexes |
+| `IterablePlayer/Mcap/readerWeight.ts` | Heuristic byte-weight estimate for a `McapIndexedReader`, used as the pool's `weigh()` hook |
+| `IterablePlayer/shared/HydratedSourcePool.ts` | Bounded LRU pool of resident heavyweight per-file readers (byte + count budget) |
 | `IterablePlayer/shared/MultiIterableSource.ts` | Multi-file orchestration |
 | `IterablePlayer/shared/utils/mergeSequentialIterators.ts` | Heap-based lazy iterator merge |
 | `IterablePlayer/shared/utils/sourceTimeOverlap.ts` | Time range filtering |
@@ -124,8 +127,39 @@ WorkerSerializedIterableSource → BufferedIterableSource → Player
 
 ### Error Recovery
 - **`keepReconnectingCallback` set** (browser mode): unlimited retries, UI notified of reconnection state
-- **No callback**: two errors within 100ms → fatal, rejects all pending reads
 - **Single error**: destroys connection, retries via `#updateState()`
+- **No callback**: two errors within 100ms → fatal, routes through shared `#closeWithError(error)` cleanup
+- **`close()` + fatal path**: both destroy the active stream, reject pending `#readRequests`, cancel `#activeUncachedReads`, and reset `#virtualBuffer`
+
+---
+
+## HydratedSourcePool (Bounded Reader Pool)
+
+`HydratedSourcePool` bounds **resident heavyweight per-file `McapIndexedReader` instances** (reader/deserializer state, plus each source's cache allocation folded into the weight estimate). It does **not** bound decoded message data; that still lives in `BufferedIterableSource`, `CachedFilelike`, and downstream playback buffers.
+
+```typescript
+const pool = new HydratedSourcePool({
+  maxCount: dataSource.maxHydratedSources ?? 12,
+  maxBytes: dataSource.maxHydratedBytes ?? 512 * 1024 * 1024,
+  minResident: 1,
+});
+```
+
+- **Hybrid budget**: `maxCount` caps resident readers, `maxBytes` caps total estimated resident weight, and `minResident` keeps a small floor hot (clamped so it never exceeds the count cap). `MultiIterableSource` constructs one shared pool and passes it to **both** the local-files and remote-urls branches.
+- **API contract**:
+  - `acquire(token, hydrator)`: open or reuse a resident reader, increment its pin count, refresh LRU recency, and keep it non-evictable until a matching `release(token)`. After `terminate()`, `acquire()` throws instead of rehydrating.
+  - `release(token)`: decrement the pin count (floor 0) and opportunistically evict
+  - `admit(token, hydrator, value)`: seed an already-open reader (for example from `initialize()` / prewarm) without calling `open()`. If the token is already resident, or the pool is already terminated, the redundant value is closed instead of replacing the existing entry.
+  - `terminate()`: mark the pool terminated first, then close every resident entry in parallel so late `acquire()` / `admit()` calls cannot repopulate it
+- **Eviction semantics**: entries live in a `Map<object, Entry>` whose insertion order is the LRU order. Re-inserting on access moves an entry to the most-recent end. Eviction scans from oldest to newest and closes the first **unpinned** entries until the pool is back under budget. If everything remaining is pinned, the pool may temporarily stay over budget by design.
+- **Weight heuristic** (`readerWeight.ts`): `weigh()` defaults to `1`, but MCAP readers use an approximate byte estimate so larger readers churn first:
+  ```typescript
+  READER_BASE_BYTES +
+    reader.chunkIndexes.length * 512 +
+    reader.channelsById.size * (16 * 1024) +
+    cacheBytes
+  ```
+  The absolute numbers are heuristic; relative weighting is what matters.
 
 ---
 
@@ -180,18 +214,22 @@ getBackfillMessages({ topics, time }) {
 ### Cache Budget Distribution
 ```typescript
 const totalCache = dataSource.totalCacheSizeInBytes ?? 500 * 1024 * 1024;  // 500MB total
-const perSourceCache = Math.floor(totalCache / urls.length);
-// Each source gets: totalCache / N
+const minPerSource = dataSource.minCachePerSourceBytes ?? 10 * 1024 * 1024;  // 10MB floor
+const perSourceCache = Math.max(minPerSource, Math.floor(totalCache / urls.length));
 ```
 - 2 files → 250MB each
 - 5 files → 100MB each
-- More files = more network re-fetches per file
+- Hundreds of files → floor at 10MiB per source by default (override `minCachePerSourceBytes`)
+- Prevents `totalCache / N` from dropping below a viable per-file metadata-read budget; if `perSourceCache * N > totalCache`, a `log.warn` notes the aggregate may exceed the nominal budget
 
 ### Initialization
-1. Creates N `McapIterableSource` instances (one per URL) with divided cache budget
-2. Initializes all sources **in parallel** (`Promise.all`)
-3. Merges results: topics, datatypes, metadata, topicStats, alerts, publishersByTopic
-4. Sorts sources by start time (`source.getStart()`)
+1. Constructs one shared `HydratedSourcePool` before branching on local files vs remote URLs (`maxHydratedSources ?? 12`, `maxHydratedBytes ?? 512 MiB`) and passes `pool` to every source constructor.
+2. Creates N `McapIterableSource` instances (one per URL) with the divided cache budget; for multiple URLs, `readAheadEnabled` defaults to **lazy** (`false`) unless the caller overrides it. Single-file remote sessions keep the legacy eager default.
+3. Initializes sources under a `Semaphore` (`initConcurrency ?? 4`, normalized to a positive integer) instead of unconstrained `Promise.all`; the returned `Initialization[]` still preserves input order.
+4. Merges results: topics, datatypes, metadata, topicStats, alerts, publishersByTopic.
+5. Sorts sources by start time (`source.getStart()`), then `#prewarmEarliestSources()` prewarms the earliest 3 sources in **reverse** order so the t=0 source ends up most-recently-used in the pool. Prewarm failures are logged at debug and treated as non-fatal.
+
+- `terminate()`: runs `Promise.allSettled` over `source.terminate?.()`, logs each rejection, re-throws the first rejection after cleanup, and always tears down `pool.terminate()` in a `finally` block.
 
 ### Message Iteration — Lazy Sequential Merge
 ```typescript
@@ -308,7 +346,7 @@ WorkerSerializedIterableSource       McapIterableSourceWorker.worker.ts
 6. **Lazy sequential merge** avoids simultaneous HTTP streams to all remote files
 7. **Indexed MCAP** required for acceptable remote performance (random access via chunk indexes)
 8. **WASM decompression preload** prevents initialization failures under slow network
-9. **Cache budget division** for multi-file: consider fewer large files over many small ones
+9. **Cache budget division** for multi-file uses a 10MiB per-source floor; many small files still increase refetch pressure and reader churn
 10. **BufferedIterableSource** (10s, 300MB) smooths network latency for playback
 11. **Read coalescing** (`BatchingReadable`): merges `read()` calls arriving in the same microtask tick (gap <64KiB, ≤4MiB span) before they reach `CachedFilelike`
 
@@ -316,7 +354,8 @@ WorkerSerializedIterableSource       McapIterableSourceWorker.worker.ts
 - Server missing `Accept-Ranges: bytes` header → fails at open
 - CORS not exposing `Accept-Ranges` header → browser can't detect range support
 - Unindexed MCAP over remote → falls back to full streaming (slow, limited to 1GB)
-- Too many remote files → cache per file drops below useful threshold
+- Too many remote files → per-source cache hits the 10MiB floor, aggregate cache may exceed the nominal total, and readers churn more often
+- Worker teardown races → follow the capture-before-`await` plus `disposeRemote()`-in-`finally` pattern from `WorkerSerializedIterableSource.terminate()` or an older terminate can leak/dispose the wrong worker
 - S3 presigned URLs with non-GET method → `BrowserHttpReader.open()` requires GET
 
 ## Skills Reference
@@ -325,3 +364,5 @@ WorkerSerializedIterableSource       McapIterableSourceWorker.worker.ts
 - Worker/Comlink patterns: `read_file(".github/skills/web-workers/SKILL.md")`
 - BufferedIterableSource or BlockLoader details: `read_file(".github/skills/caching-internals/SKILL.md")`
 - Network/read latency profiling and buffering performance: `read_file(".github/skills/performance/SKILL.md")`
+- Bounded reader pool implementation: `read_file("packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts")`
+- Reader weight heuristic: `read_file("packages/suite-base/src/players/IterablePlayer/Mcap/readerWeight.ts")`

--- a/.github/skills/player-internals/SKILL.md
+++ b/.github/skills/player-internals/SKILL.md
@@ -84,6 +84,9 @@ IterablePlayer (tick loop consumes messages)
 > ⚠️ `DeserializingIterableSource` is **optional** — it is only inserted when the underlying source
 > is serialized (`ISerializedIterableSource`). Sources that already return `IDeserializedIterableSource`
 > bypass it.
+>
+> `IIterableSource` also exposes optional `prewarm?(): Promise<void>` for pooled/multi-file sources
+> to warm up before becoming active; see `.github/skills/remote-caching/SKILL.md` for `HydratedSourcePool`.
 
 ## Backfill Strategy
 

--- a/.github/skills/remote-caching/SKILL.md
+++ b/.github/skills/remote-caching/SKILL.md
@@ -84,8 +84,9 @@ class CachedFilelike {
 
 ### Error Handling
 - **With `keepReconnectingCallback`**: unlimited retries, callback notified of reconnection state
-- **Without callback**: two errors within 100ms → fatal (rejects all pending reads, closes)
+- **Without callback**: two errors within 100ms → fatal via `#closeWithError()` (destroys the active stream, rejects all pending `#readRequests`, cancels all `#activeUncachedReads`, resets `#virtualBuffer` to an empty `VirtualLRUBuffer`, and closes)
 - **Single error**: destroys stream, clears connection, calls `#updateState()` to retry
+- `close()` also funnels through `#closeWithError()` so explicit close and fatal shutdown share the same cleanup path
 
 ### VirtualLRUBuffer Initialization
 ```typescript
@@ -322,12 +323,139 @@ Coalescing layer between `McapIndexedReader` and `CachedFilelike`. Accumulates `
 
 ---
 
+## HydratedSourcePool
+
+**Source**: `packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts`
+
+### Purpose
+Bounds resident heavyweight per-file reader objects (for example `McapIndexedReader` instances with chunk indexes, channel schemas, and deserializers) using a hybrid **count + byte** budget. This is a separate layer from `CachedFilelike`: it manages parsed reader objects, not raw downloaded file bytes and not decoded message payloads.
+
+### Key Properties
+- Constructor options are all optional: `HydratedSourcePoolOptions = { maxBytes?, maxCount?, minResident? }`
+- `maxCount` is normalized to `Math.max(1, Math.floor(...))`, or `Infinity` when unset
+- `maxBytes` defaults to `Infinity`
+- `minResident` defaults to `1`, then clamps to `Math.min(maxCount, Math.max(1, Math.floor(...)))`
+- Internal state is a `Map<object, Entry>` where:
+  - `token` = caller-owned identity object for one source
+  - `Entry = { hydrator, value: Promise<unknown>, pins: number, weight: number }`
+- JavaScript `Map` preserves insertion order. Deleting and re-setting an entry on access refreshes recency, so iteration order is LRU order (first entry = least recently used).
+
+### Architecture
+```typescript
+type SourceHydrator<T> = {
+  open: () => Promise<T>;
+  close: (value: T) => Promise<void>;
+  weigh?: (value: T) => number;
+};
+
+type Entry = {
+  hydrator: SourceHydrator<unknown>;
+  value: Promise<unknown>;
+  pins: number;
+  weight: number;
+};
+
+class HydratedSourcePool {
+  #entries: Map<object, Entry>;  // insertion order = LRU order
+  #totalWeight: number;          // sum of resident entry weights
+  #terminated: boolean;
+}
+```
+
+### Operations
+
+| Method | Description |
+|--------|-------------|
+| `acquire(token, hydrator)` | Returns a resident value, opening it on demand and pinning it while in use |
+| `release(token)` | Decrements the pin count (never below 0) and opportunistically triggers eviction |
+| `admit(token, hydrator, value)` | Seeds the pool with an already-open value, usually from a source's own initialization path |
+| `terminate()` | Prevents future admission/hydration, clears the pool, and closes every resident value |
+
+### `acquire()` / `release()` lifecycle
+1. `acquire(token, hydrator)` checks `#terminated` first and immediately throws `"HydratedSourcePool has been terminated"` when shutdown has started.
+2. If the token is already resident:
+   - delete + re-set the `Map` entry to refresh LRU position
+   - increment `pins`
+   - await and return the cached `value` promise
+   - if that promise rejects, roll back the pin increment and rethrow so a co-pending failed `open()` does not leak a phantom pin
+3. If the token is not resident:
+   - insert a new entry with `pins: 1`, `value: hydrator.open()`, `weight: 0`
+   - await the value
+   - compute `weight = Math.max(0, hydrator.weigh?.(value) ?? 1)`
+   - add the weight to `#totalWeight`
+   - run eviction and return the value
+4. If a new entry's hydration rejects:
+   - decrement `pins`
+   - only delete the map entry when `this.#entries.get(token) === entry`
+   - this identity guard prevents a late rejection from deleting a newer entry recreated for the same token by another caller
+5. `release(token)` decrements `pins` when the entry still exists, then fires-and-forgets `#evictBeyondCapacity()` so newly unpinned entries can be reclaimed.
+
+### `admit()` and `terminate()`
+- `admit(token, hydrator, value)` lets callers seed the pool with an already-hydrated value, avoiding a redundant `open()` call.
+- If the pool is already terminated, `admit()` immediately closes the supplied value instead of retaining it.
+- If the token is already resident, the pool keeps the existing entry, refreshes its LRU position, and closes the redundant newly supplied value.
+- Otherwise it inserts the value as an **unpinned** entry (`pins: 0`), computes weight, updates `#totalWeight`, and runs eviction. A newly admitted value may be evicted immediately if the pool is already over budget.
+- `terminate()` sets `#terminated = true` **before** clearing the map so concurrent or later `acquire()` / `admit()` calls cannot repopulate the pool during shutdown.
+- Shutdown snapshots the entries, clears the map, resets `#totalWeight` to 0, and closes every resolved value in parallel. Each close is individually guarded so one failing `close()` does not stop the rest.
+
+### Eviction Algorithm
+`#isOverCapacity()` returns:
+- `false` when `entries.size <= minResident`
+- otherwise `true` when either:
+  - `entries.size > maxCount`, or
+  - `#totalWeight > maxBytes`
+
+`#evictBeyondCapacity()` then:
+1. Loops while `#isOverCapacity()` remains true
+2. Scans current `Map` iteration order (LRU order)
+3. Picks the **first** entry with `pins === 0`
+4. Deletes it from the map **before** awaiting `close()` so concurrent eviction passes cannot target it twice
+5. Subtracts its weight from `#totalWeight`
+6. Awaits `hydrator.close(value)` and logs errors instead of throwing
+
+If every remaining entry is pinned, eviction stops early. The pool may temporarily remain over `maxCount` and/or `maxBytes`; that is intentional because pinned entries are actively in use and cannot be evicted.
+
+### Termination Semantics
+- `#terminated` is a hard gate, not just a best-effort hint
+- `acquire()` after termination throws immediately
+- `admit()` after termination discards and closes the supplied value immediately
+- Because the flag is set before the map is cleared, concurrent shutdown cannot race with a new resident entry being retained after `terminate()`
+
+### readerWeight.ts / `estimateReaderWeightBytes`
+
+**Source**: `packages/suite-base/src/players/IterablePlayer/Mcap/readerWeight.ts`
+
+```typescript
+export const READER_BASE_BYTES = 2 * 1024 * 1024; // fixed reader/deserializer overhead
+const BYTES_PER_CHUNK_INDEX = 512; // per chunk-index entry retained by McapIndexedReader
+const BYTES_PER_CHANNEL = 16 * 1024; // parsed schema + per-channel deserializer
+
+export function estimateReaderWeightBytes(reader: McapIndexedReader, cacheBytes: number): number {
+  return (
+    READER_BASE_BYTES +
+    reader.chunkIndexes.length * BYTES_PER_CHUNK_INDEX +
+    reader.channelsById.size * BYTES_PER_CHANNEL +
+    cacheBytes
+  );
+}
+```
+
+This is the `weigh()` heuristic for pooled MCAP readers:
+- `READER_BASE_BYTES` models fixed parser/deserializer overhead
+- chunk indexes and channels scale the estimate with file complexity
+- `cacheBytes` folds in the reader's own byte-cache allocation (for example its `CachedFilelike` budget)
+
+Absolute values are approximate; the relative weighting is what matters. Heavier readers do not get special eviction priority directly — eviction still removes the next LRU unpinned entry — but heavier readers push the pool over `maxBytes` sooner, causing LRU eviction pressure earlier.
+
+---
+
 ## Multi-File Cache Budget Distribution
 
 When `MultiIterableSource` handles multiple remote URLs:
 ```typescript
 const totalCache = dataSource.totalCacheSizeInBytes ?? 500 * 1024 * 1024;  // 500MB total
-const perSourceCache = Math.floor(totalCache / urls.length);
+const minPerSource = dataSource.minCachePerSourceBytes ?? 10 * 1024 * 1024;  // 10MiB floor
+const perSourceCache = Math.max(minPerSource, Math.floor(totalCache / urls.length));
 // Each McapIterableSource gets perSourceCache for its RemoteFileReadable
 ```
 
@@ -335,8 +463,13 @@ const perSourceCache = Math.floor(totalCache / urls.length);
 
 This means:
 - More files = less cache per file = more network re-fetches
+- `MIN_CACHE_PER_SOURCE_BYTES = 10 MiB` prevents multi-file sessions from slicing the total budget so small that a single MCAP summary/index read can crash `CachedFilelike`
+- `dataSource.minCachePerSourceBytes` overrides that floor when a caller needs a different minimum
+- For `urls.length > 1`, `readAheadEnabled` now defaults to `false` so multi-file remote sessions stay lazy instead of speculatively reading ahead across every file; single-file sessions keep the legacy eager default unless `dataSource.readAheadEnabled` overrides it
 - For large multi-file datasets, consider increasing `totalCacheSizeInBytes`
 - Each file's CachedFilelike manages its own VirtualLRUBuffer independently
+
+> `totalCacheSizeInBytes` / `perSourceCache` govern the **raw byte cache** for each source's `CachedFilelike` / `RemoteFileReadable`. `HydratedSourcePool` adds a separate resident-reader-object budget (`maxBytes` / `maxCount`) for parsed `McapIndexedReader` instances. Both budgets apply at the same time and solve different memory problems.
 
 ---
 
@@ -352,3 +485,6 @@ This means:
 | `packages/suite-base/src/util/RequestQueue.ts` | Global concurrency limiter (10 max) |
 | `packages/suite-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts` | IReadable adapter (500MB default); reads pass through BatchingReadable |
 | `packages/suite-base/src/players/IterablePlayer/Mcap/BatchingReadable.ts` | Coalesces nearby `read()` calls (gap <64KiB, ≤4MiB span) into fewer inner reads |
+| `packages/suite-base/src/players/IterablePlayer/shared/HydratedSourcePool.ts` | Resident-reader pool with LRU eviction across count and byte budgets |
+| `packages/suite-base/src/players/IterablePlayer/shared/types.ts` | `SourceHydrator` and `HydratedSourcePoolOptions` type definitions |
+| `packages/suite-base/src/players/IterablePlayer/Mcap/readerWeight.ts` | Heuristic weight estimate for pooled MCAP readers |


### PR DESCRIPTION
## Summary

Docs-only follow-up to #1262 (multi-MCAP OOM fix). Updates the AI agent/skill knowledge base
(`.github/agents/`, `.github/skills/`) so future agent sessions reason about the actual current
architecture instead of the pre-#1262 model.

#1262 introduced substantial new architecture that was not yet reflected in the specs:
- `HydratedSourcePool` — bounded LRU pool of resident heavyweight per-file MCAP readers (hybrid
  byte + count budget), shared by both the local-files and remote-urls branches of
  `MultiIterableSource`.
- `estimateReaderWeightBytes` (`Mcap/readerWeight.ts`) — heuristic weight estimate used as the
  pool's `weigh()` hook.
- Optional `prewarm?()` lifecycle hook added to `IIterableSource`.
- `MultiIterableSource` updates: per-source cache-budget floor (`MIN_CACHE_PER_SOURCE_BYTES`),
  lazy `readAheadEnabled` default for multi-file remote sessions, `Semaphore`-bounded
  initialization concurrency, `#prewarmEarliestSources()`, and `Promise.allSettled`-based
  `terminate()` with guaranteed pool teardown.
- `CachedFilelike`'s unified `#closeWithError()` cleanup path.
- The capture-before-`await` + dispose-in-`finally` pattern established in
  `WorkerSerializedIterableSource.terminate()`.

Confirmed via exhaustive grep before this change: zero prior mentions of `HydratedSourcePool`,
`prewarm`, or `estimateReaderWeightBytes`/`readerWeight` anywhere in `.github/agents/` or
`.github/skills/`.

## Files changed
- `.github/agents/lb-remote-connection.agent.md` — new HydratedSourcePool section, updated
  MultiIterableSource/CachedFilelike details, updated diagrams/tables/pitfalls.
- `.github/skills/remote-caching/SKILL.md` — new HydratedSourcePool deep-dive + readerWeight
  subsection, updated Multi-File Cache Budget Distribution and CachedFilelike error handling.
- `.github/agents/lb-player.agent.md` — `prewarm?()` interface mention, new Key Files entries,
  new Common Pitfalls entry for the async init/terminate race pattern.
- `.github/skills/player-internals/SKILL.md` — one-line `prewarm?()` cross-reference.

## Validation
Docs-only change; no source code, tests, or build affected. Each edit was verified against the
current implementation (worktree for #1262, branch `bugfix/multi-mcap-worker-oom`) before being
written, and a post-edit grep confirmed exactly the 4 intended files changed with no unintended
scope creep (`.github/skills/caching-internals/SKILL.md` was assessed and intentionally left
unchanged — distinct domain, no overlap).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for shared reader caching with count and memory limits.
  * Documented cache pinning, eviction, admission, prewarming, and cleanup behavior.
  * Clarified concurrent initialization, termination, and error handling for multi-file sources.
  * Added guidance on reader memory estimation and multi-file cache allocation.
  * Updated development references covering iterator lifecycle hooks and remote-caching architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->