### PR TITLE
Feature mcap iterator cleanup

### DIFF
--- a/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.test.ts
@@ -40,7 +40,7 @@ function makeMockSource(
     messageIterator: jest.fn().mockImplementation(async function* () {
       yield* messages;
     }),
-  } as unknown as IIterableSource<Uint8Array>;
+  } as IIterableSource<Uint8Array>;
 }
 
 // start/end may be omitted to create a "source without time info" (activated eagerly). An
@@ -76,7 +76,7 @@ function makeMockSourceWithReturn(
         },
       };
     }),
-  } as unknown as IIterableSource<Uint8Array>;
+  } as IIterableSource<Uint8Array>;
 }
 
 describe("mergeSequentialIterators", () => {
@@ -214,7 +214,7 @@ describe("mergeSequentialIterators", () => {
       messageIterator: jest.fn().mockImplementation(async function* () {
         yield makeMessageEvent("topic", 5);
       }),
-    } as unknown as IIterableSource<Uint8Array>;
+    } as IIterableSource<Uint8Array>;
 
     const sourceWithTime = makeMockSource({ sec: 10, nsec: 0 }, { sec: 20, nsec: 0 }, [
       makeMessageEvent("topic", 15),
@@ -444,6 +444,47 @@ describe("mergeSequentialIterators", () => {
     expect(activatedReturn).toHaveBeenCalledTimes(1);
     // The failing iterator itself was registered in activeIterators before its next() rejected,
     // so it must also be offered a return() call.
+    expect(failingReturn).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up a successfully activated source without time info when a subsequent timed source fails during activation", async () => {
+    // Given
+    const activatedReturn = jest.fn();
+    const failingReturn = jest.fn();
+    const activationError = new Error(BasicBuilder.string());
+
+    // The source without time info is activated eagerly and succeeds; with no queryStart, the
+    // timed source is then activated unconditionally right after and fails. This crosses the two
+    // source categories the shared try/finally was introduced to cover together.
+    const activatedSource = makeMockSourceWithReturn(
+      undefined,
+      undefined,
+      [makeMessageEvent(BasicBuilder.string(), 1)],
+      activatedReturn,
+    );
+    const failingSource = makeMockSourceWithReturn(
+      RosTimeBuilder.time({ sec: 0, nsec: 0 }),
+      RosTimeBuilder.time({ sec: 10, nsec: 0 }),
+      [],
+      failingReturn,
+      activationError,
+    );
+
+    // When
+    await expect(
+      (async () => {
+        for await (const message of mergeSequentialIterators(
+          [activatedSource, failingSource],
+          defaultArgs,
+        )) {
+          // The timed source fails right after the source without time info is activated.
+          expect(message).toBeDefined();
+        }
+      })(),
+    ).rejects.toBe(activationError);
+
+    // Then
+    expect(activatedReturn).toHaveBeenCalledTimes(1);
     expect(failingReturn).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.test.ts
@@ -43,84 +43,38 @@ function makeMockSource(
   } as unknown as IIterableSource<Uint8Array>;
 }
 
+// start/end may be omitted to create a "source without time info" (activated eagerly). An
+// error may be passed to make the iterator reject on next() instead of yielding messages,
+// simulating a network, range-read, decompression, or malformed-index error during activation.
 function makeMockSourceWithReturn(
-  start: Time,
-  end: Time,
+  start: Time | undefined,
+  end: Time | undefined,
   messages: IteratorResult<Uint8Array>[],
   returnFn: jest.Mock,
-): IIterableSource<Uint8Array> {
-  return {
-    sourceType: "serialized",
-    initialize: jest.fn(),
-    getBackfillMessages: jest.fn(),
-    getStart: () => start,
-    getEnd: () => end,
-    messageIterator: jest.fn().mockImplementation(() => {
-      let index = 0;
-      return {
-        next: async () => {
-          if (index < messages.length) {
-            return { value: messages[index++], done: false };
-          }
-          return { value: undefined, done: true };
-        },
-        return: returnFn.mockResolvedValue({ value: undefined, done: true }),
-        [Symbol.asyncIterator]() {
-          return this;
-        },
-      };
-    }),
-  } as unknown as IIterableSource<Uint8Array>;
-}
-
-// Like makeMockSourceWithReturn, but omits getStart/getEnd so the source is treated as a
-// "source without time info" and activated eagerly.
-function makeMockSourceWithoutTimeAndReturn(
-  messages: IteratorResult<Uint8Array>[],
-  returnFn: jest.Mock,
-): IIterableSource<Uint8Array> {
-  return {
-    sourceType: "serialized",
-    initialize: jest.fn(),
-    getBackfillMessages: jest.fn(),
-    messageIterator: jest.fn().mockImplementation(() => {
-      let index = 0;
-      return {
-        next: async () => {
-          if (index < messages.length) {
-            return { value: messages[index++], done: false };
-          }
-          return { value: undefined, done: true };
-        },
-        return: returnFn.mockResolvedValue({ value: undefined, done: true }),
-        [Symbol.asyncIterator]() {
-          return this;
-        },
-      };
-    }),
-  } as unknown as IIterableSource<Uint8Array>;
-}
-
-// A source whose iterator rejects on its first next(), simulating a network, range-read,
-// decompression, or malformed-index error during activation. Omit start/end to make it a
-// "source without time info".
-function makeMockRejectingSource(
-  error: Error,
-  returnFn: jest.Mock,
-  start?: Time,
-  end?: Time,
+  error?: Error,
 ): IIterableSource<Uint8Array> {
   return {
     sourceType: "serialized",
     initialize: jest.fn(),
     getBackfillMessages: jest.fn(),
     ...(start && end ? { getStart: () => start, getEnd: () => end } : {}),
-    messageIterator: jest.fn().mockReturnValue({
-      next: jest.fn().mockRejectedValue(error),
-      return: returnFn.mockResolvedValue({ value: undefined, done: true }),
-      [Symbol.asyncIterator]() {
-        return this;
-      },
+    messageIterator: jest.fn().mockImplementation(() => {
+      let index = 0;
+      return {
+        next: async () => {
+          if (error) {
+            throw error;
+          }
+          if (index < messages.length) {
+            return { value: messages[index++], done: false };
+          }
+          return { value: undefined, done: true };
+        },
+        return: returnFn.mockResolvedValue({ value: undefined, done: true }),
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
     }),
   } as unknown as IIterableSource<Uint8Array>;
 }
@@ -416,6 +370,7 @@ describe("mergeSequentialIterators", () => {
   });
 
   it("cleans up activated iterators when a later source fails during activation", async () => {
+    // Given
     const source1Return = jest.fn();
     const source2Return = jest.fn();
     const activationError = new Error("source activation failed");
@@ -425,15 +380,15 @@ describe("mergeSequentialIterators", () => {
       [makeMessageEvent("topic", 1)],
       source1Return,
     );
-    const source2 = makeMockSource({ sec: 0, nsec: 0 }, { sec: 10, nsec: 0 }, []);
-    source2.messageIterator = jest.fn().mockReturnValue({
-      next: jest.fn().mockRejectedValue(activationError),
-      return: source2Return.mockResolvedValue({ value: undefined, done: true }),
-      [Symbol.asyncIterator]() {
-        return this;
-      },
-    });
+    const source2 = makeMockSourceWithReturn(
+      { sec: 0, nsec: 0 },
+      { sec: 10, nsec: 0 },
+      [],
+      source2Return,
+      activationError,
+    );
 
+    // When
     await expect(
       (async () => {
         for await (const message of mergeSequentialIterators([source1, source2], defaultArgs)) {
@@ -443,23 +398,34 @@ describe("mergeSequentialIterators", () => {
       })(),
     ).rejects.toBe(activationError);
 
+    // Then
     expect(source1Return).toHaveBeenCalledTimes(1);
     expect(source2Return).toHaveBeenCalledTimes(1);
   });
 
   it("cleans up previously activated iterators when a later source fails during eager activation of sources without time info", async () => {
+    // Given
     const activatedReturn = jest.fn();
     const failingReturn = jest.fn();
     const activationError = new Error(BasicBuilder.string());
 
     // Both sources lack time info, so both are activated eagerly, in order, before any seek or
     // drain-loop logic runs.
-    const activatedSource = makeMockSourceWithoutTimeAndReturn(
+    const activatedSource = makeMockSourceWithReturn(
+      undefined,
+      undefined,
       [makeMessageEvent(BasicBuilder.string(), 1)],
       activatedReturn,
     );
-    const failingSource = makeMockRejectingSource(activationError, failingReturn);
+    const failingSource = makeMockSourceWithReturn(
+      undefined,
+      undefined,
+      [],
+      failingReturn,
+      activationError,
+    );
 
+    // When
     await expect(
       (async () => {
         for await (const message of mergeSequentialIterators(
@@ -472,6 +438,7 @@ describe("mergeSequentialIterators", () => {
       })(),
     ).rejects.toBe(activationError);
 
+    // Then
     // The previously activated iterator must still be closed even though it never got a chance
     // to be tracked by the drain loop's try/finally.
     expect(activatedReturn).toHaveBeenCalledTimes(1);
@@ -481,6 +448,7 @@ describe("mergeSequentialIterators", () => {
   });
 
   it("cleans up previously activated iterators when a later source fails during seek-time activation", async () => {
+    // Given
     const activatedReturn = jest.fn();
     const failingReturn = jest.fn();
     const activationError = new Error(BasicBuilder.string());
@@ -496,11 +464,12 @@ describe("mergeSequentialIterators", () => {
       [makeMessageEvent(BasicBuilder.string(), 1)],
       activatedReturn,
     );
-    const failingSource = makeMockRejectingSource(
-      activationError,
-      failingReturn,
+    const failingSource = makeMockSourceWithReturn(
       rangeStart,
       rangeEnd,
+      [],
+      failingReturn,
+      activationError,
     );
 
     const seekArgs: MessageIteratorArgs = {
@@ -508,6 +477,7 @@ describe("mergeSequentialIterators", () => {
       start: RosTimeBuilder.time({ sec: 5, nsec: 0 }),
     };
 
+    // When
     await expect(
       (async () => {
         for await (const message of mergeSequentialIterators(
@@ -521,11 +491,13 @@ describe("mergeSequentialIterators", () => {
       })(),
     ).rejects.toBe(activationError);
 
+    // Then
     expect(activatedReturn).toHaveBeenCalledTimes(1);
     expect(failingReturn).toHaveBeenCalledTimes(1);
   });
 
   it("cleans up previously activated iterators when a later source fails while advancing through initial empty sources", async () => {
+    // Given
     const failingReturn = jest.fn();
     const activationError = new Error(BasicBuilder.string());
 
@@ -542,13 +514,15 @@ describe("mergeSequentialIterators", () => {
       RosTimeBuilder.time({ sec: 20, nsec: 0 }),
       [],
     );
-    const failingSource = makeMockRejectingSource(
-      activationError,
-      failingReturn,
+    const failingSource = makeMockSourceWithReturn(
       RosTimeBuilder.time({ sec: 20, nsec: 0 }),
       RosTimeBuilder.time({ sec: 30, nsec: 0 }),
+      [],
+      failingReturn,
+      activationError,
     );
 
+    // When
     await expect(
       (async () => {
         for await (const message of mergeSequentialIterators(
@@ -561,6 +535,7 @@ describe("mergeSequentialIterators", () => {
       })(),
     ).rejects.toBe(activationError);
 
+    // Then
     // The empty sources were exhausted normally and require no cleanup; the failing source's
     // own iterator was registered in activeIterators before it rejected and must still be
     // offered a return() call.

--- a/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.test.ts
@@ -7,6 +7,8 @@ import {
   IteratorResult,
   MessageIteratorArgs,
 } from "@lichtblick/suite-base/players/IterablePlayer/IIterableSource";
+import RosTimeBuilder from "@lichtblick/suite-base/testing/builders/RosTimeBuilder";
+import { BasicBuilder } from "@lichtblick/test-builders";
 
 import { mergeSequentialIterators } from "./mergeSequentialIterators";
 
@@ -67,6 +69,58 @@ function makeMockSourceWithReturn(
           return this;
         },
       };
+    }),
+  } as unknown as IIterableSource<Uint8Array>;
+}
+
+// Like makeMockSourceWithReturn, but omits getStart/getEnd so the source is treated as a
+// "source without time info" and activated eagerly.
+function makeMockSourceWithoutTimeAndReturn(
+  messages: IteratorResult<Uint8Array>[],
+  returnFn: jest.Mock,
+): IIterableSource<Uint8Array> {
+  return {
+    sourceType: "serialized",
+    initialize: jest.fn(),
+    getBackfillMessages: jest.fn(),
+    messageIterator: jest.fn().mockImplementation(() => {
+      let index = 0;
+      return {
+        next: async () => {
+          if (index < messages.length) {
+            return { value: messages[index++], done: false };
+          }
+          return { value: undefined, done: true };
+        },
+        return: returnFn.mockResolvedValue({ value: undefined, done: true }),
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
+    }),
+  } as unknown as IIterableSource<Uint8Array>;
+}
+
+// A source whose iterator rejects on its first next(), simulating a network, range-read,
+// decompression, or malformed-index error during activation. Omit start/end to make it a
+// "source without time info".
+function makeMockRejectingSource(
+  error: Error,
+  returnFn: jest.Mock,
+  start?: Time,
+  end?: Time,
+): IIterableSource<Uint8Array> {
+  return {
+    sourceType: "serialized",
+    initialize: jest.fn(),
+    getBackfillMessages: jest.fn(),
+    ...(start && end ? { getStart: () => start, getEnd: () => end } : {}),
+    messageIterator: jest.fn().mockReturnValue({
+      next: jest.fn().mockRejectedValue(error),
+      return: returnFn.mockResolvedValue({ value: undefined, done: true }),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
     }),
   } as unknown as IIterableSource<Uint8Array>;
 }
@@ -391,6 +445,126 @@ describe("mergeSequentialIterators", () => {
 
     expect(source1Return).toHaveBeenCalledTimes(1);
     expect(source2Return).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up previously activated iterators when a later source fails during eager activation of sources without time info", async () => {
+    const activatedReturn = jest.fn();
+    const failingReturn = jest.fn();
+    const activationError = new Error(BasicBuilder.string());
+
+    // Both sources lack time info, so both are activated eagerly, in order, before any seek or
+    // drain-loop logic runs.
+    const activatedSource = makeMockSourceWithoutTimeAndReturn(
+      [makeMessageEvent(BasicBuilder.string(), 1)],
+      activatedReturn,
+    );
+    const failingSource = makeMockRejectingSource(activationError, failingReturn);
+
+    await expect(
+      (async () => {
+        for await (const message of mergeSequentialIterators(
+          [activatedSource, failingSource],
+          defaultArgs,
+        )) {
+          // Eager activation of the second source fails before any message is yielded.
+          expect(message).toBeDefined();
+        }
+      })(),
+    ).rejects.toBe(activationError);
+
+    // The previously activated iterator must still be closed even though it never got a chance
+    // to be tracked by the drain loop's try/finally.
+    expect(activatedReturn).toHaveBeenCalledTimes(1);
+    // The failing iterator itself was registered in activeIterators before its next() rejected,
+    // so it must also be offered a return() call.
+    expect(failingReturn).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up previously activated iterators when a later source fails during seek-time activation", async () => {
+    const activatedReturn = jest.fn();
+    const failingReturn = jest.fn();
+    const activationError = new Error(BasicBuilder.string());
+
+    // Both sources' ranges contain the requested queryStart, so both are activated during the
+    // seek-time matching loop, in order.
+    const rangeStart = RosTimeBuilder.time({ sec: 0, nsec: 0 });
+    const rangeEnd = RosTimeBuilder.time({ sec: 10, nsec: 0 });
+
+    const activatedSource = makeMockSourceWithReturn(
+      rangeStart,
+      rangeEnd,
+      [makeMessageEvent(BasicBuilder.string(), 1)],
+      activatedReturn,
+    );
+    const failingSource = makeMockRejectingSource(
+      activationError,
+      failingReturn,
+      rangeStart,
+      rangeEnd,
+    );
+
+    const seekArgs: MessageIteratorArgs = {
+      ...defaultArgs,
+      start: RosTimeBuilder.time({ sec: 5, nsec: 0 }),
+    };
+
+    await expect(
+      (async () => {
+        for await (const message of mergeSequentialIterators(
+          [activatedSource, failingSource],
+          seekArgs,
+        )) {
+          // Seek-time activation of the second matching source fails before any message is
+          // yielded.
+          expect(message).toBeDefined();
+        }
+      })(),
+    ).rejects.toBe(activationError);
+
+    expect(activatedReturn).toHaveBeenCalledTimes(1);
+    expect(failingReturn).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up previously activated iterators when a later source fails while advancing through initial empty sources", async () => {
+    const failingReturn = jest.fn();
+    const activationError = new Error(BasicBuilder.string());
+
+    // No queryStart is provided, so only the first timed source is activated up front. It and
+    // the next source are both empty, so the merge keeps advancing — without yielding anything
+    // yet — until it reaches the source that fails.
+    const emptySource1 = makeMockSource(
+      RosTimeBuilder.time({ sec: 0, nsec: 0 }),
+      RosTimeBuilder.time({ sec: 10, nsec: 0 }),
+      [],
+    );
+    const emptySource2 = makeMockSource(
+      RosTimeBuilder.time({ sec: 10, nsec: 0 }),
+      RosTimeBuilder.time({ sec: 20, nsec: 0 }),
+      [],
+    );
+    const failingSource = makeMockRejectingSource(
+      activationError,
+      failingReturn,
+      RosTimeBuilder.time({ sec: 20, nsec: 0 }),
+      RosTimeBuilder.time({ sec: 30, nsec: 0 }),
+    );
+
+    await expect(
+      (async () => {
+        for await (const message of mergeSequentialIterators(
+          [emptySource1, emptySource2, failingSource],
+          defaultArgs,
+        )) {
+          // The merge is still searching for the first source with data when activation fails.
+          expect(message).toBeDefined();
+        }
+      })(),
+    ).rejects.toBe(activationError);
+
+    // The empty sources were exhausted normally and require no cleanup; the failing source's
+    // own iterator was registered in activeIterators before it rejected and must still be
+    // offered a return() call.
+    expect(failingReturn).toHaveBeenCalledTimes(1);
   });
 
   it("only activates the source containing queryStart on seek (skips earlier sources)", async () => {

--- a/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.test.ts
@@ -361,6 +361,38 @@ describe("mergeSequentialIterators", () => {
     expect(returnFns[2]).toHaveBeenCalledTimes(1);
   });
 
+  it("cleans up activated iterators when a later source fails during activation", async () => {
+    const source1Return = jest.fn();
+    const source2Return = jest.fn();
+    const activationError = new Error("source activation failed");
+    const source1 = makeMockSourceWithReturn(
+      { sec: 0, nsec: 0 },
+      { sec: 10, nsec: 0 },
+      [makeMessageEvent("topic", 1)],
+      source1Return,
+    );
+    const source2 = makeMockSource({ sec: 0, nsec: 0 }, { sec: 10, nsec: 0 }, []);
+    source2.messageIterator = jest.fn().mockReturnValue({
+      next: jest.fn().mockRejectedValue(activationError),
+      return: source2Return.mockResolvedValue({ value: undefined, done: true }),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    });
+
+    await expect(
+      (async () => {
+        for await (const message of mergeSequentialIterators([source1, source2], defaultArgs)) {
+          // The second source fails before the first message can be yielded.
+          expect(message).toBeDefined();
+        }
+      })(),
+    ).rejects.toBe(activationError);
+
+    expect(source1Return).toHaveBeenCalledTimes(1);
+    expect(source2Return).toHaveBeenCalledTimes(1);
+  });
+
   it("only activates the source containing queryStart on seek (skips earlier sources)", async () => {
     // 4 sequential MCAPs: [0-10], [10-20], [20-30], [30-40]
     const source1 = makeMockSource({ sec: 0, nsec: 0 }, { sec: 10, nsec: 0 }, [

--- a/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.ts
+++ b/packages/suite-base/src/players/IterablePlayer/shared/utils/mergeSequentialIterators.ts
@@ -62,11 +62,6 @@ export async function* mergeSequentialIterators<T extends IteratorResult>(
     }
   }
 
-  // Start sources without time info eagerly.
-  for (const source of sourcesWithoutTime) {
-    await activateSource(source);
-  }
-
   // Index into the sorted sourcesWithTime array tracking the next source to potentially activate
   let nextSourceIndex = 0;
 
@@ -76,41 +71,46 @@ export async function* mergeSequentialIterators<T extends IteratorResult>(
     nextSourceIndex++;
   }
 
-  // On seek, start only sources whose range can contain queryStart; otherwise start just the
-  // earliest source. Additional sources are activated lazily as playback reaches them so we do
-  // not open remote reads for every file up front.
-  const queryStart = args.start;
-  if (queryStart != undefined) {
-    // Skip sources that end before queryStart.
-    while (nextSourceIndex < sourcesWithTime.length) {
-      const sourceInfo = sourcesWithTime[nextSourceIndex]!;
-      if (compare(sourceInfo.endTime, queryStart) >= 0) {
-        break;
-      }
-      nextSourceIndex++;
-    }
-    // Activate sources that contain queryStart.
-    while (nextSourceIndex < sourcesWithTime.length) {
-      const sourceInfo = sourcesWithTime[nextSourceIndex]!;
-      if (compare(sourceInfo.startTime, queryStart) > 0) {
-        break;
-      }
-      await activateNextSource();
-    }
-  } else {
-    // No query start: activate only the first source.
-    if (nextSourceIndex < sourcesWithTime.length) {
-      await activateNextSource();
-    }
-  }
-
-  // If the initial source(s) were empty, advance through pending sources until
-  // we find one with data or exhaust all sources.
-  while (heap.isEmpty() && nextSourceIndex < sourcesWithTime.length) {
-    await activateNextSource();
-  }
-
   try {
+    // Start sources without time info eagerly.
+    for (const source of sourcesWithoutTime) {
+      await activateSource(source);
+    }
+
+    // On seek, start only sources whose range can contain queryStart; otherwise start just the
+    // earliest source. Additional sources are activated lazily as playback reaches them so we
+    // do not open remote reads for every file up front.
+    const queryStart = args.start;
+    if (queryStart != undefined) {
+      // Skip sources that end before queryStart.
+      while (nextSourceIndex < sourcesWithTime.length) {
+        const sourceInfo = sourcesWithTime[nextSourceIndex]!;
+        if (compare(sourceInfo.endTime, queryStart) >= 0) {
+          break;
+        }
+        nextSourceIndex++;
+      }
+      // Activate sources that contain queryStart.
+      while (nextSourceIndex < sourcesWithTime.length) {
+        const sourceInfo = sourcesWithTime[nextSourceIndex]!;
+        if (compare(sourceInfo.startTime, queryStart) > 0) {
+          break;
+        }
+        await activateNextSource();
+      }
+    } else {
+      // No query start: activate only the first source.
+      if (nextSourceIndex < sourcesWithTime.length) {
+        await activateNextSource();
+      }
+    }
+
+    // If the initial source(s) were empty, advance through pending sources until
+    // we find one with data or exhaust all sources.
+    while (heap.isEmpty() && nextSourceIndex < sourcesWithTime.length) {
+      await activateNextSource();
+    }
+
     while (!heap.isEmpty()) {
       const node = heap.pop()!;
       const currentTimeMs = getTime(node.value);


### PR DESCRIPTION
## User-Facing Changes

No user-facing changes. Fixes a memory leak that could occur when loading or seeking across multiple MCAP files, preventing progressive memory growth and potential Out-of-Memory crashes during playback/seek error recovery.

## Description

`mergeSequentialIterators()` tracked activated source iterators in `activeIterators` and closed them from a `finally` block, but several activation phases ran **before** entering that `try`:
- Eager activation of sources without time information.
- Seek-time activation of timed sources containing `queryStart`.
- Activation of the first timed source when no `queryStart` is provided.
- Advancement through empty timed sources before the main drain loop.

If a source's first `iterator.next()` rejected during any of these phases, the exception escaped without running the shared cleanup, leaving any previously-activated iterators suspended forever. For pooled `McapIterableSource` instances, this meant the corresponding `HydratedSourcePool` entry stayed pinned indefinitely — ineligible for LRU eviction — causing pool budget violations, retained heavyweight MCAP reader state, increased GC pressure, and potential OOM crashes on repeated seeks/retries.

**Fix:** restructured `mergeSequentialIterators()` so a single `try/finally` now covers eager activation, seek-time/first-source activation, empty-source advancement, and the existing drain loop. The `finally` block's `Promise.allSettled` cleanup (calling `iterator.return()` on every tracked iterator) is unchanged, and lazy source-activation ordering / time-based merge behavior is preserved.

## Testing

Added 3 regression tests in `mergeSequentialIterators.test.ts`, each verifying that a previously-activated iterator receives `return()` and the original error propagates unmodified when a later source fails during:
1. Eager activation of sources without time info.
2. Seek-time activation of matching timed sources.
3. Advancement through initial empty timed sources.


## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when data sources fail during activation.
  * Ensured active iterators are properly released during seeking, cancellation, eager activation, and advancement through empty sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->