### PR TITLE
fix: restore version fields to 1.28.0 on develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lichtblick",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "license": "MPL-2.0",
   "private": true,
   "productName": "Lichtblick",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lichtblick/suite",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # General
 sonar.projectKey=Lichtblick-Suite_lichtblick
 sonar.organization=lichtblick-suite
-sonar.projectVersion=1.27.1
+sonar.projectVersion=1.28.0
 
 # TS and Lint
 sonar.typescript.tsconfigPath=tsconfig.json


### PR DESCRIPTION
## Summary
- restore the top-level package version, suite package version, and sonar project version to 1.28.0 on develop
- correct the stale 1.27.1 values left behind after PR #1253's main->develop ancestry-reconciliation merge using `-s ours`
- ensure future branches cut from develop do not regress main's released version

## Why this is needed
PR #1253 advanced the ancestry between main and develop with a zero-file-change merge, so develop never actually received main's v1.28.0 version bump. As a result, develop (and branches cut from it, such as PR #1285's `hotfix/v1.28.1` branch) inherited 1.27.1 in:
- `package.json`
- `packages/suite/package.json`
- `sonar-project.properties`

That stale state can cause release automation to compute the wrong next version and makes merges from hotfix branches appear to regress main's version. Restoring 1.28.0 on develop keeps it aligned with main's actual released version (tag `v1.28.0`) and prevents future release/hotfix branches from inheriting the wrong base version.

## Context
- PR #1253: ancestry-reconciliation merge from main to develop using `-s ours`
- PR #1285: current v1.28.1 release PR that exposed the version regression on its hotfix branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application and package version to 1.28.0.
  * Updated the code quality tracking version to match the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->