### PR TITLE
[feat]: add getMessageAtTime to LB public API

### DIFF
--- a/packages/suite-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
+++ b/packages/suite-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
@@ -208,6 +208,9 @@ function getPublicState(
     getBatchIterator: () => {
       return undefined;
     },
+    getMessageAtTime: async () => {
+      return undefined;
+    },
   };
 }
 

--- a/packages/suite-base/src/components/MessagePipeline/index.test.tsx
+++ b/packages/suite-base/src/components/MessagePipeline/index.test.tsx
@@ -111,6 +111,7 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
         setParameter: expect.any(Function),
         pauseFrame: expect.any(Function),
         getBatchIterator: expect.any(Function),
+        getMessageAtTime: expect.any(Function),
       },
       {
         playerState: {
@@ -140,6 +141,7 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
         setParameter: expect.any(Function),
         pauseFrame: expect.any(Function),
         getBatchIterator: expect.any(Function),
+        getMessageAtTime: expect.any(Function),
       },
     ]);
   });

--- a/packages/suite-base/src/components/MessagePipeline/selectors.test.ts
+++ b/packages/suite-base/src/components/MessagePipeline/selectors.test.ts
@@ -36,6 +36,7 @@ it("map schema names by topic name", () => {
     subscriptions: [],
     getMetadata: jest.fn(),
     getBatchIterator: () => undefined,
+    getMessageAtTime: jest.fn(),
   };
   const result = getTopicToSchemaNameMap(state);
   expect(result).toEqual({

--- a/packages/suite-base/src/components/MessagePipeline/store.test.ts
+++ b/packages/suite-base/src/components/MessagePipeline/store.test.ts
@@ -1,0 +1,72 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import FakePlayer from "@lichtblick/suite-base/components/MessagePipeline/FakePlayer";
+
+import { createMessagePipelineStore } from "./store";
+
+describe("createMessagePipelineStore", () => {
+  it("should return undefined when the player does not support backfill lookups", async () => {
+    // GIVEN - a store backed by a player that cannot answer backfill lookups
+    const store = createMessagePipelineStore({
+      promisesToWaitForRef: { current: [] },
+      initialPlayer: new FakePlayer(),
+    });
+
+    // WHEN - requesting a point-in-time message
+    const result = await store.getState().public.getMessageAtTime("/topic", {
+      sec: 1,
+      nsec: 0,
+    });
+
+    // THEN - the store reports that the lookup is unsupported
+    expect(result).toBeUndefined();
+  });
+
+  it("should return the matching backfill message when the player can resolve messages", async () => {
+    // GIVEN - a player that can return multiple backfill messages
+    const player = new FakePlayer() as FakePlayer & {
+      getBackfillMessages: jest.Mock;
+    };
+    const matchingMessage = {
+      topic: "/topic",
+      receiveTime: { sec: 1, nsec: 0 },
+      message: { value: 2 },
+      schemaName: "schema",
+      sizeInBytes: 0,
+    };
+    const otherMessage = {
+      topic: "/other",
+      receiveTime: { sec: 1, nsec: 0 },
+      message: { value: 1 },
+      schemaName: "schema",
+      sizeInBytes: 0,
+    };
+    player.getBackfillMessages = jest.fn().mockResolvedValue([otherMessage, matchingMessage]);
+    const store = createMessagePipelineStore({
+      promisesToWaitForRef: { current: [] },
+      initialPlayer: player,
+    });
+
+    // WHEN - requesting the message at a specific time for one topic
+    const result = await store.getState().public.getMessageAtTime("/topic", {
+      sec: 1,
+      nsec: 0,
+    });
+
+    // THEN - the store asks for that topic and returns the matching message
+    expect(player.getBackfillMessages).toHaveBeenCalledWith({
+      topics: new Map([["/topic", { topic: "/topic" }]]),
+      time: {
+        sec: 1,
+        nsec: 0,
+      },
+    });
+    expect(result).toEqual(matchingMessage);
+  });
+});

--- a/packages/suite-base/src/components/MessagePipeline/store.ts
+++ b/packages/suite-base/src/components/MessagePipeline/store.ts
@@ -222,7 +222,7 @@ export function createMessagePipelineStore({
       },
       async getMessageAtTime(topic: string, time: Time) {
         const player = get().player;
-        if (!player?.getBackfillMessages) {
+        if (player?.getBackfillMessages == undefined) {
           return undefined;
         }
         const messages = await player.getBackfillMessages({

--- a/packages/suite-base/src/components/MessagePipeline/store.ts
+++ b/packages/suite-base/src/components/MessagePipeline/store.ts
@@ -220,6 +220,17 @@ export function createMessagePipelineStore({
         const player = get().player;
         return player?.getBatchIterator(topic, options);
       },
+      async getMessageAtTime(topic: string, time: Time) {
+        const player = get().player;
+        if (!player?.getBackfillMessages) {
+          return undefined;
+        }
+        const messages = await player.getBackfillMessages({
+          topics: new Map([[topic, { topic }]]),
+          time,
+        });
+        return messages.find((msg) => msg.topic === topic);
+      },
       startPlayback: undefined,
       playUntil: undefined,
       pausePlayback: undefined,

--- a/packages/suite-base/src/components/MessagePipeline/types.ts
+++ b/packages/suite-base/src/components/MessagePipeline/types.ts
@@ -44,4 +44,8 @@ export type MessagePipelineContext = Immutable<{
     topic: string,
     options?: { start?: Time; end?: Time },
   ) => AsyncIterableIterator<Readonly<IteratorResult>> | undefined;
+  // Read the most recent message on `topic` at or before `time`, independent of the current
+  // playback position. Resolves to `undefined` if unsupported (e.g. live data sources) or if no
+  // matching message exists.
+  getMessageAtTime: (topic: string, time: Time) => Promise<MessageEvent | undefined>;
 }>;

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
@@ -91,6 +91,7 @@ describe("PanelExtensionAdapter", () => {
 
     // WHEN - requesting a message while mounted, then after unmounting
     expect(panelContext).toBeDefined();
+    expect(panelContext!.unstable_getMessageAtTime).toBeDefined();
     await expect(
       panelContext!.unstable_getMessageAtTime?.("/topic", { sec: 1, nsec: 0 }),
     ).resolves.toBeUndefined();

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
@@ -71,6 +71,37 @@ describe("PanelExtensionAdapter", () => {
     await sig;
   });
 
+  it("should expose point-in-time message lookups through the panel context", async () => {
+    // GIVEN - a panel that captures its extension context
+    let panelContext: PanelExtensionContext | undefined;
+    const initPanel = (context: PanelExtensionContext) => {
+      panelContext = context;
+    };
+
+    const handle = render(
+      <ThemeProvider isDark>
+        <MockPanelContextProvider>
+          <PanelSetup>
+            <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+          </PanelSetup>
+        </MockPanelContextProvider>
+      </ThemeProvider>,
+    );
+    await act(async () => undefined);
+
+    // WHEN - requesting a message while mounted, then after unmounting
+    expect(panelContext).toBeDefined();
+    await expect(
+      panelContext!.unstable_getMessageAtTime?.("/topic", { sec: 1, nsec: 0 }),
+    ).resolves.toBeUndefined();
+    handle.unmount();
+
+    // THEN - the adapter does not query the pipeline after it is unmounted
+    await expect(
+      panelContext!.unstable_getMessageAtTime?.("/topic", { sec: 1, nsec: 0 }),
+    ).resolves.toBeUndefined();
+  });
+
   it("sets didSeek=true when seeking", async () => {
     const mockRAF = jest
       .spyOn(window, "requestAnimationFrame")

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
@@ -91,15 +91,15 @@ describe("PanelExtensionAdapter", () => {
 
     // WHEN - requesting a message while mounted, then after unmounting
     expect(panelContext).toBeDefined();
-    expect(panelContext!.unstable_getMessageAtTime).toBeDefined();
+    expect(panelContext!.getMessageAtTime).toBeDefined();
     await expect(
-      panelContext!.unstable_getMessageAtTime?.("/topic", { sec: 1, nsec: 0 }),
+      panelContext!.getMessageAtTime?.("/topic", { sec: 1, nsec: 0 }),
     ).resolves.toBeUndefined();
     handle.unmount();
 
     // THEN - the adapter does not query the pipeline after it is unmounted
     await expect(
-      panelContext!.unstable_getMessageAtTime?.("/topic", { sec: 1, nsec: 0 }),
+      panelContext!.getMessageAtTime?.("/topic", { sec: 1, nsec: 0 }),
     ).resolves.toBeUndefined();
   });
 

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -696,7 +696,7 @@ function PanelExtensionAdapter(
         return subscribeMessageRange(args);
       },
 
-      async unstable_getMessageAtTime(topic: string, time: Time) {
+      async getMessageAtTime(topic: string, time: Time) {
         if (!isMounted()) {
           return undefined;
         }

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -696,6 +696,13 @@ function PanelExtensionAdapter(
         return subscribeMessageRange(args);
       },
 
+      async unstable_getMessageAtTime(topic: string, time: Time) {
+        if (!isMounted()) {
+          return undefined;
+        }
+        return await getMessagePipelineContext().getMessageAtTime(topic, time);
+      },
+
       unstable_setMessagePathDropConfig(dropConfig) {
         setMessagePathDropConfig(dropConfig);
       },

--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -254,8 +254,11 @@ describe("IterablePlayer", () => {
 
   it("should return no backfill messages before the range source is initialized", async () => {
     // GIVEN - a player whose asynchronous initialization has not completed
+    const source = new TestSource();
+    const sentinelMessage = messageEvent({ topic: "sentinel" });
+    jest.spyOn(source, "getBackfillMessages").mockResolvedValue([sentinelMessage]);
     const player = new IterablePlayer({
-      source: new TestSource(),
+      source,
       enablePreload: false,
       sourceId: "test",
     });

--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -236,6 +236,27 @@ describe("IterablePlayer", () => {
     await player.isClosed;
   });
 
+  it("should return no backfill messages before the range source is initialized", async () => {
+    // GIVEN - a player whose asynchronous initialization has not completed
+    const player = new IterablePlayer({
+      source: new TestSource(),
+      enablePreload: false,
+      sourceId: "test",
+    });
+
+    // WHEN - requesting a point-in-time backfill lookup immediately
+    const result = await player.getBackfillMessages({
+      topics: new Map([["foo", { topic: "foo" }]]),
+      time: fromSec(1),
+    });
+
+    // THEN - the player reports that there are no available messages yet
+    expect(result).toEqual([]);
+
+    player.close();
+    await player.isClosed;
+  });
+
   it("when seeking during a seek backfill, start another seek after the current one exits", async () => {
     const source = new TestSource();
     const player = new IterablePlayer({

--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -191,6 +191,51 @@ describe("IterablePlayer", () => {
     await player.isClosed;
   });
 
+  it("should return backfill messages from the iterable source when requested", async () => {
+    // GIVEN - a source that can resolve backfill messages for a topic
+    const source = new TestSource();
+    const backfillMessage = {
+      topic: "foo",
+      receiveTime: { sec: 0, nsec: 1 },
+      message: undefined,
+      sizeInBytes: 0,
+      schemaName: "foo",
+    };
+    const getBackfillMessagesSpy = jest
+      .spyOn(source, "getBackfillMessages")
+      .mockResolvedValue([backfillMessage]);
+    const player = new IterablePlayer({
+      source,
+      enablePreload: false,
+      sourceId: "test",
+    });
+    const ready = signal();
+    player.setListener(async (state) => {
+      if (state.activeData) {
+        ready.resolve();
+      }
+    });
+
+    // Wait until initialization has populated the message range source.
+    await ready;
+
+    // WHEN - asking the player for a point-in-time backfill lookup
+    const result = await player.getBackfillMessages({
+      topics: new Map([["foo", { topic: "foo" }]]),
+      time: fromSec(1),
+    });
+
+    // THEN - the player delegates to the source and returns the matching messages
+    expect(getBackfillMessagesSpy).toHaveBeenCalledWith({
+      topics: new Map([["foo", { topic: "foo" }]]),
+      time: fromSec(1),
+    });
+    expect(result).toEqual([backfillMessage]);
+
+    player.close();
+    await player.isClosed;
+  });
+
   it("when seeking during a seek backfill, start another seek after the current one exits", async () => {
     const source = new TestSource();
     const player = new IterablePlayer({

--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -20,6 +20,8 @@ import {
 import { HIGH_FREQUENCY_ALERT } from "@lichtblick/suite-base/players/utils/constants";
 import * as highFrequencyUtils from "@lichtblick/suite-base/players/utils/isTopicHighFrequency";
 import { mockTopicSelection } from "@lichtblick/suite-base/test/mocks/mockTopicSelection";
+import MessageEventBuilder from "@lichtblick/suite-base/testing/builders/MessageEventBuilder";
+import { BasicBuilder } from "@lichtblick/test-builders";
 
 import {
   GetBackfillMessagesArgs,
@@ -55,6 +57,22 @@ class TestSource implements IDeserializedIterableSource {
     return [];
   }
 }
+
+function messageEvent(props: Partial<MessageEvent> = {}): MessageEvent {
+  const event = MessageEventBuilder.messageEvent({
+    message: undefined,
+    sizeInBytes: 0,
+    schemaName: BasicBuilder.string(),
+    topic: BasicBuilder.string(),
+    ...props,
+  });
+  event.message = props.message;
+  delete event.publishTime;
+  delete event.topicConfig;
+  return event;
+}
+
+const defaultTopic = BasicBuilder.string();
 
 type PlayerStateWithoutPlayerId = Omit<PlayerState, "playerId">;
 
@@ -194,13 +212,11 @@ describe("IterablePlayer", () => {
   it("should return backfill messages from the iterable source when requested", async () => {
     // GIVEN - a source that can resolve backfill messages for a topic
     const source = new TestSource();
-    const backfillMessage = {
-      topic: "foo",
+    const topic = BasicBuilder.string();
+    const backfillMessage = messageEvent({
+      topic,
       receiveTime: { sec: 0, nsec: 1 },
-      message: undefined,
-      sizeInBytes: 0,
-      schemaName: "foo",
-    };
+    });
     const getBackfillMessagesSpy = jest
       .spyOn(source, "getBackfillMessages")
       .mockResolvedValue([backfillMessage]);
@@ -221,13 +237,13 @@ describe("IterablePlayer", () => {
 
     // WHEN - asking the player for a point-in-time backfill lookup
     const result = await player.getBackfillMessages({
-      topics: new Map([["foo", { topic: "foo" }]]),
+      topics: new Map([[topic, { topic }]]),
       time: fromSec(1),
     });
 
     // THEN - the player delegates to the source and returns the matching messages
     expect(getBackfillMessagesSpy).toHaveBeenCalledWith({
-      topics: new Map([["foo", { topic: "foo" }]]),
+      topics: new Map([[topic, { topic }]]),
       time: fromSec(1),
     });
     expect(result).toEqual([backfillMessage]);
@@ -243,10 +259,11 @@ describe("IterablePlayer", () => {
       enablePreload: false,
       sourceId: "test",
     });
+    const topic = BasicBuilder.string();
 
     // WHEN - requesting a point-in-time backfill lookup immediately
     const result = await player.getBackfillMessages({
-      topics: new Map([["foo", { topic: "foo" }]]),
+      topics: new Map([[topic, { topic }]]),
       time: fromSec(1),
     });
 
@@ -259,13 +276,15 @@ describe("IterablePlayer", () => {
 
   it("when seeking during a seek backfill, start another seek after the current one exits", async () => {
     const source = new TestSource();
+    const topic = BasicBuilder.string();
+    const schemaName = BasicBuilder.string();
     const player = new IterablePlayer({
       source,
       enablePreload: false,
       sourceId: "test",
     });
     const store = new PlayerStateStore(4);
-    player.setSubscriptions([{ topic: "foo" }]);
+    player.setSubscriptions([{ topic }]);
     player.setListener(async (state) => {
       await store.add(state);
     });
@@ -284,15 +303,7 @@ describe("IterablePlayer", () => {
       // Set a new backfill method and initiate another seek
       source.getBackfillMessages = async function () {
         source.getBackfillMessages = originalMethod;
-        return [
-          {
-            topic: "foo",
-            receiveTime: { sec: 0, nsec: 1 },
-            message: undefined,
-            sizeInBytes: 0,
-            schemaName: "foo",
-          },
-        ];
+        return [messageEvent({ topic, receiveTime: { sec: 0, nsec: 1 }, schemaName })];
       };
 
       player.seekPlayback({ sec: 0, nsec: 1 });
@@ -339,15 +350,7 @@ describe("IterablePlayer", () => {
       activeData: {
         ...baseState.activeData!,
         currentTime: { sec: 0, nsec: 1 },
-        messages: [
-          {
-            message: undefined,
-            receiveTime: { sec: 0, nsec: 1 },
-            sizeInBytes: 0,
-            topic: "foo",
-            schemaName: "foo",
-          },
-        ],
+        messages: [messageEvent({ topic, receiveTime: { sec: 0, nsec: 1 }, schemaName })],
       },
     };
 
@@ -363,13 +366,15 @@ describe("IterablePlayer", () => {
 
   it("while playing, seek keeps the cursor parked until the seek emit is released", async () => {
     const source = new TestSource();
+    const topic = BasicBuilder.string();
+    const schemaName = BasicBuilder.string();
     const player = new IterablePlayer({
       source,
       enablePreload: false,
       sourceId: "test",
     });
 
-    player.setSubscriptions([{ topic: "foo" }]);
+    player.setSubscriptions([{ topic }]);
 
     const initialStore = new PlayerStateStore(4);
     const playingStarted = signal();
@@ -383,15 +388,7 @@ describe("IterablePlayer", () => {
     let resumedCurrentNs: number | undefined;
 
     source.getBackfillMessages = async (args: GetBackfillMessagesArgs): Promise<MessageEvent[]> => {
-      return [
-        {
-          topic: "foo",
-          receiveTime: args.time,
-          message: undefined,
-          sizeInBytes: 0,
-          schemaName: "foo",
-        },
-      ];
+      return [messageEvent({ topic, receiveTime: args.time, schemaName })];
     };
 
     player.setListener(async (state) => {
@@ -442,20 +439,14 @@ describe("IterablePlayer", () => {
   });
 
   describe("expandBackfill hook", () => {
-    const raw: MessageEvent = {
-      topic: "foo",
-      receiveTime: { sec: 0, nsec: 1 },
-      message: undefined,
-      sizeInBytes: 0,
-      schemaName: "foo",
-    };
-    const extra: MessageEvent = {
-      topic: "foo",
+    const topic = BasicBuilder.string();
+    const schemaName = BasicBuilder.string();
+    const raw = messageEvent({ topic, receiveTime: { sec: 0, nsec: 1 }, schemaName });
+    const extra = messageEvent({
+      topic,
       receiveTime: { sec: 0, nsec: 0 },
-      message: undefined,
-      sizeInBytes: 0,
-      schemaName: "foo",
-    };
+      schemaName,
+    });
 
     it("invokes the hook with the raw backfill and emits its expanded result", async () => {
       const source = new TestSource();
@@ -470,7 +461,7 @@ describe("IterablePlayer", () => {
         expandBackfill,
       });
       const store = new PlayerStateStore(4);
-      player.setSubscriptions([{ topic: "foo" }]);
+      player.setSubscriptions([{ topic }]);
       player.setListener(async (state) => {
         await store.add(state);
       });
@@ -500,7 +491,7 @@ describe("IterablePlayer", () => {
         sourceId: "test",
       });
       const store = new PlayerStateStore(4);
-      player.setSubscriptions([{ topic: "foo" }]);
+      player.setSubscriptions([{ topic }]);
       player.setListener(async (state) => {
         await store.add(state);
       });
@@ -526,7 +517,7 @@ describe("IterablePlayer", () => {
       sourceId: "test",
     });
     const store = new PlayerStateStore(4);
-    player.setSubscriptions([{ topic: "foo" }]);
+    player.setSubscriptions([{ topic: defaultTopic }]);
     player.setListener(async (state) => {
       await store.add(state);
     });
@@ -601,13 +592,15 @@ describe("IterablePlayer", () => {
 
   it("startPlayback emits when seek-backfill state is active", async () => {
     const source = new TestSource();
+    const topic = BasicBuilder.string();
+    const schemaName = BasicBuilder.string();
     const player = new IterablePlayer({
       source,
       enablePreload: false,
       sourceId: "test",
     });
     const store = new PlayerStateStore(4);
-    player.setSubscriptions([{ topic: "foo" }]);
+    player.setSubscriptions([{ topic }]);
     player.setListener(async (state) => {
       await store.add(state);
     });
@@ -623,13 +616,11 @@ describe("IterablePlayer", () => {
 
       yield {
         type: "message-event",
-        msgEvent: {
-          topic: "foo",
+        msgEvent: messageEvent({
+          topic,
           receiveTime: { sec: 0, nsec: 99000001 },
-          message: undefined,
-          sizeInBytes: 0,
-          schemaName: "foo",
-        },
+          schemaName,
+        }),
       };
     };
 
@@ -647,15 +638,7 @@ describe("IterablePlayer", () => {
       source.getBackfillMessages = originalMethod;
       backfillStarted.resolve();
       await backfillPromise;
-      return [
-        {
-          topic: "foo",
-          receiveTime: { sec: 0, nsec: 1 },
-          message: undefined,
-          sizeInBytes: 0,
-          schemaName: "foo",
-        },
-      ];
+      return [messageEvent({ topic, receiveTime: { sec: 0, nsec: 1 }, schemaName })];
     };
 
     // Reset store to get state from the seeks
@@ -685,13 +668,15 @@ describe("IterablePlayer", () => {
 
   it("pausePlayback emits when seek-backfill state is active", async () => {
     const source = new TestSource();
+    const topic = BasicBuilder.string();
+    const schemaName = BasicBuilder.string();
     const player = new IterablePlayer({
       source,
       enablePreload: false,
       sourceId: "test",
     });
     const store = new PlayerStateStore(4);
-    player.setSubscriptions([{ topic: "foo" }]);
+    player.setSubscriptions([{ topic }]);
     player.setListener(async (state) => {
       await store.add(state);
     });
@@ -708,13 +693,11 @@ describe("IterablePlayer", () => {
 
       yield {
         type: "message-event",
-        msgEvent: {
-          topic: "foo",
+        msgEvent: messageEvent({
+          topic,
           receiveTime: { sec: 0, nsec: 99000001 },
-          message: undefined,
-          sizeInBytes: 0,
-          schemaName: "foo",
-        },
+          schemaName,
+        }),
       };
     };
 
@@ -732,15 +715,7 @@ describe("IterablePlayer", () => {
       source.getBackfillMessages = originalMethod;
       backfillStarted.resolve();
       await backfillPromise;
-      return [
-        {
-          topic: "foo",
-          receiveTime: { sec: 0, nsec: 1 },
-          message: undefined,
-          sizeInBytes: 0,
-          schemaName: "foo",
-        },
-      ];
+      return [messageEvent({ topic, receiveTime: { sec: 0, nsec: 1 }, schemaName })];
     };
     store.reset(1);
     // emit state
@@ -835,7 +810,7 @@ describe("IterablePlayer", () => {
       sourceId: "test",
     });
     const store = new PlayerStateStore(4);
-    player.setSubscriptions([{ topic: "foo" }]);
+    player.setSubscriptions([{ topic: defaultTopic }]);
     player.setListener(async (state) => {
       await store.add(state);
     });
@@ -1042,13 +1017,9 @@ describe("IterablePlayer", () => {
 
       yield {
         type: "message-event",
-        msgEvent: {
-          topic: "foo",
+        msgEvent: messageEvent({
           receiveTime: { sec: 0, nsec: 99000001 },
-          message: undefined,
-          sizeInBytes: 0,
-          schemaName: "foo",
-        },
+        }),
       };
     };
 
@@ -1091,13 +1062,9 @@ describe("IterablePlayer", () => {
 
       yield {
         type: "message-event",
-        msgEvent: {
-          topic: "foo",
+        msgEvent: messageEvent({
           receiveTime: { sec: 0, nsec: 99000001 },
-          message: undefined,
-          sizeInBytes: 0,
-          schemaName: "foo",
-        },
+        }),
       };
     };
 
@@ -1117,6 +1084,8 @@ describe("IterablePlayer", () => {
 
   it("should make a new message iterator when topic subscriptions change", async () => {
     const source = new TestSource();
+    const topic = BasicBuilder.string();
+    const secondTopic = BasicBuilder.string();
     const player = new IterablePlayer({
       source,
       enablePreload: false,
@@ -1126,7 +1095,7 @@ describe("IterablePlayer", () => {
     const messageIteratorSpy = jest.spyOn(source, "messageIterator");
 
     const store = new PlayerStateStore(4);
-    player.setSubscriptions([{ topic: "foo" }]);
+    player.setSubscriptions([{ topic }]);
     player.setListener(async (state) => {
       await store.add(state);
     });
@@ -1136,7 +1105,7 @@ describe("IterablePlayer", () => {
 
     // Call set subscriptions and add a new topic
     store.reset(2);
-    player.setSubscriptions([{ topic: "foo" }, { topic: "bar" }]);
+    player.setSubscriptions([{ topic }, { topic: secondTopic }]);
 
     await store.done;
 
@@ -1145,7 +1114,7 @@ describe("IterablePlayer", () => {
         {
           start: { sec: 0, nsec: 0 },
           end: { sec: 1, nsec: 0 },
-          topics: mockTopicSelection("foo"),
+          topics: mockTopicSelection(topic),
           consumptionType: "partial",
         },
       ],
@@ -1153,7 +1122,7 @@ describe("IterablePlayer", () => {
         {
           start: { sec: 0, nsec: 99000001 },
           end: { sec: 1, nsec: 0 },
-          topics: mockTopicSelection("bar", "foo"),
+          topics: mockTopicSelection(secondTopic, topic),
           consumptionType: "partial",
         },
       ],
@@ -1165,6 +1134,7 @@ describe("IterablePlayer", () => {
 
   it("strips unauthorized sampling requests from direct subscriptions", async () => {
     const source = new TestSource();
+    const topic = BasicBuilder.string();
     const player = new IterablePlayer({
       source,
       enablePreload: false,
@@ -1174,7 +1144,7 @@ describe("IterablePlayer", () => {
     const messageIteratorSpy = jest.spyOn(source, "messageIterator");
     player.setSubscriptions([
       {
-        topic: "foo",
+        topic,
         samplingRequest: { mode: "latest-per-render-tick" },
       },
     ]);
@@ -1187,7 +1157,7 @@ describe("IterablePlayer", () => {
 
     expect(messageIteratorSpy).toHaveBeenCalledTimes(1);
     const messageIteratorArgs = messageIteratorSpy.mock.calls[0]?.[0];
-    expect(messageIteratorArgs?.topics.get("foo")).toEqual({ topic: "foo" });
+    expect(messageIteratorArgs?.topics.get(topic)).toEqual({ topic });
 
     player.close();
     await player.isClosed;
@@ -1195,6 +1165,7 @@ describe("IterablePlayer", () => {
 
   it("keeps authorized sampling requests from trusted subscriptions", async () => {
     const source = new TestSource();
+    const topic = BasicBuilder.string();
     const player = new IterablePlayer({
       source,
       enablePreload: false,
@@ -1204,7 +1175,7 @@ describe("IterablePlayer", () => {
     const messageIteratorSpy = jest.spyOn(source, "messageIterator");
     player.setSubscriptions([
       {
-        topic: "foo",
+        topic,
         samplingRequest: { mode: "latest-per-render-tick" },
         samplingAuthorized: true,
       } as InternalSubscribePayload,
@@ -1218,8 +1189,8 @@ describe("IterablePlayer", () => {
 
     expect(messageIteratorSpy).toHaveBeenCalledTimes(1);
     const messageIteratorArgs = messageIteratorSpy.mock.calls[0]?.[0];
-    expect(messageIteratorArgs?.topics.get("foo")).toEqual({
-      topic: "foo",
+    expect(messageIteratorArgs?.topics.get(topic)).toEqual({
+      topic,
       samplingRequest: { mode: "latest-per-render-tick" },
       samplingAuthorized: true,
     });
@@ -1230,6 +1201,7 @@ describe("IterablePlayer", () => {
 
   it("should allow changing subscriptions when player in start-play state", async () => {
     const source = new TestSource();
+    const topic = BasicBuilder.string();
     const player = new IterablePlayer({
       source,
       enablePreload: false,
@@ -1244,7 +1216,7 @@ describe("IterablePlayer", () => {
     });
     // Wait for player to be in start-play state
     await store.done;
-    player.setSubscriptions([{ topic: "foo" }]);
+    player.setSubscriptions([{ topic }]);
 
     // Wait for player's initial setup to complete (seek-backfill + idle)
     store.reset(2);
@@ -1255,7 +1227,7 @@ describe("IterablePlayer", () => {
         {
           start: { sec: 0, nsec: 99000001 },
           end: { sec: 1, nsec: 0 },
-          topics: mockTopicSelection("foo"),
+          topics: mockTopicSelection(topic),
           consumptionType: "partial",
         },
       ],
@@ -1315,13 +1287,13 @@ describe("IterablePlayer", () => {
       const mockMessageIterator = jest.fn().mockImplementation(async function* () {
         yield {
           type: "message-event",
-          msgEvent: {
+          msgEvent: messageEvent({
             topic: "test_topic",
             receiveTime: { sec: 1, nsec: 0 },
-            message: { data: "test" },
+            message: { data: BasicBuilder.string() },
             sizeInBytes: 100,
             schemaName: "test_schema",
-          },
+          }),
         };
       });
 
@@ -1364,23 +1336,23 @@ describe("IterablePlayer", () => {
       const mockMessageIterator = jest.fn().mockImplementation(async function* () {
         yield {
           type: "message-event",
-          msgEvent: {
+          msgEvent: messageEvent({
             topic: "topic1",
             receiveTime: { sec: 1, nsec: 0 },
-            message: { data: "test1" },
+            message: { data: BasicBuilder.string() },
             sizeInBytes: 100,
             schemaName: "test_schema",
-          },
+          }),
         };
         yield {
           type: "message-event",
-          msgEvent: {
+          msgEvent: messageEvent({
             topic: "topic2",
             receiveTime: { sec: 2, nsec: 0 },
-            message: { data: "test2" },
+            message: { data: BasicBuilder.string() },
             sizeInBytes: 100,
             schemaName: "test_schema",
-          },
+          }),
         };
       });
 
@@ -1425,13 +1397,13 @@ describe("IterablePlayer", () => {
       const mockMessageIterator = jest.fn().mockImplementation(async function* () {
         yield {
           type: "message-event",
-          msgEvent: {
+          msgEvent: messageEvent({
             topic: "test_topic",
             receiveTime: { sec: 1, nsec: 0 },
-            message: { data: "test" },
+            message: { data: BasicBuilder.string() },
             sizeInBytes: 100,
             schemaName: "test_schema",
-          },
+          }),
         };
         yield {
           type: "alert",
@@ -1508,13 +1480,13 @@ describe("IterablePlayer", () => {
       const mockMessageIterator = jest.fn().mockImplementation(async function* () {
         yield {
           type: "message-event",
-          msgEvent: {
+          msgEvent: messageEvent({
             topic: "test_topic",
             receiveTime: { sec: 1, nsec: 0 },
-            message: { data: "test" },
+            message: { data: BasicBuilder.string() },
             sizeInBytes: 100,
             schemaName: "test_schema",
-          },
+          }),
         };
         throw new Error("Iterator error");
       });
@@ -1552,13 +1524,13 @@ describe("IterablePlayer", () => {
       const mockMessageIterator = jest.fn().mockImplementation(async function* () {
         yield {
           type: "message-event",
-          msgEvent: {
+          msgEvent: messageEvent({
             topic: "test_topic",
             receiveTime: { sec: 1, nsec: 0 },
-            message: { data: "test" },
+            message: { data: BasicBuilder.string() },
             sizeInBytes: 100,
             schemaName: "test_schema",
-          },
+          }),
         };
       });
 

--- a/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -443,6 +443,13 @@ export class IterablePlayer implements Player {
     });
   }
 
+  // Reuses #messageRangeSource (already independent of the live playback cursor/state machine,
+  // same source instance used by getBatchIterator) so point-in-time reads never interfere with
+  // seeking/backfilling the live playhead and can safely run concurrently with each other.
+  public async getBackfillMessages(args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
+    return (await this.#messageRangeSource?.getBackfillMessages(args)) ?? [];
+  }
+
   public setParameter(_key: string, _value: ParameterValue): void {
     throw new Error("Parameter editing is not supported by this data source");
   }

--- a/packages/suite-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.test.ts
+++ b/packages/suite-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.test.ts
@@ -223,6 +223,30 @@ describe("TopicAliasingPlayer", () => {
     );
   });
 
+  it("should pass through backfill lookups without alias translation when requested", async () => {
+    // GIVEN - a player whose underlying source can answer backfill lookups directly
+    const fakePlayer = new FakePlayer() as FakePlayer & {
+      getBackfillMessages: jest.Mock;
+    };
+    const backfillMessage = mockMessage("message", { topic: "/original_topic_1" });
+    const getBackfillMessagesSpy = jest.fn().mockResolvedValue([backfillMessage]);
+    fakePlayer.getBackfillMessages = getBackfillMessagesSpy;
+    const player = new TopicAliasingPlayer(fakePlayer);
+
+    // WHEN - looking up a backfill message for a topic alias
+    const result = await player.getBackfillMessages({
+      topics: new Map([["/renamed_topic_1", { topic: "/renamed_topic_1" }]]),
+      time: { sec: 0, nsec: 1 },
+    });
+
+    // THEN - the request is forwarded unchanged to the underlying player
+    expect(getBackfillMessagesSpy).toHaveBeenCalledWith({
+      topics: new Map([["/renamed_topic_1", { topic: "/renamed_topic_1" }]]),
+      time: { sec: 0, nsec: 1 },
+    });
+    expect(result).toEqual([backfillMessage]);
+  });
+
   it("provides global variables on startup", async () => {
     const fakePlayer = new FakePlayer();
     const mappers: TopicAliasFunctions = [

--- a/packages/suite-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.test.ts
+++ b/packages/suite-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.test.ts
@@ -247,6 +247,20 @@ describe("TopicAliasingPlayer", () => {
     expect(result).toEqual([backfillMessage]);
   });
 
+  it("should return no backfill messages when the wrapped player does not support lookups", async () => {
+    // GIVEN - a wrapped player without the optional backfill API
+    const player = new TopicAliasingPlayer(new FakePlayer());
+
+    // WHEN - requesting a point-in-time backfill lookup
+    const result = await player.getBackfillMessages({
+      topics: new Map([["/topic", { topic: "/topic" }]]),
+      time: { sec: 0, nsec: 1 },
+    });
+
+    // THEN - the wrapper reports that no messages are available
+    expect(result).toEqual([]);
+  });
+
   it("provides global variables on startup", async () => {
     const fakePlayer = new FakePlayer();
     const mappers: TopicAliasFunctions = [

--- a/packages/suite-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.test.ts
+++ b/packages/suite-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.test.ts
@@ -7,6 +7,7 @@
 
 import FakePlayer from "@lichtblick/suite-base/components/MessagePipeline/FakePlayer";
 import { PlayerAlert, PlayerState, Topic } from "@lichtblick/suite-base/players/types";
+import { BasicBuilder } from "@lichtblick/test-builders";
 
 import { TopicAliasFunctions } from "./StateProcessorFactory";
 import { TopicAliasingPlayer } from "./TopicAliasingPlayer";
@@ -74,6 +75,7 @@ describe("TopicAliasingPlayer", () => {
 
   it("maps messages", async () => {
     const fakePlayer = new FakePlayer();
+    const message = BasicBuilder.string();
     const mappers: TopicAliasFunctions = [
       {
         extensionId: "any",
@@ -87,8 +89,8 @@ describe("TopicAliasingPlayer", () => {
     await fakePlayer.emit(
       mockPlayerState(undefined, {
         messages: [
-          mockMessage("message", { topic: "/original_topic_1" }),
-          mockMessage("message", { topic: "/topic_2" }),
+          mockMessage(message, { topic: "/original_topic_1" }),
+          mockMessage(message, { topic: "/topic_2" }),
         ],
         topics: [{ name: "/original_topic_1", schemaName: "any.schema" }],
       }),
@@ -98,9 +100,9 @@ describe("TopicAliasingPlayer", () => {
       expect.objectContaining({
         activeData: expect.objectContaining({
           messages: [
-            mockMessage("message", { topic: "/original_topic_1" }),
-            mockMessage("message", { topic: "/renamed_topic_1" }),
-            mockMessage("message", { topic: "/topic_2" }),
+            mockMessage(message, { topic: "/original_topic_1" }),
+            mockMessage(message, { topic: "/renamed_topic_1" }),
+            mockMessage(message, { topic: "/topic_2" }),
           ],
           topics: [
             { name: "/original_topic_1", schemaName: "any.schema" },
@@ -117,6 +119,7 @@ describe("TopicAliasingPlayer", () => {
 
   it("marks disallowed mappings as player alerts", async () => {
     const fakePlayer = new FakePlayer();
+    const message = BasicBuilder.string();
     const mappers: TopicAliasFunctions = [
       {
         extensionId: "ext1",
@@ -139,7 +142,7 @@ describe("TopicAliasingPlayer", () => {
     player.setListener(listener);
     await fakePlayer.emit(
       mockPlayerState(undefined, {
-        messages: [mockMessage("message", { topic: "/original_topic_1" })],
+        messages: [mockMessage(message, { topic: "/original_topic_1" })],
         topics: [
           { name: "/original_topic_1", schemaName: "schema1" },
           { name: "/original_topic_2", schemaName: "schema2" },
@@ -163,6 +166,7 @@ describe("TopicAliasingPlayer", () => {
 
   it("maps blocks", async () => {
     const fakePlayer = new FakePlayer();
+    const message = BasicBuilder.string();
     const mappers: TopicAliasFunctions = [
       {
         extensionId: "any",
@@ -189,8 +193,8 @@ describe("TopicAliasingPlayer", () => {
             blocks: [
               {
                 messagesByTopic: {
-                  "/topic_1": [mockMessage("message", { topic: "/topic_1" })],
-                  "/topic_2": [mockMessage("message", { topic: "/topic_2" })],
+                  "/topic_1": [mockMessage(message, { topic: "/topic_1" })],
+                  "/topic_2": [mockMessage(message, { topic: "/topic_2" })],
                 },
                 sizeInBytes: 0,
               },
@@ -228,20 +232,21 @@ describe("TopicAliasingPlayer", () => {
     const fakePlayer = new FakePlayer() as FakePlayer & {
       getBackfillMessages: jest.Mock;
     };
-    const backfillMessage = mockMessage("message", { topic: "/original_topic_1" });
+    const backfillMessage = mockMessage(BasicBuilder.string(), { topic: "/original_topic_1" });
     const getBackfillMessagesSpy = jest.fn().mockResolvedValue([backfillMessage]);
     fakePlayer.getBackfillMessages = getBackfillMessagesSpy;
     const player = new TopicAliasingPlayer(fakePlayer);
+    const topic = BasicBuilder.string();
 
     // WHEN - looking up a backfill message for a topic alias
     const result = await player.getBackfillMessages({
-      topics: new Map([["/renamed_topic_1", { topic: "/renamed_topic_1" }]]),
+      topics: new Map([[topic, { topic }]]),
       time: { sec: 0, nsec: 1 },
     });
 
     // THEN - the request is forwarded unchanged to the underlying player
     expect(getBackfillMessagesSpy).toHaveBeenCalledWith({
-      topics: new Map([["/renamed_topic_1", { topic: "/renamed_topic_1" }]]),
+      topics: new Map([[topic, { topic }]]),
       time: { sec: 0, nsec: 1 },
     });
     expect(result).toEqual([backfillMessage]);
@@ -250,10 +255,11 @@ describe("TopicAliasingPlayer", () => {
   it("should return no backfill messages when the wrapped player does not support lookups", async () => {
     // GIVEN - a wrapped player without the optional backfill API
     const player = new TopicAliasingPlayer(new FakePlayer());
+    const topic = BasicBuilder.string();
 
     // WHEN - requesting a point-in-time backfill lookup
     const result = await player.getBackfillMessages({
-      topics: new Map([["/topic", { topic: "/topic" }]]),
+      topics: new Map([[topic, { topic }]]),
       time: { sec: 0, nsec: 1 },
     });
 

--- a/packages/suite-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.ts
+++ b/packages/suite-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.ts
@@ -9,7 +9,7 @@ import * as _ from "lodash-es";
 
 import { MutexLocked } from "@lichtblick/den/async";
 import { Time } from "@lichtblick/rostime";
-import { Immutable, Metadata, ParameterValue } from "@lichtblick/suite";
+import { Immutable, Metadata, MessageEvent, ParameterValue } from "@lichtblick/suite";
 import { Asset } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
 import {
@@ -27,7 +27,7 @@ import {
   StateProcessorFactory,
   TopicAliasFunctions,
 } from "./StateProcessorFactory";
-import { IteratorResult } from "../IterablePlayer/IIterableSource";
+import { GetBackfillMessagesArgs, IteratorResult } from "../IterablePlayer/IIterableSource";
 
 export type { TopicAliasFunctions };
 
@@ -79,6 +79,12 @@ export class TopicAliasingPlayer implements Player {
     options?: { start?: Time; end?: Time },
   ): AsyncIterableIterator<Readonly<IteratorResult>> | undefined {
     return this.#player.getBatchIterator(topic, options);
+  }
+
+  // No alias translation, matching getBatchIterator above — these unstable/advanced APIs
+  // operate on raw underlying topic names.
+  public async getBackfillMessages(args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
+    return (await this.#player.getBackfillMessages?.(args)) ?? [];
   }
 
   public setListener(listener: (playerState: PlayerState) => Promise<void>): void {

--- a/packages/suite-base/src/players/UserScriptPlayer/index.test.ts
+++ b/packages/suite-base/src/players/UserScriptPlayer/index.test.ts
@@ -26,9 +26,11 @@ import {
   PlayerStateActiveData,
   Topic,
 } from "@lichtblick/suite-base/players/types";
+import { mockTopicSelection } from "@lichtblick/suite-base/test/mocks/mockTopicSelection";
 import GlobalVariableBuilder from "@lichtblick/suite-base/testing/builders/GlobalVariableBuilder";
 import MessageEventBuilder from "@lichtblick/suite-base/testing/builders/MessageEventBuilder";
 import PlayerBuilder from "@lichtblick/suite-base/testing/builders/PlayerBuilder";
+import RosTimeBuilder from "@lichtblick/suite-base/testing/builders/RosTimeBuilder";
 import { RosDatatypes } from "@lichtblick/suite-base/types/RosDatatypes";
 import { UserScript } from "@lichtblick/suite-base/types/panels";
 import { basicDatatypes } from "@lichtblick/suite-base/util/basicDatatypes";
@@ -252,7 +254,7 @@ describe("UserScriptPlayer", () => {
       };
       const backfillMessage = {
         topic: "/np_input",
-        receiveTime: { sec: 0, nsec: 1 },
+        receiveTime: RosTimeBuilder.time({ sec: 0, nsec: 1 }),
         message: {
           payload: "baz",
         },
@@ -278,17 +280,14 @@ describe("UserScriptPlayer", () => {
 
       // WHEN - requesting backfill messages for both the real and virtual topics
       const result = await userScriptPlayer.getBackfillMessages({
-        topics: new Map([
-          ["/np_input", { topic: "/np_input" }],
-          [`${DEFAULT_STUDIO_SCRIPT_PREFIX}1`, { topic: `${DEFAULT_STUDIO_SCRIPT_PREFIX}1` }],
-        ]),
-        time: { sec: 0, nsec: 1 },
+        topics: mockTopicSelection("/np_input", `${DEFAULT_STUDIO_SCRIPT_PREFIX}1`),
+        time: RosTimeBuilder.time({ sec: 0, nsec: 1 }),
       });
 
       // THEN - only the real topic is forwarded to the underlying player
       expect(fakePlayer.getBackfillMessages).toHaveBeenCalledWith({
-        topics: new Map([["/np_input", { topic: "/np_input" }]]),
-        time: { sec: 0, nsec: 1 },
+        topics: mockTopicSelection("/np_input"),
+        time: RosTimeBuilder.time({ sec: 0, nsec: 1 }),
       });
       expect(result).toEqual([backfillMessage]);
     });
@@ -317,10 +316,8 @@ describe("UserScriptPlayer", () => {
 
       // WHEN - requesting backfill messages only for the script output topic
       const result = await userScriptPlayer.getBackfillMessages({
-        topics: new Map([
-          [`${DEFAULT_STUDIO_SCRIPT_PREFIX}1`, { topic: `${DEFAULT_STUDIO_SCRIPT_PREFIX}1` }],
-        ]),
-        time: { sec: 0, nsec: 1 },
+        topics: mockTopicSelection(`${DEFAULT_STUDIO_SCRIPT_PREFIX}1`),
+        time: RosTimeBuilder.time({ sec: 0, nsec: 1 }),
       });
 
       // THEN - the request short-circuits without calling the underlying player
@@ -337,8 +334,8 @@ describe("UserScriptPlayer", () => {
 
       // WHEN - requesting a lookup for a real topic
       const result = await userScriptPlayer.getBackfillMessages({
-        topics: new Map([["/np_input", { topic: "/np_input" }]]),
-        time: { sec: 0, nsec: 1 },
+        topics: mockTopicSelection("/np_input"),
+        time: RosTimeBuilder.time({ sec: 0, nsec: 1 }),
       });
 
       // THEN - the script player reports that no messages are available

--- a/packages/suite-base/src/players/UserScriptPlayer/index.test.ts
+++ b/packages/suite-base/src/players/UserScriptPlayer/index.test.ts
@@ -327,6 +327,23 @@ describe("UserScriptPlayer", () => {
       expect(fakePlayer.getBackfillMessages).not.toHaveBeenCalled();
       expect(result).toEqual([]);
     });
+
+    it("should return no messages when the wrapped player does not support lookups", async () => {
+      // GIVEN - a script player backed by a player without the optional API
+      const userScriptPlayer = new UserScriptPlayer(new FakePlayer(), defaultUserScriptActions);
+      userScriptPlayer.setListener(async () => {
+        // no-op
+      });
+
+      // WHEN - requesting a lookup for a real topic
+      const result = await userScriptPlayer.getBackfillMessages({
+        topics: new Map([["/np_input", { topic: "/np_input" }]]),
+        time: { sec: 0, nsec: 1 },
+      });
+
+      // THEN - the script player reports that no messages are available
+      expect(result).toEqual([]);
+    });
   });
 
   describe("resetWorkers", () => {

--- a/packages/suite-base/src/players/UserScriptPlayer/index.test.ts
+++ b/packages/suite-base/src/players/UserScriptPlayer/index.test.ts
@@ -244,6 +244,89 @@ describe("UserScriptPlayer", () => {
       userScriptPlayer.publish(publishPayload);
       expect(fakePlayer.publish).toHaveBeenCalledWith(publishPayload);
     });
+
+    it("should pass through backfill lookups for real topics when requested", async () => {
+      // GIVEN - a player with an initialized script and a real input topic
+      const fakePlayer = new FakePlayer() as FakePlayer & {
+        getBackfillMessages: jest.Mock;
+      };
+      const backfillMessage = {
+        topic: "/np_input",
+        receiveTime: { sec: 0, nsec: 1 },
+        message: {
+          payload: "baz",
+        },
+        schemaName: "foo",
+        sizeInBytes: 0,
+      };
+      fakePlayer.getBackfillMessages = jest.fn().mockResolvedValue([backfillMessage]);
+      const userScriptPlayer = new UserScriptPlayer(fakePlayer, defaultUserScriptActions);
+      userScriptPlayer.setListener(async () => {
+        // no-op
+      });
+
+      const activeDataWithInput = {
+        ...basicPlayerState,
+        topics: [{ name: "/np_input", schemaName: "foo" }],
+        datatypes: new Map(Object.entries({ foo: { definitions: [] } })),
+      };
+
+      await fakePlayer.emit({ activeData: activeDataWithInput });
+      await userScriptPlayer.setUserScripts({
+        nodeId: { name: `${DEFAULT_STUDIO_SCRIPT_PREFIX}1`, sourceCode: nodeUserCode },
+      });
+
+      // WHEN - requesting backfill messages for both the real and virtual topics
+      const result = await userScriptPlayer.getBackfillMessages({
+        topics: new Map([
+          ["/np_input", { topic: "/np_input" }],
+          [`${DEFAULT_STUDIO_SCRIPT_PREFIX}1`, { topic: `${DEFAULT_STUDIO_SCRIPT_PREFIX}1` }],
+        ]),
+        time: { sec: 0, nsec: 1 },
+      });
+
+      // THEN - only the real topic is forwarded to the underlying player
+      expect(fakePlayer.getBackfillMessages).toHaveBeenCalledWith({
+        topics: new Map([["/np_input", { topic: "/np_input" }]]),
+        time: { sec: 0, nsec: 1 },
+      });
+      expect(result).toEqual([backfillMessage]);
+    });
+
+    it("should return no messages when backfill lookups only include virtual topics", async () => {
+      // GIVEN - a player with an initialized script whose output topic is virtual
+      const fakePlayer = new FakePlayer() as FakePlayer & {
+        getBackfillMessages: jest.Mock;
+      };
+      fakePlayer.getBackfillMessages = jest.fn();
+      const userScriptPlayer = new UserScriptPlayer(fakePlayer, defaultUserScriptActions);
+      userScriptPlayer.setListener(async () => {
+        // no-op
+      });
+
+      const activeDataWithInput = {
+        ...basicPlayerState,
+        topics: [{ name: "/np_input", schemaName: "foo" }],
+        datatypes: new Map(Object.entries({ foo: { definitions: [] } })),
+      };
+
+      await fakePlayer.emit({ activeData: activeDataWithInput });
+      await userScriptPlayer.setUserScripts({
+        nodeId: { name: `${DEFAULT_STUDIO_SCRIPT_PREFIX}1`, sourceCode: nodeUserCode },
+      });
+
+      // WHEN - requesting backfill messages only for the script output topic
+      const result = await userScriptPlayer.getBackfillMessages({
+        topics: new Map([
+          [`${DEFAULT_STUDIO_SCRIPT_PREFIX}1`, { topic: `${DEFAULT_STUDIO_SCRIPT_PREFIX}1` }],
+        ]),
+        time: { sec: 0, nsec: 1 },
+      });
+
+      // THEN - the request short-circuits without calling the underlying player
+      expect(fakePlayer.getBackfillMessages).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
   });
 
   describe("resetWorkers", () => {

--- a/packages/suite-base/src/players/UserScriptPlayer/index.ts
+++ b/packages/suite-base/src/players/UserScriptPlayer/index.ts
@@ -30,7 +30,10 @@ import {
   PerformanceMetricID,
 } from "@lichtblick/suite-base/context/PerformanceContext";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
-import { IteratorResult as IIterableSourceIteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
+import {
+  GetBackfillMessagesArgs,
+  IteratorResult as IIterableSourceIteratorResult,
+} from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import { MemoizedLibGenerator } from "@lichtblick/suite-base/players/UserScriptPlayer/MemoizedLibGenerator";
 import { generateTypesLib } from "@lichtblick/suite-base/players/UserScriptPlayer/transformerWorker/generateTypesLib";
 import { TransformArgs } from "@lichtblick/suite-base/players/UserScriptPlayer/transformerWorker/types";
@@ -1026,6 +1029,18 @@ export default class UserScriptPlayer implements Player {
     }
 
     return this.#getVirtualBatchIterator(registration, options);
+  }
+
+  // Script-output (virtual) topics aren't supported for point-in-time backfill — that would
+  // require re-running the transform against historical input backfill. Real topics pass through.
+  public async getBackfillMessages(args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
+    const realTopics = new Map(
+      Array.from(args.topics).filter(([topic]) => !this.#outputTopicRegistrations.has(topic)),
+    );
+    if (realTopics.size === 0) {
+      return [];
+    }
+    return (await this.#player.getBackfillMessages?.({ ...args, topics: realTopics })) ?? [];
   }
 
   #collectInputIterators(

--- a/packages/suite-base/src/players/types.ts
+++ b/packages/suite-base/src/players/types.ts
@@ -20,7 +20,10 @@ import type { MessageEvent, Metadata, ParameterValue } from "@lichtblick/suite";
 import { Immutable } from "@lichtblick/suite";
 import { Asset } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
 import { GlobalVariables } from "@lichtblick/suite-base/hooks/useGlobalVariables";
-import { IteratorResult } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
+import {
+  GetBackfillMessagesArgs,
+  IteratorResult,
+} from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
 import { PLAYER_CAPABILITIES } from "@lichtblick/suite-base/players/constants";
 import { RosDatatypes } from "@lichtblick/suite-base/types/RosDatatypes";
 import { Range } from "@lichtblick/suite-base/util/ranges";
@@ -82,6 +85,9 @@ export interface Player {
     topic: string,
     options?: { start?: Time; end?: Time },
   ) => AsyncIterableIterator<Readonly<IteratorResult>> | undefined;
+  // Read the most recent message per topic at or before a given time, independent of the current
+  // playback position. Not available for live/real-time data sources.
+  getBackfillMessages?(args: GetBackfillMessagesArgs): Promise<MessageEvent[]>;
 }
 
 export enum PlayerPresence {

--- a/packages/suite/src/index.ts
+++ b/packages/suite/src/index.ts
@@ -517,6 +517,23 @@ export type PanelExtensionContext = {
   unstable_subscribeMessageRange: (args: SubscribeMessageRangeArgs) => () => void;
 
   /**
+   * Reads the most recent message on `topic` at or before `time`, without moving the playback
+   * cursor and without affecting `currentFrame`, `didSeek`, or any other panel's subscriptions.
+   *
+   * Unlike `subscribe()` + `watch("currentFrame")` or `seekPlayback()`, this does not depend on
+   * shared playback state, so multiple calls — including concurrent calls issued via
+   * `Promise.all()` for different topics or timestamps — are fully independent of each other and
+   * of the current playback position.
+   *
+   * Note: This functionality is unavailable for real-time data sources, including foxglove_bridge,
+   * rosbridge, or ROS 1 native connections. For such sources this resolves to `undefined`.
+   *
+   * @returns The message at or before `time`, or `undefined` if none exists or the active data
+   * source does not support point-in-time queries.
+   */
+  unstable_getMessageAtTime?: (topic: string, time: Time) => Promise<MessageEvent | undefined>;
+
+  /**
    * Returns the schema definition for a given topic, without requiring a subscription or reading
    * any message data. Useful for inspecting message field structure (e.g. building field path
    * selectors) at panel initialization time.

--- a/packages/suite/src/index.ts
+++ b/packages/suite/src/index.ts
@@ -531,7 +531,7 @@ export type PanelExtensionContext = {
    * @returns The message at or before `time`, or `undefined` if none exists or the active data
    * source does not support point-in-time queries.
    */
-  unstable_getMessageAtTime?: (topic: string, time: Time) => Promise<MessageEvent | undefined>;
+  getMessageAtTime?: (topic: string, time: Time) => Promise<MessageEvent | undefined>;
 
   /**
    * Returns the schema definition for a given topic, without requiring a subscription or reading


### PR DESCRIPTION
## User-Facing Changes

Expose `unstable_getMessageAtTime` through the panel extension API so panels can read the most recent message for a topic at or before a timestamp without moving the playback cursor.

## Description

Add point-in-time message lookups across the message pipeline and player layers. The lookup:

- Uses the message range source without affecting playback state or other subscriptions.
- Returns `undefined` for unsupported live data sources and when no matching message exists.
- Passes through real topics for user scripts while excluding virtual script-output topics.
- Forwards requests through topic-aliasing players without alias translation.

The public API is marked unstable and documented as unavailable for real-time sources.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Panels can query the latest message for a topic at or before a specified timestamp without changing playback state or subscriptions.
  * Message pipelines and supported players now provide point-in-time message retrieval.
  * Requests gracefully return no result when backfill is unavailable, unsupported, or no matching message exists.
  * Virtual script-output topics are excluded from backfill requests.

* **Tests**
  * Added coverage for supported, unsupported, unavailable, virtual-topic, and unmounted scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->