### PR TITLE
fix: gaps are well displayed in the state-transition panel

### DIFF
--- a/packages/suite-base/src/components/TimeBasedChart/downsampleStates.test.ts
+++ b/packages/suite-base/src/components/TimeBasedChart/downsampleStates.test.ts
@@ -116,4 +116,22 @@ describe("downsampleStates", () => {
       { x: 100, index: 3 },
     ]);
   });
+
+  it("clamps synthetic endpoint when a multi-state interval is followed by a gap in the same pixel", () => {
+    // in:  A-B-gap (all within one pixel interval around x=50)
+    // out: first point + synthetic endpoint clamped to gap + gap point
+    const gapData: Datum[] = [
+      { x: 50, y: 0, label: A },
+      { x: 50.02, y: 0, label: B },
+      { x: 50.04, y: Number.NaN },
+    ];
+
+    const result = downsampleStates(iterateObjects(gapData), bounds, numPoints);
+
+    expect(result).toEqual([
+      { x: 50, index: undefined, states: [A, B] },
+      { x: 50.04, index: 1 },
+      { x: 50.04, index: 2 },
+    ]);
+  });
 });

--- a/packages/suite-base/src/components/TimeBasedChart/downsampleStates.test.ts
+++ b/packages/suite-base/src/components/TimeBasedChart/downsampleStates.test.ts
@@ -96,4 +96,24 @@ describe("downsampleStates", () => {
       { x: 100, index: 4 },
     ]);
   });
+
+  it("preserves the first segment after a gap when pre/post states are equal", () => {
+    // in:  --A gap A-- (all within one interval around x=50)
+    // out: --A gap A-- (post-gap A must not be merged away)
+    const gapData: Datum[] = [
+      { x: 50, y: 0, label: A },
+      { x: 50.1, y: Number.NaN },
+      { x: 50.2, y: 0, label: A },
+      { x: 100, y: 0, label: A },
+    ];
+
+    const result = downsampleStates(iterateObjects(gapData), bounds, numPoints);
+
+    expect(result).toEqual([
+      { x: 50, index: 0 },
+      { x: 50.1, index: 1 },
+      { x: 50.2, index: 2 },
+      { x: 100, index: 3 },
+    ]);
+  });
 });

--- a/packages/suite-base/src/components/TimeBasedChart/downsampleStates.ts
+++ b/packages/suite-base/src/components/TimeBasedChart/downsampleStates.ts
@@ -163,9 +163,12 @@ export function downsampleStates(
       continue;
     }
 
-    // This only seems to occur when we've inserted a dummy final point, which
-    // we need to add
+    // Gap markers and synthetic endpoints are represented without labels.
+    // They must also break the current interval so that the first point of the
+    // next segment is not merged away when it has the same state value.
     if (label == undefined) {
+      finishInterval();
+      interval = undefined;
       indices.push({
         x,
         index,

--- a/packages/suite-base/src/components/TimeBasedChart/downsampleStates.ts
+++ b/packages/suite-base/src/components/TimeBasedChart/downsampleStates.ts
@@ -110,7 +110,7 @@ export function downsampleStates(
    * * One at the x-value of the end of the interval (which is not a real point)
    * This allows the renderer to draw a gray line segment between these two points.
    */
-  const finishInterval = () => {
+  const finishInterval = (gapX?: number) => {
     if (interval == undefined) {
       return;
     }
@@ -135,7 +135,7 @@ export function downsampleStates(
     }
 
     indices.push({
-      x: endX,
+      x: gapX != undefined ? Math.min(endX, gapX) : endX,
       index: last.index,
     });
   };
@@ -167,7 +167,7 @@ export function downsampleStates(
     // They must also break the current interval so that the first point of the
     // next segment is not merged away when it has the same state value.
     if (label == undefined) {
-      finishInterval();
+      finishInterval(x);
       interval = undefined;
       indices.push({
         x,


### PR DESCRIPTION
## User-Facing Changes

Gaps were not displayed correctly in the State Transitions panel, especially at default zoom levels.
This PR fixes gap rendering so null/gap values are now shown consistently.

Here the result :

Before the fix : 
<img width="1132" height="468" alt="image" src="https://github.com/user-attachments/assets/4b82d2bd-2f4d-424c-91d2-8bb60d5348a7" />
After the fix :
<img width="1130" height="467" alt="image" src="https://github.com/user-attachments/assets/0fab033a-f48b-43e5-bd65-6aff2d4405d0" />


## Description

This change fixes a regression in state downsampling where points right after a gap could be dropped, which made some gaps appear as continuous segments.

What changed:

Treat gap/unlabeled points as hard boundaries in state downsampling.
Reset interval state when a gap marker is encountered.
Preserve the first segment after a gap even when labels before and after are identical.
Add a regression test to lock this behavior.

## Checklist

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed time-based chart downsampling so points after missing-value gaps are preserved, including when they share the same state as points before the gap.
  - Improved gap handling to keep synthetic chart endpoints within the gap boundary and maintain the correct point order.

- **Tests**
  - Added coverage for state data split by missing-value gaps and for multi-state intervals ending at a gap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->