### PR TITLE
feature: AV1 video codec support

### DIFF
--- a/packages/den/testing/builders/AV1FrameBuilder.ts
+++ b/packages/den/testing/builders/AV1FrameBuilder.ts
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  LEB128_CONTINUATION_FLAG,
+  LEB128_PAYLOAD_MASK,
+  OBU_EXTENSION_FLAG,
+  OBU_HAS_SIZE_FLAG,
+  OBU_TYPE_SHIFT,
+} from "../../video/av1/constants";
+import { AV1FrameType, AV1ObuType } from "../../video/av1/types";
+
+type SequenceHeaderOptions = {
+  bitDepth?: 8 | 10 | 12;
+  decoderModel?: boolean;
+  height?: number;
+  initialDisplayDelay?: boolean;
+  level?: number;
+  operatingPoints?: { level: number; tier?: 0 | 1 }[];
+  profile?: 0 | 1 | 2;
+  /** Emits `still_picture = 1` and `reduced_still_picture_header = 1`, which omits most fields. */
+  reducedStillPicture?: boolean;
+  timingInfo?: boolean;
+  tier?: 0 | 1;
+  width?: number;
+};
+
+type FrameOptions = {
+  frameType?: AV1FrameType;
+  showExistingFrame?: boolean;
+  showFrame?: boolean;
+};
+
+class BitWriter {
+  readonly #bits: number[] = [];
+
+  public write(value: number, width: number): void {
+    for (let bit = width - 1; bit >= 0; bit--) {
+      this.#bits.push(Math.floor(value / 2 ** bit) & 1);
+    }
+  }
+
+  public bytes(): number[] {
+    const result: number[] = [];
+    for (let offset = 0; offset < this.#bits.length; offset += 8) {
+      let byte = 0;
+      for (let bit = 0; bit < 8; bit++) {
+        byte = (byte << 1) | (this.#bits[offset + bit] ?? 0);
+      }
+      result.push(byte);
+    }
+    return result;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export default class AV1FrameBuilder {
+  public static obu(type: number, payload: number[], extension?: number): number[] {
+    const header =
+      (type << OBU_TYPE_SHIFT) |
+      (extension == undefined ? 0 : OBU_EXTENSION_FLAG) |
+      OBU_HAS_SIZE_FLAG;
+    return [
+      header,
+      ...(extension == undefined ? [] : [extension]), // extension should come just after obu_header
+      ...encodeLeb128(payload.length),
+      ...payload,
+    ];
+  }
+
+  public static sequenceHeader(options: SequenceHeaderOptions = {}): number[] {
+    const {
+      bitDepth = 8,
+      decoderModel = false,
+      height = 480,
+      initialDisplayDelay = false,
+      level = 5,
+      profile = 0,
+      reducedStillPicture = false,
+      timingInfo = false,
+      tier = 0,
+      width = 640,
+    } = options;
+    const operatingPoints = options.operatingPoints ?? [{ level, tier }];
+    const bits = new BitWriter();
+    bits.write(profile, 3);
+    bits.write(reducedStillPicture ? 1 : 0, 1); // still_picture
+    bits.write(reducedStillPicture ? 1 : 0, 1); // reduced_still_picture_header
+    if (reducedStillPicture) {
+      bits.write(level, 5); // seq_level_idx[0]
+    } else {
+      bits.write(timingInfo ? 1 : 0, 1);
+      if (timingInfo) {
+        bits.write(1, 32); // num_units_in_display_tick
+        bits.write(30, 32); // time_scale
+        bits.write(0, 1); // equal_picture_interval
+        bits.write(decoderModel ? 1 : 0, 1);
+        if (decoderModel) {
+          bits.write(3, 5); // buffer_delay_length_minus_1
+          bits.write(1, 32); // num_units_in_decoding_tick
+          bits.write(3, 5); // buffer_removal_time_length_minus_1
+          bits.write(3, 5); // frame_presentation_time_length_minus_1
+        }
+      }
+      bits.write(initialDisplayDelay ? 1 : 0, 1);
+      bits.write(operatingPoints.length - 1, 5);
+      for (const operatingPoint of operatingPoints) {
+        bits.write(0, 12); // operating_point_idc
+        bits.write(operatingPoint.level, 5);
+        if (operatingPoint.level > 7) {
+          bits.write(operatingPoint.tier ?? 0, 1);
+        }
+        if (decoderModel) {
+          bits.write(1, 1); // decoder_model_present_for_this_op
+          bits.write(1, 4); // decoder_buffer_delay
+          bits.write(1, 4); // encoder_buffer_delay
+          bits.write(0, 1); // low_delay_mode_flag
+        }
+        if (initialDisplayDelay) {
+          bits.write(1, 1); // initial_display_delay_present_for_this_op
+          bits.write(0, 4); // initial_display_delay_minus_1
+        }
+      }
+    }
+
+    const widthBits = Math.max(1, Math.ceil(Math.log2(width)));
+    const heightBits = Math.max(1, Math.ceil(Math.log2(height)));
+    bits.write(widthBits - 1, 4);
+    bits.write(heightBits - 1, 4);
+    bits.write(width - 1, widthBits);
+    bits.write(height - 1, heightBits);
+    if (!reducedStillPicture) {
+      bits.write(0, 1); // frame_id_numbers_present_flag
+    }
+    bits.write(0, 3); // superblock and intra feature flags
+    if (!reducedStillPicture) {
+      bits.write(0, 4); // inter-frame feature flags
+      bits.write(0, 1); // enable_order_hint
+      bits.write(1, 1); // seq_choose_screen_content_tools
+      bits.write(1, 1); // seq_choose_integer_mv
+    }
+    bits.write(0, 3); // superres, CDEF, restoration
+    bits.write(bitDepth === 8 ? 0 : 1, 1); // high_bitdepth
+    if (profile === 2 && bitDepth !== 8) {
+      bits.write(bitDepth === 12 ? 1 : 0, 1); // twelve_bit
+    }
+    return bits.bytes();
+  }
+
+  /**
+   * Builds an OBU_FRAME whose payload starts with the only `uncompressed_header()` fields keyframe
+   * detection reads: `show_existing_frame` f(1) and, unless the frame is re-displayed, `frame_type`
+   * f(2) and `show_frame` f(1). The remaining bits are zero padding standing in for the tile group.
+   */
+  public static frame(options: FrameOptions = {}): number[] {
+    const {
+      frameType = AV1FrameType.KeyFrame,
+      showExistingFrame = false,
+      showFrame = true,
+    } = options;
+    const bits = new BitWriter();
+    bits.write(showExistingFrame ? 1 : 0, 1);
+    if (showExistingFrame) {
+      bits.write(0, 3); // frame_to_show_map_idx
+    } else {
+      bits.write(frameType, 2);
+      bits.write(showFrame ? 1 : 0, 1);
+    }
+    return AV1FrameBuilder.obu(AV1ObuType.Frame, bits.bytes());
+  }
+
+  /** A sequence header followed by a shown key frame, i.e. a random-access point. */
+  public static keyframe(options?: SequenceHeaderOptions): Uint8Array {
+    return new Uint8Array([
+      ...AV1FrameBuilder.obu(AV1ObuType.SequenceHeader, AV1FrameBuilder.sequenceHeader(options)),
+      ...AV1FrameBuilder.frame(),
+    ]);
+  }
+
+  public static deltaFrame(): Uint8Array {
+    return new Uint8Array(AV1FrameBuilder.frame({ frameType: AV1FrameType.InterFrame }));
+  }
+
+  /**
+   * A delta frame preceded by a repeated Sequence Header OBU. The AV1 specification permits this,
+   * so it must not be mistaken for a random-access point.
+   */
+  public static deltaFrameWithSequenceHeader(options?: SequenceHeaderOptions): Uint8Array {
+    return new Uint8Array([
+      ...AV1FrameBuilder.obu(AV1ObuType.SequenceHeader, AV1FrameBuilder.sequenceHeader(options)),
+      ...AV1FrameBuilder.frame({ frameType: AV1FrameType.InterFrame }),
+    ]);
+  }
+}
+
+function encodeLeb128(value: number): number[] {
+  const result: number[] = [];
+  let remaining = value;
+  do {
+    const byte = remaining & LEB128_PAYLOAD_MASK; // Get the lower 7bits
+    remaining = Math.floor(remaining / (LEB128_PAYLOAD_MASK + 1));
+    result.push(remaining === 0 ? byte : byte | LEB128_CONTINUATION_FLAG);
+  } while (remaining !== 0);
+  return result;
+}

--- a/packages/den/testing/builders/AV1FrameBuilder.ts
+++ b/packages/den/testing/builders/AV1FrameBuilder.ts
@@ -57,6 +57,54 @@ class BitWriter {
   }
 }
 
+function writeNonReducedSequenceHeaderFields(
+  bits: BitWriter,
+  {
+    decoderModel,
+    initialDisplayDelay,
+    operatingPoints,
+    timingInfo,
+  }: {
+    decoderModel: boolean;
+    initialDisplayDelay: boolean;
+    operatingPoints: { level: number; tier?: 0 | 1 }[];
+    timingInfo: boolean;
+  },
+): void {
+  bits.write(timingInfo ? 1 : 0, 1);
+  if (timingInfo) {
+    bits.write(1, 32); // num_units_in_display_tick
+    bits.write(30, 32); // time_scale
+    bits.write(0, 1); // equal_picture_interval
+    bits.write(decoderModel ? 1 : 0, 1);
+    if (decoderModel) {
+      bits.write(3, 5); // buffer_delay_length_minus_1
+      bits.write(1, 32); // num_units_in_decoding_tick
+      bits.write(3, 5); // buffer_removal_time_length_minus_1
+      bits.write(3, 5); // frame_presentation_time_length_minus_1
+    }
+  }
+  bits.write(initialDisplayDelay ? 1 : 0, 1);
+  bits.write(operatingPoints.length - 1, 5);
+  for (const operatingPoint of operatingPoints) {
+    bits.write(0, 12); // operating_point_idc
+    bits.write(operatingPoint.level, 5);
+    if (operatingPoint.level > 7) {
+      bits.write(operatingPoint.tier ?? 0, 1);
+    }
+    if (decoderModel) {
+      bits.write(1, 1); // decoder_model_present_for_this_op
+      bits.write(1, 4); // decoder_buffer_delay
+      bits.write(1, 4); // encoder_buffer_delay
+      bits.write(0, 1); // low_delay_mode_flag
+    }
+    if (initialDisplayDelay) {
+      bits.write(1, 1); // initial_display_delay_present_for_this_op
+      bits.write(0, 4); // initial_display_delay_minus_1
+    }
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export default class AV1FrameBuilder {
   public static obu(type: number, payload: number[], extension?: number): number[] {
@@ -93,38 +141,12 @@ export default class AV1FrameBuilder {
     if (reducedStillPicture) {
       bits.write(level, 5); // seq_level_idx[0]
     } else {
-      bits.write(timingInfo ? 1 : 0, 1);
-      if (timingInfo) {
-        bits.write(1, 32); // num_units_in_display_tick
-        bits.write(30, 32); // time_scale
-        bits.write(0, 1); // equal_picture_interval
-        bits.write(decoderModel ? 1 : 0, 1);
-        if (decoderModel) {
-          bits.write(3, 5); // buffer_delay_length_minus_1
-          bits.write(1, 32); // num_units_in_decoding_tick
-          bits.write(3, 5); // buffer_removal_time_length_minus_1
-          bits.write(3, 5); // frame_presentation_time_length_minus_1
-        }
-      }
-      bits.write(initialDisplayDelay ? 1 : 0, 1);
-      bits.write(operatingPoints.length - 1, 5);
-      for (const operatingPoint of operatingPoints) {
-        bits.write(0, 12); // operating_point_idc
-        bits.write(operatingPoint.level, 5);
-        if (operatingPoint.level > 7) {
-          bits.write(operatingPoint.tier ?? 0, 1);
-        }
-        if (decoderModel) {
-          bits.write(1, 1); // decoder_model_present_for_this_op
-          bits.write(1, 4); // decoder_buffer_delay
-          bits.write(1, 4); // encoder_buffer_delay
-          bits.write(0, 1); // low_delay_mode_flag
-        }
-        if (initialDisplayDelay) {
-          bits.write(1, 1); // initial_display_delay_present_for_this_op
-          bits.write(0, 4); // initial_display_delay_minus_1
-        }
-      }
+      writeNonReducedSequenceHeaderFields(bits, {
+        decoderModel,
+        initialDisplayDelay,
+        operatingPoints,
+        timingInfo,
+      });
     }
 
     const widthBits = Math.max(1, Math.ceil(Math.log2(width)));

--- a/packages/den/testing/builders/index.ts
+++ b/packages/den/testing/builders/index.ts
@@ -6,3 +6,4 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 export { default as H265FrameBuilder } from "./H265FrameBuilder";
+export { default as AV1FrameBuilder } from "./AV1FrameBuilder";

--- a/packages/den/video/VideoPlayer.test.ts
+++ b/packages/den/video/VideoPlayer.test.ts
@@ -234,6 +234,26 @@ describe("VideoPlayer", () => {
     await expect(decodePromise).resolves.toEqual({ type: "timeout" });
   });
 
+  it("should use the extended target-frame timeout for AV1", async () => {
+    // Given an AV1-configured player with a no-op decoder
+    const { player } = setup();
+    await player.init({ codec: "av01.0.05M.08" });
+    let settled = false;
+
+    // When the default timeout elapses without output
+    const decodePromise = player
+      .decodeFrames([{ data: new Uint8Array([1]), timestampMicros: 0, type: "key" }])
+      .finally(() => {
+        settled = true;
+      });
+    await jest.advanceTimersByTimeAsync(10);
+
+    // Then AV1 remains pending until the extended buffered-codec deadline
+    expect(settled).toBe(false);
+    await jest.advanceTimersByTimeAsync(1990);
+    await expect(decodePromise).resolves.toEqual({ type: "timeout" });
+  });
+
   it("should return aborted on resetForSeek", async () => {
     // Given an HEVC-configured player with an in-flight decode
     const { player } = setup();

--- a/packages/den/video/VideoPlayer.ts
+++ b/packages/den/video/VideoPlayer.ts
@@ -13,10 +13,9 @@ import { H265_TARGET_FRAME_WAIT_MS } from "./h265/constants";
 // foxglove-depcheck-used: @types/dom-webcodecs
 
 // H.264 typically emits a decoded VideoFrame within a couple of milliseconds of submitting an
-// EncodedVideoChunk, so a tight 30 ms ceiling lets us return quickly when decoding is healthy and
-// fail fast when the decoder is stuck. The H.265 budgets live in `./h265/constants.ts` and are
-// much larger because HEVC decoders may need to consume an entire GOP before emitting the target
-// frame.
+// EncodedVideoChunk, so a tight 10 ms ceiling lets us return quickly when decoding is healthy and
+// fail fast when the decoder is stuck. H.265 and AV1 can buffer an entire GOP before emitting the
+// target frame, so they share the larger budget from `./h265/constants.ts`.
 const DEFAULT_TARGET_FRAME_WAIT_MS = 10;
 
 /** A single chunk of encoded video bitstream representing one frame. */
@@ -269,10 +268,13 @@ export class VideoPlayer extends EventEmitter<VideoPlayerEventTypes> {
           return;
         }
 
-        const isH265 =
+        const needsExtendedFrameWait =
           this.#decoderConfig?.codec.startsWith("hev1") === true ||
-          this.#decoderConfig?.codec.startsWith("hvc1") === true;
-        const targetFrameWaitMs = isH265 ? H265_TARGET_FRAME_WAIT_MS : DEFAULT_TARGET_FRAME_WAIT_MS;
+          this.#decoderConfig?.codec.startsWith("hvc1") === true ||
+          this.#decoderConfig?.codec.startsWith("av01") === true;
+        const targetFrameWaitMs = needsExtendedFrameWait
+          ? H265_TARGET_FRAME_WAIT_MS
+          : DEFAULT_TARGET_FRAME_WAIT_MS;
 
         // Register the target waiter BEFORE submitting so the output callback always finds it,
         // even if the decoder delivers the frame synchronously during decode(). Reference

--- a/packages/den/video/av1/AV1.test.ts
+++ b/packages/den/video/av1/AV1.test.ts
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { AV1 } from "./AV1";
+import { OBU_TYPE_SHIFT } from "./constants";
+import { AV1FrameType, AV1ObuType } from "./types";
+import AV1FrameBuilder from "../../testing/builders/AV1FrameBuilder";
+
+describe("AV1", () => {
+  it("detects a shown key frame carrying a sequence header", () => {
+    // Given a compliant AV1 keyframe and delta frame
+    const keyframe = AV1FrameBuilder.keyframe();
+    const deltaFrame = AV1FrameBuilder.deltaFrame();
+
+    // When keyframe detection runs
+    // Then only the shown key frame is a keyframe
+    expect(AV1.IsKeyframe(keyframe)).toBe(true);
+    expect(AV1.IsKeyframe(deltaFrame)).toBe(false);
+  });
+
+  it("does not treat a sequence header in front of a delta frame as a keyframe", () => {
+    // Given an inter frame preceded by a repeated sequence header, which AV1 permits
+    const deltaFrame = AV1FrameBuilder.deltaFrameWithSequenceHeader();
+
+    // When keyframe detection runs
+    // Then the frame header, not the sequence header, decides the outcome
+    expect(AV1.IsKeyframe(deltaFrame)).toBe(false);
+  });
+
+  it("rejects frame types that are not random-access points", () => {
+    // Given frames that are intra-only, switch, or merely re-displayed from the reference buffer
+    const frames = [
+      AV1FrameBuilder.frame({ frameType: AV1FrameType.IntraOnlyFrame }),
+      AV1FrameBuilder.frame({ frameType: AV1FrameType.SwitchFrame }),
+      AV1FrameBuilder.frame({ showExistingFrame: true }),
+    ];
+
+    // When each is inspected together with a sequence header
+    // Then none of them qualifies as a keyframe
+    for (const frame of frames) {
+      const data = new Uint8Array([
+        ...AV1FrameBuilder.obu(AV1ObuType.SequenceHeader, AV1FrameBuilder.sequenceHeader()),
+        ...frame,
+      ]);
+      expect(AV1.IsKeyframe(data)).toBe(false);
+    }
+  });
+
+  it("treats a hidden key frame as a random-access point", () => {
+    // Given a forward key frame, i.e. a key frame coded with show_frame = 0 and displayed later
+    const data = new Uint8Array([
+      ...AV1FrameBuilder.obu(AV1ObuType.SequenceHeader, AV1FrameBuilder.sequenceHeader()),
+      ...AV1FrameBuilder.frame({ showFrame: false }),
+    ]);
+
+    // When keyframe detection runs
+    // Then it is still a point the decoder can be started from
+    expect(AV1.IsKeyframe(data)).toBe(true);
+  });
+
+  it("finds a key frame that is not the first frame of the temporal unit", () => {
+    // Given a temporal unit that packs hidden frames ahead of the key frame, as encoders do
+    const data = new Uint8Array([
+      ...AV1FrameBuilder.obu(AV1ObuType.SequenceHeader, AV1FrameBuilder.sequenceHeader()),
+      ...AV1FrameBuilder.frame({ frameType: AV1FrameType.InterFrame, showFrame: false }),
+      ...AV1FrameBuilder.frame(),
+    ]);
+
+    // When keyframe detection runs
+    // Then the whole temporal unit is scanned instead of stopping at its first frame header
+    expect(AV1.IsKeyframe(data)).toBe(true);
+  });
+
+  it("does not mistake a hidden inter frame for a key frame", () => {
+    // Given the common alt-ref layout: hidden inter frames followed by the shown inter frame
+    const data = new Uint8Array([
+      ...AV1FrameBuilder.obu(AV1ObuType.SequenceHeader, AV1FrameBuilder.sequenceHeader()),
+      ...AV1FrameBuilder.frame({ frameType: AV1FrameType.InterFrame, showFrame: false }),
+      ...AV1FrameBuilder.frame({ frameType: AV1FrameType.InterFrame }),
+    ]);
+
+    // When the whole temporal unit is scanned
+    // Then no frame in it is a random-access point
+    expect(AV1.IsKeyframe(data)).toBe(false);
+  });
+
+  it("requires a sequence header for a random-access point", () => {
+    // Given a shown key frame without the sequence header the decoder needs
+    const data = new Uint8Array(AV1FrameBuilder.frame());
+
+    // When keyframe detection runs
+    // Then the temporal unit is not a usable random-access point
+    expect(AV1.IsKeyframe(data)).toBe(false);
+  });
+
+  it("treats a reduced still picture as a keyframe", () => {
+    // Given a still picture, whose frame header codes no fields and implies a shown key frame
+    const data = new Uint8Array([
+      ...AV1FrameBuilder.obu(
+        AV1ObuType.SequenceHeader,
+        AV1FrameBuilder.sequenceHeader({ reducedStillPicture: true }),
+      ),
+      ...AV1FrameBuilder.obu(AV1ObuType.Frame, [0x00]),
+    ]);
+
+    // When it is inspected
+    // Then the implied key frame is detected and the reduced header remains correctly aligned
+    expect(AV1.IsKeyframe(data)).toBe(true);
+    expect(AV1.ParseDecoderConfig(data)).toEqual({
+      codec: "av01.0.05M.08",
+      codedWidth: 640,
+      codedHeight: 480,
+    });
+  });
+
+  it("ignores a temporal unit without a coded frame", () => {
+    // Given a sequence header preceded by a temporal delimiter, but no frame data
+    const data = new Uint8Array([
+      ...AV1FrameBuilder.obu(AV1ObuType.TemporalDelimiter, []),
+      ...AV1FrameBuilder.obu(AV1ObuType.SequenceHeader, AV1FrameBuilder.sequenceHeader()),
+    ]);
+
+    // When keyframe detection runs
+    // Then there is no frame to classify as a keyframe
+    expect(AV1.IsKeyframe(data)).toBe(false);
+  });
+
+  it("derives the WebCodecs configuration from the sequence header", () => {
+    // Given a Main profile, level 3.1, 8-bit 640x480 keyframe
+    const keyframe = AV1FrameBuilder.keyframe();
+
+    // When its decoder configuration is parsed
+    const config = AV1.ParseDecoderConfig(keyframe);
+
+    // Then the codec string and coded dimensions match the sequence header
+    expect(config).toEqual({ codec: "av01.0.05M.08", codedWidth: 640, codedHeight: 480 });
+  });
+
+  it("supports high-tier Professional profile 12-bit streams", () => {
+    // Given a Professional profile, high-tier, 12-bit keyframe
+    const keyframe = AV1FrameBuilder.keyframe({
+      bitDepth: 12,
+      height: 1080,
+      level: 13,
+      profile: 2,
+      tier: 1,
+      width: 1920,
+    });
+
+    // When its decoder configuration is parsed
+    const config = AV1.ParseDecoderConfig(keyframe);
+
+    // Then all mandatory AV1 codec parameters and dimensions are retained
+    expect(config).toEqual({ codec: "av01.2.13H.12", codedWidth: 1920, codedHeight: 1080 });
+  });
+
+  it("parses conditional timing and operating-point fields", () => {
+    // Given a sequence header with decoder timing, initial delay, and two operating points
+    const keyframe = AV1FrameBuilder.keyframe({
+      decoderModel: true,
+      initialDisplayDelay: true,
+      operatingPoints: [
+        { level: 9, tier: 1 },
+        { level: 5, tier: 0 },
+      ],
+      timingInfo: true,
+    });
+
+    // When its decoder configuration is parsed
+    const config = AV1.ParseDecoderConfig(keyframe);
+
+    // Then the first operating point controls the codec string and dimensions stay aligned
+    expect(config).toEqual({ codec: "av01.0.09H.08", codedWidth: 640, codedHeight: 480 });
+  });
+
+  it("supports a final sequence header OBU without an explicit size", () => {
+    // Given a final low-overhead OBU whose payload consumes the rest of the message
+    const data = new Uint8Array([
+      AV1ObuType.SequenceHeader << OBU_TYPE_SHIFT,
+      ...AV1FrameBuilder.sequenceHeader(),
+    ]);
+
+    // When it is parsed
+    const config = AV1.ParseDecoderConfig(data);
+
+    // Then the implicit payload boundary is accepted
+    expect(config).toEqual({ codec: "av01.0.05M.08", codedWidth: 640, codedHeight: 480 });
+  });
+
+  it("accepts an OBU extension header", () => {
+    // Given a sequence header OBU carrying a valid extension header, plus a shown key frame
+    const data = new Uint8Array([
+      ...AV1FrameBuilder.obu(
+        AV1ObuType.SequenceHeader,
+        AV1FrameBuilder.sequenceHeader(),
+        0b0010_1000,
+      ),
+      ...AV1FrameBuilder.frame(),
+    ]);
+
+    // When it is inspected
+    // Then the extension is skipped and the sequence header is parsed normally
+    expect(AV1.IsKeyframe(data)).toBe(true);
+    expect(AV1.ParseDecoderConfig(data)?.codec).toBe("av01.0.05M.08");
+  });
+
+  it("returns no configuration for malformed or truncated OBUs", () => {
+    // Given invalid reserved bits, a truncated size, and a truncated payload
+    const invalidHeader = new Uint8Array([0x0b, 0x00]);
+    const truncatedSize = new Uint8Array([0x0a, 0x80]);
+    const truncatedPayload = new Uint8Array([0x0a, 0x05, 0x00]);
+
+    // When each malformed frame is parsed
+    // Then it is rejected without throwing
+    for (const data of [invalidHeader, truncatedSize, truncatedPayload]) {
+      expect(AV1.IsKeyframe(data)).toBe(false);
+      expect(AV1.ParseDecoderConfig(data)).toBeUndefined();
+    }
+  });
+
+  /**
+   * Byte-exact temporal units captured from libaom-av1, 64x48 8-bit Main profile:
+   *
+   *   ffmpeg -f lavfi -i color=size=64x48:rate=10:duration=2:color=gray \
+   *     -c:v libaom-av1 -cpu-used 8 -crf 63 -f ivf out.ivf                       # key, delta
+   *   ffmpeg -f lavfi -i testsrc=size=64x48:rate=10:duration=2 \
+   *     -c:v libaom-av1 -cpu-used 8 -crf 63 -lag-in-frames 19 -auto-alt-ref 1 \
+   *     -g 20 -f ivf out.ivf                                       # altRef, showExisting
+   *
+   * The synthetic builder writes the same bit order this parser reads, so it cannot catch a
+   * misreading of the specification. These recorded units can: they pin the OBU framing and the
+   * `uncompressed_header()` field order against a conforming encoder, including the alt-ref layout
+   * that packs hidden frames ahead of the shown one in a single temporal unit.
+   */
+  const RECORDED_TEMPORAL_UNITS = {
+    /** Temporal delimiter, sequence header, shown key frame. */
+    key: "12000a0a00000002aff79b5f2008320b1000c98000028000000988",
+    /** Shown inter frame, no sequence header. */
+    delta: "120032113003c080000006ff800002c00020009910",
+    /** Hidden (alt-ref) inter frame followed by the shown inter frame that references it. */
+    altRef: "1200321129035803d42841bec00000b000140093dc321032052407a0e8837fc000016000380098",
+    /** Frame header that only re-displays a frame already held in the reference buffer. */
+    showExisting: "12001a01c8",
+  };
+
+  function recorded(hex: string): Uint8Array {
+    return new Uint8Array((hex.match(/../g) ?? []).map((byte) => parseInt(byte, 16)));
+  }
+
+  it("detects a recorded libaom keyframe and derives its configuration", () => {
+    // Given a temporal unit produced by libaom-av1
+    const data = recorded(RECORDED_TEMPORAL_UNITS.key);
+
+    // When it is inspected
+    // Then the recorded sequence header and key frame are read exactly as the encoder wrote them
+    expect(AV1.IsKeyframe(data)).toBe(true);
+    expect(AV1.ParseDecoderConfig(data)).toEqual({
+      codec: "av01.0.00M.08",
+      codedWidth: 64,
+      codedHeight: 48,
+    });
+  });
+
+  it("rejects recorded libaom temporal units that are not random-access points", () => {
+    // Given recorded delta, alt-ref, and re-display temporal units
+    const units = [
+      RECORDED_TEMPORAL_UNITS.delta,
+      RECORDED_TEMPORAL_UNITS.altRef,
+      RECORDED_TEMPORAL_UNITS.showExisting,
+    ];
+
+    // When each is inspected
+    // Then none is treated as a keyframe and none carries a decoder configuration
+    for (const hex of units) {
+      const data = recorded(hex);
+      expect(AV1.IsKeyframe(data)).toBe(false);
+      expect(AV1.ParseDecoderConfig(data)).toBeUndefined();
+    }
+  });
+});

--- a/packages/den/video/av1/AV1.test.ts
+++ b/packages/den/video/av1/AV1.test.ts
@@ -281,4 +281,38 @@ describe("AV1", () => {
       expect(AV1.ParseDecoderConfig(data)).toBeUndefined();
     }
   });
+
+  it.each([0, 1, 2] as const)("accepts valid sequence profile %i", (seqProfile) => {
+    // Given a sequence header with a valid sequence profile
+    const seqHeaderWithProfile = AV1FrameBuilder.sequenceHeader({ profile: seqProfile });
+    const data = new Uint8Array([
+      ...AV1FrameBuilder.obu(AV1ObuType.SequenceHeader, seqHeaderWithProfile),
+      ...AV1FrameBuilder.frame(),
+    ]);
+
+    // When its decoder configuration is parsed
+    const config = AV1.ParseDecoderConfig(data);
+
+    // Then a valid configuration is returned
+    expect(config).toBeDefined();
+    expect(config?.codec).toBe(`av01.${seqProfile}.05M.08`);
+  });
+
+  it.each([3, 4, 5, 6, 7])("rejects reserved sequence profile %i", (seqProfile) => {
+    // Given a sequence header with a reserved sequence profile
+    const seqHeaderWithProfile = AV1FrameBuilder.sequenceHeader();
+    // Set the raw `seq_profile` value (the most significant 3 bits) directly
+    // because reserved values are not valid builder options.
+    seqHeaderWithProfile[0] = (seqHeaderWithProfile[0]! & 0b0001_1111) | (seqProfile << 5);
+    const data = new Uint8Array([
+      ...AV1FrameBuilder.obu(AV1ObuType.SequenceHeader, seqHeaderWithProfile),
+      ...AV1FrameBuilder.frame(),
+    ]);
+
+    // When its decoder configuration is parsed
+    const config = AV1.ParseDecoderConfig(data);
+
+    // Then no configuration is returned
+    expect(config).toBeUndefined();
+  });
 });

--- a/packages/den/video/av1/AV1.ts
+++ b/packages/den/video/av1/AV1.ts
@@ -287,65 +287,74 @@ function parseFrameHeader(
   return { frameType: bits.read(2), showExistingFrame: false };
 }
 
-function parseSequenceHeader(data: Uint8Array): AV1SequenceHeader {
-  const bits = new BitReader(data);
-  const profile = bits.read(3);
-  bits.skip(1); // still_picture
-  const reducedStillPictureHeader = bits.read(1) === 1;
+function readTimingAndDecoderModelInfo(bits: BitReader): {
+  bufferDelayLength: number;
+  decoderModelInfoPresent: boolean;
+} {
+  const timingInfoPresent = bits.read(1) === 1;
+  if (!timingInfoPresent) {
+    return { bufferDelayLength: 0, decoderModelInfoPresent: false };
+  }
 
-  let decoderModelInfoPresent = false;
-  let bufferDelayLength = 0;
-  let initialDisplayDelayPresent = false;
-  let operatingPointsCount = 1;
+  bits.skip(32); // num_units_in_display_tick
+  bits.skip(32); // time_scale
+  const equalPictureInterval = bits.read(1) === 1;
+  if (equalPictureInterval) {
+    bits.readUnsignedVariableLength();
+  }
+
+  const decoderModelInfoPresent = bits.read(1) === 1;
+  if (!decoderModelInfoPresent) {
+    return { bufferDelayLength: 0, decoderModelInfoPresent: false };
+  }
+
+  const bufferDelayLength = bits.read(5) + 1;
+  bits.skip(32); // num_units_in_decoding_tick
+  bits.skip(5); // buffer_removal_time_length_minus_1
+  bits.skip(5); // frame_presentation_time_length_minus_1
+  return { bufferDelayLength, decoderModelInfoPresent };
+}
+
+function readOperatingPoints(
+  bits: BitReader,
+  {
+    bufferDelayLength,
+    decoderModelInfoPresent,
+  }: {
+    bufferDelayLength: number;
+    decoderModelInfoPresent: boolean;
+  },
+): Pick<AV1SequenceHeader, "level" | "tier"> {
+  const initialDisplayDelayPresent = bits.read(1) === 1;
+  const operatingPointsCount = bits.read(5) + 1;
   let level = 0;
   let tier = 0;
 
-  if (reducedStillPictureHeader) {
-    level = bits.read(5);
-  } else {
-    const timingInfoPresent = bits.read(1) === 1;
-    if (timingInfoPresent) {
-      bits.skip(32); // num_units_in_display_tick
-      bits.skip(32); // time_scale
-      const equalPictureInterval = bits.read(1) === 1;
-      if (equalPictureInterval) {
-        bits.readUnsignedVariableLength();
-      }
-      decoderModelInfoPresent = bits.read(1) === 1;
-      if (decoderModelInfoPresent) {
-        bufferDelayLength = bits.read(5) + 1;
-        bits.skip(32); // num_units_in_decoding_tick
-        bits.skip(5); // buffer_removal_time_length_minus_1
-        bits.skip(5); // frame_presentation_time_length_minus_1
-      }
+  for (let i = 0; i < operatingPointsCount; i++) {
+    bits.skip(12); // operating_point_idc
+    const operatingPointLevel = bits.read(5);
+    const operatingPointTier = operatingPointLevel > 7 ? bits.read(1) : 0;
+    if (i === 0) {
+      level = operatingPointLevel;
+      tier = operatingPointTier;
     }
-
-    initialDisplayDelayPresent = bits.read(1) === 1;
-    operatingPointsCount = bits.read(5) + 1;
-    for (let i = 0; i < operatingPointsCount; i++) {
-      bits.skip(12); // operating_point_idc
-      const operatingPointLevel = bits.read(5);
-      const operatingPointTier = operatingPointLevel > 7 ? bits.read(1) : 0;
-      if (i === 0) {
-        level = operatingPointLevel;
-        tier = operatingPointTier;
-      }
-      if (decoderModelInfoPresent && bits.read(1) === 1) {
-        bits.skip(bufferDelayLength); // decoder_buffer_delay
-        bits.skip(bufferDelayLength); // encoder_buffer_delay
-        bits.skip(1); // low_delay_mode_flag
-      }
-      if (initialDisplayDelayPresent && bits.read(1) === 1) {
-        bits.skip(4); // initial_display_delay_minus_1
-      }
+    if (decoderModelInfoPresent && bits.read(1) === 1) {
+      bits.skip(bufferDelayLength); // decoder_buffer_delay
+      bits.skip(bufferDelayLength); // encoder_buffer_delay
+      bits.skip(1); // low_delay_mode_flag
+    }
+    if (initialDisplayDelayPresent && bits.read(1) === 1) {
+      bits.skip(4); // initial_display_delay_minus_1
     }
   }
 
-  const frameWidthBits = bits.read(4) + 1;
-  const frameHeightBits = bits.read(4) + 1;
-  const codedWidth = bits.read(frameWidthBits) + 1;
-  const codedHeight = bits.read(frameHeightBits) + 1;
+  return { level, tier };
+}
 
+function skipSequenceFeatureFlags(
+  bits: BitReader,
+  { reducedStillPictureHeader }: { reducedStillPictureHeader: boolean },
+): void {
   if (!reducedStillPictureHeader && bits.read(1) === 1) {
     bits.skip(4); // delta_frame_id_length_minus_2
     bits.skip(3); // additional_frame_id_length_minus_1
@@ -353,27 +362,52 @@ function parseSequenceHeader(data: Uint8Array): AV1SequenceHeader {
 
   bits.skip(3); // use_128x128_superblock, enable_filter_intra, enable_intra_edge_filter
   if (reducedStillPictureHeader) {
-    // Reduced headers imply the remaining inter-frame feature flags.
-  } else {
-    bits.skip(4); // interintra, masked compound, warped motion, dual filter
-    const enableOrderHint = bits.read(1) === 1;
-    if (enableOrderHint) {
-      bits.skip(2); // enable_jnt_comp, enable_ref_frame_mvs
-    }
-    const chooseScreenContentTools = bits.read(1) === 1;
-    const forceScreenContentTools = chooseScreenContentTools ? 2 : bits.read(1);
-    if (forceScreenContentTools > 0) {
-      const chooseIntegerMv = bits.read(1) === 1;
-      if (!chooseIntegerMv) {
-        bits.skip(1); // seq_force_integer_mv
-      }
-    }
-    if (enableOrderHint) {
-      bits.skip(3); // order_hint_bits_minus_1
-    }
+    bits.skip(3); // enable_superres, enable_cdef, enable_restoration
+    return;
   }
 
+  bits.skip(4); // interintra, masked compound, warped motion, dual filter
+  const enableOrderHint = bits.read(1) === 1;
+  if (enableOrderHint) {
+    bits.skip(2); // enable_jnt_comp, enable_ref_frame_mvs
+  }
+  const chooseScreenContentTools = bits.read(1) === 1;
+  const forceScreenContentTools = chooseScreenContentTools ? 2 : bits.read(1);
+  if (forceScreenContentTools > 0) {
+    const chooseIntegerMv = bits.read(1) === 1;
+    if (!chooseIntegerMv) {
+      bits.skip(1); // seq_force_integer_mv
+    }
+  }
+  if (enableOrderHint) {
+    bits.skip(3); // order_hint_bits_minus_1
+  }
   bits.skip(3); // enable_superres, enable_cdef, enable_restoration
+}
+
+function parseSequenceHeader(data: Uint8Array): AV1SequenceHeader {
+  const bits = new BitReader(data);
+  const profile = bits.read(3);
+  bits.skip(1); // still_picture
+  const reducedStillPictureHeader = bits.read(1) === 1;
+
+  let level: number;
+  let tier: number;
+
+  if (reducedStillPictureHeader) {
+    level = bits.read(5);
+    tier = 0;
+  } else {
+    const decoderModelInfo = readTimingAndDecoderModelInfo(bits);
+    ({ level, tier } = readOperatingPoints(bits, decoderModelInfo));
+  }
+
+  const frameWidthBits = bits.read(4) + 1;
+  const frameHeightBits = bits.read(4) + 1;
+  const codedWidth = bits.read(frameWidthBits) + 1;
+  const codedHeight = bits.read(frameHeightBits) + 1;
+
+  skipSequenceFeatureFlags(bits, { reducedStillPictureHeader });
   const highBitdepth = bits.read(1) === 1;
   let bitDepth = highBitdepth ? 10 : 8;
   if (profile === AV1_PROFILE_PROFESSIONAL && highBitdepth && bits.read(1) === 1) {

--- a/packages/den/video/av1/AV1.ts
+++ b/packages/den/video/av1/AV1.ts
@@ -155,6 +155,10 @@ export class AV1 {
 
     try {
       const parsed = parseSequenceHeader(sequenceHeader);
+      if (parsed.profile > AV1_PROFILE_PROFESSIONAL) {
+        // Section 6.4.1 of the AV1 specification reserves `seq_profile` values 3 through 7.
+        return undefined;
+      }
       const tier = parsed.tier === 0 ? AV1_MAIN_TIER : AV1_HIGH_TIER;
       const level = parsed.level.toString().padStart(AV1_CODEC_FIELD_DIGITS, "0");
       const bitDepth = parsed.bitDepth.toString().padStart(AV1_CODEC_FIELD_DIGITS, "0");

--- a/packages/den/video/av1/AV1.ts
+++ b/packages/den/video/av1/AV1.ts
@@ -1,0 +1,380 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  AV1_CODEC_FIELD_DIGITS,
+  AV1_CODEC_PREFIX,
+  AV1_HIGH_TIER,
+  AV1_MAIN_TIER,
+  AV1_PROFILE_PROFESSIONAL,
+  LEB128_CONTINUATION_FLAG,
+  LEB128_MAX_BYTES,
+  LEB128_PAYLOAD_BITS,
+  LEB128_PAYLOAD_MASK,
+  OBU_EXTENSION_FLAG,
+  OBU_EXTENSION_MUST_BE_ZERO_MASK,
+  OBU_HAS_SIZE_FLAG,
+  OBU_HEADER_MUST_BE_ZERO_MASK,
+  OBU_TYPE_MASK,
+  OBU_TYPE_SHIFT,
+  UVLC_ESCAPE_VALUE,
+  UVLC_MAX_LEADING_ZEROS,
+} from "./constants";
+import { AV1FrameType, AV1ObuType } from "./types";
+
+type AV1Obu = {
+  payload: Uint8Array;
+  type: number;
+};
+
+/**
+ * The leading fields of `uncompressed_header()` that identify a frame. `frameType` is undefined for
+ * a re-displayed frame, which codes no `frame_type` of its own.
+ */
+type AV1FrameHeader = {
+  frameType: number | undefined;
+  showExistingFrame: boolean;
+};
+
+type AV1SequenceHeader = {
+  bitDepth: number;
+  codedHeight: number;
+  codedWidth: number;
+  level: number;
+  profile: number;
+  tier: number;
+};
+
+class BitReader {
+  readonly #data: Uint8Array;
+  #offset = 0;
+
+  public constructor(data: Uint8Array) {
+    this.#data = data;
+  }
+
+  public read(width: number): number {
+    if (width < 0 || width > 32 || this.#offset + width > this.#data.byteLength * 8) {
+      throw new Error("AV1 bitstream exhausted");
+    }
+
+    let value = 0;
+    for (let i = 0; i < width; i++) {
+      // Read bits most-significant-bit first from each 8-bit byte.
+      const byte = this.#data[this.#offset >> 3]!;
+      value = value * 2 + ((byte >> (7 - (this.#offset & 7))) & 1);
+      this.#offset++;
+    }
+    return value;
+  }
+
+  public skip(width: number): void {
+    this.read(width);
+  }
+
+  public readUnsignedVariableLength(): number {
+    let leadingZeros = 0;
+    while (this.read(1) === 0) {
+      leadingZeros++;
+      if (leadingZeros >= UVLC_MAX_LEADING_ZEROS) {
+        return UVLC_ESCAPE_VALUE;
+      }
+    }
+    return 2 ** leadingZeros - 1 + this.read(leadingZeros);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export class AV1 {
+  /**
+   * Returns whether the temporal unit is a random-access point, i.e. whether a decoder can be
+   * started from this message alone. That requires both:
+   *
+   * - a Sequence Header OBU, without which the decoder cannot be configured. Foxglove requires
+   *   every AV1 keyframe message to carry one, and
+   * - a coded key frame, i.e. a frame header with `show_existing_frame == 0` and
+   *   `frame_type == KEY_FRAME` (AV1 specification sections 5.9.2 and 6.8.2). A key frame
+   *   refreshes every reference frame slot, so decoding can begin at the temporal unit holding it.
+   *
+   * `show_frame` is deliberately not part of the condition. A key frame coded with
+   * `show_frame == 0` (a "forward key frame", displayed later by a `show_existing_frame` temporal
+   * unit) is still an independently decodable start point, which is exactly what both consumers of
+   * this predicate need: the WebCodecs chunk type, where `key` means "decoding may start here",
+   * and the GOP anchor used by seek backfill and queue filtering.
+   *
+   * A Sequence Header OBU alone is not sufficient evidence: the specification permits sequence
+   * headers to be repeated ahead of delta frames, so keying off their presence would mislabel
+   * inter frames as keyframes and submit them to WebCodecs as key chunks.
+   */
+  public static IsKeyframe(data: Uint8Array): boolean {
+    try {
+      let hasSequenceHeader = false;
+      let reducedStillPictureHeader = false;
+
+      for (const obu of parseObus(data)) {
+        if (obu.type === AV1ObuType.SequenceHeader) {
+          hasSequenceHeader = true;
+          reducedStillPictureHeader = readReducedStillPictureHeader(obu.payload);
+          continue;
+        }
+
+        // Every frame header in the temporal unit is inspected, not just the first: encoders pack
+        // hidden frames ahead of the shown one in a single temporal unit, so the key frame is not
+        // necessarily first. Walking the rest of the unit only follows the explicit OBU sizes and
+        // reads at most three bits per frame header, so the extra work is negligible.
+        // OBU_FRAME embeds a frame header ahead of its tile group, and OBU_REDUNDANT_FRAME_HEADER
+        // repeats a preceding one, which cannot change the outcome.
+        if (obu.type === AV1ObuType.FrameHeader || obu.type === AV1ObuType.Frame) {
+          const header = parseFrameHeader(obu.payload, { reducedStillPictureHeader });
+          if (
+            hasSequenceHeader &&
+            !header.showExistingFrame &&
+            header.frameType === AV1FrameType.KeyFrame
+          ) {
+            return true;
+          }
+        }
+      }
+    } catch {
+      return false;
+    }
+
+    // No sequence header, or no coded key frame: not a point the decoder can be started from.
+    return false;
+  }
+
+  public static ParseDecoderConfig(data: Uint8Array): VideoDecoderConfig | undefined {
+    const sequenceHeader = AV1.GetSequenceHeader(data);
+    if (sequenceHeader == undefined) {
+      return undefined;
+    }
+
+    try {
+      const parsed = parseSequenceHeader(sequenceHeader);
+      const tier = parsed.tier === 0 ? AV1_MAIN_TIER : AV1_HIGH_TIER;
+      const level = parsed.level.toString().padStart(AV1_CODEC_FIELD_DIGITS, "0");
+      const bitDepth = parsed.bitDepth.toString().padStart(AV1_CODEC_FIELD_DIGITS, "0");
+      return {
+        codec: `${AV1_CODEC_PREFIX}.${parsed.profile}.${level}${tier}.${bitDepth}`,
+        codedWidth: parsed.codedWidth,
+        codedHeight: parsed.codedHeight,
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  private static GetSequenceHeader(data: Uint8Array): Uint8Array | undefined {
+    try {
+      for (const obu of parseObus(data)) {
+        if (obu.type === AV1ObuType.SequenceHeader) {
+          return obu.payload;
+        }
+      }
+    } catch {
+      return undefined;
+    }
+    return undefined;
+  }
+}
+
+function* parseObus(data: Uint8Array): Iterable<AV1Obu> {
+  let offset = 0;
+  while (offset < data.byteLength) {
+    const header = data[offset++];
+    if (header == undefined || (header & OBU_HEADER_MUST_BE_ZERO_MASK) !== 0) {
+      throw new Error("Invalid AV1 OBU header");
+    }
+
+    const type = (header >> OBU_TYPE_SHIFT) & OBU_TYPE_MASK;
+    const hasExtension = (header & OBU_EXTENSION_FLAG) !== 0;
+    const hasSize = (header & OBU_HAS_SIZE_FLAG) !== 0;
+    if (hasExtension) {
+      const extension = data[offset++];
+      if (extension == undefined || (extension & OBU_EXTENSION_MUST_BE_ZERO_MASK) !== 0) {
+        throw new Error("Invalid AV1 OBU extension header");
+      }
+    }
+
+    let payloadSize = data.byteLength - offset;
+    if (hasSize) {
+      const decoded = readLeb128(data, offset);
+      payloadSize = decoded.value;
+      offset = decoded.nextOffset;
+    }
+    if (payloadSize > data.byteLength - offset) {
+      throw new Error("Truncated AV1 OBU payload");
+    }
+
+    const payloadEnd = offset + payloadSize;
+    yield { payload: data.subarray(offset, payloadEnd), type };
+    offset = payloadEnd;
+
+    // Without an explicit size, the final OBU consumes the remainder of the temporal unit.
+    if (!hasSize) {
+      return;
+    }
+  }
+}
+
+function readLeb128(data: Uint8Array, offset: number): { nextOffset: number; value: number } {
+  let value = 0;
+  let nextOffset = offset;
+  for (let byteIndex = 0; byteIndex < LEB128_MAX_BYTES; byteIndex++) {
+    const byte = data[nextOffset++];
+    if (byte == undefined) {
+      throw new Error("Truncated AV1 LEB128 value");
+    }
+    value += (byte & LEB128_PAYLOAD_MASK) * 2 ** (byteIndex * LEB128_PAYLOAD_BITS);
+    if (!Number.isSafeInteger(value)) {
+      throw new Error("AV1 OBU size exceeds safe integer range");
+    }
+    if ((byte & LEB128_CONTINUATION_FLAG) === 0) {
+      return { nextOffset, value };
+    }
+  }
+  throw new Error("Invalid AV1 LEB128 value");
+}
+
+/**
+ * Reads `reduced_still_picture_header` from a Sequence Header OBU (AV1 specification section
+ * 5.5.1). Only the three leading fields are decoded, keeping the per-message cost of keyframe
+ * detection at a handful of bits instead of a full sequence header parse.
+ */
+function readReducedStillPictureHeader(data: Uint8Array): boolean {
+  const bits = new BitReader(data);
+  bits.skip(3); // seq_profile
+  bits.skip(1); // still_picture
+  return bits.read(1) === 1;
+}
+
+/**
+ * Parses the leading fields of `uncompressed_header()` (AV1 specification section 5.9.2), which
+ * codes `show_existing_frame` f(1) and then, only when it is 0, `frame_type` f(2). Decoding stops
+ * there because nothing beyond it identifies the frame.
+ *
+ * The conditional fields of that syntax structure cannot shift those bits: `temporal_point_info()`
+ * and `display_frame_id` — the fields gated on `decoder_model_info_present_flag` and
+ * `frame_id_numbers_present_flag` — sit inside the `show_existing_frame == 1` branch, which ends
+ * in a `return`, and the branch infers `frame_type` from `RefFrameType[frame_to_show_map_idx]`
+ * instead of reading it. On the path this function reads, the two fields are therefore always
+ * adjacent, and no sequence header state beyond `reduced_still_picture_header` is needed.
+ */
+function parseFrameHeader(
+  data: Uint8Array,
+  { reducedStillPictureHeader }: { reducedStillPictureHeader: boolean },
+): AV1FrameHeader {
+  // A reduced still picture header codes none of these fields; it implies a single shown key frame.
+  if (reducedStillPictureHeader) {
+    return { frameType: AV1FrameType.KeyFrame, showExistingFrame: false };
+  }
+
+  const bits = new BitReader(data);
+  if (bits.read(1) === 1) {
+    // A frame re-displayed from the reference buffer codes no frame_type of its own, and it is not
+    // independently decodable: the frame it displays was decoded by an earlier temporal unit.
+    return { frameType: undefined, showExistingFrame: true };
+  }
+
+  return { frameType: bits.read(2), showExistingFrame: false };
+}
+
+function parseSequenceHeader(data: Uint8Array): AV1SequenceHeader {
+  const bits = new BitReader(data);
+  const profile = bits.read(3);
+  bits.skip(1); // still_picture
+  const reducedStillPictureHeader = bits.read(1) === 1;
+
+  let decoderModelInfoPresent = false;
+  let bufferDelayLength = 0;
+  let initialDisplayDelayPresent = false;
+  let operatingPointsCount = 1;
+  let level = 0;
+  let tier = 0;
+
+  if (reducedStillPictureHeader) {
+    level = bits.read(5);
+  } else {
+    const timingInfoPresent = bits.read(1) === 1;
+    if (timingInfoPresent) {
+      bits.skip(32); // num_units_in_display_tick
+      bits.skip(32); // time_scale
+      const equalPictureInterval = bits.read(1) === 1;
+      if (equalPictureInterval) {
+        bits.readUnsignedVariableLength();
+      }
+      decoderModelInfoPresent = bits.read(1) === 1;
+      if (decoderModelInfoPresent) {
+        bufferDelayLength = bits.read(5) + 1;
+        bits.skip(32); // num_units_in_decoding_tick
+        bits.skip(5); // buffer_removal_time_length_minus_1
+        bits.skip(5); // frame_presentation_time_length_minus_1
+      }
+    }
+
+    initialDisplayDelayPresent = bits.read(1) === 1;
+    operatingPointsCount = bits.read(5) + 1;
+    for (let i = 0; i < operatingPointsCount; i++) {
+      bits.skip(12); // operating_point_idc
+      const operatingPointLevel = bits.read(5);
+      const operatingPointTier = operatingPointLevel > 7 ? bits.read(1) : 0;
+      if (i === 0) {
+        level = operatingPointLevel;
+        tier = operatingPointTier;
+      }
+      if (decoderModelInfoPresent && bits.read(1) === 1) {
+        bits.skip(bufferDelayLength); // decoder_buffer_delay
+        bits.skip(bufferDelayLength); // encoder_buffer_delay
+        bits.skip(1); // low_delay_mode_flag
+      }
+      if (initialDisplayDelayPresent && bits.read(1) === 1) {
+        bits.skip(4); // initial_display_delay_minus_1
+      }
+    }
+  }
+
+  const frameWidthBits = bits.read(4) + 1;
+  const frameHeightBits = bits.read(4) + 1;
+  const codedWidth = bits.read(frameWidthBits) + 1;
+  const codedHeight = bits.read(frameHeightBits) + 1;
+
+  if (!reducedStillPictureHeader && bits.read(1) === 1) {
+    bits.skip(4); // delta_frame_id_length_minus_2
+    bits.skip(3); // additional_frame_id_length_minus_1
+  }
+
+  bits.skip(3); // use_128x128_superblock, enable_filter_intra, enable_intra_edge_filter
+  if (reducedStillPictureHeader) {
+    // Reduced headers imply the remaining inter-frame feature flags.
+  } else {
+    bits.skip(4); // interintra, masked compound, warped motion, dual filter
+    const enableOrderHint = bits.read(1) === 1;
+    if (enableOrderHint) {
+      bits.skip(2); // enable_jnt_comp, enable_ref_frame_mvs
+    }
+    const chooseScreenContentTools = bits.read(1) === 1;
+    const forceScreenContentTools = chooseScreenContentTools ? 2 : bits.read(1);
+    if (forceScreenContentTools > 0) {
+      const chooseIntegerMv = bits.read(1) === 1;
+      if (!chooseIntegerMv) {
+        bits.skip(1); // seq_force_integer_mv
+      }
+    }
+    if (enableOrderHint) {
+      bits.skip(3); // order_hint_bits_minus_1
+    }
+  }
+
+  bits.skip(3); // enable_superres, enable_cdef, enable_restoration
+  const highBitdepth = bits.read(1) === 1;
+  let bitDepth = highBitdepth ? 10 : 8;
+  if (profile === AV1_PROFILE_PROFESSIONAL && highBitdepth && bits.read(1) === 1) {
+    bitDepth = 12;
+  }
+
+  return { bitDepth, codedHeight, codedWidth, level, profile, tier };
+}

--- a/packages/den/video/av1/constants.ts
+++ b/packages/den/video/av1/constants.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * Bit layout of the OBU header byte (AV1 specification section 5.3.2):
+ * `obu_forbidden_bit` f(1), `obu_type` f(4), `obu_extension_flag` f(1), `obu_has_size_field` f(1),
+ * `obu_reserved_1bit` f(1).
+ */
+export const OBU_HEADER_MUST_BE_ZERO_MASK = 0x81;
+export const OBU_TYPE_SHIFT = 3;
+export const OBU_TYPE_MASK = 0x0f;
+export const OBU_EXTENSION_FLAG = 0x04;
+export const OBU_HAS_SIZE_FLAG = 0x02;
+
+/** Reserved bits of `obu_extension_header()` (AV1 specification section 5.3.3). */
+export const OBU_EXTENSION_MUST_BE_ZERO_MASK = 0x07;
+
+/** `leb128()` encodes at most eight bytes, seven payload bits each (section 4.10.5). */
+export const LEB128_MAX_BYTES = 8;
+export const LEB128_CONTINUATION_FLAG = 0x80;
+export const LEB128_PAYLOAD_MASK = 0x7f;
+export const LEB128_PAYLOAD_BITS = 7;
+
+/**
+ * `uvlc()` returns `(1 << 32) - 1` once it has read 32 leading zeros, rather than continuing to
+ * read a value that cannot be represented (section 4.10.3).
+ */
+export const UVLC_MAX_LEADING_ZEROS = 32;
+export const UVLC_ESCAPE_VALUE = 0xffffffff;
+
+/**
+ * Pieces of the WebCodecs AV1 codec string `av01.<profile>.<level><tier>.<bitDepth>`, whose level
+ * and bit depth fields are two digits each.
+ */
+export const AV1_CODEC_PREFIX = "av01";
+export const AV1_CODEC_FIELD_DIGITS = 2;
+export const AV1_MAIN_TIER = "M";
+export const AV1_HIGH_TIER = "H";
+
+/** `seq_profile` value of the Professional profile, the only one that can code 12-bit streams. */
+export const AV1_PROFILE_PROFESSIONAL = 2;

--- a/packages/den/video/av1/index.ts
+++ b/packages/den/video/av1/index.ts
@@ -5,8 +5,5 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-export * from "./codec";
-export * from "./h264";
-export * from "./h265";
-export * from "./av1";
-export * from "./VideoPlayer";
+export * from "./AV1";
+export * from "./types";

--- a/packages/den/video/av1/types.ts
+++ b/packages/den/video/av1/types.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * `obu_type` values of the AV1 Open Bitstream Unit header (AV1 specification section 6.2.2).
+ */
+export enum AV1ObuType {
+  SequenceHeader = 1,
+  TemporalDelimiter = 2,
+  FrameHeader = 3,
+  TileGroup = 4,
+  Metadata = 5,
+  Frame = 6,
+  RedundantFrameHeader = 7,
+  TileList = 8,
+  Padding = 15,
+}
+
+/**
+ * `frame_type` values of the AV1 uncompressed header (AV1 specification section 6.8.2). Only
+ * `KeyFrame` resets every reference frame slot and is therefore a random-access point.
+ */
+export enum AV1FrameType {
+  KeyFrame = 0,
+  InterFrame = 1,
+  IntraOnlyFrame = 2,
+  SwitchFrame = 3,
+}

--- a/packages/den/video/codec.test.ts
+++ b/packages/den/video/codec.test.ts
@@ -5,6 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { AV1 } from "./av1";
 import {
   VideoCodec,
   canonicalVideoCodec,
@@ -20,6 +21,13 @@ afterEach(() => {
 });
 
 describe("canonicalVideoCodec", () => {
+  it("maps 'av1' to AV1", () => {
+    // GIVEN the AV1 format string
+    // WHEN canonicalVideoCodec normalizes it
+    // THEN it maps to the AV1 canonical codec
+    expect(canonicalVideoCodec("av1")).toBe(VideoCodec.AV1);
+  });
+
   it("maps H.265 codec-string prefixes to H265", () => {
     // GIVEN codec strings that start with known H.265 identifiers
     // WHEN canonicalVideoCodec normalizes them
@@ -77,12 +85,21 @@ describe("isVideoKeyframe", () => {
     expect(spy).toHaveBeenCalledWith(data);
   });
 
+  it("dispatches to the AV1 parser for av1", () => {
+    const spy = jest.spyOn(AV1, "IsKeyframe").mockReturnValue(true);
+    const data = new Uint8Array([0x0a]);
+    expect(isVideoKeyframe("av1", data)).toBe(true);
+    expect(spy).toHaveBeenCalledWith(data);
+  });
+
   it("returns false for unrecognized formats without consulting any parser", () => {
     const h264Spy = jest.spyOn(H264, "IsKeyframe");
     const h265Spy = jest.spyOn(H265, "IsKeyframe");
+    const av1Spy = jest.spyOn(AV1, "IsKeyframe");
     expect(isVideoKeyframe("vp9", new Uint8Array([0x01]))).toBe(false);
     expect(h264Spy).not.toHaveBeenCalled();
     expect(h265Spy).not.toHaveBeenCalled();
+    expect(av1Spy).not.toHaveBeenCalled();
   });
 });
 
@@ -90,6 +107,7 @@ describe("videoCodecNeedsKeyframeReplay", () => {
   it("is true only for codecs that cannot decode a delta frame in isolation", () => {
     expect(videoCodecNeedsKeyframeReplay(VideoCodec.H265)).toBe(true);
     expect(videoCodecNeedsKeyframeReplay(VideoCodec.H264)).toBe(false);
+    expect(videoCodecNeedsKeyframeReplay(VideoCodec.AV1)).toBe(true);
     expect(videoCodecNeedsKeyframeReplay(undefined)).toBe(false);
   });
 });
@@ -101,6 +119,7 @@ describe("videoCodecNeedsSeekBackfill", () => {
     // picture, so backfill is required at the player/source boundary.
     expect(videoCodecNeedsSeekBackfill(VideoCodec.H264)).toBe(true);
     expect(videoCodecNeedsSeekBackfill(VideoCodec.H265)).toBe(true);
+    expect(videoCodecNeedsSeekBackfill(VideoCodec.AV1)).toBe(true);
     expect(videoCodecNeedsSeekBackfill(undefined)).toBe(false);
   });
 });

--- a/packages/den/video/codec.ts
+++ b/packages/den/video/codec.ts
@@ -5,17 +5,18 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { AV1 as AV1Parser } from "./av1";
 import { H265_CODEC_FORMAT_STRINGS } from "./constants";
 import { H264 as H264Parser } from "./h264";
 import { H265 as H265Parser } from "./h265";
 
 /**
- * Canonical codec identifier used internally so callers do not need to know that some recordings
- * tag H.265 streams as "hevc" while others tag them as "h265".
+ * Canonical codec identifier used internally so callers do not need to handle external aliases.
  */
 export enum VideoCodec {
   H264 = "h264",
   H265 = "h265",
+  AV1 = "av1",
 }
 
 /**
@@ -23,6 +24,10 @@ export enum VideoCodec {
  * undefined if the format is not a recognized video codec.
  */
 export function canonicalVideoCodec(format: string): VideoCodec | undefined {
+  if (format === "av1") {
+    return VideoCodec.AV1;
+  }
+
   if (H265_CODEC_FORMAT_STRINGS.some((substr) => format.startsWith(substr))) {
     return VideoCodec.H265;
   }
@@ -49,6 +54,8 @@ export function isVideoKeyframe(
       return H264Parser.IsKeyframe(data);
     case VideoCodec.H265:
       return H265Parser.IsKeyframe(data);
+    case VideoCodec.AV1:
+      return AV1Parser.IsKeyframe(data);
   }
   return false;
 }
@@ -57,23 +64,18 @@ export function isVideoKeyframe(
  * Codecs whose non-keyframes can only be decoded by replaying the full GOP (the most recent
  * keyframe plus every frame after it). For these we cannot decode from the latest frame alone.
  *
- * This gates the in-renderable queue + drain serialization. H.265 needs it because the decoder
- * holds many submitted chunks in its pipeline before emitting the target frame, so the renderable
- * must drive submission in order. H.264, by contrast, emits a decoded VideoFrame within ~2 ms and
- * can run its `#startDecode` calls in parallel — serializing it through the drain queue adds
- * per-frame latency that surfaces as 30 fps jank. Use {@link videoCodecNeedsSeekBackfill} (not
- * this predicate) when deciding whether a seek target needs its preceding GOP attached: both
- * H.264 and H.265 P-frames require the GOP for a correct seek, but only H.265 needs the
- * renderable's queue to drive submission order during normal playback.
+ * This gates the in-renderable GOP history used to replay a dependency chain after decoder resets.
+ * AV1 and H.265 may buffer several submitted chunks before emitting the target frame. H.264 emits
+ * promptly and only needs source-side seek backfill, not an additional in-renderable history.
  */
 export function videoCodecNeedsKeyframeReplay(codec: VideoCodec | undefined): boolean {
-  return codec === VideoCodec.H265;
+  return codec === VideoCodec.H265 || codec === VideoCodec.AV1;
 }
 
 /**
  * Codecs whose seek target may be a P-frame that cannot be decoded without first replaying the
- * preceding GOP (most recent keyframe → target). Both H.264 and H.265 have inter-frame
- * dependencies, so for either codec a seek that lands on a non-keyframe needs the keyframe and
+ * preceding GOP (most recent keyframe → target). AV1, H.264, and H.265 have inter-frame
+ * dependencies, so a seek that lands on a non-keyframe needs the keyframe and
  * every intervening P-frame attached. Without this, a forward seek to a P-frame produces garbled
  * decoder output (stale reference state) and a backward seek waits seconds for the next IDR
  * before any picture appears.
@@ -83,5 +85,5 @@ export function videoCodecNeedsKeyframeReplay(codec: VideoCodec | undefined): bo
  * codec-specific performance trade-off inside the renderable.
  */
 export function videoCodecNeedsSeekBackfill(codec: VideoCodec | undefined): boolean {
-  return codec === VideoCodec.H264 || codec === VideoCodec.H265;
+  return codec === VideoCodec.H264 || codec === VideoCodec.H265 || codec === VideoCodec.AV1;
 }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -6,6 +6,7 @@
 import * as THREE from "three";
 
 import { PinholeCameraModel } from "@lichtblick/den/image";
+import AV1FrameBuilder from "@lichtblick/den/testing/builders/AV1FrameBuilder";
 import { H265SliceType, VideoPlayer } from "@lichtblick/den/video";
 import { IRenderer } from "@lichtblick/suite-base/panels/ThreeDeeRender/IRenderer";
 import H265FrameBuilder from "@lichtblick/suite-base/testing/builders/H265FrameBuilder";
@@ -68,6 +69,10 @@ const h265BFrame = H265FrameBuilder.deltaFrameWithPps(H265SliceType.B);
 
 function createH265Frame(data: Uint8Array, timestamp = { sec: 0, nsec: 1 }) {
   return H265FrameBuilder.frame({ data, frame_id: "camera", timestamp });
+}
+
+function createAV1Frame(data: Uint8Array, timestamp = { sec: 0, nsec: 1 }): CompressedVideo {
+  return { data, format: "av1", frame_id: "camera", timestamp };
 }
 
 function createDecodedVideoFrame(timestamp = 0): VideoFrame {
@@ -258,6 +263,48 @@ describe("ImageRenderable error handling", () => {
     await decodeAndSettle(renderable, h265Keyframe);
 
     expect(init).toHaveBeenCalledWith({ codec: "hvc1.1.6.L93.B0" });
+    self.createImageBitmap = originalCreateImageBitmap;
+  });
+
+  it("should initialize AV1 and decode key and delta frames in order", async () => {
+    // GIVEN an AV1 renderable waiting for its first keyframe
+    const renderable = new ImageRenderable(mockUserData.topic, mockRenderer, { ...mockUserData });
+    jest.spyOn(renderable, "update").mockImplementation(() => undefined);
+    let initialized = false;
+    const init = jest.fn().mockImplementation(async () => {
+      initialized = true;
+    });
+    const decode = jest
+      .fn<Promise<VideoFrame | undefined>, [Uint8Array, number, "key" | "delta"]>()
+      .mockResolvedValue(createDecodedVideoFrame());
+    renderable.videoPlayer = {
+      isInitialized: jest.fn(() => initialized),
+      init,
+      decode,
+      decodeFrames: jest.fn(),
+      codedSize: jest.fn(),
+      decoderConfig: jest.fn().mockReturnValue(undefined),
+      resetForSeek: jest.fn(),
+      lastImageBitmap: undefined,
+      lastVideoFrame: undefined,
+    } as unknown as ImageRenderable["videoPlayer"];
+    const originalCreateImageBitmap = self.createImageBitmap;
+    self.createImageBitmap = jest.fn().mockResolvedValue(new ImageBitmap());
+
+    // WHEN an AV1 keyframe and its dependent delta frame are decoded
+    renderable.setImage(createAV1Frame(AV1FrameBuilder.keyframe(), { sec: 0, nsec: 0 }));
+    renderable.setImage(createAV1Frame(AV1FrameBuilder.deltaFrame(), { sec: 0, nsec: 33_333_333 }));
+    renderable.flushPendingDecodes();
+    await renderable.settleVideoDecodes();
+
+    // THEN WebCodecs is initialized from the sequence header and receives both frames in order
+    expect(init).toHaveBeenCalledWith({
+      codec: "av01.0.05M.08",
+      codedWidth: 640,
+      codedHeight: 480,
+    });
+    expect(decode).toHaveBeenNthCalledWith(1, expect.any(Uint8Array), 0, "key");
+    expect(decode).toHaveBeenNthCalledWith(2, expect.any(Uint8Array), 33333, "delta");
     self.createImageBitmap = originalCreateImageBitmap;
   });
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.test.ts
@@ -3,11 +3,14 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
+import AV1FrameBuilder from "@lichtblick/den/testing/builders/AV1FrameBuilder";
 import {
   H264 as H264Parser,
   H265 as H265Parser,
   H265NaluType,
   H265SliceType,
+  AV1 as AV1Parser,
+  AV1ObuType,
   VideoPlayer,
 } from "@lichtblick/den/video";
 import H265FrameBuilder from "@lichtblick/suite-base/testing/builders/H265FrameBuilder";
@@ -95,6 +98,16 @@ describe("isCompressedVideoKeyframe", () => {
     // THEN the H.265 parser is used and reports a keyframe
     expect(isCompressedVideoKeyframe(mockVideoFrame)).toBe(true);
   });
+
+  it("should use AV1 keyframe detection for av1 format", () => {
+    // GIVEN an AV1 frame that the parser reports as a keyframe
+    const mockVideoFrame = createMockVideoFrame({ format: "av1", data: new Uint8Array([0x0a]) });
+    jest.spyOn(AV1Parser, "IsKeyframe").mockReturnValue(true);
+
+    // WHEN keyframe detection runs
+    // THEN the AV1 parser is used and reports a keyframe
+    expect(isCompressedVideoKeyframe(mockVideoFrame)).toBe(true);
+  });
 });
 
 describe("getVideoDecoderConfig", () => {
@@ -134,6 +147,17 @@ describe("getVideoDecoderConfig", () => {
 
     // WHEN the decoder config is requested
     // THEN the H.265 parser config is returned
+    expect(getVideoDecoderConfig(mockVideoFrame)).toEqual(mockConfig);
+  });
+
+  it("should return a VideoDecoderConfig for av1 format", () => {
+    // GIVEN an AV1 keyframe and a stubbed decoder config
+    const mockVideoFrame = createMockVideoFrame({ format: "av1", data: new Uint8Array([0x0a]) });
+    const mockConfig = { codec: "av01.0.05M.08" };
+    jest.spyOn(AV1Parser, "ParseDecoderConfig").mockReturnValue(mockConfig);
+
+    // WHEN the decoder config is requested
+    // THEN the AV1 parser config is returned
     expect(getVideoDecoderConfig(mockVideoFrame)).toEqual(mockConfig);
   });
 });
@@ -336,6 +360,60 @@ describe("prepareVideoFrame", () => {
     expect(preparedFrame.data).toBe(data);
     expect(preparedFrame.decoderConfig).toBe(decoderConfig);
     expect(preparedFrame.type).toBe("key");
+  });
+
+  it("should pass through av1 keyframes with a sequence-derived decoder config", () => {
+    // GIVEN a Foxglove-compliant AV1 keyframe
+    const data = AV1FrameBuilder.keyframe();
+    const mockVideoFrame = createMockVideoFrame({ format: "av1", data });
+
+    // WHEN the frame is prepared for decoding
+    const preparedFrame = prepareVideoFrame(mockVideoFrame);
+
+    // THEN the low-overhead OBU bytes pass through with their decoder configuration
+    expect(preparedFrame).toEqual({
+      data,
+      decoderConfig: { codec: "av01.0.05M.08", codedWidth: 640, codedHeight: 480 },
+      diagnostics: undefined,
+      status: PreparedVideoFrameStatus.Ok,
+      type: "key",
+    });
+  });
+
+  it("should report an invalid av1 sequence header", () => {
+    // GIVEN a key frame whose Sequence Header OBU carries a truncated payload
+    const data = new Uint8Array([
+      ...AV1FrameBuilder.obu(AV1ObuType.SequenceHeader, [0x00]),
+      ...AV1FrameBuilder.frame(),
+    ]);
+    const mockVideoFrame = createMockVideoFrame({ format: "av1", data });
+
+    // WHEN the frame is prepared for decoding
+    const preparedFrame = prepareVideoFrame(mockVideoFrame);
+
+    // THEN it is identified as a keyframe but cannot initialize the decoder
+    expect(preparedFrame.decoderConfig).toBeUndefined();
+    expect(preparedFrame.diagnostics).toBe("invalid AV1 sequence header");
+    expect(preparedFrame.status).toBe(PreparedVideoFrameStatus.UnsupportedBitstream);
+    expect(preparedFrame.type).toBe("key");
+  });
+
+  it("should pass through av1 delta frames without decoder config", () => {
+    // GIVEN a Foxglove-compliant AV1 delta frame
+    const data = AV1FrameBuilder.deltaFrame();
+    const mockVideoFrame = createMockVideoFrame({ format: "av1", data });
+
+    // WHEN the frame is prepared for decoding
+    const preparedFrame = prepareVideoFrame(mockVideoFrame);
+
+    // THEN the OBU bytes pass through and reuse the decoder's cached keyframe configuration
+    expect(preparedFrame).toEqual({
+      data,
+      decoderConfig: undefined,
+      diagnostics: undefined,
+      status: PreparedVideoFrameStatus.Ok,
+      type: "delta",
+    });
   });
 });
 

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
@@ -26,6 +26,7 @@ import {
 import {
   H264 as H264Parser,
   H265 as H265Parser,
+  AV1 as AV1Parser,
   VideoCodec,
   VideoPlayer,
   canonicalVideoCodec,
@@ -64,6 +65,8 @@ export function getVideoDecoderConfig(frameMsg: CompressedVideo): VideoDecoderCo
       return H264Parser.ParseDecoderConfig(frameMsg.data);
     case VideoCodec.H265:
       return H265Parser.ParseDecoderConfig(frameMsg.data);
+    case VideoCodec.AV1:
+      return AV1Parser.ParseDecoderConfig(frameMsg.data);
   }
   return undefined;
 }
@@ -101,6 +104,22 @@ export function prepareVideoFrame(
             : (frameInfo.strippedData ?? frameInfo.normalizedData),
         decoderConfig: H265Parser.ParseDecoderConfig(frameInfo.normalizedData),
         status: PreparedVideoFrameStatus.Ok,
+        type,
+      };
+    }
+    case VideoCodec.AV1: {
+      const frameData = frameMsg.data;
+      const type = AV1Parser.IsKeyframe(frameData) ? "key" : "delta";
+      const decoderConfig = type === "key" ? AV1Parser.ParseDecoderConfig(frameData) : undefined;
+      return {
+        data: frameData,
+        decoderConfig,
+        diagnostics:
+          type === "key" && decoderConfig == undefined ? "invalid AV1 sequence header" : undefined,
+        status:
+          type === "key" && decoderConfig == undefined
+            ? PreparedVideoFrameStatus.UnsupportedBitstream
+            : PreparedVideoFrameStatus.Ok,
         type,
       };
     }

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
@@ -77,65 +77,75 @@ export function prepareVideoFrame(
   resolvedCodec?: VideoCodec,
 ): PreparedVideoFrame {
   switch (resolvedCodec ?? canonicalVideoCodec(frameMsg.format)) {
-    case VideoCodec.H265: {
-      const frameInfo = H265Parser.InspectFrame(frameMsg.data, context?.h265);
-      if (frameInfo.bitstreamFormat === "unknown" || frameInfo.normalizedData == undefined) {
-        return {
-          data: frameMsg.data,
-          status: PreparedVideoFrameStatus.UnsupportedBitstream,
-          diagnostics: "unsupported H.265 bitstream format",
-          type: "delta",
-        };
-      }
-      if (frameInfo.frameType === "B") {
-        return {
-          data: frameInfo.normalizedData,
-          status: PreparedVideoFrameStatus.UnsupportedBFrame,
-          diagnostics: "H.265 B frames are not supported",
-          type: "delta",
-        };
-      }
-
-      const type = frameInfo.isKeyframe ? "key" : "delta";
-      return {
-        data:
-          type === "key"
-            ? frameInfo.normalizedData
-            : (frameInfo.strippedData ?? frameInfo.normalizedData),
-        decoderConfig: H265Parser.ParseDecoderConfig(frameInfo.normalizedData),
-        status: PreparedVideoFrameStatus.Ok,
-        type,
-      };
-    }
-    case VideoCodec.AV1: {
-      const frameData = frameMsg.data;
-      const type = AV1Parser.IsKeyframe(frameData) ? "key" : "delta";
-      const decoderConfig = type === "key" ? AV1Parser.ParseDecoderConfig(frameData) : undefined;
-      return {
-        data: frameData,
-        decoderConfig,
-        diagnostics:
-          type === "key" && decoderConfig == undefined ? "invalid AV1 sequence header" : undefined,
-        status:
-          type === "key" && decoderConfig == undefined
-            ? PreparedVideoFrameStatus.UnsupportedBitstream
-            : PreparedVideoFrameStatus.Ok,
-        type,
-      };
-    }
+    case VideoCodec.H265:
+      return prepareH265VideoFrame(frameMsg.data, context?.h265);
+    case VideoCodec.AV1:
+      return prepareAV1VideoFrame(frameMsg.data);
     case VideoCodec.H264:
-    default: {
-      const frameData = frameMsg.data;
-      const type = H264Parser.IsKeyframe(frameData) ? "key" : "delta";
-      return {
-        data: frameData,
-        // Only keyframes carry an SPS; delta frames have nothing to parse.
-        decoderConfig: type === "key" ? H264Parser.ParseDecoderConfig(frameData) : undefined,
-        status: PreparedVideoFrameStatus.Ok,
-        type,
-      };
-    }
+    default:
+      return prepareH264VideoFrame(frameMsg.data);
   }
+}
+
+function prepareH265VideoFrame(
+  frameData: Uint8Array,
+  context?: PrepareVideoFrameContext["h265"],
+): PreparedVideoFrame {
+  const frameInfo = H265Parser.InspectFrame(frameData, context);
+  if (frameInfo.bitstreamFormat === "unknown" || frameInfo.normalizedData == undefined) {
+    return {
+      data: frameData,
+      status: PreparedVideoFrameStatus.UnsupportedBitstream,
+      diagnostics: "unsupported H.265 bitstream format",
+      type: "delta",
+    };
+  }
+  if (frameInfo.frameType === "B") {
+    return {
+      data: frameInfo.normalizedData,
+      status: PreparedVideoFrameStatus.UnsupportedBFrame,
+      diagnostics: "H.265 B frames are not supported",
+      type: "delta",
+    };
+  }
+
+  const type = frameInfo.isKeyframe ? "key" : "delta";
+  return {
+    data:
+      type === "key"
+        ? frameInfo.normalizedData
+        : (frameInfo.strippedData ?? frameInfo.normalizedData),
+    decoderConfig: H265Parser.ParseDecoderConfig(frameInfo.normalizedData),
+    status: PreparedVideoFrameStatus.Ok,
+    type,
+  };
+}
+
+function prepareAV1VideoFrame(frameData: Uint8Array): PreparedVideoFrame {
+  const type = AV1Parser.IsKeyframe(frameData) ? "key" : "delta";
+  const decoderConfig = type === "key" ? AV1Parser.ParseDecoderConfig(frameData) : undefined;
+  return {
+    data: frameData,
+    decoderConfig,
+    diagnostics:
+      type === "key" && decoderConfig == undefined ? "invalid AV1 sequence header" : undefined,
+    status:
+      type === "key" && decoderConfig == undefined
+        ? PreparedVideoFrameStatus.UnsupportedBitstream
+        : PreparedVideoFrameStatus.Ok,
+    type,
+  };
+}
+
+function prepareH264VideoFrame(frameData: Uint8Array): PreparedVideoFrame {
+  const type = H264Parser.IsKeyframe(frameData) ? "key" : "delta";
+  return {
+    data: frameData,
+    // Only keyframes carry an SPS; delta frames have nothing to parse.
+    decoderConfig: type === "key" ? H264Parser.ParseDecoderConfig(frameData) : undefined,
+    status: PreparedVideoFrameStatus.Ok,
+    type,
+  };
 }
 
 export async function decodeCompressedVideoToBitmap(

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/filterCompressedVideoQueue.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/filterCompressedVideoQueue.test.ts
@@ -5,6 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import AV1FrameBuilder from "@lichtblick/den/testing/builders/AV1FrameBuilder";
 import { MessageEvent } from "@lichtblick/suite";
 import H265FrameBuilder from "@lichtblick/suite-base/testing/builders/H265FrameBuilder";
 
@@ -53,6 +54,15 @@ function h265DeltaFrame(): CompressedVideo {
   return {
     format: "h265",
     data: H265FrameBuilder.deltaFrame(),
+    frame_id: "camera",
+    timestamp: { sec: 0, nsec: 0 },
+  };
+}
+
+function av1Frame(data: Uint8Array): CompressedVideo {
+  return {
+    format: "av1",
+    data,
     frame_id: "camera",
     timestamp: { sec: 0, nsec: 0 },
   };
@@ -178,5 +188,29 @@ describe("filterCompressedVideoQueue", () => {
     filterCompressedVideoQueue(messages);
 
     expect(messages).toEqual(snapshot);
+  });
+
+  it("keeps the AV1 GOP starting from the most recent keyframe", () => {
+    // GIVEN two AV1 GOPs followed by their delta frames
+    const oldKey = videoMessageEvent("/av1", av1Frame(AV1FrameBuilder.keyframe()), 1);
+    const oldDelta = videoMessageEvent("/av1", av1Frame(AV1FrameBuilder.deltaFrame()), 2);
+    const newKey = videoMessageEvent("/av1", av1Frame(AV1FrameBuilder.keyframe()), 3);
+    const newDelta = videoMessageEvent("/av1", av1Frame(AV1FrameBuilder.deltaFrame()), 4);
+
+    // WHEN the subscription queue is filtered
+    const result = filterCompressedVideoQueue([oldKey, oldDelta, newKey, newDelta]);
+
+    // THEN only the newest complete GOP is retained
+    expect(result).toEqual([newKey, newDelta]);
+  });
+
+  it("Keeps the full AV1 queue when no keyframe is preset yet", () => {
+    const deltaA = videoMessageEvent("/av1", av1Frame(AV1FrameBuilder.deltaFrame()), 1);
+    const deltaB = videoMessageEvent("/av1", av1Frame(AV1FrameBuilder.deltaFrame()), 2);
+    const deltaC = videoMessageEvent("/av1", av1Frame(AV1FrameBuilder.deltaFrame()), 3);
+
+    const result = filterCompressedVideoQueue([deltaA, deltaB, deltaC]);
+
+    expect(result).toEqual([deltaA, deltaB, deltaC]);
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/filterCompressedVideoQueue.test.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/filterCompressedVideoQueue.test.ts
@@ -204,13 +204,16 @@ describe("filterCompressedVideoQueue", () => {
     expect(result).toEqual([newKey, newDelta]);
   });
 
-  it("Keeps the full AV1 queue when no keyframe is preset yet", () => {
+  it("keeps the full AV1 queue when no keyframe is present yet", () => {
+    // GIVEN an AV1 queue containing only delta frames
     const deltaA = videoMessageEvent("/av1", av1Frame(AV1FrameBuilder.deltaFrame()), 1);
     const deltaB = videoMessageEvent("/av1", av1Frame(AV1FrameBuilder.deltaFrame()), 2);
     const deltaC = videoMessageEvent("/av1", av1Frame(AV1FrameBuilder.deltaFrame()), 3);
 
+    // WHEN the subscription queue is filtered
     const result = filterCompressedVideoQueue([deltaA, deltaB, deltaC]);
 
+    // THEN the full queue is retained
     expect(result).toEqual([deltaA, deltaB, deltaC]);
   });
 });

--- a/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/filterCompressedVideoQueue.ts
+++ b/packages/suite-base/src/panels/ThreeDeeRender/renderables/Images/filterCompressedVideoQueue.ts
@@ -16,7 +16,7 @@ import { isCompressedVideoKeyframe } from "./decodeImage";
 /**
  * Filters the per-frame queue for the `CompressedVideo` subscription.
  *
- * Codecs whose delta frames depend on a preceding GOP (H.264 and H.265) need the entire chain
+ * Codecs whose delta frames depend on a preceding GOP (H.264, H.265, and AV1) need the entire chain
  * from the most recent keyframe through the latest delta preserved — dropping older queued frames
  * leaves the decoder unable to produce a picture for the new latest frame until the next
  * keyframe arrives (which can be several seconds away for typical recordings, and is exactly the

--- a/packages/suite-base/src/players/IterablePlayer/videoSeekBackfill.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/videoSeekBackfill.test.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
 // SPDX-License-Identifier: MPL-2.0
 
+import AV1FrameBuilder from "@lichtblick/den/testing/builders/AV1FrameBuilder";
 import { H265 } from "@lichtblick/den/video";
 import { MessageEvent } from "@lichtblick/suite";
 import MessageEventBuilder from "@lichtblick/suite-base/testing/builders/MessageEventBuilder";
@@ -38,7 +39,7 @@ describe("needsGopBackfill", () => {
     expect(result).toBe(false);
   });
 
-  it("accepts inter-frame-dependent video codecs (H.264 and H.265, including the 'hevc' alias)", () => {
+  it("accepts inter-frame-dependent video codecs", () => {
     // H.264 belongs here too: a seek that lands on a P-frame is not decodable without the
     // preceding GOP, so backfill is required at the player/source boundary even though the
     // renderable doesn't serialize its decoder submissions for H.264 during normal playback.
@@ -64,16 +65,25 @@ describe("needsGopBackfill", () => {
       message: { format: "hevc", data: new Uint8Array([0x02]) },
       sizeInBytes: 1,
     });
+    const av1 = MessageEventBuilder.messageEvent({
+      topic: "video",
+      schemaName: "foxglove.CompressedVideo",
+      receiveTime: { sec: 0, nsec: 0 },
+      message: { format: "av1", data: AV1FrameBuilder.deltaFrame() },
+      sizeInBytes: 1,
+    });
 
     // When
     const h264Result = needsGopBackfill(h264);
     const h265Result = needsGopBackfill(h265);
     const hevcResult = needsGopBackfill(hevc);
+    const av1Result = needsGopBackfill(av1);
 
     // Then
     expect(h264Result).toBe(true);
     expect(h265Result).toBe(true);
     expect(hevcResult).toBe(true);
+    expect(av1Result).toBe(true);
   });
 
   it("rejects unrecognized codecs and non-Uint8Array payloads", () => {

--- a/packages/suite-base/src/players/IterablePlayer/videoSeekBackfill.ts
+++ b/packages/suite-base/src/players/IterablePlayer/videoSeekBackfill.ts
@@ -27,7 +27,7 @@ export type GetBackfillMessages = (args: GetBackfillMessagesArgs) => Promise<Mes
 
 /**
  * Returns true for a `foxglove.CompressedVideo` message whose codec can only be decoded by
- * replaying the full GOP (the keyframe and every frame after it). H.264 and H.265 both qualify:
+ * replaying the full GOP (the keyframe and every frame after it). H.264, H.265, and AV1 qualify:
  * a seek that lands on a P/B-frame is not decodable without the preceding keyframe and every
  * intervening delta frame, regardless of whether the renderable serializes its decoder
  * submissions at playback time. The codec decision is delegated to


### PR DESCRIPTION
## User-Facing Changes

<!-- will be used as a changelog entry -->
Lichtblick now supports AV1 compressed video.

## Description

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

Hello Lichtblick team! First of all, thank you very much for your continuous work on this great project!

Similar to #1175, this PR adds AV1 video (which is a royalty-free, high-efficiency codec) decoding support to Lichtblick, based on the [specification](https://aomediacodec.github.io/av1-spec/av1-spec.pdf).

Since this PR adds over 1,000 lines, I'd like to reduce the reviewers' burden as much as possible. For context, 703 of the ~1,216 added lines are unit tests and test builders; the production code is 513 lines. The change is also split into four commits that can be reviewed in order, and each one passes the test suite on its own:

1. `feat: add AV1 bitstream parser and test builder` — the parser itself, not yet called
2. `feat: recognize AV1 as a GOP-dependent video codec` — codec registry, queue filtering, seek backfill
3. `feat: use the extended decode budget for AV1` — WebCodecs target-frame wait
4. `feat: decode AV1 frames in the image panel` — what actually enables playback

If splitting into smaller PRs is still preferred, I'd be happy to do that.

Reviewers can test the behavior using the sample script:
<details>
<summary>sample script to publish `foxglove_msgs/CompressedVideo` w/ AV1 encoded data</summary>

The contents of `ffmpeg_test_frame_publisher.py`: 
```python
#!/usr/bin/env python3

import rclpy
from rclpy.node import Node
import subprocess
import struct
import threading
from foxglove_msgs.msg import CompressedVideo

class FFmpegAV1Publisher(Node):
    def __init__(self):
        super().__init__('ffmpeg_av1_publisher')
        self.pub = self.create_publisher(CompressedVideo, 'foxglove_video/av1', 10)

        cmd = [
            'ffmpeg', '-hide_banner', '-loglevel', 'error',
            '-re', '-f', 'lavfi', '-i', 'testsrc2=size=640x480:rate=30',
            '-c:v', 'libaom-av1',
            '-cpu-used', '8',
            '-usage', 'realtime',
            '-g', '10',         # GOP size
            '-f', 'ivf',
            'pipe:1'
        ]

        self.get_logger().info(f"Starting FFmpeg (640x480 @ 30fps) with cmd: {' '.join(cmd)}")

        # Execute FFmpeg as subprocess
        self.process = subprocess.Popen(cmd, stdout=subprocess.PIPE)

        # spawn a thread to read video data from the pipe
        self.thread = threading.Thread(target=self.read_loop, daemon=True)
        self.thread.start()

    def read_loop(self):
        # skip the global header (32 bytes) of IVF container
        header = self.process.stdout.read(32)
        if len(header) < 32:
            self.get_logger().error("Failed to read IVF header")
            return

        while rclpy.ok():
            # read IVF frame header (12 bytes)
            frame_hdr = self.process.stdout.read(12)
            if len(frame_hdr) < 12:
                break

            # The first 4 bytes are the frame data sizes (in little endian)
            size = struct.unpack('<I', frame_hdr[:4])[0]

            # read the actual data
            data = self.process.stdout.read(size)
            if len(data) < size:
                break

            # pack message and publish it
            msg = CompressedVideo()
            msg.timestamp = self.get_clock().now().to_msg()
            msg.frame_id = "ffmpeg_test_pattern"
            msg.format = "av1"
            msg.data = data
            self.pub.publish(msg)

    def destroy_node(self):
        # terminate FFmpeg process when the node is destroyed
        self.process.kill()
        super().destroy_node()

def main(args=None):
    rclpy.init(args=args)
    node = FFmpegAV1Publisher()
    try:
        rclpy.spin(node)
    except KeyboardInterrupt:
        pass
    finally:
        node.destroy_node()
        rclpy.shutdown()

if __name__ == '__main__':
    main()
```

This can be executed by `python3 ffmpeg_test_frame_publisher.py`

Note that this script only exercises live playback. To also check seeking (a seek that lands on a delta frame replays the preceding GOP), record the topic with `ros2 bag record -o av1_test /foxglove_video/av1` and seek within the resulting file.

</details>


A simple test should produce the following result:

| Before (decode fails) | After (AV1 renders) |
| :-------: | :-----: |
| <img width="1352" height="925" alt="image" src="https://github.com/user-attachments/assets/b64b72a6-80e1-496c-b176-723acce44027" /> | <img width="1352" height="925" alt="image" src="https://github.com/user-attachments/assets/2d35421a-f89b-4a91-881a-f34f21a27405" /> |


## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [x] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added AV1 video codec support, including keyframe detection and decoder configuration.
  - AV1 videos can now be decoded and rendered alongside existing formats.
  - Added AV1 support for seeking, GOP backfill, frame ordering, and keyframe replay.
  - Added handling for AV1 sequence headers, frame types, bit depths, profiles, and timing information.

- **Bug Fixes**
  - AV1 decoding now uses the appropriate extended buffering timeout.
  - Invalid AV1 sequence headers produce clear unsupported-bitstream diagnostics.

- **Tests**
  - Added comprehensive coverage for AV1 parsing, decoding, rendering, seeking, and malformed data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->