### PR TITLE
docs(agents): add release-process skill and lb-release prompt

### DIFF
--- a/.github/agents/lb-orchestrator.agent.md
+++ b/.github/agents/lb-orchestrator.agent.md
@@ -48,6 +48,10 @@ Parallelism happens at two distinct layers — do not conflate them:
 
 This orchestrator does **not** create worktrees: it has no `execute` tool, and prompt files are human-invoked entry points, not agent-callable. Do not route a task expecting a sub-agent to provision its own worktree — sub-agent invocations share this workspace's filesystem and working directory.
 
+## Release Requests
+
+Release-cutting requests (creating a release branch, triggering a release, or verifying that a release/RC published successfully) are **not** routed to a sub-agent. Point the user to `.github/prompts/lb-release.prompt.md`, which is a human-invoked runbook. Like `lb-setup-worktree.prompt.md`, it is a prompt file rather than an agent tool target, and this orchestrator has no `execute` tool, so release execution stays a human-invoked entry point rather than an agent delegation.
+
 ## Routing Rules
 
 ### Tier 1: Cross-cutting (action-capable)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -153,6 +153,7 @@ Reusable workflow prompts live in `.github/prompts/`.
 | `lb-feature-adopt.prompt.md` | Evaluate and adopt a specific upstream feature safely |
 | `lb-open-pr.prompt.md` | Build a complete PR title/body with validation evidence |
 | `lb-review-pr.prompt.md` | Two-phase PR review: structured analysis integrating CodeRabbit findings, then implement CodeRabbit's AI agent prompt |
+| `lb-release.prompt.md` | Guided runbook to cut a release (major/minor/hotfix/RC) and verify the automated publish pipeline |
 
 ---
 

--- a/.github/prompts/lb-release.prompt.md
+++ b/.github/prompts/lb-release.prompt.md
@@ -1,0 +1,69 @@
+---
+name: 'Release Lichtblick'
+description: 'Guided runbook to cut a new Lichtblick release (major/minor/hotfix) or a manual pre-release/RC, and verify the automated build/publish pipeline afterward.'
+---
+
+Use this workflow when cutting a new stable release, a hotfix, or a manual RC/pre-release build.
+
+## Skill Reference
+
+Load `.github/skills/release-process/SKILL.md` for the full pipeline detail: trigger conditions, job steps, branch-to-bump mapping, and release artifact lists. Do not duplicate that workflow detail here.
+
+## Inputs
+
+Ask the user for the following before proceeding:
+
+1. **Release type** — `major`, `minor`, `hotfix`, or `rc`
+2. If `rc`:
+   - **Branch to build from** — `develop` or a `release/*` branch
+   - **Version type** — `prerelease`, `prepatch`, `preminor`, or `premajor`
+   - **Create GitHub Pre-release automatically** — `true` or `false`
+   - **Custom release notes** (optional)
+
+## Stable Release (major / minor / hotfix)
+
+1. Check out `develop` and pull the latest changes.
+2. Create a release branch per the branch-naming table in `.github/skills/release-process/SKILL.md`:
+   - `release/major/<desc>`
+   - `release/minor/<desc>`
+   - `hotfix/<desc>`
+3. Push the branch to the remote.
+4. Open a pull request targeting `main`.
+   - Reuse `.github/prompts/lb-open-pr.prompt.md` for PR title/body mechanics.
+   - The target branch for this release PR is `main`, not `develop`.
+5. Merge the PR once it is approved and ready.
+6. After merge, no manual workflow dispatch is needed — `release.yml` and its downstream chain run automatically. See the "Overview" and "Workflow Trigger Reference" sections of `.github/skills/release-process/SKILL.md` for the full trigger chain.
+
+## Manual Pre-release / RC
+
+1. Ensure the chosen source branch is up to date.
+2. Trigger `.github/workflows/prerelease.yml` with the desired inputs, for example:
+
+```bash
+gh workflow run prerelease.yml \
+  -f branch=develop \
+  -f version_type=prerelease \
+  -f create_release=true
+```
+
+3. If custom notes are needed, add `-f release_notes="..."` to the command.
+
+4. Watch or poll the run:
+   - `gh run watch`
+   - `gh run list --workflow=prerelease.yml`
+
+## Post-Release Verification Checklist
+
+- [ ] Confirm the `release.yml` run succeeded and the GitHub Release exists with all expected artifacts.
+- [ ] Confirm `post-release.yml` succeeded.
+- [ ] Verify the published npm version at https://www.npmjs.com/package/@lichtblick/suite matches the release version.
+- [ ] Verify the new GHCR image tag exists.
+- [ ] Confirm `release-sync.yml` opened a `sync/main-to-develop-{version}` PR into `develop`.
+- [ ] If the sync PR auto-merged after a clean merge, no further action is needed.
+- [ ] If the sync PR has merge conflicts, resolve them manually and merge per the merge-commit rule in the skill's "Release Sync" section (never squash/rebase).
+
+## Output format
+
+- Release type and computed version
+- Links: GitHub Release URL, npm package URL, GHCR image tag
+- Release-sync PR status: auto-merged or needs manual conflict resolution

