### PR TITLE
Add floating panel title

### DIFF
--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
@@ -9,7 +9,8 @@
 
 /* eslint-disable jest/no-done-callback */
 
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import { act } from "react";
 import { createStore } from "zustand";
 
@@ -1557,6 +1558,75 @@ describe("PanelExtensionAdapter", () => {
 
       // THEN the previously set alert is cleared
       expect(clearAlert).toHaveBeenCalledWith(expect.stringMatching(/^panel-alert:.+:my-alert$/));
+    });
+  });
+
+  describe("setToolbarActions", () => {
+    it("renders a custom toolbar action registered by the panel", async () => {
+      // GIVEN a panel that registers a custom toolbar action during init
+      const onClick = jest.fn();
+      const sig = signal();
+      const initPanel = (context: PanelExtensionContext) => {
+        context.setToolbarActions?.([
+          { id: "reset", title: "Reset view", iconPath: "M0 0h24v24H0z", onClick },
+        ]);
+        sig.resolve();
+      };
+
+      // WHEN the panel is rendered
+      const handle = render(
+        <ThemeProvider isDark>
+          <MockPanelContextProvider>
+            <PanelSetup>
+              <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+            </PanelSetup>
+          </MockPanelContextProvider>
+        </ThemeProvider>,
+      );
+      await act(async () => undefined);
+      await sig;
+
+      // THEN a toolbar button with the action's title is rendered
+      const button = handle.getByTitle("Reset view");
+      expect(button).toBeInTheDocument();
+
+      // AND clicking it invokes the action's onClick
+      fireEvent.click(button);
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("removes previously registered actions when called again with an empty array", async () => {
+      // GIVEN a panel that registers a custom toolbar action during init
+      const sig = signal();
+      let capturedContext: PanelExtensionContext;
+      const initPanel = (context: PanelExtensionContext) => {
+        capturedContext = context;
+        context.setToolbarActions?.([
+          { id: "reset", title: "Reset view", iconPath: "M0 0h24v24H0z", onClick: () => {} },
+        ]);
+        sig.resolve();
+      };
+
+      const handle = render(
+        <ThemeProvider isDark>
+          <MockPanelContextProvider>
+            <PanelSetup>
+              <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+            </PanelSetup>
+          </MockPanelContextProvider>
+        </ThemeProvider>,
+      );
+      await act(async () => undefined);
+      await sig;
+      expect(handle.getByTitle("Reset view")).toBeInTheDocument();
+
+      // WHEN the panel clears its toolbar actions
+      await act(async () => {
+        capturedContext.setToolbarActions?.([]);
+      });
+
+      // THEN the button is removed
+      expect(handle.queryByTitle("Reset view")).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
@@ -1628,5 +1628,52 @@ describe("PanelExtensionAdapter", () => {
       // THEN the button is removed
       expect(handle.queryByTitle("Reset view")).not.toBeInTheDocument();
     });
+
+    it("clears stale toolbar actions when the panel re-initializes without registering new ones", async () => {
+      // GIVEN a first panel instance that registers a custom toolbar action during init
+      const sig1 = signal();
+      const initPanelWithAction = (context: PanelExtensionContext) => {
+        context.setToolbarActions?.([
+          { id: "reset", title: "Reset view", iconPath: "M0 0h24v24H0z", onClick: () => {} },
+        ]);
+        sig1.resolve();
+      };
+
+      const config = {};
+      const saveConfig = () => {};
+
+      const Wrapper = ({ initPanel }: { initPanel: (context: PanelExtensionContext) => void }) => (
+        <ThemeProvider isDark>
+          <MockPanelContextProvider>
+            <PanelSetup>
+              <PanelExtensionAdapter
+                config={config}
+                saveConfig={saveConfig}
+                initPanel={initPanel}
+              />
+            </PanelSetup>
+          </MockPanelContextProvider>
+        </ThemeProvider>
+      );
+
+      const handle = render(<Wrapper initPanel={initPanelWithAction} />);
+      await act(async () => undefined);
+      await sig1;
+      expect(handle.getByTitle("Reset view")).toBeInTheDocument();
+
+      // WHEN the panel re-initializes (e.g. because the data source changed) with an instance
+      // that does not register any toolbar actions itself
+      const sig2 = signal();
+      const initPanelWithoutAction = (_context: PanelExtensionContext) => {
+        sig2.resolve();
+      };
+      handle.rerender(<Wrapper initPanel={initPanelWithoutAction} />);
+      await act(async () => undefined);
+      await sig2;
+
+      // THEN the stale button (and its now-orphaned callback) from the previous instance is no
+      // longer rendered
+      expect(handle.queryByTitle("Reset view")).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -125,6 +125,8 @@ type PanelExtensionAdapterProps = {
   highestSupportedConfigVersion?: number;
   config: unknown;
   saveConfig: SaveConfig<unknown>;
+  /** @see ExtensionPanelRegistration.floatingToolbar */
+  floatingToolbar?: boolean;
 };
 
 function selectContext(ctx: MessagePipelineContext) {
@@ -144,7 +146,13 @@ type RenderFn = NonNullable<PanelExtensionContext["onRender"]>;
 function PanelExtensionAdapter(
   props: React.PropsWithChildren<PanelExtensionAdapterProps>,
 ): React.JSX.Element {
-  const { initPanel, config, saveConfig, highestSupportedConfigVersion } = props;
+  const {
+    initPanel,
+    config,
+    saveConfig,
+    highestSupportedConfigVersion,
+    floatingToolbar = false,
+  } = props;
 
   // Unlike the react data flow, the config is only provided to the panel once on setup.
   // The panel is meant to manage the config and call saveConfig on its own.
@@ -175,6 +183,9 @@ function PanelExtensionAdapter(
   const [forceConversion, setForceConversion] = useState(new Set<string>());
   const [watchedFields, setWatchedFields] = useState(new Set<keyof RenderState>());
   const messageConverters = useExtensionCatalog(selectInstalledMessageConverters);
+  // Tracks whether the mouse is anywhere within the panel, so a floating toolbar's controls
+  // (settings, fullscreen, etc.) are revealed as soon as the panel is hovered.
+  const [isPanelHovered, setIsPanelHovered] = useState(false);
 
   const [localSubscriptions, setLocalSubscriptions] = useState<Subscription[]>([]);
 
@@ -875,10 +886,25 @@ function PanelExtensionAdapter(
         overflow: "hidden",
         width: "100%",
         zIndex: 0,
+        position: floatingToolbar ? "relative" : undefined,
         ...style,
       }}
+      onPointerEnter={
+        floatingToolbar
+          ? () => {
+              setIsPanelHovered(true);
+            }
+          : undefined
+      }
+      onPointerLeave={
+        floatingToolbar
+          ? () => {
+              setIsPanelHovered(false);
+            }
+          : undefined
+      }
     >
-      <PanelToolbar />
+      <PanelToolbar floating={floatingToolbar} hovered={isPanelHovered} />
       {configTooNew && <PanelConfigVersionError />}
       {props.children}
       <div style={{ flex: 1, overflow: "hidden" }} ref={panelContainerRef} />

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -826,6 +826,10 @@ function PanelExtensionAdapter(
     setRenderFn(undefined);
     renderingRef.current = false;
     setSlowRender(false);
+    // Clear any toolbar actions registered by the previous panel instance so stale buttons
+    // (retaining the old instance's callbacks) don't remain visible if the new instance never
+    // calls `context.setToolbarActions` itself.
+    setToolbarActionsState([]);
 
     setBuildRenderState(() => initRenderStateBuilder());
 

--- a/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/suite-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -19,6 +19,7 @@ import {
   ExtensionPanelRegistration,
   Immutable,
   PanelExtensionContext,
+  PanelToolbarAction,
   ParameterValue,
   RenderState,
   SettingsTree,
@@ -39,6 +40,7 @@ import {
   ConverterKey,
 } from "@lichtblick/suite-base/components/PanelExtensionAdapter/messageProcessing";
 import PanelToolbar from "@lichtblick/suite-base/components/PanelToolbar";
+import ToolbarIconButton from "@lichtblick/suite-base/components/PanelToolbar/ToolbarIconButton";
 import { useAlertsActions } from "@lichtblick/suite-base/context/AlertsContext";
 import { useAppConfiguration } from "@lichtblick/suite-base/context/AppConfigurationContext";
 import {
@@ -186,6 +188,9 @@ function PanelExtensionAdapter(
   // Tracks whether the mouse is anywhere within the panel, so a floating toolbar's controls
   // (settings, fullscreen, etc.) are revealed as soon as the panel is hovered.
   const [isPanelHovered, setIsPanelHovered] = useState(false);
+  // Custom toolbar actions the panel has registered via `context.setToolbarActions`, rendered
+  // alongside the built-in fullscreen/settings/more-options icons.
+  const [toolbarActions, setToolbarActionsState] = useState<readonly PanelToolbarAction[]>([]);
 
   const [localSubscriptions, setLocalSubscriptions] = useState<Subscription[]>([]);
 
@@ -672,6 +677,13 @@ function PanelExtensionAdapter(
         setDefaultPanelTitle(title);
       },
 
+      setToolbarActions: (actions: readonly PanelToolbarAction[]) => {
+        if (!isMounted()) {
+          return;
+        }
+        setToolbarActionsState(actions);
+      },
+
       unstable_setAlert: (alertId: string, alert: Immutable<PlayerAlert> | undefined) => {
         if (!isMounted()) {
           return;
@@ -876,6 +888,24 @@ function PanelExtensionAdapter(
     throw error;
   }
 
+  const additionalIcons =
+    toolbarActions.length > 0 ? (
+      <>
+        {toolbarActions.map((action) => (
+          <ToolbarIconButton
+            key={action.id}
+            title={action.title}
+            disabled={action.disabled}
+            onClick={action.onClick}
+          >
+            <svg viewBox="0 0 24 24" width="1em" height="1em">
+              <path d={action.iconPath} fill="currentColor" />
+            </svg>
+          </ToolbarIconButton>
+        ))}
+      </>
+    ) : undefined;
+
   return (
     <div
       style={{
@@ -904,7 +934,11 @@ function PanelExtensionAdapter(
           : undefined
       }
     >
-      <PanelToolbar floating={floatingToolbar} hovered={isPanelHovered} />
+      <PanelToolbar
+        floating={floatingToolbar}
+        hovered={isPanelHovered}
+        additionalIcons={additionalIcons}
+      />
       {configTooNew && <PanelConfigVersionError />}
       {props.children}
       <div style={{ flex: 1, overflow: "hidden" }} ref={panelContainerRef} />

--- a/packages/suite-base/src/components/PanelToolbar/PanelToolbar.style.ts
+++ b/packages/suite-base/src/components/PanelToolbar/PanelToolbar.style.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
+import { alpha } from "@mui/material";
 import { makeStyles } from "tss-react/mui";
 
 import { PANEL_TOOLBAR_MIN_HEIGHT } from "@lichtblick/suite-base/components/PanelToolbar/constants";
@@ -23,5 +24,42 @@ export const useStyles = makeStyles()((theme) => ({
     position: "relative !important" as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     top: "auto !important" as any,
+  },
+  // Toolbar no longer reserves layout space: it floats on top of the panel content instead of
+  // pushing it down. Only the title (see `floatingTitle`) stays always visible; the rest of the
+  // toolbar (see `floatingControls`) is transparent until hovered, so it doesn't visually cover
+  // the content underneath when not in use.
+  floatingRoot: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    position: "absolute !important" as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    top: "0 !important" as any,
+    backgroundColor: "transparent",
+    pointerEvents: "none",
+    // Keep the title pinned to the start and the controls pinned to the end without either one
+    // growing to fill the row, so each one's background only wraps its own content.
+    justifyContent: "space-between",
+  },
+  floatingTitle: {
+    pointerEvents: "none",
+    backgroundColor: alpha(theme.palette.background.paper, 0.7),
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(0.25, 0.75),
+  },
+  floatingControls: {
+    opacity: 0,
+    pointerEvents: "auto",
+    transition: "opacity 80ms ease-in-out",
+    backgroundColor: alpha(theme.palette.background.paper, 0.7),
+    borderRadius: theme.shape.borderRadius,
+
+    "&:hover": {
+      opacity: 1,
+    },
+  },
+  // Applied in addition to `floatingControls` while the mouse is anywhere within the panel, so
+  // the controls aren't only revealed when hovering their own small area.
+  floatingControlsVisible: {
+    opacity: 1,
   },
 }));

--- a/packages/suite-base/src/components/PanelToolbar/PanelToolbar.style.ts
+++ b/packages/suite-base/src/components/PanelToolbar/PanelToolbar.style.ts
@@ -53,6 +53,12 @@ export const useStyles = makeStyles()((theme) => ({
     backgroundColor: alpha(theme.palette.background.paper, 0.7),
     borderRadius: theme.shape.borderRadius,
 
+    // Keyboard users tab through the (invisible until hovered) controls same as anyone else; if
+    // a control receives focus it must be shown, or a sighted keyboard user could focus and
+    // invoke a control they can't see.
+    "&:focus-within": {
+      opacity: 1,
+    },
     "&:hover": {
       opacity: 1,
     },

--- a/packages/suite-base/src/components/PanelToolbar/index.tsx
+++ b/packages/suite-base/src/components/PanelToolbar/index.tsx
@@ -37,6 +37,8 @@ export default React.memo<PanelToolbarProps>(function PanelToolbar({
   children,
   className,
   isUnknownPanel = false,
+  floating = false,
+  hovered = false,
 }: PanelToolbarProps) {
   const { classes, cx } = useStyles();
   const {
@@ -86,24 +88,39 @@ export default React.memo<PanelToolbarProps>(function PanelToolbar({
       : defaultPanelTitle;
 
   const title = customPanelTitle ?? panelContext?.title;
+  const controls = (
+    <PanelToolbarControls
+      additionalIcons={additionalIconsWithHelp}
+      isUnknownPanel={isUnknownPanel}
+      ref={controlsDragRef}
+    />
+  );
   return (
     <header
-      className={cx(classes.root, className)}
+      className={cx(classes.root, floating && classes.floatingRoot, className)}
       data-testid="mosaic-drag-handle"
       ref={rootDragRef}
       style={{ backgroundColor, cursor: rootDragRef != undefined ? "grab" : "auto" }}
     >
       {children ??
         (title && (
-          <Typography noWrap variant="body2" color="text.secondary" flex="auto">
+          <Typography
+            noWrap
+            variant="body2"
+            color="text.secondary"
+            flex={floating ? "0 1 auto" : "auto"}
+            className={floating ? classes.floatingTitle : undefined}
+          >
             {title}
           </Typography>
         ))}
-      <PanelToolbarControls
-        additionalIcons={additionalIconsWithHelp}
-        isUnknownPanel={isUnknownPanel}
-        ref={controlsDragRef}
-      />
+      {floating ? (
+        <div className={cx(classes.floatingControls, hovered && classes.floatingControlsVisible)}>
+          {controls}
+        </div>
+      ) : (
+        controls
+      )}
     </header>
   );
 });

--- a/packages/suite-base/src/components/PanelToolbar/types.ts
+++ b/packages/suite-base/src/components/PanelToolbar/types.ts
@@ -14,4 +14,17 @@ export type PanelToolbarProps = {
   children?: React.ReactNode;
   className?: string;
   isUnknownPanel?: boolean;
+  /**
+   * When true, the toolbar no longer reserves layout space above the panel content.
+   * Only the title stays always visible, floating above the content; the rest of the
+   * toolbar (icons, settings, etc.) is revealed as an overlay when hovering the panel
+   * (see `hovered`) or the toolbar area itself.
+   */
+  floating?: boolean;
+  /**
+   * When `floating` is true, controls whether the floating controls (icons, settings, etc.)
+   * are shown. Pass whether the mouse is anywhere within the panel so the controls appear as
+   * soon as the panel is hovered, not only when hovering the small controls area itself.
+   */
+  hovered?: boolean;
 };

--- a/packages/suite-base/src/context/CurrentLayoutContext/actions.ts
+++ b/packages/suite-base/src/context/CurrentLayoutContext/actions.ts
@@ -41,6 +41,13 @@ export type LayoutData = {
    * studio trying to load and possibly corrupt the layout.
    */
   version?: number;
+  /**
+   * When `true`, every Plot panel in this layout floats its title/toolbar above the plot
+   * (instead of reserving a full-height title bar strip). This is a plain JSON field intended
+   * to be set by hand-editing (or generating) the layout file - there is no per-panel override
+   * and no UI control for it.
+   */
+  plotPanelsFloatingToolbar?: boolean;
 };
 
 export type ConfigsPayload = {

--- a/packages/suite-base/src/panels/Plot/Plot.test.tsx
+++ b/packages/suite-base/src/panels/Plot/Plot.test.tsx
@@ -10,6 +10,7 @@ import useGlobalSync from "@lichtblick/suite-base/panels/Plot/hooks/useGlobalSyn
 import usePanning from "@lichtblick/suite-base/panels/Plot/hooks/usePanning";
 import usePlotDataHandling from "@lichtblick/suite-base/panels/Plot/hooks/usePlotDataHandling";
 import usePlotPanelSettings from "@lichtblick/suite-base/panels/Plot/hooks/usePlotPanelSettings";
+import usePlotPanelsFloatingToolbar from "@lichtblick/suite-base/panels/Plot/hooks/usePlotPanelsFloatingToolbar";
 import useRenderer from "@lichtblick/suite-base/panels/Plot/hooks/useRenderer";
 import useSubscriptions from "@lichtblick/suite-base/panels/Plot/hooks/useSubscriptions";
 import { PlotProps } from "@lichtblick/suite-base/panels/Plot/types";
@@ -38,9 +39,13 @@ jest.mock("@lichtblick/suite-base/components/MessagePipeline", () => ({
 jest.mock("@lichtblick/suite-base/components/PanelContextMenu", () => ({
   PanelContextMenu: jest.fn(() => <div data-testid="panel-context-menu" />),
 }));
+let mockLatestPanelToolbarProps: any;
 jest.mock("@lichtblick/suite-base/components/PanelToolbar", () => ({
   __esModule: true,
-  default: () => <div data-testid="panel-toolbar" />,
+  default: (props: any) => {
+    mockLatestPanelToolbarProps = props;
+    return <div data-testid="panel-toolbar" />;
+  },
 }));
 
 let mockLatestLegendProps: any;
@@ -62,6 +67,10 @@ jest.mock("@lichtblick/suite-base/panels/Plot/hooks/useGlobalSync");
 jest.mock("@lichtblick/suite-base/panels/Plot/hooks/usePanning");
 jest.mock("@lichtblick/suite-base/panels/Plot/hooks/useSubscriptions");
 jest.mock("@lichtblick/suite-base/panels/Plot/hooks/usePlotPanelSettings");
+jest.mock("@lichtblick/suite-base/panels/Plot/hooks/usePlotPanelsFloatingToolbar", () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
+}));
 jest.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -155,8 +164,10 @@ describe("Plot Component", () => {
     (usePanning as jest.Mock).mockReturnValue(undefined);
     (useSubscriptions as jest.Mock).mockReturnValue(undefined);
     (usePlotPanelSettings as jest.Mock).mockReturnValue(undefined);
+    (usePlotPanelsFloatingToolbar as jest.Mock).mockReturnValue(false);
     mockLatestSetActiveTooltip = undefined;
     mockLatestLegendProps = undefined;
+    mockLatestPanelToolbarProps = undefined;
     Object.values(mockInteractionHandlers).forEach((handler) => {
       if (typeof handler === "function") {
         handler.mockClear();
@@ -244,6 +255,32 @@ describe("Plot Component", () => {
 
     // Then
     expect(screen.queryByTestId("plot-legend")).toBeNull();
+  });
+
+  it("Given the layout-wide floatingToolbar switch is off When rendering Then the toolbar does not float", () => {
+    // Given
+    (usePlotPanelsFloatingToolbar as jest.Mock).mockReturnValue(false);
+    const config = new PlotConfigBuilder().build();
+
+    // When
+    renderPlot(config);
+
+    // Then
+    expect(mockLatestPanelToolbarProps?.floating).toBe(false);
+    expect(mockLatestLegendProps?.floatingToolbar).toBe(false);
+  });
+
+  it("Given the layout-wide floatingToolbar switch is on When rendering Then the toolbar floats", () => {
+    // Given
+    (usePlotPanelsFloatingToolbar as jest.Mock).mockReturnValue(true);
+    const config = new PlotConfigBuilder().build();
+
+    // When
+    renderPlot(config);
+
+    // Then
+    expect(mockLatestPanelToolbarProps?.floating).toBe(true);
+    expect(mockLatestLegendProps?.floatingToolbar).toBe(true);
   });
 
   it("Given reset allowed When clicking reset button Then onResetView is called", async () => {

--- a/packages/suite-base/src/panels/Plot/Plot.tsx
+++ b/packages/suite-base/src/panels/Plot/Plot.tsx
@@ -21,12 +21,14 @@ import { usePanelContext } from "@lichtblick/suite-base/components/PanelContext"
 import { PanelContextMenu } from "@lichtblick/suite-base/components/PanelContextMenu";
 import { useSubscribeMessageRange } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
 import PanelToolbar from "@lichtblick/suite-base/components/PanelToolbar";
+import { PANEL_TOOLBAR_MIN_HEIGHT } from "@lichtblick/suite-base/components/PanelToolbar/constants";
 import Stack from "@lichtblick/suite-base/components/Stack";
 import TimeBasedChartTooltipContent from "@lichtblick/suite-base/components/TimeBasedChart/TimeBasedChartTooltipContent";
 import useGlobalVariables from "@lichtblick/suite-base/hooks/useGlobalVariables";
 import { VerticalBars } from "@lichtblick/suite-base/panels/Plot/VerticalBars";
 import usePanning from "@lichtblick/suite-base/panels/Plot/hooks/usePanning";
 import usePlotInteractionHandlers from "@lichtblick/suite-base/panels/Plot/hooks/usePlotInteractionHandlers";
+import usePlotPanelsFloatingToolbar from "@lichtblick/suite-base/panels/Plot/hooks/usePlotPanelsFloatingToolbar";
 import { PlotProps, TooltipStateSetter } from "@lichtblick/suite-base/panels/Plot/types";
 
 import { useStyles } from "./Plot.style";
@@ -47,6 +49,8 @@ const Plot = (props: PlotProps): React.JSX.Element => {
     legendDisplay,
     sidebarDimension,
   } = config;
+
+  const floatingToolbar = usePlotPanelsFloatingToolbar();
 
   const { classes } = useStyles();
   const theme = useTheme();
@@ -233,18 +237,21 @@ const Plot = (props: PlotProps): React.JSX.Element => {
         setIsPanelHovered(false);
       }}
     >
-      <PanelToolbar floating hovered={isPanelHovered} />
+      <PanelToolbar floating={floatingToolbar} hovered={isPanelHovered} />
       <Stack
         direction={legendDisplay === "top" ? "column" : "row"}
         flex="auto"
         fullWidth
-        style={{ height: "100%" }}
+        style={{
+          height: floatingToolbar ? "100%" : `calc(100% - ${PANEL_TOOLBAR_MIN_HEIGHT}px)`,
+        }}
         position="relative"
       >
         {/* Pass stable values here for properties when not showing values so that the legend memoization remains stable. */}
         {legendDisplay !== "none" && (
           <PlotLegend
             coordinator={coordinator}
+            floatingToolbar={floatingToolbar}
             legendDisplay={legendDisplay}
             onClickPath={onClickPath}
             paths={series}

--- a/packages/suite-base/src/panels/Plot/Plot.tsx
+++ b/packages/suite-base/src/panels/Plot/Plot.tsx
@@ -21,7 +21,6 @@ import { usePanelContext } from "@lichtblick/suite-base/components/PanelContext"
 import { PanelContextMenu } from "@lichtblick/suite-base/components/PanelContextMenu";
 import { useSubscribeMessageRange } from "@lichtblick/suite-base/components/PanelExtensionAdapter";
 import PanelToolbar from "@lichtblick/suite-base/components/PanelToolbar";
-import { PANEL_TOOLBAR_MIN_HEIGHT } from "@lichtblick/suite-base/components/PanelToolbar/constants";
 import Stack from "@lichtblick/suite-base/components/Stack";
 import TimeBasedChartTooltipContent from "@lichtblick/suite-base/components/TimeBasedChart/TimeBasedChartTooltipContent";
 import useGlobalVariables from "@lichtblick/suite-base/hooks/useGlobalVariables";
@@ -58,6 +57,10 @@ const Plot = (props: PlotProps): React.JSX.Element => {
 
   // When true the user can reset the plot back to the original view
   const [canReset, setCanReset] = useState(false);
+
+  // Tracks whether the mouse is anywhere within the panel, so the floating toolbar's controls
+  // (settings, fullscreen, etc.) are revealed as soon as the panel is hovered.
+  const [isPanelHovered, setIsPanelHovered] = useState(false);
 
   const [activeTooltip, setActiveTooltip] = useState<TooltipStateSetter>();
 
@@ -223,13 +226,19 @@ const Plot = (props: PlotProps): React.JSX.Element => {
       justifyContent="center"
       overflow="hidden"
       position="relative"
+      onPointerEnter={() => {
+        setIsPanelHovered(true);
+      }}
+      onPointerLeave={() => {
+        setIsPanelHovered(false);
+      }}
     >
-      <PanelToolbar />
+      <PanelToolbar floating hovered={isPanelHovered} />
       <Stack
         direction={legendDisplay === "top" ? "column" : "row"}
         flex="auto"
         fullWidth
-        style={{ height: `calc(100% - ${PANEL_TOOLBAR_MIN_HEIGHT}px)` }}
+        style={{ height: "100%" }}
         position="relative"
       >
         {/* Pass stable values here for properties when not showing values so that the legend memoization remains stable. */}

--- a/packages/suite-base/src/panels/Plot/PlotLegend.test.tsx
+++ b/packages/suite-base/src/panels/Plot/PlotLegend.test.tsx
@@ -19,6 +19,7 @@ const defaultProps = {
   saveConfig: jest.fn(),
   sidebarDimension: BasicBuilder.number(),
   paths: [],
+  floatingToolbar: false,
 };
 
 const getContextValue = () => ({

--- a/packages/suite-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/suite-base/src/panels/Plot/PlotLegend.tsx
@@ -33,6 +33,7 @@ const maxLegendWidth = 800;
 
 type Props = Immutable<{
   coordinator: PlotCoordinator | undefined;
+  floatingToolbar: boolean;
   legendDisplay: "floating" | "top" | "left";
   onClickPath: (index: number) => void;
   paths: PlotPath[];
@@ -43,119 +44,126 @@ type Props = Immutable<{
   hoveredValuesBySeriesIndex?: string[];
 }>;
 
-const useStyles = makeStyles<void, "grid" | "toggleButton" | "toggleButtonFloating">()(
-  ({ palette, shadows, shape, spacing }, _params, classes) => ({
-    root: {
-      display: "flex",
-      overflow: "hidden",
-    },
-    rootFloating: {
-      pointerEvents: "none",
-      alignItems: "flex-start",
-      justifyContent: "flex-start",
-      position: "absolute",
-      inset: "0 0 0 0",
-      height: "100%",
-      width: "100%",
-      overflow: "hidden",
-      zIndex: 1000,
-      gap: spacing(0.75),
-      // Extra top clearance (beyond the usual padding) so the legend doesn't render underneath
-      // the panel's floating title.
-      padding: `calc(${spacing(1.5)} + ${PANEL_TOOLBAR_MIN_HEIGHT}px) ${spacing(3.75)} ${spacing(4)} ${spacing(4.5)}`,
+const useStyles = makeStyles<
+  { floatingToolbar: boolean },
+  "grid" | "toggleButton" | "toggleButtonFloating"
+>()(({ palette, shadows, shape, spacing }, { floatingToolbar }, classes) => ({
+  root: {
+    display: "flex",
+    overflow: "hidden",
+  },
+  rootFloating: {
+    pointerEvents: "none",
+    alignItems: "flex-start",
+    justifyContent: "flex-start",
+    position: "absolute",
+    inset: "0 0 0 0",
+    height: "100%",
+    width: "100%",
+    overflow: "hidden",
+    zIndex: 1000,
+    gap: spacing(0.75),
+    // Extra top clearance (beyond the usual padding) so the legend doesn't render underneath
+    // the panel's floating title - only needed when the toolbar actually floats; otherwise the
+    // toolbar already reserves its own space above the legend.
+    padding: floatingToolbar
+      ? `calc(${spacing(1.5)} + ${PANEL_TOOLBAR_MIN_HEIGHT}px) ${spacing(3.75)} ${spacing(4)} ${spacing(4.5)}`
+      : spacing(1.5, 3.75, 4, 4.5),
 
-      [`.${classes.grid}`]: {
-        pointerEvents: "auto",
-        flex: "0 1 auto",
-        width: "max-content",
-        maxHeight: "100%",
-        borderRadius: shape.borderRadius,
-        gridTemplateColumns: "auto repeat(2, minmax(max-content, auto)) auto",
-        backgroundImage: `linear-gradient(${[
-          "0deg",
-          tinycolor(palette.background.default).setAlpha(0.2).toHex8String(),
-          tinycolor(palette.background.default).setAlpha(0.2).toHex8String(),
-        ].join(" ,")})`,
-        backgroundColor: tinycolor(palette.background.paper).setAlpha(0.8).toHex8String(),
-        backdropFilter: "blur(3px)",
-        boxShadow: shadows[3],
-      },
-    },
-    rootLeft: {
-      alignItems: "flex-start",
-      maxWidth: "80%",
-      // Clear the panel's floating title, which otherwise renders on top of the legend.
-      paddingTop: PANEL_TOOLBAR_MIN_HEIGHT,
-
-      [`.${classes.toggleButton}`]: {
-        padding: spacing(0.25),
-        height: "100%",
-        borderRadius: 0,
-        borderTop: "none",
-        borderBottom: "none",
-      },
-      [`.${classes.grid}`]: {
-        overflow: "auto",
-        height: "100%",
-        alignContent: "flex-start",
-      },
-    },
-    rootTop: {
-      flexDirection: "column",
-      maxHeight: "80%",
-      // Clear the panel's floating title, which otherwise renders on top of the legend.
-      paddingTop: PANEL_TOOLBAR_MIN_HEIGHT,
-
-      [`.${classes.toggleButton}`]: {
-        padding: spacing(0.25),
-        borderRadius: 0,
-        borderRight: "none",
-        borderLeft: "none",
-      },
-    },
-    grid: {
-      alignItems: "center",
-      display: "grid",
-      gridTemplateColumns: "auto repeat(2, minmax(max-content, 1fr)) auto",
-      gridAutoRows: ROW_HEIGHT,
-      width: "100%",
-      columnGap: 1,
-      overflow: "auto",
-      justifyItems: "flex-start",
-    },
-    dragHandle: {
-      userSelect: "none",
-      border: `0px solid ${palette.action.hover}`,
-
-      "&:hover": {
-        borderColor: palette.action.selected,
-      },
-    },
-    toggleButton: {},
-    toggleButtonFloating: {
-      backdropFilter: "blur(3px)",
+    [`.${classes.grid}`]: {
       pointerEvents: "auto",
+      flex: "0 1 auto",
+      width: "max-content",
+      maxHeight: "100%",
+      borderRadius: shape.borderRadius,
+      gridTemplateColumns: "auto repeat(2, minmax(max-content, auto)) auto",
       backgroundImage: `linear-gradient(${[
         "0deg",
         tinycolor(palette.background.default).setAlpha(0.2).toHex8String(),
         tinycolor(palette.background.default).setAlpha(0.2).toHex8String(),
       ].join(" ,")})`,
       backgroundColor: tinycolor(palette.background.paper).setAlpha(0.8).toHex8String(),
+      backdropFilter: "blur(3px)",
       boxShadow: shadows[3],
-
-      "&:hover": {
-        backgroundColor: palette.background.paper,
-        backgroundImage: `linear-gradient(0deg, ${palette.action.hover}, ${palette.action.hover})`,
-      },
     },
-  }),
-);
+  },
+  rootLeft: {
+    alignItems: "flex-start",
+    maxWidth: "80%",
+    // Clear the panel's floating title, which otherwise renders on top of the legend. Not
+    // needed when the toolbar reserves its own space instead of floating.
+    paddingTop: floatingToolbar ? PANEL_TOOLBAR_MIN_HEIGHT : 0,
+
+    [`.${classes.toggleButton}`]: {
+      padding: spacing(0.25),
+      height: "100%",
+      borderRadius: 0,
+      borderTop: "none",
+      borderBottom: "none",
+    },
+    [`.${classes.grid}`]: {
+      overflow: "auto",
+      height: "100%",
+      alignContent: "flex-start",
+    },
+  },
+  rootTop: {
+    flexDirection: "column",
+    maxHeight: "80%",
+    // Clear the panel's floating title, which otherwise renders on top of the legend. Not
+    // needed when the toolbar reserves its own space instead of floating.
+    paddingTop: floatingToolbar ? PANEL_TOOLBAR_MIN_HEIGHT : 0,
+
+    [`.${classes.toggleButton}`]: {
+      padding: spacing(0.25),
+      borderRadius: 0,
+      borderRight: "none",
+      borderLeft: "none",
+    },
+  },
+  grid: {
+    alignItems: "center",
+    display: "grid",
+    gridTemplateColumns: "auto repeat(2, minmax(max-content, 1fr)) auto",
+    gridAutoRows: ROW_HEIGHT,
+    width: "100%",
+    columnGap: 1,
+    overflow: "auto",
+    justifyItems: "flex-start",
+  },
+  dragHandle: {
+    userSelect: "none",
+    border: `0px solid ${palette.action.hover}`,
+
+    "&:hover": {
+      borderColor: palette.action.selected,
+    },
+  },
+  toggleButton: {},
+  toggleButtonFloating: {
+    backdropFilter: "blur(3px)",
+    pointerEvents: "auto",
+    backgroundImage: `linear-gradient(${[
+      "0deg",
+      tinycolor(palette.background.default).setAlpha(0.2).toHex8String(),
+      tinycolor(palette.background.default).setAlpha(0.2).toHex8String(),
+    ].join(" ,")})`,
+    backgroundColor: tinycolor(palette.background.paper).setAlpha(0.8).toHex8String(),
+    boxShadow: shadows[3],
+
+    "&:hover": {
+      backgroundColor: palette.background.paper,
+      backgroundImage: `linear-gradient(0deg, ${palette.action.hover}, ${palette.action.hover})`,
+    },
+  },
+}));
 
 const emptyPaths: string[] = [];
 
 function PlotLegendComponent(props: Props): React.JSX.Element {
   const {
     coordinator,
+    floatingToolbar,
     legendDisplay,
     onClickPath,
     paths,
@@ -165,7 +173,7 @@ function PlotLegendComponent(props: Props): React.JSX.Element {
     showValues,
     hoveredValuesBySeriesIndex,
   } = props;
-  const { classes, cx } = useStyles();
+  const { classes, cx } = useStyles({ floatingToolbar });
 
   const dragStart = useRef({ x: 0, y: 0, sidebarDimension: 0 });
 

--- a/packages/suite-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/suite-base/src/panels/Plot/PlotLegend.tsx
@@ -20,6 +20,7 @@ import tinycolor from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
 
 import { Immutable } from "@lichtblick/suite";
+import { PANEL_TOOLBAR_MIN_HEIGHT } from "@lichtblick/suite-base/components/PanelToolbar/constants";
 import { DEFAULT_PLOT_PATH } from "@lichtblick/suite-base/panels/Plot/constants";
 import { SaveConfig } from "@lichtblick/suite-base/types/panels";
 
@@ -59,7 +60,9 @@ const useStyles = makeStyles<void, "grid" | "toggleButton" | "toggleButtonFloati
       overflow: "hidden",
       zIndex: 1000,
       gap: spacing(0.75),
-      padding: spacing(1.5, 3.75, 4, 4.5),
+      // Extra top clearance (beyond the usual padding) so the legend doesn't render underneath
+      // the panel's floating title.
+      padding: `calc(${spacing(1.5)} + ${PANEL_TOOLBAR_MIN_HEIGHT}px) ${spacing(3.75)} ${spacing(4)} ${spacing(4.5)}`,
 
       [`.${classes.grid}`]: {
         pointerEvents: "auto",
@@ -81,6 +84,8 @@ const useStyles = makeStyles<void, "grid" | "toggleButton" | "toggleButtonFloati
     rootLeft: {
       alignItems: "flex-start",
       maxWidth: "80%",
+      // Clear the panel's floating title, which otherwise renders on top of the legend.
+      paddingTop: PANEL_TOOLBAR_MIN_HEIGHT,
 
       [`.${classes.toggleButton}`]: {
         padding: spacing(0.25),
@@ -98,6 +103,8 @@ const useStyles = makeStyles<void, "grid" | "toggleButton" | "toggleButtonFloati
     rootTop: {
       flexDirection: "column",
       maxHeight: "80%",
+      // Clear the panel's floating title, which otherwise renders on top of the legend.
+      paddingTop: PANEL_TOOLBAR_MIN_HEIGHT,
 
       [`.${classes.toggleButton}`]: {
         padding: spacing(0.25),

--- a/packages/suite-base/src/panels/Plot/hooks/usePlotPanelsFloatingToolbar.ts
+++ b/packages/suite-base/src/panels/Plot/hooks/usePlotPanelsFloatingToolbar.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2020-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import {
+  LayoutState,
+  useCurrentLayoutSelector,
+} from "@lichtblick/suite-base/context/CurrentLayoutContext";
+
+const selectPlotPanelsFloatingToolbar = (state: LayoutState) =>
+  state.selectedLayout?.data?.plotPanelsFloatingToolbar ?? false;
+
+/**
+ * Reads the layout-wide, JSON-only switch for the Plot panel's floating title/toolbar (see
+ * `LayoutData.plotPanelsFloatingToolbar`). Applies uniformly to every Plot panel in the layout;
+ * there is no per-panel override.
+ */
+export default function usePlotPanelsFloatingToolbar(): boolean {
+  return useCurrentLayoutSelector(selectPlotPanelsFloatingToolbar);
+}

--- a/packages/suite-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/suite-base/src/providers/PanelCatalogProvider.tsx
@@ -38,6 +38,7 @@ export default function PanelCatalogProvider(props: PropsWithChildren): React.Re
               config={panelProps.config}
               saveConfig={panelProps.saveConfig}
               initPanel={panel.registration.initPanel}
+              floatingToolbar={panel.registration.floatingToolbar}
             />
           </>
         );

--- a/packages/suite/src/index.ts
+++ b/packages/suite/src/index.ts
@@ -503,6 +503,14 @@ export type PanelExtensionContext = {
   setDefaultPanelTitle(defaultTitle: string | undefined): void;
 
   /**
+   * Sets the panel's custom toolbar actions, rendered next to the panel's built-in toolbar icons
+   * (fullscreen, settings, more-options). Call again with a new array to update the set of
+   * actions (e.g. to change an action's disabled state); call with an empty array to remove them
+   * all.
+   */
+  setToolbarActions?(actions: readonly PanelToolbarAction[]): void;
+
+  /**
    * Enables subscription to retrieve complete message history for a specified topic from the active data source.
    *
    * See {@link SubscribeMessageRangeArgs} for more information on behavior.
@@ -553,6 +561,33 @@ export type PanelExtensionContext = {
    *   if the schema is unknown or no active data source is available.
    */
   getSchema: (schemaName: string) => Immutable<MessageDefinition> | undefined;
+};
+
+/**
+ * Describes a custom action button rendered in a panel's toolbar, alongside the panel's built-in
+ * toolbar icons (fullscreen, settings, more-options). See {@link PanelExtensionContext.setToolbarActions}.
+ */
+export type PanelToolbarAction = {
+  /**
+   * Unique id for this action. Used as the React key; passing a new list of actions with the
+   * same id updates that action's button in place instead of remounting it.
+   */
+  id: string;
+
+  /** Tooltip / accessible label shown for the action. */
+  title: string;
+
+  /**
+   * SVG path data (the `d` attribute of an SVG `<path>` element) used to render the action's
+   * icon, drawn within a 24x24 viewBox.
+   */
+  iconPath: string;
+
+  /** Called when the user activates (clicks) the action. */
+  onClick: () => void;
+
+  /** When true, the action is rendered but not clickable. */
+  disabled?: boolean;
 };
 
 export type ExtensionPanelRegistration = {

--- a/packages/suite/src/index.ts
+++ b/packages/suite/src/index.ts
@@ -568,6 +568,15 @@ export type ExtensionPanelRegistration = {
    * @return: (optional) A function which is called when the panel is removed or replaced. Typically intended for cleanup logic to gracefully teardown your panel.
    */
   initPanel: (context: PanelExtensionContext) => void | (() => void);
+
+  /**
+   * When true, the panel's built-in toolbar (title, fullscreen/settings/more-options icons) no
+   * longer reserves layout space above the panel content. Only the title stays always visible,
+   * floating above the content; the rest of the toolbar is revealed on hover.
+   *
+   * @default false
+   */
+  floatingToolbar?: boolean;
 };
 
 export interface PanelSettings<ExtensionSettings> {


### PR DESCRIPTION
## User-Facing Changes

After:
<img width="466" height="549" alt="image" src="https://github.com/user-attachments/assets/f8f28601-3818-4625-bbe1-25eb51201acb" />

Before:
<img width="473" height="547" alt="image" src="https://github.com/user-attachments/assets/3dc26d7d-1687-47af-bc8d-b2924bba80ee" />



Optional opt-in tight layout for plot panel, that can be activated in the layout.
* Narrower border margins
* Floating plot title and toolbar
* Toolbar only visible when mouse-over
* Panel extension adapter provides interface for additional buttons in panel toolbar
* Panel extension also opt-in to the narrow layout in order to assure backwards compatibility

## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional floating toolbars for Plot and extension panels, showing controls over panel content on hover or keyboard focus.
  * Added support for custom panel toolbar actions with titles, icons, click handlers, and disabled states.
  * Added a layout setting to enable floating toolbars across all Plot panels.
  * Updated Plot legends and content layout to accommodate floating toolbar titles.

* **Bug Fixes**
  * Prevented stale toolbar actions from remaining after panel reinitialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->