### PR TITLE
fix: decode encoded video published as sensor_msgs/CompressedImage

### DIFF
--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -293,12 +293,12 @@ export class ImageMode
   }
 
   /**
-   * Encoded frame filter: same shape as `#filterMessageQueue` but aware that HEVC P-frames
-   * cannot be dropped without losing decodability. When synchronization is on we keep every
-   * message (sync needs the full timeline); when it is off we delegate to
-   * {@link filterCompressedVideoQueue}, which trims to the latest frame for non-HEVC topics and
-   * to the active GOP for HEVC topics. Used for every subscription that can deliver an encoded
-   * stream, including the compressed image schemas that carry one when `format` names a codec.
+   * Encoded frame filter: same shape as `#filterMessageQueue` but aware that the delta frames of
+   * an inter-frame codec cannot be dropped without losing decodability. When synchronization is on
+   * we keep every message (sync needs the full timeline); when it is off we delegate to
+   * {@link filterCompressedVideoQueue}, which keeps the active GOP for both H.264 and H.265 topics
+   * and trims to the latest frame for topics whose `format` names no codec. Used for every
+   * subscription that can deliver an encoded stream, including the compressed image schemas.
    */
   #filterEncodedFrameQueue<T extends Pick<CompressedVideo, "format" | "data">>(
     msgs: MessageEvent<T>[],

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -250,7 +250,7 @@ export class ImageMode
         subscription: {
           handler: this.messageHandler.handleRosCompressedImage,
           shouldSubscribe: this.imageShouldSubscribe,
-          filterQueue: this.#filterMessageQueue.bind(this),
+          filterQueue: this.#filterEncodedFrameQueue.bind(this),
         },
       },
       {
@@ -268,7 +268,7 @@ export class ImageMode
         subscription: {
           handler: this.messageHandler.handleCompressedImage,
           shouldSubscribe: this.imageShouldSubscribe,
-          filterQueue: this.#filterMessageQueue.bind(this),
+          filterQueue: this.#filterEncodedFrameQueue.bind(this),
         },
       },
       {
@@ -277,7 +277,7 @@ export class ImageMode
         subscription: {
           handler: this.messageHandler.handleCompressedVideo,
           shouldSubscribe: this.imageShouldSubscribe,
-          filterQueue: this.#filterCompressedVideoMessageQueue.bind(this),
+          filterQueue: this.#filterEncodedFrameQueue.bind(this),
         },
       },
     ];
@@ -293,15 +293,16 @@ export class ImageMode
   }
 
   /**
-   * Compressed video filter: same shape as `#filterMessageQueue` but aware that HEVC P-frames
+   * Encoded frame filter: same shape as `#filterMessageQueue` but aware that HEVC P-frames
    * cannot be dropped without losing decodability. When synchronization is on we keep every
    * message (sync needs the full timeline); when it is off we delegate to
    * {@link filterCompressedVideoQueue}, which trims to the latest frame for non-HEVC topics and
-   * to the active GOP for HEVC topics.
+   * to the active GOP for HEVC topics. Used for every subscription that can deliver an encoded
+   * stream, including the compressed image schemas that carry one when `format` names a codec.
    */
