### PR TITLE
fix(desktop): allow blob: images in CSP so COLLADA textures load over the websocket bridge

### DIFF
--- a/packages/suite-desktop/src/main/index.ts
+++ b/packages/suite-desktop/src/main/index.ts
@@ -281,7 +281,8 @@ export async function main(): Promise<void> {
       "connect-src": "'self' ws: wss: http: https: package: blob: data: file:",
       "font-src": "'self' data:",
       // Include http in the CSP to allow loading images (i.e. map tiles) from http endpoints like localhost
-      "img-src": "'self' data: https: package: x-foxglove-converted-tiff: http:",
+      // Include blob: to allow loading mesh textures fetched as assets and served via object URLs
+      "img-src": "'self' data: https: package: x-foxglove-converted-tiff: http: blob:",
       "media-src": "'self' data: https: http: blob: file:",
     };
     const cspHeader = Object.entries(contentSecurityPolicy)


### PR DESCRIPTION
## User-Facing Changes

COLLADA mesh textures now load in the desktop app when meshes are fetched over a websocket bridge.

## Description

I'm running the desktop app against a ROS 2 foxglove_bridge with the assets capability enabled. Textured .dae meshes load their geometry fine, but the textures never appear and each mesh reports `Failed to load COLLADA asset "blob:file:///..."` on the 3D panel. The devtools console shows why:

    Loading the image 'blob:<URL>' violates the following Content Security Policy directive: "img-src 'self' data: https: package: x-foxglove-converted-tiff: http:".

ModelCache preloads bridge-fetched textures into blob object URLs, but img-src in the desktop CSP doesn't include blob:, so the images get blocked. This PR adds blob: to img-src, which worker-src, media-src and connect-src already include.

Tested on macOS against a ROS 2 Jazzy foxglove_bridge: textures render in both the desktop and web apps and the CSP violations are gone from the console.

Happy to adjust anything if you'd prefer this done differently.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image loading for content served through object URLs, including mesh textures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->