### PR TITLE
Fix idempotency in release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@ env:
 permissions:
   contents: write
 
+# Serialize runs so concurrent triggers (e.g. a manual retry while a merge-triggered run is
+# still in-flight) can't both compute and push the same "chore: release" commit/tag.
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
 jobs:
   release:
     if: |
@@ -23,6 +29,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           token: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}
+          ref: ${{ github.ref }}
+          # Full history is required for the ancestry-based duplicate-release detection below.
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -38,7 +47,7 @@ jobs:
       - name: Determine version bump type
         id: bump_type
         run: |
-          branch_name="${GITHUB_HEAD_REF}"
+          branch_name="$GITHUB_HEAD_REF"
           if [[ "$branch_name" == hotfix/* ]]; then
             echo "type=patch" >> "$GITHUB_ENV"
           elif [[ "$branch_name" =~ ^release/major(/.*)?$ ]]; then
@@ -54,21 +63,30 @@ jobs:
             exit 1
           fi
 
+      # See .github/workflows/scripts/check-existing-release.sh for what this detects and why.
+      - name: Check for existing release commit
+        run: bash .github/workflows/scripts/check-existing-release.sh
+
       - name: Bump root version
+        if: env.already_released != 'true'
         run: yarn version ${{ env.type }}
 
       - name: Bump suite version
+        if: env.already_released != 'true'
         working-directory: packages/suite
         run: yarn version ${{ env.type }}
 
       - name: Get new version
+        if: env.already_released != 'true'
         id: get_version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
 
       - name: Update Sonar version
+        if: env.already_released != 'true'
         run: sed -i "" "s/^sonar.projectVersion=.*/sonar.projectVersion=${{ env.version }}/" sonar-project.properties
 
       - name: Commit and tag
+        if: env.already_released != 'true'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -76,6 +94,18 @@ jobs:
           git commit -m "chore: release v${{ env.version }} [skip actions]"
           git tag "v${{ env.version }}"
           git push origin main --tags
+
+      # Retry path: the bump/commit/tag already landed on main in a previous attempt.
+      # Reset to the exact release commit (not origin/main's tip), in case later
+      # commits have since landed on main.
+      - name: Use existing release commit
+        if: env.already_released == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git reset --hard "${{ env.release_commit_sha }}"
+          git tag -f "v${{ env.version }}"
+          git push --force origin "v${{ env.version }}"
 
       - name: Build prod files
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           token: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}
-          ref: ${{ github.ref }}
+          ref: main
           # Full history is required for the ancestry-based duplicate-release detection below.
           fetch-depth: 0
 
@@ -65,6 +65,11 @@ jobs:
 
       # See .github/workflows/scripts/check-existing-release.sh for what this detects and why.
       - name: Check for existing release commit
+        env:
+          # github.ref/github.sha would be the ephemeral pull_request merge-preview ref/commit,
+          # which can be stale or gone once the PR is closed. merge_commit_sha is the actual,
+          # permanent commit that landed on main.
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: bash .github/workflows/scripts/check-existing-release.sh
 
       - name: Bump root version

--- a/.github/workflows/scripts/check-existing-release.sh
+++ b/.github/workflows/scripts/check-existing-release.sh
@@ -13,13 +13,16 @@
 # after the release commit was pushed.
 #
 # Requires a full (unshallow) checkout: `fetch-depth: 0` in actions/checkout.
+# Requires $MERGE_COMMIT_SHA (the PR's merge_commit_sha, not github.sha/HEAD).
 # Writes already_released, version, and release_commit_sha to $GITHUB_ENV.
 
 set -euo pipefail
 
+: "${MERGE_COMMIT_SHA:?MERGE_COMMIT_SHA env var is required}"
+
 git fetch origin main
 
-merge_commit="$(git rev-parse HEAD)"
+merge_commit="$MERGE_COMMIT_SHA"
 release_commit_pattern='^chore: release v(.*) \[skip actions\]$'
 already_released=false
 

--- a/.github/workflows/scripts/check-existing-release.sh
+++ b/.github/workflows/scripts/check-existing-release.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (C) 2023-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)<lichtblick@bmwgroup.com>
+# SPDX-License-Identifier: MPL-2.0
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+# Used by .github/workflows/release.yml to detect a prior successful run of the
+# same PR merge (e.g. a re-run after a later step failed), so retries don't
+# create a duplicate "chore: release" commit. Searches the full ancestry path
+# (not just origin/main's tip), since other commits may have landed on main
+# after the release commit was pushed.
+#
+# Requires a full (unshallow) checkout: `fetch-depth: 0` in actions/checkout.
+# Writes already_released, version, and release_commit_sha to $GITHUB_ENV.
+
+set -euo pipefail
+
+git fetch origin main
+
+merge_commit="$(git rev-parse HEAD)"
+release_commit_pattern='^chore: release v(.*) \[skip actions\]$'
+already_released=false
+
+if git merge-base --is-ancestor "$merge_commit" origin/main; then
+  # --max-count is applied before --reverse (see git-rev-list(1) Commit Limiting), so it's only
+  # safe to combine them while the true count is under the cap - otherwise we'd silently get
+  # origin/main's tip instead of the immediate child of merge_commit. Fail loudly if the cap is
+  # hit instead of guessing.
+  ancestry_path_cap=1000
+  mapfile -t ancestry_path < <(git rev-list --ancestry-path --reverse --max-count="$ancestry_path_cap" "${merge_commit}..origin/main")
+  if [[ "${#ancestry_path[@]}" -eq "$ancestry_path_cap" ]]; then
+    echo "ERROR: more than $ancestry_path_cap commits between $merge_commit and origin/main; refusing to guess the immediate child commit." >&2
+    exit 1
+  fi
+  child_commit="${ancestry_path[0]:-}"
+  if [[ -n "$child_commit" ]]; then
+    child_parent="$(git rev-parse "${child_commit}^")"
+    child_subject="$(git log -1 --format=%s "$child_commit")"
+    if [[ "$child_parent" == "$merge_commit" && "$child_subject" =~ $release_commit_pattern ]]; then
+      already_released=true
+      version="${BASH_REMATCH[1]}"
+      release_commit_sha="$child_commit"
+    fi
+  fi
+fi
+
+if [[ "$already_released" == "true" ]]; then
+  echo "already_released=true" >> "$GITHUB_ENV"
+  echo "version=$version" >> "$GITHUB_ENV"
+  echo "release_commit_sha=$release_commit_sha" >> "$GITHUB_ENV"
+else
+  echo "already_released=false" >> "$GITHUB_ENV"
+fi


### PR DESCRIPTION
## User-Facing Changes

N/A

# Description

Fixes non-idempotent behavior in `.github/workflows/release.yml`: a retry after a partial failure would redo the version bump and fail trying to recreate the same commit/tag.

- `.github/workflows/scripts/check-existing-release.sh` checks if the release commit already exists on `main` before bumping anything, and if so, resets/re-tags to that exact commit instead of redoing the bump.
- Checkout now uses `fetch-depth: 0` (required for the ancestry check above).
- Added a `concurrency` group to prevent overlapping runs from racing.

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate release commits and tags when release workflows are retried or triggered concurrently.
  - Improved release recovery by restoring the existing release commit and updating the corresponding tag when needed.
  - Added safeguards to detect previously completed releases before creating new version bumps.
  - Improved release reliability by ensuring retries preserve the correct version and release history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->