### PR TITLE
Fix nanoid vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16332,11 +16332,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10/8004af92b5541af1dbd23b69845b5026f777d5b7ef07163cea1837aae86e052ced8b383cecbf8a4f1b5e77ae207df96dc45e16b9e0fa3c4b761d085f1e42851b
+  checksum: 10/1b3b4fdac831b92b56d1dbe8b1e63a372432faf86ea383134e3b53141ef8108a60b7f84343b5cefecac9550bb74edf8164da93ea07d1c4f757039bc75d8a5d9e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## User-Facing Changes

N/A

## Description

Fixes a high-severity security advisory ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)) flagged by `yarn npm audit --all --recursive --severity high`: `nanoid@3.3.16` (transitive dependency of `postcss@8.5.24`, pulled in via `css-loader`, `@vue/compiler-sfc`, and `sanitize-html`) is vulnerable to an infinite loop when a custom generator is used with `size` `0`.


## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated