### PR TITLE
fix: restore version fields to 1.28.0 on develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lichtblick",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "license": "MPL-2.0",
   "private": true,
   "productName": "Lichtblick",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lichtblick/suite",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # General
 sonar.projectKey=Lichtblick-Suite_lichtblick
 sonar.organization=lichtblick-suite
-sonar.projectVersion=1.27.1
+sonar.projectVersion=1.28.0
 
 # TS and Lint
 sonar.typescript.tsconfigPath=tsconfig.json


### PR DESCRIPTION
## Summary
Restore develop's stale version fields to `1.28.0` in:
- `package.json`
- `packages/suite/package.json`
- `sonar-project.properties`

## Root cause
The main -> develop ancestry-reconciliation merge done with `-s ours` in PR #1253 advanced the merge-base without bringing over the version-file changes from main. As a result, develop's release version fields stayed at `1.27.1` even though main had already released `v1.28.0`.

That stale state then caused hotfix/v1.28.1 (branched from develop) to regress main's version metadata in PR #1285.

## Why this PR
This PR brings develop's version fields back in line with main (`v1.28.0`) so future release and hotfix branches inherit the correct base version.

## References
- PR #1253
- PR #1285
- Supersedes and replaces closed PR #1286 (renamed branch to satisfy develop branch naming rules)