--- a/.github/prompts/lb-release.prompt.md
+++ b/.github/prompts/lb-release.prompt.md
@@ -15,7 +15,7 @@ Ask the user for the following before proceeding:
 
 1. **Release type** — `major`, `minor`, `hotfix`, or `rc`
 2. If `rc`:
-   - **Branch to build from** — `develop` or a `release/*` branch
+   - **Branch to build from** — the workflow's `branch` input only offers two literal dropdown values, `develop` or the literal string `release/*` (not a wildcard — see the skill's note on this input)
    - **Version type** — `prerelease`, `prepatch`, `preminor`, or `premajor`
    - **Create GitHub Pre-release automatically** — `true` or `false`
    - **Custom release notes** (optional)
@@ -54,16 +54,23 @@ gh workflow run prerelease.yml \
 
 ## Post-Release Verification Checklist
 
+### Stable release
 - [ ] Confirm the `release.yml` run succeeded and the GitHub Release exists with all expected artifacts.
-- [ ] Confirm `post-release.yml` succeeded.
+- [ ] Confirm `post-release.yml` succeeded (it fires automatically because stable releases emit GitHub's `released` event).
 - [ ] Verify the published npm version at https://www.npmjs.com/package/@lichtblick/suite matches the release version.
 - [ ] Verify the new GHCR image tag exists.
 - [ ] Confirm `release-sync.yml` opened a `sync/main-to-develop-{version}` PR into `develop`.
 - [ ] If the sync PR auto-merged after a clean merge, no further action is needed.
 - [ ] If the sync PR has merge conflicts, resolve them manually and merge per the merge-commit rule in the skill's "Release Sync" section (never squash/rebase).
 
+### Manual pre-release / RC
+- [ ] Confirm the `prerelease.yml` run succeeded.
+- [ ] If `create_release=true`, confirm the GitHub Pre-release was created with the expected artifacts.
+- [ ] If `create_release=false`, no release or artifacts are published anywhere — the build output is discarded when the job ends.
+- [ ] Do **not** expect `post-release.yml` or `release-sync.yml` to run: GitHub fires `prereleased` (not `released`) for pre-releases, and both workflows only trigger on `released`. No npm publish, no GHCR push, and no develop-sync PR happen for RCs.
+
 ## Output format
 
 - Release type and computed version
-- Links: GitHub Release URL, npm package URL, GHCR image tag
-- Release-sync PR status: auto-merged or needs manual conflict resolution
+- **Stable release:** GitHub Release URL, npm package URL, GHCR image tag, and release-sync PR status (auto-merged or needs manual conflict resolution)
+- **RC / pre-release:** GitHub Pre-release URL (only if `create_release=true`) — npm package URL, GHCR image tag, and sync-PR status do not apply

--- a/.github/skills/release-process/SKILL.md
+++ b/.github/skills/release-process/SKILL.md
@@ -10,7 +10,7 @@ description: "Release pipeline knowledge covering the stable release flow (relea
 Lichtblick has two release tracks:
 
 1. **Stable releases** — triggered automatically when a merged pull request into `main` comes from a `release/*` or `hotfix/*` branch. This runs `.github/workflows/release.yml`, which creates the GitHub Release and then fan-outs into post-release publishing and main→develop sync via GitHub's `release: released` event.
-2. **Manual pre-release / RC builds** — triggered manually through `.github/workflows/prerelease.yml` (`workflow_dispatch` only). This builds the same production artifacts and, when `create_release: true`, creates a GitHub **Pre-release** through `ncipollo/release-action` with `prerelease: true`.
+2. **Manual pre-release / RC builds** — triggered manually through `.github/workflows/prerelease.yml` (`workflow_dispatch` only). This builds the same production artifacts and, when `create_release: true`, creates a GitHub **Pre-release** through `ncipollo/release-action` with `prerelease: true`. Because GitHub's `release` event fires `prereleased` (not `released`) for pre-releases, this does **not** trigger `post-release.yml` or `release-sync.yml` — RC builds are never auto-published to NPM/GHCR or auto-synced to `develop`.
 
 The stable and RC flows share the same artifact packaging shape, but only the stable flow performs the in-repo version bump, commit, and tag push to `main`.
 
@@ -87,12 +87,14 @@ Release artifacts:
 
 Trigger:
 
-- `release: types: [released]`
-- manual `workflow_dispatch`
+- `release: types: [released]` — fires only for full (non-prerelease) GitHub Releases; pre-releases fire GitHub's separate `prereleased` event, which this workflow does not listen for.
+- manual `workflow_dispatch` — declares no inputs, so `github.event.release.tag_name` is empty on a manual run. The checkout and Docker version-tagging steps both depend on that value, so triggering this workflow manually checks out an empty ref and produces an empty Docker version tag; treat this trigger path as non-functional until the workflow is changed to accept an explicit tag input.
 
 This workflow fans out into two parallel jobs:
 
 ### `npm`
+
+> Yarn 3.6.3 via Corepack remains this repo's dependency manager everywhere else; `npm publish` here is an intentional, pipeline-only exception used solely to publish the built package to the npm registry.
 
 1. Check out the release tag (`github.event.release.tag_name`).
 2. Set up Node.js 24 and point npm at `https://registry.npmjs.org`.
@@ -114,7 +116,7 @@ This workflow fans out into two parallel jobs:
 
 Trigger:
 
-- `release: types: [released]`
+- `release: types: [released]` — same caveat as `post-release.yml`: pre-releases fire `prereleased`, not `released`, so this workflow does not run for RC builds.
 - manual `workflow_dispatch`
 
 This workflow keeps `develop` descended from `main` after a release:
@@ -137,10 +139,12 @@ This workflow is manual-only (`workflow_dispatch`).
 
 | Input | Type / options | Default | Purpose |
 |-------|----------------|---------|---------|
-| `branch` | choice: `develop`, `release/*` | `develop` | Branch to build the pre-release from |
+| `branch` | choice (fixed dropdown values): `develop`, `release/*` | `develop` | Branch to build the pre-release from |
 | `version_type` | choice: `prerelease`, `prepatch`, `preminor`, `premajor` | `prerelease` | How to compute the next RC version |
 | `create_release` | boolean | `true` | Whether to publish a GitHub Pre-release |
 | `release_notes` | string | none | Optional custom release notes body |
+
+> **Note:** `release/*` is a literal option string in the workflow's `choice` input, not a wildcard/glob pattern. Selecting it only works if a branch is literally named `release/*`; to build an RC from an actual release branch (e.g. `release/minor/v1.5.0`), that exact branch name would need to be added as its own choice option (or the input changed to a free-text `string` type).
 
 Version computation logic:
 
@@ -162,16 +166,16 @@ Build and release steps:
 3. Create `dist/lichtblick-web.tar.gz`.
 4. If `create_release == true`, create a GitHub Pre-release with `ncipollo/release-action@v1`, `prerelease: true`, and the same artifact list as the stable release flow.
 
-> **Note:** This flow does not commit a version bump into git history in the workflow as summarized here. It is also worth verifying whether creating a GitHub Pre-release emits the same `release: released` event that triggers `post-release.yml` and `release-sync.yml`; after creating an RC, check the GitHub Actions run history for those workflows to confirm what actually fired.
+> **Note:** This flow does not commit a version bump into git history. As covered above, GitHub fires `prereleased` (not `released`) for pre-releases, so `post-release.yml` and `release-sync.yml` do not run automatically after this workflow creates a GitHub Pre-release — NPM publishing, the GHCR image push, and the develop-sync PR only happen for stable releases.
 
 ## Workflow Trigger Reference
 
 | Workflow file | Trigger | Jobs |
 |---------------|---------|------|
 | `.github/workflows/release.yml` | `pull_request` closed on `main`, gated to merged PRs whose head branch starts with `release/` or `hotfix/` | `release` |
-| `.github/workflows/post-release.yml` | `release: released` or `workflow_dispatch` | `npm`, `docker` |
+| `.github/workflows/post-release.yml` | `release: released` (excludes pre-releases) or `workflow_dispatch` (non-functional — no tag context) | `npm`, `docker` |
 | `.github/workflows/prerelease.yml` | `workflow_dispatch` | `prerelease` |
-| `.github/workflows/release-sync.yml` | `release: released` or `workflow_dispatch` | `sync` |
+| `.github/workflows/release-sync.yml` | `release: released` (excludes pre-releases) or `workflow_dispatch` | `sync` |
 
 ## Key Files
 

--- a/.github/skills/release-process/SKILL.md
+++ b/.github/skills/release-process/SKILL.md
@@ -94,7 +94,7 @@ This workflow fans out into two parallel jobs:
 
 ### `npm`
 
-> Yarn 3.6.3 via Corepack remains this repo's dependency manager everywhere else; `npm publish` here is an intentional, pipeline-only exception used solely to publish the built package to the npm registry.
+> Yarn (per the `packageManager` field in `package.json`, currently 4.17.0) via Corepack remains this repo's dependency manager everywhere else; `npm publish` here is an intentional, pipeline-only exception used solely to publish the built package to the npm registry.
 
 1. Check out the release tag (`github.event.release.tag_name`).
 2. Set up Node.js 24 and point npm at `https://registry.npmjs.org`.

--- a/.github/skills/release-process/SKILL.md
+++ b/.github/skills/release-process/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: "release-process"
+description: "Release pipeline knowledge covering the stable release flow (release.yml -> post-release.yml -> release-sync.yml), the manual pre-release/RC flow (prerelease.yml), branch-naming to version-bump mapping, and NPM/GHCR publishing. Use when cutting a release, verifying a completed release, or troubleshooting the release pipeline."
+---
+
+# Release Process Skill
+
+## Overview
+
+Lichtblick has two release tracks:
+
+1. **Stable releases** — triggered automatically when a merged pull request into `main` comes from a `release/*` or `hotfix/*` branch. This runs `.github/workflows/release.yml`, which creates the GitHub Release and then fan-outs into post-release publishing and main→develop sync via GitHub's `release: released` event.
+2. **Manual pre-release / RC builds** — triggered manually through `.github/workflows/prerelease.yml` (`workflow_dispatch` only). This builds the same production artifacts and, when `create_release: true`, creates a GitHub **Pre-release** through `ncipollo/release-action` with `prerelease: true`.
+
+The stable and RC flows share the same artifact packaging shape, but only the stable flow performs the in-repo version bump, commit, and tag push to `main`.
+
+## Branch Naming -> Version Bump Mapping
+
+The version bump is computed by regex in the `bump_type` step of `.github/workflows/release.yml`.
+
+| Branch prefix pattern | Bump type | Example |
+|-----------------------|-----------|---------|
+| `hotfix/*` | `patch` | `hotfix/fix-crash` |
+| `release/major` or `release/major/*` | `major` | `release/major/v2.0.0` |
+| `release/minor` or `release/minor/*` | `minor` | `release/minor/v1.5.0` |
+
+Any other branch prefix causes the workflow to fail with an explicit error.
+
+## Stable Release Pipeline (release.yml)
+
+Trigger condition:
+
+```yaml
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  release:
+    if: |
+      github.event.pull_request.merged == true &&
+      (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/'))
+```
+
+Step order:
+
+1. Check out the repository on `main`.
+2. Set up Node.js 24 and enable Yarn via Corepack.
+3. Install dependencies with `yarn install --immutable`.
+4. Determine the bump type from the source branch name:
+   - `hotfix/*` -> `patch`
+   - `release/major(/.*)?` -> `major`
+   - `release/minor(/.*)?` -> `minor`
+   - anything else -> fail
+5. Bump the root version with `yarn version <type>`.
+6. Bump `packages/suite/package.json` with `yarn version <type>`.
+7. Read the new version from the root `package.json`.
+8. Update `sonar-project.properties` so `sonar.projectVersion` matches the new version.
+9. Commit the version files and tag `main` as `v${version}`, then push `main` and tags.
+10. Build the production desktop and web bundles:
+    - `yarn desktop:build:prod`
+    - `yarn web:build:prod`
+11. Package release binaries for Windows, Linux, and macOS:
+    - `yarn package:win`
+    - `yarn package:linux`
+    - `yarn package:darwin`
+12. Create the web static tarball at `dist/lichtblick-web.tar.gz`.
+13. Create the GitHub Release with `ncipollo/release-action@v1`.
+14. Trigger `sonarqube.yml` on `main` via `gh workflow run`.
+
+Release artifacts:
+
+- `dist/lichtblick-${version}-linux-amd64.deb`
+- `dist/lichtblick-${version}-linux-x64.tar.gz`
+- `dist/lichtblick-${version}-linux-arm64.deb`
+- `dist/lichtblick-${version}-linux-arm64.tar.gz`
+- `dist/lichtblick-${version}-mac-universal.dmg`
+- `dist/lichtblick-${version}-win.exe`
+- `dist/lichtblick-web.tar.gz`
+- `dist/latest-linux.yml`
+- `dist/latest-mac.yml`
+- `dist/latest.yml`
+
+## Post-Release Publishing (post-release.yml)
+
+Trigger:
+
+- `release: types: [released]`
+- manual `workflow_dispatch`
+
+This workflow fans out into two parallel jobs:
+
+### `npm`
+
+1. Check out the release tag (`github.event.release.tag_name`).
+2. Set up Node.js 24 and point npm at `https://registry.npmjs.org`.
+3. Enable Yarn and run `yarn install --immutable`.
+4. Publish `./packages/suite` to npm with `npm publish ./packages/suite`.
+
+### `docker`
+
+1. Check out the same release tag.
+2. Set up QEMU and Docker Buildx.
+3. Log in to GHCR.
+4. Strip the leading `v` from the release tag for the versioned container tag.
+5. Build and push a multi-arch image for `linux/amd64,linux/arm64`.
+6. Push both:
+   - `ghcr.io/<repo>:latest`
+   - `ghcr.io/<repo>:<version-without-v-prefix>`
+
+## Release Sync (release-sync.yml)
+
+Trigger:
+
+- `release: types: [released]`
+- manual `workflow_dispatch`
+
+This workflow keeps `develop` descended from `main` after a release:
+
+1. Check out `main` with full history.
+2. Read the released version from `package.json`.
+3. Create `sync/main-to-develop-{version}` from `origin/develop`.
+4. Attempt `git merge origin/main --no-ff`.
+
+Two paths follow:
+
+- **Clean merge** — push the sync branch, open a PR into `develop`, and enable auto-merge with `gh pr merge --merge --auto`.
+- **Conflicted merge** — commit the conflict markers, push the branch, and open a PR whose body warns that conflicts must be resolved manually.
+
+In both cases, the workflow emphasizes the same rule: merge the sync PR with a **MERGE COMMIT** only — never squash or rebase — so `main` remains an ancestor of `develop`.
+
+## Manual Pre-release / RC Flow (prerelease.yml)
+
+This workflow is manual-only (`workflow_dispatch`).
+
+| Input | Type / options | Default | Purpose |
+|-------|----------------|---------|---------|
+| `branch` | choice: `develop`, `release/*` | `develop` | Branch to build the pre-release from |
+| `version_type` | choice: `prerelease`, `prepatch`, `preminor`, `premajor` | `prerelease` | How to compute the next RC version |
+| `create_release` | boolean | `true` | Whether to publish a GitHub Pre-release |
+| `release_notes` | string | none | Optional custom release notes body |
+
+Version computation logic:
+
+1. Check out the selected branch with full history.
+2. Find the latest RC tag matching `v*rc.*`.
+3. Compute the next version:
+   - If `version_type == "prerelease"`:
+     - with no RC tag yet: `semver.inc(baseVersion, "prerelease", "rc")`
+     - with an existing RC tag: `semver.inc(lastRcWithoutLeadingV, "prerelease", "rc")`
+   - Otherwise:
+     - derive a stable base version from `package.json`
+     - run `semver.inc(stableBase, version_type, "rc")`
+4. Use the computed version for artifact naming and release metadata.
+
+Build and release steps:
+
+1. Build production desktop and web bundles.
+2. Package Windows, Linux, and macOS artifacts using `--config.extraMetadata.version=${version}`.
+3. Create `dist/lichtblick-web.tar.gz`.
+4. If `create_release == true`, create a GitHub Pre-release with `ncipollo/release-action@v1`, `prerelease: true`, and the same artifact list as the stable release flow.
+
+> **Note:** This flow does not commit a version bump into git history in the workflow as summarized here. It is also worth verifying whether creating a GitHub Pre-release emits the same `release: released` event that triggers `post-release.yml` and `release-sync.yml`; after creating an RC, check the GitHub Actions run history for those workflows to confirm what actually fired.
+
+## Workflow Trigger Reference
+
+| Workflow file | Trigger | Jobs |
+|---------------|---------|------|
+| `.github/workflows/release.yml` | `pull_request` closed on `main`, gated to merged PRs whose head branch starts with `release/` or `hotfix/` | `release` |
+| `.github/workflows/post-release.yml` | `release: released` or `workflow_dispatch` | `npm`, `docker` |
+| `.github/workflows/prerelease.yml` | `workflow_dispatch` | `prerelease` |
+| `.github/workflows/release-sync.yml` | `release: released` or `workflow_dispatch` | `sync` |
+
+## Key Files
+
+- `.github/workflows/release.yml`
+- `.github/workflows/post-release.yml`
+- `.github/workflows/prerelease.yml`
+- `.github/workflows/release-sync.yml`

--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -80,7 +80,7 @@ Located in `.github/agents/`. Each file uses YAML frontmatter with `description`
 
 ---
 
-## Skills (26)
+## Skills (27)
 
 Located in `.github/skills/<name>/SKILL.md`. Each file uses YAML frontmatter with a `description` field. Skills provide deep implementation knowledge that agents load on demand.
 
@@ -106,6 +106,7 @@ Located in `.github/skills/<name>/SKILL.md`. Each file uses YAML frontmatter wit
 | `player-internals`          | IterablePlayer state machine internals, tick loop, and data source iteration patterns.                                                                                                  |
 | `plot-internals`            | Chart.js integration for the Plot panel: Worker-based rendering, dataset management, downsampling strategies, scale handling, and interaction patterns.                                 |
 | `remote-caching`            | HTTP-layer caching for remote file access: CachedFilelike, VirtualLRUBuffer, connection management algorithm, BrowserHttpReader, FetchReader streaming, and RequestQueue concurrency.   |
+| `release-process`           | Release pipeline knowledge: the stable release flow (release.yml -> post-release.yml -> release-sync.yml), the manual pre-release/RC flow (prerelease.yml), branch-naming to version-bump mapping, and NPM/GHCR publishing. |
 | `theme`                     | Theme system: createMuiTheme factory, dark/light palette tokens, typography scale, ThemeProvider application, and tss-react/mui styling.                                                |
 | `unit-testing`              | Unit testing patterns, mock builder usage, and test data construction strategies.                                                                                                       |
 | `web-workers`               | Web Worker patterns: Comlink integration, ComlinkWrap lifecycle, transfer handlers, OffscreenCanvas, SharedWorker isolation, and testing utilities.                                     |
@@ -172,7 +173,7 @@ Located in `.github/instructions/`. Each file uses YAML frontmatter with an `app
 
 ---
 
-## Prompts (6)
+## Prompts (7)
 
 Located in `.github/prompts/`. Prompt files provide reusable workflows for multi-step development and review tasks.
 
@@ -184,6 +185,7 @@ Located in `.github/prompts/`. Prompt files provide reusable workflows for multi
 | `lb-feature-adopt.prompt.md` | Evaluate and adopt a specific upstream feature with an explicit decision matrix.                                        |
 | `lb-open-pr.prompt.md`                      | Create a complete PR description with testing evidence and risk notes. Uses `github` MCP server.                        |
 | `lb-review-pr.prompt.md`                    | Two-phase PR review: structured analysis integrating CodeRabbit, then implement CodeRabbit AI agent prompt suggestions. |
+| `lb-release.prompt.md`                  | Guided runbook to cut a release (major/minor/hotfix) or manual RC/pre-release, and verify the automated publish pipeline (release.yml/post-release.yml/release-sync.yml). |
 
 ---
 


### PR DESCRIPTION
## Summary
Add agentic documentation for Lichtblick releases so Copilot agents have an accurate runbook and reference skill for the current pipeline. This fills gaps in the user-provided release guide, which was partially outdated and did not cover the `prerelease.yml` RC flow, Docker/GHCR publishing, or the stronger auto-merge behavior in `release-sync.yml`.

## Changes
- `.github/skills/release-process/SKILL.md` — new skill documenting the release pipeline workflows, branch/version mapping, publishing, release-sync, and RC flow.
- `.github/prompts/lb-release.prompt.md` — new release runbook prompt for cutting stable releases and RCs, referencing the skill rather than duplicating its detail.
- `.github/copilot-instructions.md` — registers the new skill and prompt in the main Copilot instructions catalog.
- `.github/agents/lb-orchestrator.agent.md` — adds release-request routing guidance to the orchestrator agent catalog.
- `docs/ai-agents/README.md` — updates the public AI agents docs tables for the new skill and prompt.

## Scope
Agentic docs only — no workflow YAML, `CONTRIBUTING.md`, or release guide changes.

## Testing
Documentation-only change; no build/lint/test run applicable. Manually verified the new skill/prompt frontmatter and formatting against existing conventions such as the `mcap-format` and `electron-internals` skills, plus the `lb-open-pr` and `lb-setup-worktree` prompts. Reviewed the skill and prompt together to remove unnecessary duplicated explanatory content (the prompt now references the skill instead of restating pipeline trigger-chain and merge-commit-rule detail).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guided release runbook covering stable releases, hotfixes, and release candidates.
  * Documented versioning, branching, publishing, artifact packaging, verification, workflow monitoring, and conflict handling.
  * Clarified release candidate versioning and prerelease workflow behavior.
  * Updated AI agent documentation to include the new release prompt and process skill.
  * Updated documented counts for available skills and prompts.
  * Clarified that release requests should use the human-invoked release runbook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->