### PR TITLE
Replace mapfile with bash3.2 logic for macOS workers

### DIFF
--- a/.github/workflows/scripts/check-existing-release.sh
+++ b/.github/workflows/scripts/check-existing-release.sh
@@ -32,7 +32,10 @@ if git merge-base --is-ancestor "$merge_commit" origin/main; then
   # origin/main's tip instead of the immediate child of merge_commit. Fail loudly if the cap is
   # hit instead of guessing.
   ancestry_path_cap=1000
-  mapfile -t ancestry_path < <(git rev-list --ancestry-path --reverse --max-count="$ancestry_path_cap" "${merge_commit}..origin/main")
+  ancestry_path=()
+  while IFS= read -r commit_sha; do
+    ancestry_path+=("$commit_sha")
+  done < <(git rev-list --ancestry-path --reverse --max-count="$ancestry_path_cap" "${merge_commit}..origin/main")
   if [[ "${#ancestry_path[@]}" -eq "$ancestry_path_cap" ]]; then
     echo "ERROR: more than $ancestry_path_cap commits between $merge_commit and origin/main; refusing to guess the immediate child commit." >&2
     exit 1


### PR DESCRIPTION
## User-Facing Changes

No user-facing changes.

## Description

Replace the use of `mapfile` with a compatible bash 3.2 logic to ensure functionality on macOS workers.

## Checklist

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated release-checking behavior without changing its results or user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->