-  #filterCompressedVideoMessageQueue(
-    msgs: MessageEvent<CompressedVideo>[],
-  ): MessageEvent<CompressedVideo>[] {
+  #filterEncodedFrameQueue<T extends Pick<CompressedVideo, "format" | "data">>(
+    msgs: MessageEvent<T>[],
+  ): MessageEvent<T>[] {
     if (this.getImageModeSettings().synchronize) {
       return msgs;
     }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -146,7 +146,10 @@ export class Images extends SceneExtension<ImageRenderable> {
         schemaNames: ROS_COMPRESSED_IMAGE_DATATYPES,
         subscription: {
           handler: this.#handleRosCompressedImage,
-          filterQueue: onlyLastByTopicMessage,
+          // Compressed images are usually stills, where this collapses to onlyLastByTopicMessage.
+          // When the format names a video codec, the filter keeps the active GOP so P-frames stay
+          // decodable instead of being dropped along with the rest of the queue.
+          filterQueue: filterCompressedVideoQueue,
         },
       },
       {
@@ -162,7 +165,7 @@ export class Images extends SceneExtension<ImageRenderable> {
         schemaNames: COMPRESSED_IMAGE_DATATYPES,
         subscription: {
           handler: this.#handleCompressedImage,
-          filterQueue: onlyLastByTopicMessage,
+          filterQueue: filterCompressedVideoQueue,
         },
       },
       {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -543,17 +543,19 @@ describe("ImageRenderable error handling", () => {
       data,
     });
 
-    renderable.setImage(rosFrame(h265Keyframe, { sec: 8, nsec: 0 }));
-    renderable.setImage(rosFrame(h265DeltaFrame, { sec: 8, nsec: 16_666_666 }));
-    renderable.flushPendingDecodes();
-    await renderable.settleVideoDecodes();
+    try {
+      renderable.setImage(rosFrame(h265Keyframe, { sec: 8, nsec: 0 }));
+      renderable.setImage(rosFrame(h265DeltaFrame, { sec: 8, nsec: 16_666_666 }));
+      renderable.flushPendingDecodes();
+      await renderable.settleVideoDecodes();
 
-    // Presentation timestamps are relative to the first frame, so a stamp-derived time gives
-    // 0 then 16666 microseconds. Any other origin means the header stamp was not used.
-    expect(decode).toHaveBeenNthCalledWith(1, expect.any(Uint8Array), 0, "key");
-    expect(decode).toHaveBeenNthCalledWith(2, expect.any(Uint8Array), 16666, "delta");
-
-    self.createImageBitmap = originalCreateImageBitmap;
+      // Presentation timestamps are relative to the first frame, so a stamp-derived time gives
+      // 0 then 16666 microseconds. Any other origin means the header stamp was not used.
+      expect(decode).toHaveBeenNthCalledWith(1, expect.any(Uint8Array), 0, "key");
+      expect(decode).toHaveBeenNthCalledWith(2, expect.any(Uint8Array), 16666, "delta");
+    } finally {
+      self.createImageBitmap = originalCreateImageBitmap;
+    }
   });
 
   it("should decode every pending h265 frame in order", async () => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -486,6 +486,76 @@ describe("ImageRenderable error handling", () => {
     decodeResolvers.get(33333)?.();
   });
 
+  it("should accept an encoded stream published as sensor_msgs/CompressedImage", async () => {
+    // Regression guard: a ROS CompressedImage keeps its time in `header.stamp`, so reading
+    // `timestamp` off it yielded undefined and threw out of setImage — before the frame reached
+    // the decoder and outside any catch, which took down the whole panel.
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    jest.spyOn(renderable, "update").mockImplementation(() => undefined);
+    const decodeImage = jest
+      .spyOn(renderable as unknown as { decodeImage: jest.Mock }, "decodeImage")
+      .mockResolvedValue({});
+
+    const rosFrame = {
+      header: { frame_id: "camera", stamp: { sec: 4, nsec: 500_000_000 } },
+      format: "h264",
+      data: h265Keyframe,
+    };
+
+    renderable.setImage(rosFrame);
+
+    // Queued rather than decoded inline, which is what marks it as taking the video path.
+    await Promise.resolve();
+    expect(decodeImage).not.toHaveBeenCalled();
+
+    renderable.flushPendingDecodes();
+    await renderable.settleVideoDecodes();
+
+    expect(decodeImage).toHaveBeenCalledWith(rosFrame, undefined);
+    expect(mockAddToTopic).not.toHaveBeenCalled();
+  });
+
+  it("should decode a sensor_msgs/CompressedImage stream against its header stamp", async () => {
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    jest.spyOn(renderable, "update").mockImplementation(() => undefined);
+
+    const decode = jest
+      .fn<Promise<VideoFrame | undefined>, [Uint8Array, number, "key" | "delta"]>()
+      .mockResolvedValueOnce(createDecodedVideoFrame(0))
+      .mockResolvedValueOnce(createDecodedVideoFrame(16666));
+    renderable.videoPlayer = {
+      isInitialized: jest.fn().mockReturnValue(true),
+      init: jest.fn().mockResolvedValue(undefined),
+      decode,
+      codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue({ codec: "hvc1.1.6.L93.B0" }),
+      resetForSeek: jest.fn(),
+      lastImageBitmap: undefined,
+      lastVideoFrame: undefined,
+    } as unknown as ImageRenderable["videoPlayer"];
+
+    const originalCreateImageBitmap = self.createImageBitmap;
+    self.createImageBitmap = jest.fn().mockResolvedValue(new ImageBitmap());
+
+    const rosFrame = (data: Uint8Array, stamp: { sec: number; nsec: number }) => ({
+      header: { frame_id: "camera", stamp },
+      format: "hevc",
+      data,
+    });
+
+    renderable.setImage(rosFrame(h265Keyframe, { sec: 8, nsec: 0 }));
+    renderable.setImage(rosFrame(h265DeltaFrame, { sec: 8, nsec: 16_666_666 }));
+    renderable.flushPendingDecodes();
+    await renderable.settleVideoDecodes();
+
+    // Presentation timestamps are relative to the first frame, so a stamp-derived time gives
+    // 0 then 16666 microseconds. Any other origin means the header stamp was not used.
+    expect(decode).toHaveBeenNthCalledWith(1, expect.any(Uint8Array), 0, "key");
+    expect(decode).toHaveBeenNthCalledWith(2, expect.any(Uint8Array), 16666, "delta");
+
+    self.createImageBitmap = originalCreateImageBitmap;
+  });
+
   it("should decode every pending h265 frame in order", async () => {
     const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
     jest.spyOn(renderable, "update").mockImplementation(() => undefined);

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -30,7 +30,7 @@ import { WorkerImageDecoder } from "@lichtblick/suite-base/panels/ThreeDeeRender
 import { projectPixel } from "@lichtblick/suite-base/panels/ThreeDeeRender/renderables/projections";
 import { RosValue } from "@lichtblick/suite-base/players/types";
 
-import { AnyImage, CompressedVideo } from "./ImageTypes";
+import { AnyImage, CompressedVideo, toCompressedVideoFrame } from "./ImageTypes";
 import {
   decodeCompressedImageToBitmap,
   decodeCompressedVideoToBitmap,
@@ -289,7 +289,8 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.userData.image = image;
 
     const seq = ++this.#receivedImageSequenceNumber;
-    const incomingFormat = "format" in image ? image.format : undefined;
+    const compressedImage = "format" in image ? image : undefined;
+    const incomingFormat = compressedImage?.format;
     const incomingCodec =
       incomingFormat == undefined ? undefined : this.#cachedCanonicalCodec(incomingFormat);
     const incomingVideoFormat = incomingCodec == undefined ? undefined : incomingFormat;
@@ -298,8 +299,8 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     }
     const codec = this.#codec;
 
-    if (codec != undefined) {
-      const videoImage = image as CompressedVideo;
+    if (codec != undefined && compressedImage != undefined) {
+      const videoImage = toCompressedVideoFrame(compressedImage);
       const messageTime = toNanoSec(videoImage.timestamp);
       // Duplicate exact-timestamp resubmission — `expandVideoSeekBackfill` can include the
       // already-delivered target frame alongside its preceding GOP. Suppress the redundant decode.
@@ -668,7 +669,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       if (this.#codec == undefined) {
         return await decodeCompressedImageToBitmap(image, resizeWidth);
       } else {
-        const frameMsg = image as CompressedVideo;
+        const frameMsg = toCompressedVideoFrame(image);
 
         if (frameMsg.data.byteLength === 0) {
           const error = "Empty video frame";

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageTypes.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageTypes.test.ts
@@ -14,6 +14,7 @@ import {
   CompressedVideo,
   getFrameIdFromImage,
   getTimestampFromImage,
+  toCompressedVideoFrame,
 } from "./ImageTypes";
 import { Image as RosImage, CompressedImage as RosCompressedImage } from "../../ros";
 
@@ -113,6 +114,22 @@ describe("ImageTypes utility functions", () => {
       it(`should return the correct timestamp for ${name}`, () => {
         expect(getTimestampFromImage(image)).toEqual(expectedTime);
       });
+    });
+  });
+
+  describe("toCompressedVideoFrame", () => {
+    it("should move the ROS header fields onto the video frame", () => {
+      expect(toCompressedVideoFrame({ ...rosCompressedImage, format: "h264" })).toEqual({
+        timestamp: mockTime,
+        frame_id: "ros_frame",
+        format: "h264",
+        data: mockData,
+      });
+    });
+
+    it("should pass through messages that already have the video frame shape", () => {
+      expect(toCompressedVideoFrame(compressedVideo)).toBe(compressedVideo);
+      expect(toCompressedVideoFrame(compressedImage)).toBe(compressedImage);
     });
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageTypes.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageTypes.ts
@@ -48,3 +48,24 @@ export function getTimestampFromImage(image: AnyImage): Time {
     return image.timestamp;
   }
 }
+
+/**
+ * Adapts any compressed image message to the `CompressedVideo` shape the video decode path works
+ * with. Encoded video streams are routed there purely by codec `format`, and `sensor_msgs/
+ * CompressedImage` is commonly published with such a format even though it keeps its time and
+ * frame in `header`. Every consumer of a video frame must go through this so no code path reads
+ * `timestamp`/`frame_id` off a message that does not have them.
+ */
+export function toCompressedVideoFrame(
+  image: CompressedImageTypes | CompressedVideo,
+): CompressedVideo {
+  if (!("header" in image)) {
+    return image;
+  }
+  return {
+    timestamp: image.header.stamp,
+    frame_id: image.header.frame_id,
+    data: image.data,
+    format: image.format,
+  };
+}

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
@@ -51,7 +51,7 @@ export async function decodeCompressedImageToBitmap(
 }
 
 export function isCompressedVideoKeyframe(
-  frameMsg: CompressedVideo,
+  frameMsg: Pick<CompressedVideo, "format" | "data">,
   resolvedCodec?: VideoCodec,
 ): boolean {
   return isVideoKeyframe(frameMsg.format, frameMsg.data, resolvedCodec);

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/filterCompressedVideoQueue.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/filterCompressedVideoQueue.test.ts
@@ -10,6 +10,7 @@ import H265FrameBuilder from "@lichtblick/suite-base/testing/builders/H265FrameB
 
 import { CompressedVideo } from "./ImageTypes";
 import { filterCompressedVideoQueue } from "./filterCompressedVideoQueue";
+import { CompressedImage as RosCompressedImage } from "../../ros";
 
 function videoMessageEvent(
   topic: string,
@@ -166,6 +167,31 @@ describe("filterCompressedVideoQueue", () => {
     // Both /h264 and /h265 keep from their latest keyframe onward. The pre-keyframe h264Delta1
     // is dropped; everything else survives. Output stays sorted by original arrival order.
     expect(result).toEqual([h265Key, h264Key, h265Delta1, h264Delta2, h265Delta2]);
+  });
+
+  it("keeps the GOP for a stream published as sensor_msgs/CompressedImage", () => {
+    // The same encoded stream can arrive on a ROS schema, where time and frame live in `header`.
+    // Only `format` and `data` matter for GOP decisions, so those topics get the same treatment
+    // instead of being trimmed to the latest frame and losing the reference chain.
+    const rosFrame = (data: number[], receiveSec: number): MessageEvent<RosCompressedImage> => ({
+      topic: "/head/camera/color",
+      schemaName: "sensor_msgs/CompressedImage",
+      message: {
+        header: { stamp: { sec: receiveSec, nsec: 0 }, frame_id: "camera" },
+        format: "h264",
+        data: new Uint8Array(data),
+      },
+      receiveTime: { sec: receiveSec, nsec: 0 },
+      sizeInBytes: data.length,
+    });
+
+    const olderDelta = rosFrame([0x00, 0x00, 0x00, 0x01, 0x41], 1);
+    const key = rosFrame([0x00, 0x00, 0x00, 0x01, 0x65], 2);
+    const delta = rosFrame([0x00, 0x00, 0x00, 0x01, 0x41], 3);
+
+    const result = filterCompressedVideoQueue([olderDelta, key, delta]);
+
+    expect(result).toEqual([key, delta]);
   });
 
   it("does not mutate the input array", () => {

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/filterCompressedVideoQueue.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/filterCompressedVideoQueue.ts
@@ -13,8 +13,13 @@ import { MessageEvent } from "@lichtblick/suite";
 import { CompressedVideo } from "./ImageTypes";
 import { isCompressedVideoKeyframe } from "./decodeImage";
 
+/** Minimum shape needed to recognize an encoded frame, shared by every schema that can carry one. */
+type EncodedFrame = Pick<CompressedVideo, "format" | "data">;
+
 /**
- * Filters the per-frame queue for the `CompressedVideo` subscription.
+ * Filters the per-frame queue for a subscription that can deliver encoded video frames. That is
+ * `foxglove.CompressedVideo`, but also `sensor_msgs/CompressedImage` and `foxglove.CompressedImage`,
+ * which carry encoded streams in the wild by naming a codec in `format`.
  *
  * Codecs whose delta frames depend on a preceding GOP (H.264 and H.265) need the entire chain
  * from the most recent keyframe through the latest delta preserved — dropping older queued frames
@@ -27,24 +32,24 @@ import { isCompressedVideoKeyframe } from "./decodeImage";
  * The relative order of the kept messages is preserved so downstream handlers see the stream in
  * the same order it arrived.
  */
-export function filterCompressedVideoQueue(
-  msgs: MessageEvent<CompressedVideo>[],
-): MessageEvent<CompressedVideo>[] {
+export function filterCompressedVideoQueue<T extends EncodedFrame>(
+  msgs: MessageEvent<T>[],
+): MessageEvent<T>[] {
   if (msgs.length <= 1) {
     return msgs;
   }
 
-  const originalIndex = new Map<MessageEvent<CompressedVideo>, number>();
+  const originalIndex = new Map<MessageEvent<T>, number>();
   msgs.forEach((msg, index) => originalIndex.set(msg, index));
 
   const msgsByTopic = _.groupBy(msgs, (msg) => msg.topic);
-  const kept: MessageEvent<CompressedVideo>[] = Object.values(msgsByTopic).flatMap(filterTopic);
+  const kept: MessageEvent<T>[] = Object.values(msgsByTopic).flatMap(filterTopic);
 
   kept.sort((a, b) => (originalIndex.get(a) ?? 0) - (originalIndex.get(b) ?? 0));
   return kept;
 }
 
-function filterTopic(topicMsgs: MessageEvent<CompressedVideo>[]): MessageEvent<CompressedVideo>[] {
+function filterTopic<T extends EncodedFrame>(topicMsgs: MessageEvent<T>[]): MessageEvent<T>[] {
   const latest = topicMsgs.at(-1);
   if (latest == undefined) {
     return [];
@@ -62,10 +67,10 @@ function filterTopic(topicMsgs: MessageEvent<CompressedVideo>[]): MessageEvent<C
  * can be replayed. If we never find one in the queue, keep the entire topic queue — the next
  * keyframe will arrive eventually and we want the intervening frames available.
  */
-function keepFromLatestKeyframe(
-  topicMsgs: MessageEvent<CompressedVideo>[],
+function keepFromLatestKeyframe<T extends EncodedFrame>(
+  topicMsgs: MessageEvent<T>[],
   codec: VideoCodec,
-): MessageEvent<CompressedVideo>[] {
+): MessageEvent<T>[] {
   let keyIndex = -1;
   for (let i = topicMsgs.length - 1; i >= 0; i--) {
     if (isCompressedVideoKeyframe(topicMsgs[i]!.message, codec)) {

--- a/packages/suite-base/src/players/IterablePlayer/videoSeekBackfill.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/videoSeekBackfill.test.ts
@@ -21,18 +21,42 @@ afterEach(() => {
 });
 
 describe("needsGopBackfill", () => {
-  it("rejects messages with the wrong schema name", () => {
+  it("accepts an encoded stream regardless of the schema carrying it", () => {
+    // Encoded video is commonly published as sensor_msgs/CompressedImage with a codec format. A
+    // seek into such a topic needs the same GOP backfill as foxglove.CompressedVideo, so the frame
+    // is recognized by its payload rather than by schema name.
     // Given
-    const message = MessageEventBuilder.messageEvent({
+    const rosCompressedImage = MessageEventBuilder.messageEvent({
       topic: "video",
-      schemaName: "something.else",
+      schemaName: "sensor_msgs/CompressedImage",
       receiveTime: { sec: 0, nsec: 0 },
-      message: { format: "h265", data: new Uint8Array([0x01]) },
+      message: {
+        header: { stamp: { sec: 0, nsec: 0 }, frame_id: "camera" },
+        format: "h264",
+        data: new Uint8Array([0x01]),
+      },
       sizeInBytes: 1,
     });
 
     // When
-    const result = needsGopBackfill(message);
+    const result = needsGopBackfill(rosCompressedImage);
+
+    // Then
+    expect(result).toBe(true);
+  });
+
+  it("rejects messages that do not carry an encoded frame", () => {
+    // Given
+    const notAFrame = MessageEventBuilder.messageEvent({
+      topic: "/diagnostics",
+      schemaName: "something.else",
+      receiveTime: { sec: 0, nsec: 0 },
+      message: { level: 1, name: "sensor" },
+      sizeInBytes: 1,
+    });
+
+    // When
+    const result = needsGopBackfill(notAFrame);
 
     // Then
     expect(result).toBe(false);

--- a/packages/suite-base/src/players/IterablePlayer/videoSeekBackfill.ts
+++ b/packages/suite-base/src/players/IterablePlayer/videoSeekBackfill.ts
@@ -12,7 +12,6 @@ import {
 } from "@lichtblick/den/video";
 import { compare, fromNanoSec, toNanoSec } from "@lichtblick/rostime";
 import { MessageEvent } from "@lichtblick/suite";
-import { COMPRESSED_VIDEO_DATATYPES } from "@lichtblick/suite-base/util/foxgloveSchemas";
 
 import { GetBackfillMessagesArgs } from "./IIterableSource";
 
@@ -26,20 +25,22 @@ type CompressedVideoLike = {
 export type GetBackfillMessages = (args: GetBackfillMessagesArgs) => Promise<MessageEvent[]>;
 
 /**
- * Returns true for a `foxglove.CompressedVideo` message whose codec can only be decoded by
- * replaying the full GOP (the keyframe and every frame after it). H.264 and H.265 both qualify:
- * a seek that lands on a P/B-frame is not decodable without the preceding keyframe and every
- * intervening delta frame, regardless of whether the renderable serializes its decoder
- * submissions at playback time. The codec decision is delegated to
- * {@link videoCodecNeedsSeekBackfill} so this stays codec-agnostic.
+ * Returns true for an encoded video frame whose codec can only be decoded by replaying the full
+ * GOP (the keyframe and every frame after it). H.264 and H.265 both qualify: a seek that lands on
+ * a P/B-frame is not decodable without the preceding keyframe and every intervening delta frame,
+ * regardless of whether the renderable serializes its decoder submissions at playback time. The
+ * codec decision is delegated to {@link videoCodecNeedsSeekBackfill} so this stays codec-agnostic.
+ *
+ * Recognition is by payload rather than by schema name: `foxglove.CompressedVideo` is the schema
+ * designed for this, but encoded streams are also published as `sensor_msgs/CompressedImage` with
+ * a codec `format`, and those need the same backfill to survive a seek. A byte payload plus a
+ * `format` naming a video codec identifies a frame unambiguously enough, and the cost of a false
+ * positive is one wasted backfill read rather than a decode error.
  */
 export function needsGopBackfill(message: MessageEvent): boolean {
-  if (!COMPRESSED_VIDEO_DATATYPES.has(message.schemaName)) {
-    return false;
-  }
-  const video = message.message as CompressedVideoLike;
+  const video = message.message as CompressedVideoLike | undefined;
   return (
-    video.data instanceof Uint8Array &&
+    video?.data instanceof Uint8Array &&
     videoCodecNeedsSeekBackfill(canonicalVideoCodec(video.format ?? ""))
   );
 }


### PR DESCRIPTION
An image message is routed to the video decode path by its codec `format` alone, which lets a `sensor_msgs/CompressedImage` carrying H.264/H.265 in. That schema keeps its time and frame in `header`, but `setImage` read `timestamp` off it, so `toNanoSec` threw "Cannot destructure property 'sec' of 'undefined'". The throw happens on the synchronous path before any decode and outside the catch in `#startDecode`, so it reached the panel error boundary and took the whole panel down on the first frame. `decodeImage` already adapted the shape, but only after `setImage` had read the timestamp.

Add `toCompressedVideoFrame` as the single adapter to the `CompressedVideo` shape and use it at both entry points, so no code path reads `timestamp`/`frame_id` off a message that does not carry them.

Encoded streams on the compressed image schemas also missed the two mechanisms that keep inter-frame codecs decodable, both gated on the `foxglove.CompressedVideo` schema name rather than on the payload:

- `needsGopBackfill` now recognizes a frame by its `data` and codec `format`, so a seek onto a P-frame fetches the preceding GOP no matter which schema carries the stream.
- The compressed image subscriptions use the codec-aware queue filter, which preserves the active GOP instead of dropping every queued frame but the last. For stills it collapses to the previous keep-latest behavior.

## User-Facing Changes

<!-- will be used as a changelog entry -->

## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for H.264 and HEVC video streams delivered through compressed image messages.
  * Improved video frame ordering, GOP handling, seeking, and presentation timestamps.
  * Preserved still-image behavior while enabling compressed image streams to use video decoding.

* **Bug Fixes**
  * Prevented errors and dropped frames when displaying codec-based compressed images.
  * Improved keyframe detection across supported compressed image formats.

* **Tests**
  * Added coverage for decoding, timestamps, queue filtering, seeking, and keyframe handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->